### PR TITLE
Add test of Multiple result reporting

### DIFF
--- a/src/test-nunit-summary.exe/MultipleInputSingleOutputTest.cs
+++ b/src/test-nunit-summary.exe/MultipleInputSingleOutputTest.cs
@@ -1,0 +1,121 @@
+﻿// ***********************************************************************
+// Copyright(c) 2016 Charlie Poole
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+// ***********************************************************************
+
+using System;
+using NUnit.Framework;
+
+namespace NUnit.Extras.Tests
+{
+    public class MultipleInputSingleOutputTest : ReportCreationTests
+    {
+        protected override string Input
+        {
+            get { return "TestInput/TestResult-*.xml"; }
+        }
+
+        protected override string Output
+        {
+            get { return "MultipleTestResultReport.txt"; }
+        }
+
+        protected override string Options
+        {
+            get { return "-brief"; }
+        }
+
+        static TestCaseData[] ExpectedText = new TestCaseData[]
+        {
+            new TestCaseData(0, @"C:\Program Files\NUnit-Net-2.0 2.2.10\bin\NUnitTests.nunit"),
+            new TestCaseData(2, "NUnit Version 2.2.10"),
+            new TestCaseData(4, "Runtime Environment -"),
+            new TestCaseData(5, "OS Version: Microsoft Windows NT 5.1.2600 Service Pack 2"),
+            new TestCaseData(6, "CLR Version: 2.0.50727"),
+            new TestCaseData(8, "Tests run: 774, Failures: 1, Not run: 2, Time: 37.063 seconds"),
+
+            new TestCaseData(9, @"C:\Program Files\NUnit 2.4.8\bin\NUnitTests.nunit"),
+            new TestCaseData(11, "NUnit Version 2.4.8"),
+            new TestCaseData(13, "Runtime Environment -"),
+            new TestCaseData(14, "OS Version: Microsoft Windows NT 5.1.2600 Service Pack 2"),
+            new TestCaseData(15, "CLR Version: 2.0.50727"),
+            new TestCaseData(17, "Tests run: 1264, Failures: 0, Not run: 2, Time: 79.859 seconds"),
+
+            new TestCaseData(18, @"C:\Program Files\NUnit 2.5.10\bin\net-2.0\NUnitTests.nunit"),
+            new TestCaseData(20, "NUnit Version 2.5.10"),
+            new TestCaseData(22, "Runtime Environment -"),
+            new TestCaseData(23, "OS Version: Microsoft Windows NT 6.1.7601 Service Pack 1"),
+            new TestCaseData(24, "CLR Version: 2.0.50727"),
+            new TestCaseData(26, "Tests run: 3001, Errors: 0, Failures: 0, Inconclusive: 13, Time: 71.132 seconds"),
+            new TestCaseData(27, "Not run: 2, Invalid: 0, Ignored: 0, Skipped: 2"),
+
+            new TestCaseData(28, @"C:\Program Files\NUnit 2.5.2\bin\net-2.0\NUnitTests.nunit"),
+            new TestCaseData(30, "NUnit Version 2.5.2"),
+            new TestCaseData(32, "Runtime Environment -"),
+            new TestCaseData(33, "OS Version: Microsoft Windows NT 5.1.2600 Service Pack 2"),
+            new TestCaseData(34, "CLR Version: 2.0.50727"),
+            new TestCaseData(36, "Tests run: 2625, Errors: 0, Failures: 0, Inconclusive: 7, Time: 181.688 seconds"),
+            new TestCaseData(37, "Not run: 2, Invalid: 0, Ignored: 0, Skipped: 2"),
+
+            new TestCaseData(38, @"C:\Program Files\NUnit 2.6\bin\NUnitTests.nunit"),
+            new TestCaseData(40, "NUnit Version 2.6.0"),
+            new TestCaseData(42, "Runtime Environment -"),
+            new TestCaseData(43, "OS Version: Microsoft Windows NT 6.1.7601 Service Pack 1"),
+            new TestCaseData(44, "CLR Version: 2.0.50727"),
+            new TestCaseData(46, "Tests run: 3242, Errors: 0, Failures: 0, Inconclusive: 17, Time: 58.148 seconds"),
+            new TestCaseData(47, "Not run: 8, Invalid: 0, Ignored: 0, Skipped: 8"),
+
+            new TestCaseData(48, @"C:\Program Files\NUnit 2.6.2\bin\NUnitTests.nunit"),
+            new TestCaseData(50, "NUnit Version 2.6.2"),
+            new TestCaseData(52, "Runtime Environment -"),
+            new TestCaseData(53, "OS Version: Microsoft Windows NT 6.1.7601 Service Pack 1"),
+            new TestCaseData(54, "CLR Version: 2.0.50727"),
+            new TestCaseData(56, "Tests run: 3480, Errors: 0, Failures: 0, Inconclusive: 19, Time: 78.534 seconds"),
+            new TestCaseData(57, "Not run: 8, Invalid: 0, Ignored: 0, Skipped: 8"),
+
+            new TestCaseData(58, @"D:\Dev\NUnit\nunit-2.6\bin\Debug\tests\nunit.framework.tests.dll"),
+            new TestCaseData(60, "NUnit Version 2.6.4"),
+            new TestCaseData(62, "Runtime Environment -"),
+            new TestCaseData(63, "OS Version: Microsoft Windows NT 6.1.7601 Service Pack 1"),
+            new TestCaseData(64, "CLR Version: 2.0.50727"),
+            new TestCaseData(66, "Tests run: 1580, Errors: 0, Failures: 0, Inconclusive: 0, Time: 18.407 seconds"),
+            new TestCaseData(67, "Not run: 0, Invalid: 0, Ignored: 0, Skipped: 0"),
+        };
+
+        [TestCaseSource("ExpectedText")]
+        public void CheckReportContent(int lineno, string text)
+        {
+            //int count = 0;
+            //int index = 0;
+            //for (;;)
+            //{
+            //    index = Report.IndexOf(text, index);
+            //    if (index < 0) break;
+
+            //    count++;
+
+            //    index += text.Length;
+            //    if (index >= Report.Length) break;
+            //}
+
+            //Assert.That(count, Is.EqualTo(expectedCount), "Error finding text \"" + text + "\"");
+            Assert.That(ReportLines[lineno], Contains.Substring(text));
+        }
+    }
+}

--- a/src/test-nunit-summary.exe/TestInput/TestResult-2.2.10.xml
+++ b/src/test-nunit-summary.exe/TestInput/TestResult-2.2.10.xml
@@ -1,0 +1,1325 @@
+﻿<?xml version="1.0" encoding="utf-8" standalone="no"?>
+<!--This file represents the results of running a test suite-->
+<test-results name="C:\Program Files\NUnit-Net-2.0 2.2.10\bin\NUnitTests.nunit" total="774" failures="1" not-run="2" date="2009-11-30" time="17:20:28">
+  <environment nunit-version="2.2.10.0" clr-version="2.0.50727.3053" os-version="Microsoft Windows NT 5.1.2600 Service Pack 2" platform="Win32NT" cwd="D:\Dev\NUnit\nunit-results\1.0" machine-name="FERRARI" user="Charlie" user-domain="FERRARI" />
+  <culture-info current-culture="en-US" current-uiculture="en-US" />
+  <test-suite name="C:\Program Files\NUnit-Net-2.0 2.2.10\bin\NUnitTests.nunit" success="False" time="37.063" asserts="0">
+    <results>
+      <test-suite name="C:\Program Files\NUnit-Net-2.0 2.2.10\bin\nunit.extensions.tests.dll" success="True" time="0.094" asserts="0">
+        <results>
+          <test-suite name="NUnit" success="True" time="0.078" asserts="0">
+            <results>
+              <test-suite name="Core" success="True" time="0.078" asserts="0">
+                <results>
+                  <test-suite name="Extensions" success="True" time="0.078" asserts="0">
+                    <results>
+                      <test-suite name="Tests" success="True" time="0.078" asserts="0">
+                        <results>
+                          <test-suite name="RepeatedTestFixture" success="True" time="0.063" asserts="0">
+                            <results>
+                              <test-case name="NUnit.Core.Extensions.Tests.RepeatedTestFixture.IgnoreWorksWithRepeatedTest" executed="True" success="True" time="0.047" asserts="3" />
+                              <test-case name="NUnit.Core.Extensions.Tests.RepeatedTestFixture.RepeatFailOnFirst" executed="True" success="True" time="0.000" asserts="4" />
+                              <test-case name="NUnit.Core.Extensions.Tests.RepeatedTestFixture.RepeatFailOnThird" executed="True" success="True" time="0.016" asserts="4" />
+                              <test-case name="NUnit.Core.Extensions.Tests.RepeatedTestFixture.RepeatSuccess" executed="True" success="True" time="0.000" asserts="4" />
+                            </results>
+                          </test-suite>
+                          <test-suite name="SampleSuiteExtensionTests" success="True" time="0.016" asserts="0">
+                            <results>
+                              <test-case name="NUnit.Core.Extensions.Tests.SampleSuiteExtensionTests.SampleTest1" executed="True" success="True" time="0.016" asserts="0" />
+                              <test-case name="NUnit.Core.Extensions.Tests.SampleSuiteExtensionTests.SampleTest2" executed="True" success="True" time="0.000" asserts="0" />
+                            </results>
+                          </test-suite>
+                        </results>
+                      </test-suite>
+                    </results>
+                  </test-suite>
+                </results>
+              </test-suite>
+              <test-suite name="Extensions" success="True" time="0.000" asserts="0">
+                <results>
+                  <test-suite name="Tests" success="True" time="0.000" asserts="0">
+                    <results>
+                      <test-suite name="SampleFixtureExtensionTests" success="True" time="0.000" asserts="0">
+                        <results>
+                          <test-case name="NUnit.Extensions.Tests.SampleFixtureExtensionTests.AnotherTest" executed="True" success="True" time="0.000" asserts="0" />
+                          <test-case name="NUnit.Extensions.Tests.SampleFixtureExtensionTests.SomeTest" executed="True" success="True" time="0.000" asserts="0" />
+                        </results>
+                      </test-suite>
+                    </results>
+                  </test-suite>
+                </results>
+              </test-suite>
+            </results>
+          </test-suite>
+        </results>
+      </test-suite>
+      <test-suite name="C:\Program Files\NUnit-Net-2.0 2.2.10\bin\nunit.framework.tests.dll" success="True" time="7.500" asserts="0">
+        <results>
+          <test-suite name="NUnit" success="True" time="7.500" asserts="0">
+            <results>
+              <test-suite name="Core" success="True" time="7.031" asserts="0">
+                <results>
+                  <test-suite name="Tests" success="True" time="6.984" asserts="0">
+                    <results>
+                      <test-suite name="AssemblyTests" success="True" time="0.484" asserts="0">
+                        <results>
+                          <test-case name="NUnit.Core.Tests.AssemblyTests.AppSettingsLoaded" executed="True" success="True" time="0.078" asserts="3" />
+                          <test-case name="NUnit.Core.Tests.AssemblyTests.LoadAssembly" executed="True" success="True" time="0.266" asserts="2" />
+                          <test-case name="NUnit.Core.Tests.AssemblyTests.LoadAssemblyNotFound" executed="True" success="True" time="0.016" asserts="0" />
+                          <test-case name="NUnit.Core.Tests.AssemblyTests.LoadAssemblyWithoutTestFixtures" executed="True" success="True" time="0.094" asserts="4" />
+                          <test-case name="NUnit.Core.Tests.AssemblyTests.LoadTestFixtureFromAssembly" executed="True" success="True" time="0.031" asserts="1" />
+                          <test-case name="NUnit.Core.Tests.AssemblyTests.RunSetsCurrentDirectory" executed="True" success="True" time="0.000" asserts="1" />
+                        </results>
+                      </test-suite>
+                      <test-suite name="AssemblyVersionFixture" success="True" time="0.016" asserts="0">
+                        <results>
+                          <test-case name="NUnit.Core.Tests.AssemblyVersionFixture.Version" executed="True" success="True" time="0.016" asserts="1" />
+                        </results>
+                      </test-suite>
+                      <test-suite name="CallContextTests" success="True" time="0.016" asserts="0">
+                        <results>
+                          <test-case name="NUnit.Core.Tests.CallContextTests.GenericPrincipalTest" executed="True" success="True" time="0.000" asserts="0" />
+                          <test-case name="NUnit.Core.Tests.CallContextTests.ILogicalThreadAffinativeTest" executed="True" success="True" time="0.000" asserts="0" />
+                          <test-case name="NUnit.Core.Tests.CallContextTests.ILogicalThreadAffinativeTestConsole" executed="True" success="True" time="0.000" asserts="0" />
+                          <test-case name="NUnit.Core.Tests.CallContextTests.SetCustomPrincipalOnThread" executed="True" success="True" time="0.000" asserts="0" />
+                          <test-case name="NUnit.Core.Tests.CallContextTests.SetGenericPrincipalOnThread" executed="True" success="True" time="0.000" asserts="0" />
+                          <test-case name="NUnit.Core.Tests.CallContextTests.UseCustomIdentity" executed="True" success="True" time="0.000" asserts="0" />
+                        </results>
+                      </test-suite>
+                      <test-suite name="CategoryManagerTest" success="True" time="0.000" asserts="0">
+                        <results>
+                          <test-case name="NUnit.Core.Tests.CategoryManagerTest.NoDuplicates" executed="True" success="True" time="0.000" asserts="1" />
+                        </results>
+                      </test-suite>
+                      <test-suite name="DirectorySwapperTests" success="True" time="0.000" asserts="0">
+                        <results>
+                          <test-case name="NUnit.Core.Tests.DirectorySwapperTests.ChangeAndRestore" executed="True" success="True" time="0.000" asserts="3" />
+                          <test-case name="NUnit.Core.Tests.DirectorySwapperTests.SwapAndRestore" executed="True" success="True" time="0.000" asserts="2" />
+                        </results>
+                      </test-suite>
+                      <test-suite name="EventQueueTests" success="True" time="0.031" asserts="0">
+                        <results>
+                          <test-case name="NUnit.Core.Tests.EventQueueTests.PumpAutoStopsOnRunFinished" executed="True" success="True" time="0.016" asserts="3" />
+                          <test-case name="NUnit.Core.Tests.EventQueueTests.PumpEvents" executed="True" success="True" time="0.000" asserts="9" />
+                          <test-case name="NUnit.Core.Tests.EventQueueTests.PumpEventsWithAutoStop" executed="True" success="True" time="0.000" asserts="7" />
+                          <test-case name="NUnit.Core.Tests.EventQueueTests.QueueEvents" executed="True" success="True" time="0.000" asserts="6" />
+                          <test-case name="NUnit.Core.Tests.EventQueueTests.SendEvents" executed="True" success="True" time="0.000" asserts="6" />
+                          <test-case name="NUnit.Core.Tests.EventQueueTests.StartAndStopPumpOnEmptyQueue" executed="True" success="True" time="0.000" asserts="2" />
+                        </results>
+                      </test-suite>
+                      <test-suite name="EventTestFixture" description="Tests that proper events are generated when running  test" success="True" time="0.109" asserts="0">
+                        <results>
+                          <test-case name="NUnit.Core.Tests.EventTestFixture.CheckEventListening" executed="True" success="True" time="0.109" asserts="4" />
+                        </results>
+                      </test-suite>
+                      <test-suite name="ExpectExceptionTest" success="True" time="0.109" asserts="0">
+                        <results>
+                          <test-case name="NUnit.Core.Tests.ExpectExceptionTest.AssertFailBeforeException" executed="True" success="True" time="0.016" asserts="2" />
+                          <test-case name="NUnit.Core.Tests.ExpectExceptionTest.CanSpecifyExceptionName" executed="True" success="True" time="0.000" asserts="0" />
+                          <test-case name="NUnit.Core.Tests.ExpectExceptionTest.CanSpecifyExceptionNameAndMessage" executed="True" success="True" time="0.000" asserts="0" />
+                          <test-case name="NUnit.Core.Tests.ExpectExceptionTest.CanSpecifyExceptionType" executed="True" success="True" time="0.000" asserts="0" />
+                          <test-case name="NUnit.Core.Tests.ExpectExceptionTest.CanSpecifyExceptionTypeAndMessage" executed="True" success="True" time="0.000" asserts="0" />
+                          <test-case name="NUnit.Core.Tests.ExpectExceptionTest.MethodThrowsArgumentOutOfRange" executed="True" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Core.Tests.ExpectExceptionTest.MethodThrowsException" executed="True" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Core.Tests.ExpectExceptionTest.MethodThrowsRightExceptionMessage" executed="True" success="True" time="0.016" asserts="1" />
+                          <test-case name="NUnit.Core.Tests.ExpectExceptionTest.MethodThrowsWrongExceptionMessage" executed="True" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Core.Tests.ExpectExceptionTest.SetUpThrowsSameException" executed="True" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Core.Tests.ExpectExceptionTest.TearDownThrowsSameException" executed="True" success="True" time="0.016" asserts="1" />
+                          <test-case name="NUnit.Core.Tests.ExpectExceptionTest.TestBaseException" executed="True" success="True" time="0.000" asserts="2" />
+                          <test-case name="NUnit.Core.Tests.ExpectExceptionTest.TestExceptionNameNotThrown" executed="True" success="True" time="0.016" asserts="2" />
+                          <test-case name="NUnit.Core.Tests.ExpectExceptionTest.TestExceptionTypeNotThrown" executed="True" success="True" time="0.000" asserts="2" />
+                          <test-case name="NUnit.Core.Tests.ExpectExceptionTest.TestInvalidExceptionName" executed="True" success="True" time="0.000" asserts="2" />
+                          <test-case name="NUnit.Core.Tests.ExpectExceptionTest.TestMismatchedExceptionName" executed="True" success="True" time="0.016" asserts="2" />
+                          <test-case name="NUnit.Core.Tests.ExpectExceptionTest.TestMismatchedExceptionType" executed="True" success="True" time="0.000" asserts="2" />
+                          <test-case name="NUnit.Core.Tests.ExpectExceptionTest.ThrowingMyAppException" executed="True" success="True" time="0.000" asserts="0" />
+                          <test-case name="NUnit.Core.Tests.ExpectExceptionTest.ThrowingMyAppExceptionWithMessage" executed="True" success="True" time="0.000" asserts="0" />
+                          <test-case name="NUnit.Core.Tests.ExpectExceptionTest.ThrowNunitException" executed="True" success="True" time="0.000" asserts="0" />
+                        </results>
+                      </test-suite>
+                      <test-suite name="FailFixture" success="True" time="0.016" asserts="0">
+                        <results>
+                          <test-case name="NUnit.Core.Tests.FailFixture.BadStackTraceIsHandled" executed="True" success="True" time="0.000" asserts="3" />
+                          <test-case name="NUnit.Core.Tests.FailFixture.CustomExceptionIsHandled" executed="True" success="True" time="0.000" asserts="2" />
+                          <test-case name="NUnit.Core.Tests.FailFixture.FailInheritsFromSystemException" executed="True" success="True" time="0.000" asserts="0" />
+                          <test-case name="NUnit.Core.Tests.FailFixture.FailRecordsInnerException" executed="True" success="True" time="0.016" asserts="2" />
+                          <test-case name="NUnit.Core.Tests.FailFixture.FailThrowsAssertionException" executed="True" success="True" time="0.000" asserts="0" />
+                          <test-case name="NUnit.Core.Tests.FailFixture.FailWorks" executed="True" success="True" time="0.000" asserts="2" />
+                        </results>
+                      </test-suite>
+                      <test-suite name="FixtureSetupTearDownTest" success="True" time="0.063" asserts="0">
+                        <results>
+                          <test-case name="NUnit.Core.Tests.FixtureSetupTearDownTest.CheckInheritedSetUpAndTearDownAreCalled" executed="True" success="True" time="0.000" asserts="2" />
+                          <test-case name="NUnit.Core.Tests.FixtureSetupTearDownTest.CheckInheritedSetUpAndTearDownAreNotCalled" executed="True" success="True" time="0.000" asserts="4" />
+                          <test-case name="NUnit.Core.Tests.FixtureSetupTearDownTest.FixtureWithNoTestsShouldNotCallFixtureSetUpOrTearDown" executed="True" success="True" time="0.000" asserts="2" />
+                          <test-case name="NUnit.Core.Tests.FixtureSetupTearDownTest.HandleErrorInFixtureSetup" executed="True" success="True" time="0.016" asserts="12" />
+                          <test-case name="NUnit.Core.Tests.FixtureSetupTearDownTest.HandleErrorInFixtureTearDown" executed="True" success="True" time="0.000" asserts="10" />
+                          <test-case name="NUnit.Core.Tests.FixtureSetupTearDownTest.HandleExceptionInFixtureConstructor" executed="True" success="True" time="0.000" asserts="10" />
+                          <test-case name="NUnit.Core.Tests.FixtureSetupTearDownTest.HandleIgnoreInFixtureSetup" executed="True" success="True" time="0.000" asserts="8" />
+                          <test-case name="NUnit.Core.Tests.FixtureSetupTearDownTest.HandleSetUpAndTearDownWithTestInName" executed="True" success="True" time="0.000" asserts="2" />
+                          <test-case name="NUnit.Core.Tests.FixtureSetupTearDownTest.IgnoredFixtureShouldNotCallFixtureSetUpOrTearDown" executed="True" success="True" time="0.000" asserts="2" />
+                          <test-case name="NUnit.Core.Tests.FixtureSetupTearDownTest.MakeSureSetUpAndTearDownAreCalled" executed="True" success="True" time="0.000" asserts="2" />
+                          <test-case name="NUnit.Core.Tests.FixtureSetupTearDownTest.RerunFixtureAfterSetUpFixed" executed="True" success="True" time="0.016" asserts="5" />
+                          <test-case name="NUnit.Core.Tests.FixtureSetupTearDownTest.RerunFixtureAfterTearDownFixed" executed="True" success="True" time="0.000" asserts="5" />
+                          <test-case name="NUnit.Core.Tests.FixtureSetupTearDownTest.RunningSingleMethodCallsSetUpAndTearDown" executed="True" success="True" time="0.000" asserts="2" />
+                        </results>
+                      </test-suite>
+                      <test-suite name="IgnoreFixture" success="True" time="0.016" asserts="0">
+                        <results>
+                          <test-case name="NUnit.Core.Tests.IgnoreFixture.IgnoreThrowsIgnoreException" executed="True" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Core.Tests.IgnoreFixture.IgnoreWithUserMessage" executed="True" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Core.Tests.IgnoreFixture.IgnoreWithUserMessage_ArrayOfArgs" executed="True" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Core.Tests.IgnoreFixture.IgnoreWithUserMessage_OneArg" executed="True" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Core.Tests.IgnoreFixture.IgnoreWithUserMessage_ThreeArgs" executed="True" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Core.Tests.IgnoreFixture.IgnoreWorksForTestCase" executed="True" success="True" time="0.000" asserts="2" />
+                          <test-case name="NUnit.Core.Tests.IgnoreFixture.IgnoreWorksForTestSuite" executed="True" success="True" time="0.000" asserts="3" />
+                          <test-case name="NUnit.Core.Tests.IgnoreFixture.IgnoreWorksFromSetUp" executed="True" success="True" time="0.016" asserts="3" />
+                        </results>
+                      </test-suite>
+                      <test-suite name="InheritedTestFixture" success="True" time="0.016" asserts="0">
+                        <results>
+                          <test-case name="NUnit.Core.Tests.InheritedTestFixture.OneTestCase.TestCase" executed="True" success="True" time="0.000" asserts="0" />
+                          <test-case name="NUnit.Core.Tests.InheritedTestFixture.Test2" executed="True" success="True" time="0.000" asserts="0" />
+                        </results>
+                      </test-suite>
+                      <test-suite name="NameFilterTest" success="True" time="0.031" asserts="0">
+                        <results>
+                          <test-case name="NUnit.Core.Tests.NameFilterTest.HighLevelSuite" executed="True" success="True" time="0.016" asserts="3" />
+                          <test-case name="NUnit.Core.Tests.NameFilterTest.MultipleNameMatch" executed="True" success="True" time="0.000" asserts="3" />
+                          <test-case name="NUnit.Core.Tests.NameFilterTest.SingleNameMatch" executed="True" success="True" time="0.016" asserts="4" />
+                          <test-case name="NUnit.Core.Tests.NameFilterTest.SuiteNameMatch" executed="True" success="True" time="0.000" asserts="3" />
+                          <test-case name="NUnit.Core.Tests.NameFilterTest.TestDoesNotMatch" executed="True" success="True" time="0.000" asserts="2" />
+                        </results>
+                      </test-suite>
+                      <test-suite name="NamespaceAssemblyTests" success="True" time="0.484" asserts="0">
+                        <results>
+                          <test-case name="NUnit.Core.Tests.NamespaceAssemblyTests.Hierarchy" executed="True" success="True" time="0.172" asserts="19" />
+                          <test-case name="NUnit.Core.Tests.NamespaceAssemblyTests.LoadTestFixtureFromAssembly" executed="True" success="True" time="0.094" asserts="1" />
+                          <test-case name="NUnit.Core.Tests.NamespaceAssemblyTests.NoNamespaceInAssembly" executed="True" success="True" time="0.156" asserts="5" />
+                          <test-case name="NUnit.Core.Tests.NamespaceAssemblyTests.TestRoot" executed="True" success="True" time="0.063" asserts="1" />
+                        </results>
+                      </test-suite>
+                      <test-suite name="OneTestCase" success="True" time="0.031" asserts="0">
+                        <results>
+                          <test-case name="NUnit.Core.Tests.OneTestCase.TestCase" executed="True" success="True" time="0.031" asserts="0" />
+                        </results>
+                      </test-suite>
+                      <test-suite name="PlatformDetectionTests" success="True" time="0.031" asserts="0">
+                        <results>
+                          <test-case name="NUnit.Core.Tests.PlatformDetectionTests.ArrayOfPlatforms" executed="True" success="True" time="0.000" asserts="2" />
+                          <test-case name="NUnit.Core.Tests.PlatformDetectionTests.DetectExactVersion" executed="True" success="True" time="0.000" asserts="4" />
+                          <test-case name="NUnit.Core.Tests.PlatformDetectionTests.DetectMono10" executed="True" success="True" time="0.000" asserts="0" />
+                          <test-case name="NUnit.Core.Tests.PlatformDetectionTests.DetectMono20" executed="True" success="True" time="0.000" asserts="0" />
+                          <test-case name="NUnit.Core.Tests.PlatformDetectionTests.DetectNet10" executed="True" success="True" time="0.000" asserts="0" />
+                          <test-case name="NUnit.Core.Tests.PlatformDetectionTests.DetectNet11" executed="True" success="True" time="0.000" asserts="0" />
+                          <test-case name="NUnit.Core.Tests.PlatformDetectionTests.DetectNet20" executed="True" success="True" time="0.000" asserts="0" />
+                          <test-case name="NUnit.Core.Tests.PlatformDetectionTests.DetectNetCF" executed="True" success="True" time="0.000" asserts="0" />
+                          <test-case name="NUnit.Core.Tests.PlatformDetectionTests.DetectNT3" executed="True" success="True" time="0.000" asserts="0" />
+                          <test-case name="NUnit.Core.Tests.PlatformDetectionTests.DetectNT4" executed="True" success="True" time="0.000" asserts="0" />
+                          <test-case name="NUnit.Core.Tests.PlatformDetectionTests.DetectSSCLI" executed="True" success="True" time="0.000" asserts="0" />
+                          <test-case name="NUnit.Core.Tests.PlatformDetectionTests.DetectUnixUnderMicrosoftDotNet" executed="True" success="True" time="0.000" asserts="0" />
+                          <test-case name="NUnit.Core.Tests.PlatformDetectionTests.DetectUnixUnderMono" executed="False">
+                            <reason>
+                              <message><![CDATA[Only supported on Mono]]></message>
+                            </reason>
+                          </test-case>
+                          <test-case name="NUnit.Core.Tests.PlatformDetectionTests.DetectWin2003Server" executed="True" success="True" time="0.000" asserts="0" />
+                          <test-case name="NUnit.Core.Tests.PlatformDetectionTests.DetectWin2K" executed="True" success="True" time="0.000" asserts="0" />
+                          <test-case name="NUnit.Core.Tests.PlatformDetectionTests.DetectWin95" executed="True" success="True" time="0.000" asserts="0" />
+                          <test-case name="NUnit.Core.Tests.PlatformDetectionTests.DetectWin98" executed="True" success="True" time="0.000" asserts="0" />
+                          <test-case name="NUnit.Core.Tests.PlatformDetectionTests.DetectWinCE" executed="True" success="True" time="0.000" asserts="0" />
+                          <test-case name="NUnit.Core.Tests.PlatformDetectionTests.DetectWinMe" executed="True" success="True" time="0.000" asserts="0" />
+                          <test-case name="NUnit.Core.Tests.PlatformDetectionTests.DetectWinXP" executed="True" success="True" time="0.000" asserts="0" />
+                          <test-case name="NUnit.Core.Tests.PlatformDetectionTests.PlatformAttribute_Exclude" executed="True" success="True" time="0.000" asserts="3" />
+                          <test-case name="NUnit.Core.Tests.PlatformDetectionTests.PlatformAttribute_Include" executed="True" success="True" time="0.000" asserts="3" />
+                          <test-case name="NUnit.Core.Tests.PlatformDetectionTests.PlatformAttribute_IncludeAndExclude" executed="True" success="True" time="0.000" asserts="7" />
+                          <test-case name="NUnit.Core.Tests.PlatformDetectionTests.PlatformAttribute_InvalidPlatform" executed="True" success="True" time="0.000" asserts="2" />
+                        </results>
+                      </test-suite>
+                      <test-suite name="RemoteRunnerTests" success="True" time="1.359" asserts="0">
+                        <results>
+                          <test-case name="NUnit.Core.Tests.RemoteRunnerTests.BasicRunnerTests.CountTestCases" executed="True" success="True" time="0.063" asserts="1" />
+                          <test-case name="NUnit.Core.Tests.RemoteRunnerTests.BasicRunnerTests.CountTestCasesAcrossMultipleAssemblies" executed="True" success="True" time="0.078" asserts="1" />
+                          <test-case name="NUnit.Core.Tests.RemoteRunnerTests.BasicRunnerTests.LoadAssembly" executed="True" success="True" time="0.047" asserts="1" />
+                          <test-case name="NUnit.Core.Tests.RemoteRunnerTests.BasicRunnerTests.LoadAssemblyWithFixture" executed="True" success="True" time="0.031" asserts="1" />
+                          <test-case name="NUnit.Core.Tests.RemoteRunnerTests.BasicRunnerTests.LoadAssemblyWithSuite" executed="True" success="True" time="0.047" asserts="1" />
+                          <test-case name="NUnit.Core.Tests.RemoteRunnerTests.BasicRunnerTests.LoadMultipleAssemblies" executed="True" success="True" time="0.281" asserts="1" />
+                          <test-case name="NUnit.Core.Tests.RemoteRunnerTests.BasicRunnerTests.LoadMultipleAssembliesWithFixture" executed="True" success="True" time="0.078" asserts="1" />
+                          <test-case name="NUnit.Core.Tests.RemoteRunnerTests.BasicRunnerTests.LoadMultipleAssembliesWithSuite" executed="True" success="True" time="0.078" asserts="1" />
+                          <test-case name="NUnit.Core.Tests.RemoteRunnerTests.BasicRunnerTests.RunAssembly" executed="True" success="True" time="0.063" asserts="1" />
+                          <test-case name="NUnit.Core.Tests.RemoteRunnerTests.BasicRunnerTests.RunAssemblyUsingBeginAndEndRun" executed="True" success="True" time="0.063" asserts="3" />
+                          <test-case name="NUnit.Core.Tests.RemoteRunnerTests.BasicRunnerTests.RunMultipleAssemblies" executed="True" success="True" time="0.375" asserts="1" />
+                          <test-case name="NUnit.Core.Tests.RemoteRunnerTests.BasicRunnerTests.RunMultipleAssembliesUsingBeginAndEndRun" executed="True" success="True" time="0.109" asserts="3" />
+                        </results>
+                      </test-suite>
+                      <test-suite name="SerializationBug" success="True" time="0.031" asserts="0">
+                        <results>
+                          <test-case name="NUnit.Core.Tests.SerializationBug.SaveAndLoad" executed="True" success="True" time="0.016" asserts="3" />
+                        </results>
+                      </test-suite>
+                      <test-suite name="SetUpTest" success="True" time="0.000" asserts="0">
+                        <results>
+                          <test-case name="NUnit.Core.Tests.SetUpTest.CheckInheritedSetUpAndTearDownAreCalled" executed="True" success="True" time="0.000" asserts="2" />
+                          <test-case name="NUnit.Core.Tests.SetUpTest.CheckInheritedSetUpAndTearDownAreNotCalled" executed="True" success="True" time="0.000" asserts="4" />
+                          <test-case name="NUnit.Core.Tests.SetUpTest.MakeSureSetUpAndTearDownAreCalled" executed="True" success="True" time="0.000" asserts="2" />
+                          <test-case name="NUnit.Core.Tests.SetUpTest.SetUpAndTearDownCounter" executed="True" success="True" time="0.000" asserts="2" />
+                        </results>
+                      </test-suite>
+                      <test-suite name="SimpleTestRunnerTests" success="True" time="0.781" asserts="0">
+                        <results>
+                          <test-case name="NUnit.Core.Tests.SimpleTestRunnerTests.BasicRunnerTests.CountTestCases" executed="True" success="True" time="0.078" asserts="1" />
+                          <test-case name="NUnit.Core.Tests.SimpleTestRunnerTests.BasicRunnerTests.CountTestCasesAcrossMultipleAssemblies" executed="True" success="True" time="0.078" asserts="1" />
+                          <test-case name="NUnit.Core.Tests.SimpleTestRunnerTests.BasicRunnerTests.LoadAssembly" executed="True" success="True" time="0.031" asserts="1" />
+                          <test-case name="NUnit.Core.Tests.SimpleTestRunnerTests.BasicRunnerTests.LoadAssemblyWithFixture" executed="True" success="True" time="0.031" asserts="1" />
+                          <test-case name="NUnit.Core.Tests.SimpleTestRunnerTests.BasicRunnerTests.LoadAssemblyWithSuite" executed="True" success="True" time="0.047" asserts="1" />
+                          <test-case name="NUnit.Core.Tests.SimpleTestRunnerTests.BasicRunnerTests.LoadMultipleAssemblies" executed="True" success="True" time="0.141" asserts="1" />
+                          <test-case name="NUnit.Core.Tests.SimpleTestRunnerTests.BasicRunnerTests.LoadMultipleAssembliesWithFixture" executed="True" success="True" time="0.047" asserts="1" />
+                          <test-case name="NUnit.Core.Tests.SimpleTestRunnerTests.BasicRunnerTests.LoadMultipleAssembliesWithSuite" executed="True" success="True" time="0.063" asserts="1" />
+                          <test-case name="NUnit.Core.Tests.SimpleTestRunnerTests.BasicRunnerTests.RunAssembly" executed="True" success="True" time="0.063" asserts="1" />
+                          <test-case name="NUnit.Core.Tests.SimpleTestRunnerTests.BasicRunnerTests.RunAssemblyUsingBeginAndEndRun" executed="True" success="True" time="0.047" asserts="3" />
+                          <test-case name="NUnit.Core.Tests.SimpleTestRunnerTests.BasicRunnerTests.RunMultipleAssemblies" executed="True" success="True" time="0.078" asserts="1" />
+                          <test-case name="NUnit.Core.Tests.SimpleTestRunnerTests.BasicRunnerTests.RunMultipleAssembliesUsingBeginAndEndRun" executed="True" success="True" time="0.078" asserts="3" />
+                        </results>
+                      </test-suite>
+                      <test-suite name="StackOverflowTestFixture" success="True" time="0.000" asserts="0">
+                        <results>
+                          <test-case name="NUnit.Core.Tests.StackOverflowTestFixture.SimpleOverflow" executed="False">
+                            <reason>
+                              <message><![CDATA[Not supported on Net-2.0,Mono]]></message>
+                            </reason>
+                          </test-case>
+                        </results>
+                      </test-suite>
+                      <test-suite name="SuiteBuilderTests" success="True" time="0.641" asserts="0">
+                        <results>
+                          <test-case name="NUnit.Core.Tests.SuiteBuilderTests.DiscoverSuite" executed="True" success="True" time="0.031" asserts="1" />
+                          <test-case name="NUnit.Core.Tests.SuiteBuilderTests.FileNotFound" executed="True" success="True" time="0.000" asserts="0" />
+                          <test-case name="NUnit.Core.Tests.SuiteBuilderTests.FixtureNotFound" executed="True" success="True" time="0.031" asserts="1" />
+                          <test-case name="NUnit.Core.Tests.SuiteBuilderTests.LoadAssembly" executed="True" success="True" time="0.234" asserts="1" />
+                          <test-case name="NUnit.Core.Tests.SuiteBuilderTests.LoadFixture" executed="True" success="True" time="0.031" asserts="1" />
+                          <test-case name="NUnit.Core.Tests.SuiteBuilderTests.LoadNamespaceAsSuite" executed="True" success="True" time="0.156" asserts="3" />
+                          <test-case name="NUnit.Core.Tests.SuiteBuilderTests.LoadSuite" executed="True" success="True" time="0.063" asserts="2" />
+                          <test-case name="NUnit.Core.Tests.SuiteBuilderTests.WrongReturnTypeSuite" executed="True" success="True" time="0.047" asserts="1" />
+                        </results>
+                      </test-suite>
+                      <test-suite name="SuiteBuilderTests_Multiple" success="True" time="0.422" asserts="0">
+                        <results>
+                          <test-case name="NUnit.Core.Tests.SuiteBuilderTests_Multiple.AssemblyNodes" executed="True" success="True" time="0.047" asserts="2" />
+                          <test-case name="NUnit.Core.Tests.SuiteBuilderTests_Multiple.BuildSuite" executed="True" success="True" time="0.078" asserts="1" />
+                          <test-case name="NUnit.Core.Tests.SuiteBuilderTests_Multiple.LoadFixture" executed="True" success="True" time="0.141" asserts="2" />
+                          <test-case name="NUnit.Core.Tests.SuiteBuilderTests_Multiple.RootNode" executed="True" success="True" time="0.047" asserts="2" />
+                          <test-case name="NUnit.Core.Tests.SuiteBuilderTests_Multiple.TestCaseCount" executed="True" success="True" time="0.109" asserts="1" />
+                        </results>
+                      </test-suite>
+                      <test-suite name="TestAttributeFixture" success="True" time="0.031" asserts="0">
+                        <results>
+                          <test-case name="NUnit.Core.Tests.TestAttributeFixture.Description" executed="True" success="True" time="0.016" asserts="1" />
+                          <test-case name="NUnit.Core.Tests.TestAttributeFixture.DescriptionInResult" executed="True" success="True" time="0.000" asserts="0" />
+                          <test-case name="NUnit.Core.Tests.TestAttributeFixture.FixtureDescription" executed="True" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Core.Tests.TestAttributeFixture.FixtureDescriptionInResult" executed="True" success="True" time="0.016" asserts="1" />
+                          <test-case name="NUnit.Core.Tests.TestAttributeFixture.NoDescription" executed="True" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Core.Tests.TestAttributeFixture.ReflectionTest" executed="True" success="True" time="0.000" asserts="1" />
+                        </results>
+                      </test-suite>
+                      <test-suite name="TestCaseNameTest" success="True" time="0.016" asserts="0">
+                        <results>
+                          <test-case name="NUnit.Core.Tests.TestCaseNameTest.TestExpectedException" executed="True" success="True" time="0.016" asserts="1" />
+                          <test-case name="NUnit.Core.Tests.TestCaseNameTest.TestName" executed="True" success="True" time="0.000" asserts="2" />
+                        </results>
+                      </test-suite>
+                      <test-suite name="TestCaseResultFixture" success="True" time="0.016" asserts="0">
+                        <results>
+                          <test-case name="NUnit.Core.Tests.TestCaseResultFixture.TestCaseFailure" executed="True" success="True" time="0.000" asserts="4" />
+                          <test-case name="NUnit.Core.Tests.TestCaseResultFixture.TestCaseNotRun" executed="True" success="True" time="0.000" asserts="2" />
+                          <test-case name="NUnit.Core.Tests.TestCaseResultFixture.TestCaseSuccess" executed="True" success="True" time="0.000" asserts="1" />
+                        </results>
+                      </test-suite>
+                      <test-suite name="TestCaseTest" success="True" time="0.000" asserts="0">
+                        <results>
+                          <test-case name="NUnit.Core.Tests.TestCaseTest.CreateIgnoredTestCase" executed="True" success="True" time="0.000" asserts="3" />
+                          <test-case name="NUnit.Core.Tests.TestCaseTest.LoadMethodCategories" executed="True" success="True" time="0.000" asserts="3" />
+                          <test-case name="NUnit.Core.Tests.TestCaseTest.RunIgnoredTestCase" executed="True" success="True" time="0.000" asserts="2" />
+                        </results>
+                      </test-suite>
+                      <test-suite name="TestConsole" success="True" time="0.016" asserts="0">
+                        <results>
+                          <test-case name="NUnit.Core.Tests.TestConsole.ConsoleWrite" executed="True" success="True" time="0.000" asserts="0" />
+                          <test-case name="NUnit.Core.Tests.TestConsole.ConsoleWriteLine" executed="True" success="True" time="0.000" asserts="0" />
+                        </results>
+                      </test-suite>
+                      <test-suite name="TestDelegateFixture" success="True" time="0.000" asserts="0">
+                        <results>
+                          <test-case name="NUnit.Core.Tests.TestDelegateFixture.DelegateTest" executed="True" success="True" time="0.000" asserts="1" />
+                        </results>
+                      </test-suite>
+                      <test-suite name="TestFixtureBuilderTests" success="True" time="0.109" asserts="0">
+                        <results>
+                          <test-case name="NUnit.Core.Tests.TestFixtureBuilderTests.GoodSignature" executed="True" success="True" time="0.063" asserts="3" />
+                          <test-case name="NUnit.Core.Tests.TestFixtureBuilderTests.LoadCategories" executed="True" success="True" time="0.047" asserts="3" />
+                        </results>
+                      </test-suite>
+                      <test-suite name="TestFixtureExtension" success="True" time="0.172" asserts="0">
+                        <results>
+                          <test-case name="NUnit.Core.Tests.TestFixtureExtension.CheckMultipleSetUp" executed="True" success="True" time="0.031" asserts="1" />
+                          <test-case name="NUnit.Core.Tests.TestFixtureExtension.DerivedTest" executed="True" success="True" time="0.047" asserts="1" />
+                          <test-case name="NUnit.Core.Tests.TestFixtureExtension.InheritSetup" executed="True" success="True" time="0.016" asserts="1" />
+                          <test-case name="NUnit.Core.Tests.TestFixtureExtension.InheritTearDown" executed="True" success="True" time="0.031" asserts="1" />
+                        </results>
+                      </test-suite>
+                      <test-suite name="TestFixtureTests" success="True" time="0.063" asserts="0">
+                        <results>
+                          <test-case name="NUnit.Core.Tests.TestFixtureTests.CannotRunAbstractFixture" executed="True" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Core.Tests.TestFixtureTests.CannotRunBadConstructor" executed="True" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Core.Tests.TestFixtureTests.CannotRunFixtureSetupWithParameters" executed="True" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Core.Tests.TestFixtureTests.CannotRunFixtureSetupWithReturnValue" executed="True" success="True" time="0.016" asserts="1" />
+                          <test-case name="NUnit.Core.Tests.TestFixtureTests.CannotRunFixtureTearDownWithParameters" executed="True" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Core.Tests.TestFixtureTests.CannotRunFixtureTearDownWithReturnValue" executed="True" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Core.Tests.TestFixtureTests.CannotRunIgnoredFixture" executed="True" success="True" time="0.000" asserts="2" />
+                          <test-case name="NUnit.Core.Tests.TestFixtureTests.CannotRunMultipleSetUp" executed="True" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Core.Tests.TestFixtureTests.CannotRunMultipleTearDown" executed="True" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Core.Tests.TestFixtureTests.CannotRunMultipleTestFixtureSetUp" executed="True" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Core.Tests.TestFixtureTests.CannotRunMultipleTestFixtureTearDown" executed="True" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Core.Tests.TestFixtureTests.CannotRunNoDefaultConstructor" executed="True" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Core.Tests.TestFixtureTests.CannotRunPrivateFixtureSetUp" executed="True" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Core.Tests.TestFixtureTests.CannotRunPrivateFixtureTearDown" executed="True" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Core.Tests.TestFixtureTests.CannotRunPrivateSetUp" executed="True" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Core.Tests.TestFixtureTests.CannotRunPrivateTearDown" executed="True" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Core.Tests.TestFixtureTests.CannotRunProtectedFixtureSetUp" executed="True" success="True" time="0.016" asserts="1" />
+                          <test-case name="NUnit.Core.Tests.TestFixtureTests.CannotRunProtectedFixtureTearDown" executed="True" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Core.Tests.TestFixtureTests.CannotRunProtectedSetUp" executed="True" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Core.Tests.TestFixtureTests.CannotRunProtectedTearDown" executed="True" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Core.Tests.TestFixtureTests.CannotRunSetupWithParameters" executed="True" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Core.Tests.TestFixtureTests.CannotRunSetupWithReturnValue" executed="True" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Core.Tests.TestFixtureTests.CannotRunStaticFixtureSetUp" executed="True" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Core.Tests.TestFixtureTests.CannotRunStaticFixtureTearDown" executed="True" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Core.Tests.TestFixtureTests.CannotRunStaticSetUp" executed="True" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Core.Tests.TestFixtureTests.CannotRunStaticTearDown" executed="True" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Core.Tests.TestFixtureTests.CannotRunTearDownWithParameters" executed="True" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Core.Tests.TestFixtureTests.CannotRunTearDownWithReturnValue" executed="True" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Core.Tests.TestFixtureTests.ConstructFromDoublyNestedType" executed="True" success="True" time="0.016" asserts="2" />
+                          <test-case name="NUnit.Core.Tests.TestFixtureTests.ConstructFromNestedType" executed="True" success="True" time="0.000" asserts="2" />
+                          <test-case name="NUnit.Core.Tests.TestFixtureTests.ConstructFromType" executed="True" success="True" time="0.000" asserts="2" />
+                          <test-case name="NUnit.Core.Tests.TestFixtureTests.ConstructFromTypeWithoutNamespace" executed="True" success="True" time="0.000" asserts="2" />
+                        </results>
+                      </test-suite>
+                      <test-suite name="TestRunnerThreadTests" success="True" time="0.063" asserts="0">
+                        <results>
+                          <test-case name="NUnit.Core.Tests.TestRunnerThreadTests.RunMultipleTests" executed="True" success="True" time="0.063" asserts="2" />
+                          <test-case name="NUnit.Core.Tests.TestRunnerThreadTests.RunNamedTest" executed="True" success="True" time="0.000" asserts="2" />
+                          <test-case name="NUnit.Core.Tests.TestRunnerThreadTests.RunTestSuite" executed="True" success="True" time="0.000" asserts="2" />
+                        </results>
+                      </test-suite>
+                      <test-suite name="TestSuiteResultFixture" success="True" time="0.031" asserts="0">
+                        <results>
+                          <test-case name="NUnit.Core.Tests.TestSuiteResultFixture.EmptySuite" executed="True" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Core.Tests.TestSuiteResultFixture.SuiteSuccess" executed="True" success="True" time="0.016" asserts="1" />
+                          <test-case name="NUnit.Core.Tests.TestSuiteResultFixture.TestSuiteFailure" executed="True" success="True" time="0.000" asserts="4" />
+                        </results>
+                      </test-suite>
+                      <test-suite name="TestSuiteTest" success="True" time="0.156" asserts="0">
+                        <results>
+                          <test-case name="NUnit.Core.Tests.TestSuiteTest.CountTestCasesFilteredByName" executed="True" success="True" time="0.016" asserts="4" />
+                          <test-case name="NUnit.Core.Tests.TestSuiteTest.ExcludingCategoryDoesNotRunExplicitTests" executed="True" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Core.Tests.TestSuiteTest.InheritedTestCount" executed="True" success="True" time="0.016" asserts="1" />
+                          <test-case name="NUnit.Core.Tests.TestSuiteTest.RunExplicitTestByCategory" executed="True" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Core.Tests.TestSuiteTest.RunExplicitTestByName" executed="True" success="True" time="0.016" asserts="1" />
+                          <test-case name="NUnit.Core.Tests.TestSuiteTest.RunExplicitTestDirectly" executed="True" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Core.Tests.TestSuiteTest.RunNoTestSuite" executed="True" success="True" time="0.016" asserts="4" />
+                          <test-case name="NUnit.Core.Tests.TestSuiteTest.RunSingleTest" executed="True" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Core.Tests.TestSuiteTest.RunSuiteByCategory" executed="True" success="True" time="0.016" asserts="1" />
+                          <test-case name="NUnit.Core.Tests.TestSuiteTest.RunSuiteByName" executed="True" success="True" time="0.000" asserts="2" />
+                          <test-case name="NUnit.Core.Tests.TestSuiteTest.RunTestByCategory" executed="True" success="True" time="0.047" asserts="3" />
+                          <test-case name="NUnit.Core.Tests.TestSuiteTest.RunTestByName" executed="True" success="True" time="0.000" asserts="2" />
+                          <test-case name="NUnit.Core.Tests.TestSuiteTest.RunTestsInFixture" executed="True" success="True" time="0.000" asserts="5" />
+                          <test-case name="NUnit.Core.Tests.TestSuiteTest.SuiteRunInitialized" executed="True" success="True" time="0.016" asserts="1" />
+                          <test-case name="NUnit.Core.Tests.TestSuiteTest.SuiteWithNoTests" executed="True" success="True" time="0.000" asserts="3" />
+                        </results>
+                      </test-suite>
+                      <test-suite name="ThreadedTestRunnerTests" success="True" time="0.703" asserts="0">
+                        <results>
+                          <test-case name="NUnit.Core.Tests.ThreadedTestRunnerTests.BasicRunnerTests.CountTestCases" executed="True" success="True" time="0.047" asserts="1" />
+                          <test-case name="NUnit.Core.Tests.ThreadedTestRunnerTests.BasicRunnerTests.CountTestCasesAcrossMultipleAssemblies" executed="True" success="True" time="0.063" asserts="1" />
+                          <test-case name="NUnit.Core.Tests.ThreadedTestRunnerTests.BasicRunnerTests.LoadAssembly" executed="True" success="True" time="0.016" asserts="1" />
+                          <test-case name="NUnit.Core.Tests.ThreadedTestRunnerTests.BasicRunnerTests.LoadAssemblyWithFixture" executed="True" success="True" time="0.031" asserts="1" />
+                          <test-case name="NUnit.Core.Tests.ThreadedTestRunnerTests.BasicRunnerTests.LoadAssemblyWithSuite" executed="True" success="True" time="0.031" asserts="1" />
+                          <test-case name="NUnit.Core.Tests.ThreadedTestRunnerTests.BasicRunnerTests.LoadMultipleAssemblies" executed="True" success="True" time="0.094" asserts="1" />
+                          <test-case name="NUnit.Core.Tests.ThreadedTestRunnerTests.BasicRunnerTests.LoadMultipleAssembliesWithFixture" executed="True" success="True" time="0.063" asserts="1" />
+                          <test-case name="NUnit.Core.Tests.ThreadedTestRunnerTests.BasicRunnerTests.LoadMultipleAssembliesWithSuite" executed="True" success="True" time="0.063" asserts="1" />
+                          <test-case name="NUnit.Core.Tests.ThreadedTestRunnerTests.BasicRunnerTests.RunAssembly" executed="True" success="True" time="0.047" asserts="1" />
+                          <test-case name="NUnit.Core.Tests.ThreadedTestRunnerTests.BasicRunnerTests.RunAssemblyUsingBeginAndEndRun" executed="True" success="True" time="0.063" asserts="3" />
+                          <test-case name="NUnit.Core.Tests.ThreadedTestRunnerTests.BasicRunnerTests.RunMultipleAssemblies" executed="True" success="True" time="0.094" asserts="1" />
+                          <test-case name="NUnit.Core.Tests.ThreadedTestRunnerTests.BasicRunnerTests.RunMultipleAssembliesUsingBeginAndEndRun" executed="True" success="True" time="0.063" asserts="3" />
+                        </results>
+                      </test-suite>
+                      <test-suite name="XmlTest" success="True" time="0.875" asserts="0">
+                        <results>
+                          <test-case name="NUnit.Core.Tests.XmlTest.removeTime" executed="True" success="True" time="0.016" asserts="1" />
+                          <test-case name="NUnit.Core.Tests.XmlTest.TestSchemaValidatorFrenchCulture" executed="True" success="True" time="0.516" asserts="1" />
+                          <test-case name="NUnit.Core.Tests.XmlTest.TestSchemaValidatorInvariantCulture" executed="True" success="True" time="0.094" asserts="1" />
+                          <test-case name="NUnit.Core.Tests.XmlTest.TestSchemaValidatorUnitedStatesCulture" executed="True" success="True" time="0.031" asserts="1" />
+                          <test-case name="NUnit.Core.Tests.XmlTest.TestStream" executed="True" success="True" time="0.078" asserts="1" />
+                        </results>
+                      </test-suite>
+                    </results>
+                  </test-suite>
+                </results>
+              </test-suite>
+              <test-suite name="Framework" success="True" time="0.453" asserts="0">
+                <results>
+                  <test-suite name="Tests" success="True" time="0.453" asserts="0">
+                    <results>
+                      <test-suite name="ArrayEqualsFixture" success="True" time="0.031" asserts="0">
+                        <results>
+                          <test-case name="NUnit.Framework.Tests.ArrayEqualsFixture.ArrayOfIntVersusArrayOfDouble" executed="True" success="True" time="0.000" asserts="2" />
+                          <test-case name="NUnit.Framework.Tests.ArrayEqualsFixture.ArraysOfDecimal" executed="True" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Framework.Tests.ArrayEqualsFixture.ArraysOfDouble" executed="True" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Framework.Tests.ArrayEqualsFixture.ArraysOfInt" executed="True" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Framework.Tests.ArrayEqualsFixture.ArraysPassedAsObjects" executed="True" success="True" time="0.000" asserts="2" />
+                          <test-case name="NUnit.Framework.Tests.ArrayEqualsFixture.DifferentArraysAreEqual" executed="True" success="True" time="0.000" asserts="2" />
+                          <test-case name="NUnit.Framework.Tests.ArrayEqualsFixture.DifferentArrayTypesButEqual" executed="True" success="True" time="0.000" asserts="2" />
+                          <test-case name="NUnit.Framework.Tests.ArrayEqualsFixture.DifferentArrayTypesNotEqual" executed="True" success="True" time="0.000" asserts="2" />
+                          <test-case name="NUnit.Framework.Tests.ArrayEqualsFixture.DifferentLengthArrays" executed="True" success="True" time="0.016" asserts="1" />
+                          <test-case name="NUnit.Framework.Tests.ArrayEqualsFixture.MixedTypesAreEqual" executed="True" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Framework.Tests.ArrayEqualsFixture.MultiDimensionedArraysNotSupported" executed="True" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Framework.Tests.ArrayEqualsFixture.RanksOfArraysMustMatch" executed="True" success="True" time="0.000" asserts="2" />
+                          <test-case name="NUnit.Framework.Tests.ArrayEqualsFixture.SameArraysAreEqual" executed="True" success="True" time="0.000" asserts="2" />
+                          <test-case name="NUnit.Framework.Tests.ArrayEqualsFixture.SameLengthDifferentContent" executed="True" success="True" time="0.000" asserts="1" />
+                        </results>
+                      </test-suite>
+                      <test-suite name="AssertExtensionTests" success="True" time="0.000" asserts="0">
+                        <results>
+                          <test-case name="NUnit.Framework.Tests.AssertExtensionTests.FormattedMessageTests" executed="True" success="True" time="0.000" asserts="6" />
+                          <test-case name="NUnit.Framework.Tests.AssertExtensionTests.OddNumber" executed="True" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Framework.Tests.AssertExtensionTests.OddNumberFails" executed="True" success="True" time="0.000" asserts="2" />
+                        </results>
+                      </test-suite>
+                      <test-suite name="AssertionTest" success="True" time="0.016" asserts="0">
+                        <results>
+                          <test-case name="NUnit.Framework.Tests.AssertionTest.AssertByte" executed="True" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Framework.Tests.AssertionTest.AssertEquals" executed="True" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Framework.Tests.AssertionTest.AssertEqualsFail" executed="True" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Framework.Tests.AssertionTest.AssertEqualsNaNFails" executed="True" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Framework.Tests.AssertionTest.AssertEqualsNull" executed="True" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Framework.Tests.AssertionTest.AssertEqualsSameTypes" executed="True" success="True" time="0.000" asserts="21" />
+                          <test-case name="NUnit.Framework.Tests.AssertionTest.AssertEqualsTestCaseFail" executed="True" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Framework.Tests.AssertionTest.AssertNanEqualsFails" executed="True" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Framework.Tests.AssertionTest.AssertNanEqualsNaNSucceeds" executed="True" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Framework.Tests.AssertionTest.AssertNegInfinityEqualsInfinity" executed="True" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Framework.Tests.AssertionTest.AssertNull" executed="True" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Framework.Tests.AssertionTest.AssertNullNotEqualsNull" executed="True" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Framework.Tests.AssertionTest.AssertPosInfinityEqualsInfinity" executed="True" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Framework.Tests.AssertionTest.AssertPosInfinityNotEquals" executed="True" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Framework.Tests.AssertionTest.AssertPosInfinityNotEqualsNegInfinity" executed="True" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Framework.Tests.AssertionTest.AssertSame" executed="True" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Framework.Tests.AssertionTest.AssertSameFails" executed="True" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Framework.Tests.AssertionTest.AssertShort" executed="True" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Framework.Tests.AssertionTest.AssertSingle" executed="True" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Framework.Tests.AssertionTest.AssertSinglePosInfinityNotEqualsNegInfinity" executed="True" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Framework.Tests.AssertionTest.AssertString" executed="True" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Framework.Tests.AssertionTest.Bug1076043AreEqualsNotTransitiveForDecimal" executed="True" success="True" time="0.016" asserts="9" />
+                          <test-case name="NUnit.Framework.Tests.AssertionTest.Bug561909FailInheritsFromSystemException" executed="True" success="True" time="0.000" asserts="0" />
+                          <test-case name="NUnit.Framework.Tests.AssertionTest.Bug575936Int32Int64Comparison" executed="True" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Framework.Tests.AssertionTest.Fail" executed="True" success="True" time="0.000" asserts="0" />
+                          <test-case name="NUnit.Framework.Tests.AssertionTest.FailAssertFalse" executed="True" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Framework.Tests.AssertionTest.FailAssertNotNull" executed="True" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Framework.Tests.AssertionTest.IntegerLongComparison" executed="True" success="True" time="0.000" asserts="2" />
+                          <test-case name="NUnit.Framework.Tests.AssertionTest.SucceedAssertFail" executed="True" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Framework.Tests.AssertionTest.SucceedAssertNotNull" executed="True" success="True" time="0.000" asserts="1" />
+                        </results>
+                      </test-suite>
+                      <test-suite name="ConditionAssertTests" success="True" time="0.109" asserts="0">
+                        <results>
+                          <test-case name="NUnit.Framework.Tests.ConditionAssertTests.IsEmpty" executed="True" success="True" time="0.000" asserts="4" />
+                          <test-case name="NUnit.Framework.Tests.ConditionAssertTests.IsEmptyFailsOnNonEmptyArray" executed="True" success="True" time="0.063" asserts="1" />
+                          <test-case name="NUnit.Framework.Tests.ConditionAssertTests.IsEmptyFailsOnNullString" executed="True" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Framework.Tests.ConditionAssertTests.IsEmptyFailsOnString" executed="True" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Framework.Tests.ConditionAssertTests.IsFalse" executed="True" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Framework.Tests.ConditionAssertTests.IsFalseFails" executed="True" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Framework.Tests.ConditionAssertTests.IsNaN" executed="True" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Framework.Tests.ConditionAssertTests.IsNaNFails" executed="True" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Framework.Tests.ConditionAssertTests.IsNotEmpty" executed="True" success="True" time="0.000" asserts="4" />
+                          <test-case name="NUnit.Framework.Tests.ConditionAssertTests.IsNotEmptyFailsOnEmptyArray" executed="True" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Framework.Tests.ConditionAssertTests.IsNotEmptyFailsOnEmptyArrayList" executed="True" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Framework.Tests.ConditionAssertTests.IsNotEmptyFailsOnEmptyHashTable" executed="True" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Framework.Tests.ConditionAssertTests.IsNotEmptyFailsOnEmptyString" executed="True" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Framework.Tests.ConditionAssertTests.IsNotNull" executed="True" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Framework.Tests.ConditionAssertTests.IsNotNullFails" executed="True" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Framework.Tests.ConditionAssertTests.IsNull" executed="True" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Framework.Tests.ConditionAssertTests.IsNullFails" executed="True" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Framework.Tests.ConditionAssertTests.IsTrue" executed="True" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Framework.Tests.ConditionAssertTests.IsTrueFails" executed="True" success="True" time="0.000" asserts="1" />
+                        </results>
+                      </test-suite>
+                      <test-suite name="EqualsFixture" success="True" time="0.063" asserts="0">
+                        <results>
+                          <test-case name="NUnit.Framework.Tests.EqualsFixture.Bug575936Int32Int64Comparison" executed="True" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Framework.Tests.EqualsFixture.Byte" executed="True" success="True" time="0.000" asserts="2" />
+                          <test-case name="NUnit.Framework.Tests.EqualsFixture.DateTimeEqual" executed="True" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Framework.Tests.EqualsFixture.DateTimeNotEqual" executed="True" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Framework.Tests.EqualsFixture.Decimal" executed="True" success="True" time="0.000" asserts="2" />
+                          <test-case name="NUnit.Framework.Tests.EqualsFixture.DoubleNotEqualMessageDisplaysAllDigits" executed="True" success="True" time="0.000" asserts="2" />
+                          <test-case name="NUnit.Framework.Tests.EqualsFixture.EnumsEqual" executed="True" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Framework.Tests.EqualsFixture.EnumsNotEqual" executed="True" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Framework.Tests.EqualsFixture.Equals" executed="True" success="True" time="0.000" asserts="2" />
+                          <test-case name="NUnit.Framework.Tests.EqualsFixture.EqualsFail" executed="True" success="True" time="0.000" asserts="2" />
+                          <test-case name="NUnit.Framework.Tests.EqualsFixture.EqualsNaNFails" executed="True" success="True" time="0.016" asserts="1" />
+                          <test-case name="NUnit.Framework.Tests.EqualsFixture.EqualsNull" executed="True" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Framework.Tests.EqualsFixture.EqualsSameTypes" executed="True" success="True" time="0.016" asserts="21" />
+                          <test-case name="NUnit.Framework.Tests.EqualsFixture.EqualsThrowsException" executed="True" success="True" time="0.000" asserts="0" />
+                          <test-case name="NUnit.Framework.Tests.EqualsFixture.Float" executed="True" success="True" time="0.000" asserts="2" />
+                          <test-case name="NUnit.Framework.Tests.EqualsFixture.FloatNotEqualMessageDisplaysAllDigits" executed="True" success="True" time="0.000" asserts="2" />
+                          <test-case name="NUnit.Framework.Tests.EqualsFixture.Int" executed="True" success="True" time="0.000" asserts="2" />
+                          <test-case name="NUnit.Framework.Tests.EqualsFixture.IntegerLongComparison" executed="True" success="True" time="0.000" asserts="2" />
+                          <test-case name="NUnit.Framework.Tests.EqualsFixture.IntergerEquals" executed="True" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Framework.Tests.EqualsFixture.NanEqualsFails" executed="True" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Framework.Tests.EqualsFixture.NanEqualsNaNSucceeds" executed="True" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Framework.Tests.EqualsFixture.NegInfinityEqualsInfinity" executed="True" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Framework.Tests.EqualsFixture.PosInfinityEqualsInfinity" executed="True" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Framework.Tests.EqualsFixture.PosInfinityNotEquals" executed="True" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Framework.Tests.EqualsFixture.PosInfinityNotEqualsNegInfinity" executed="True" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Framework.Tests.EqualsFixture.ReferenceEqualsThrowsException" executed="True" success="True" time="0.000" asserts="0" />
+                          <test-case name="NUnit.Framework.Tests.EqualsFixture.Short" executed="True" success="True" time="0.000" asserts="2" />
+                          <test-case name="NUnit.Framework.Tests.EqualsFixture.SinglePosInfinityNotEqualsNegInfinity" executed="True" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Framework.Tests.EqualsFixture.String" executed="True" success="True" time="0.000" asserts="2" />
+                          <test-case name="NUnit.Framework.Tests.EqualsFixture.UInt" executed="True" success="True" time="0.000" asserts="2" />
+                        </results>
+                      </test-suite>
+                      <test-suite name="GreaterFixture" success="True" time="0.063" asserts="0">
+                        <results>
+                          <test-case name="NUnit.Framework.Tests.GreaterFixture.FailureMessage" executed="True" success="True" time="0.000" asserts="3" />
+                          <test-case name="NUnit.Framework.Tests.GreaterFixture.Greater" executed="True" success="True" time="0.000" asserts="5" />
+                          <test-case name="NUnit.Framework.Tests.GreaterFixture.NotGreater" executed="True" success="True" time="0.016" asserts="1" />
+                          <test-case name="NUnit.Framework.Tests.GreaterFixture.NotGreaterIComparable" executed="True" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Framework.Tests.GreaterFixture.NotGreaterWhenEqual" executed="True" success="True" time="0.000" asserts="1" />
+                        </results>
+                      </test-suite>
+                      <test-suite name="LessFixture" success="True" time="0.016" asserts="0">
+                        <results>
+                          <test-case name="NUnit.Framework.Tests.LessFixture.FailureMessage" executed="True" success="True" time="0.000" asserts="3" />
+                          <test-case name="NUnit.Framework.Tests.LessFixture.Less" executed="True" success="True" time="0.016" asserts="14" />
+                          <test-case name="NUnit.Framework.Tests.LessFixture.NotLess" executed="True" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Framework.Tests.LessFixture.NotLessIComparable" executed="True" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Framework.Tests.LessFixture.NotLessWhenEqual" executed="True" success="True" time="0.000" asserts="1" />
+                        </results>
+                      </test-suite>
+                      <test-suite name="ListContentsTests" success="True" time="0.047" asserts="0">
+                        <results>
+                          <test-case name="NUnit.Framework.Tests.ListContentsTests.ArrayFails" executed="True" success="True" time="0.000" asserts="2" />
+                          <test-case name="NUnit.Framework.Tests.ListContentsTests.ArrayListFails" executed="True" success="True" time="0.000" asserts="2" />
+                          <test-case name="NUnit.Framework.Tests.ListContentsTests.ArrayListSucceeds" executed="True" success="True" time="0.000" asserts="3" />
+                          <test-case name="NUnit.Framework.Tests.ListContentsTests.ArraySucceeds" executed="True" success="True" time="0.000" asserts="3" />
+                          <test-case name="NUnit.Framework.Tests.ListContentsTests.DifferentTypesFail" executed="True" success="True" time="0.000" asserts="2" />
+                          <test-case name="NUnit.Framework.Tests.ListContentsTests.EmptyArrayFails" executed="True" success="True" time="0.000" asserts="2" />
+                          <test-case name="NUnit.Framework.Tests.ListContentsTests.NullArrayFails" executed="True" success="True" time="0.000" asserts="2" />
+                        </results>
+                      </test-suite>
+                      <test-suite name="MyAssertionFailureMessage+FailureMessageFixture" success="True" time="0.063" asserts="0">
+                        <results>
+                          <test-case name="NUnit.Framework.Tests.MyAssertionFailureMessage+FailureMessageFixture.DisplayListElements" executed="True" success="True" time="0.000" asserts="6" />
+                          <test-case name="NUnit.Framework.Tests.MyAssertionFailureMessage+FailureMessageFixture.TestClipAroundPosition" executed="True" success="True" time="0.000" asserts="26" />
+                          <test-case name="NUnit.Framework.Tests.MyAssertionFailureMessage+FailureMessageFixture.TestClipAroundPosition2" executed="True" success="True" time="0.000" asserts="80" />
+                          <test-case name="NUnit.Framework.Tests.MyAssertionFailureMessage+FailureMessageFixture.TestConvertWhitespace" executed="True" success="True" time="0.000" asserts="14" />
+                          <test-case name="NUnit.Framework.Tests.MyAssertionFailureMessage+FailureMessageFixture.TestCreateStringBuilder" executed="True" success="True" time="0.000" asserts="5" />
+                          <test-case name="NUnit.Framework.Tests.MyAssertionFailureMessage+FailureMessageFixture.TestFormatMessageForArraysNotEqual" executed="True" success="True" time="0.000" asserts="4" />
+                          <test-case name="NUnit.Framework.Tests.MyAssertionFailureMessage+FailureMessageFixture.TestFormatMessageForFailNotEquals" executed="True" success="True" time="0.016" asserts="13" />
+                          <test-case name="NUnit.Framework.Tests.MyAssertionFailureMessage+FailureMessageFixture.TestFormatMessageForFailNotEqualsIgnoringCase" executed="True" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Framework.Tests.MyAssertionFailureMessage+FailureMessageFixture.TestFormatMessageForFailNotEqualsNewlines2" executed="True" success="True" time="0.000" asserts="3" />
+                          <test-case name="NUnit.Framework.Tests.MyAssertionFailureMessage+FailureMessageFixture.TestInputsAreStrings" executed="True" success="True" time="0.000" asserts="8" />
+                          <test-case name="NUnit.Framework.Tests.MyAssertionFailureMessage+FailureMessageFixture.TestStringLengthsDiffer" executed="True" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Framework.Tests.MyAssertionFailureMessage+FailureMessageFixture.TestStringLengthsDiffer2" executed="True" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Framework.Tests.MyAssertionFailureMessage+FailureMessageFixture.TestStringLengthsDiffer3" executed="True" success="True" time="0.031" asserts="995" />
+                        </results>
+                      </test-suite>
+                      <test-suite name="NotEqualFixture" success="True" time="0.031" asserts="0">
+                        <results>
+                          <test-case name="NUnit.Framework.Tests.NotEqualFixture.ArraysNotEqual" executed="True" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Framework.Tests.NotEqualFixture.ArraysNotEqualFails" executed="True" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Framework.Tests.NotEqualFixture.NotEqual" executed="True" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Framework.Tests.NotEqualFixture.NotEqualFails" executed="True" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Framework.Tests.NotEqualFixture.NotEqualSameTypes" executed="True" success="True" time="0.000" asserts="21" />
+                          <test-case name="NUnit.Framework.Tests.NotEqualFixture.NullEqualsNull" executed="True" success="True" time="0.031" asserts="1" />
+                          <test-case name="NUnit.Framework.Tests.NotEqualFixture.NullNotEqualToNonNull" executed="True" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Framework.Tests.NotEqualFixture.UInt" executed="True" success="True" time="0.000" asserts="1" />
+                        </results>
+                      </test-suite>
+                      <test-suite name="NotSameFixture" success="True" time="0.000" asserts="0">
+                        <results>
+                          <test-case name="NUnit.Framework.Tests.NotSameFixture.NotSame" executed="True" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Framework.Tests.NotSameFixture.NotSameFails" executed="True" success="True" time="0.000" asserts="2" />
+                        </results>
+                      </test-suite>
+                      <test-suite name="SameFixture" success="True" time="0.000" asserts="0">
+                        <results>
+                          <test-case name="NUnit.Framework.Tests.SameFixture.Same" executed="True" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Framework.Tests.SameFixture.SameFails" executed="True" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Framework.Tests.SameFixture.SameValueTypes" executed="True" success="True" time="0.000" asserts="1" />
+                        </results>
+                      </test-suite>
+                      <test-suite name="StringAssertTests" success="True" time="0.016" asserts="0">
+                        <results>
+                          <test-case name="NUnit.Framework.Tests.StringAssertTests.CaseInsensitiveCompare" executed="True" success="True" time="0.016" asserts="1" />
+                          <test-case name="NUnit.Framework.Tests.StringAssertTests.CaseInsensitiveCompareFails" executed="True" success="True" time="0.000" asserts="2" />
+                          <test-case name="NUnit.Framework.Tests.StringAssertTests.Contains" executed="True" success="True" time="0.000" asserts="3" />
+                          <test-case name="NUnit.Framework.Tests.StringAssertTests.ContainsFails" executed="True" success="True" time="0.000" asserts="2" />
+                          <test-case name="NUnit.Framework.Tests.StringAssertTests.EndsWith" executed="True" success="True" time="0.000" asserts="2" />
+                          <test-case name="NUnit.Framework.Tests.StringAssertTests.EndsWithFails" executed="True" success="True" time="0.000" asserts="2" />
+                          <test-case name="NUnit.Framework.Tests.StringAssertTests.StartsWith" executed="True" success="True" time="0.000" asserts="2" />
+                          <test-case name="NUnit.Framework.Tests.StringAssertTests.StartsWithFails" executed="True" success="True" time="0.000" asserts="2" />
+                        </results>
+                      </test-suite>
+                      <test-suite name="TypeAssertTests" success="True" time="0.000" asserts="0">
+                        <results>
+                          <test-case name="NUnit.Framework.Tests.TypeAssertTests.IsAssignableFrom" executed="True" success="True" time="0.000" asserts="3" />
+                          <test-case name="NUnit.Framework.Tests.TypeAssertTests.IsAssignableFromFails" executed="True" success="True" time="0.000" asserts="2" />
+                          <test-case name="NUnit.Framework.Tests.TypeAssertTests.IsInstanceOfType" executed="True" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Framework.Tests.TypeAssertTests.IsInstanceOfTypeFails" executed="True" success="True" time="0.000" asserts="2" />
+                          <test-case name="NUnit.Framework.Tests.TypeAssertTests.IsNotAssignableFrom" executed="True" success="True" time="0.000" asserts="3" />
+                          <test-case name="NUnit.Framework.Tests.TypeAssertTests.IsNotAssignableFromFails" executed="True" success="True" time="0.000" asserts="2" />
+                          <test-case name="NUnit.Framework.Tests.TypeAssertTests.IsNotInstanceOfType" executed="True" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Framework.Tests.TypeAssertTests.IsNotInstanceOfTypeFails" executed="True" success="True" time="0.000" asserts="2" />
+                        </results>
+                      </test-suite>
+                    </results>
+                  </test-suite>
+                </results>
+              </test-suite>
+            </results>
+          </test-suite>
+        </results>
+      </test-suite>
+      <test-suite name="C:\Program Files\NUnit-Net-2.0 2.2.10\bin\nunit.mocks.tests.dll" success="True" time="0.266" asserts="0">
+        <results>
+          <test-suite name="NUnit" success="True" time="0.266" asserts="0">
+            <results>
+              <test-suite name="Mocks" success="True" time="0.266" asserts="0">
+                <results>
+                  <test-suite name="Tests" success="True" time="0.266" asserts="0">
+                    <results>
+                      <test-suite name="DynamicMockTests" success="True" time="0.203" asserts="0">
+                        <results>
+                          <test-case name="NUnit.Mocks.Tests.DynamicMockTests.CallMethod" executed="True" success="True" time="0.000" asserts="0" />
+                          <test-case name="NUnit.Mocks.Tests.DynamicMockTests.CallMethodWithArgs" executed="True" success="True" time="0.000" asserts="0" />
+                          <test-case name="NUnit.Mocks.Tests.DynamicMockTests.CreateMockForMBRClass" executed="True" success="True" time="0.109" asserts="8" />
+                          <test-case name="NUnit.Mocks.Tests.DynamicMockTests.CreateMockForNonMBRClassFails" executed="True" success="True" time="0.016" asserts="0" />
+                          <test-case name="NUnit.Mocks.Tests.DynamicMockTests.DefaultReturnValues" executed="True" success="True" time="0.000" asserts="5" />
+                          <test-case name="NUnit.Mocks.Tests.DynamicMockTests.ExpectedMethod" executed="True" success="True" time="0.000" asserts="2" />
+                          <test-case name="NUnit.Mocks.Tests.DynamicMockTests.ExpectedMethodNotCalled" executed="True" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Mocks.Tests.DynamicMockTests.MethodWithReturnValue" executed="True" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Mocks.Tests.DynamicMockTests.MockHasDefaultName" executed="True" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Mocks.Tests.DynamicMockTests.MockHasNonDefaultName" executed="True" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Mocks.Tests.DynamicMockTests.OverrideMethodOnDynamicMock" executed="True" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Mocks.Tests.DynamicMockTests.WrongReturnType" executed="True" success="True" time="0.000" asserts="0" />
+                        </results>
+                      </test-suite>
+                      <test-suite name="MockTests" success="True" time="0.063" asserts="0">
+                        <results>
+                          <test-case name="NUnit.Mocks.Tests.MockTests.CallMultipleMethodsInDifferentOrder" executed="True" success="True" time="0.000" asserts="6" />
+                          <test-case name="NUnit.Mocks.Tests.MockTests.CallMultipleMethodsSomeWithoutExpectations" executed="True" success="True" time="0.000" asserts="5" />
+                          <test-case name="NUnit.Mocks.Tests.MockTests.ChangeExpectAndReturnToFixedReturn" executed="True" success="True" time="0.000" asserts="8" />
+                          <test-case name="NUnit.Mocks.Tests.MockTests.ChangeFixedReturnToExpectAndReturn" executed="True" success="True" time="0.000" asserts="9" />
+                          <test-case name="NUnit.Mocks.Tests.MockTests.ExpectAndReturn" executed="True" success="True" time="0.000" asserts="4" />
+                          <test-case name="NUnit.Mocks.Tests.MockTests.ExpectAndReturnNull" executed="True" success="True" time="0.000" asserts="4" />
+                          <test-case name="NUnit.Mocks.Tests.MockTests.ExpectAndReturnWithArgument" executed="True" success="True" time="0.000" asserts="5" />
+                          <test-case name="NUnit.Mocks.Tests.MockTests.ExpectAndReturnWithWrongArgument" executed="True" success="True" time="0.000" asserts="3" />
+                          <test-case name="NUnit.Mocks.Tests.MockTests.ExpectAndThrowException" executed="True" success="True" time="0.031" asserts="2" />
+                          <test-case name="NUnit.Mocks.Tests.MockTests.ExpectNoCallFails" executed="True" success="True" time="0.000" asserts="0" />
+                          <test-case name="NUnit.Mocks.Tests.MockTests.ExpectNoCallSucceeds" executed="True" success="True" time="0.000" asserts="0" />
+                          <test-case name="NUnit.Mocks.Tests.MockTests.FailWithParametersSpecified" executed="True" success="True" time="0.000" asserts="2" />
+                          <test-case name="NUnit.Mocks.Tests.MockTests.IgnoreArguments" executed="True" success="True" time="0.000" asserts="2" />
+                          <test-case name="NUnit.Mocks.Tests.MockTests.MethodNotCalled" executed="True" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Mocks.Tests.MockTests.MockHasName" executed="True" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Mocks.Tests.MockTests.MultipleCallsToSameMethod" executed="True" success="True" time="0.000" asserts="4" />
+                          <test-case name="NUnit.Mocks.Tests.MockTests.MultipleExpectAndReturn" executed="True" success="True" time="0.000" asserts="10" />
+                          <test-case name="NUnit.Mocks.Tests.MockTests.MultipleExpectations" executed="True" success="True" time="0.000" asserts="12" />
+                          <test-case name="NUnit.Mocks.Tests.MockTests.NotEnoughCalls" executed="True" success="True" time="0.000" asserts="3" />
+                          <test-case name="NUnit.Mocks.Tests.MockTests.OneExpectation" executed="True" success="True" time="0.000" asserts="2" />
+                          <test-case name="NUnit.Mocks.Tests.MockTests.RequireArguments" executed="True" success="True" time="0.000" asserts="2" />
+                          <test-case name="NUnit.Mocks.Tests.MockTests.SetReturnValue" executed="True" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Mocks.Tests.MockTests.SetReturnValueMultipleTimesOnMultipleMethods" executed="True" success="True" time="0.000" asserts="7" />
+                          <test-case name="NUnit.Mocks.Tests.MockTests.SetReturnValueRepeatedCalls" executed="True" success="True" time="0.000" asserts="3" />
+                          <test-case name="NUnit.Mocks.Tests.MockTests.SetReturnValueWithoutCalling" executed="True" success="True" time="0.000" asserts="0" />
+                          <test-case name="NUnit.Mocks.Tests.MockTests.StrictDefaultsToFalse" executed="True" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Mocks.Tests.MockTests.StrictMode" executed="True" success="True" time="0.000" asserts="2" />
+                          <test-case name="NUnit.Mocks.Tests.MockTests.TooManyCalls" executed="True" success="True" time="0.000" asserts="3" />
+                          <test-case name="NUnit.Mocks.Tests.MockTests.UnexpectedCallsIgnored" executed="True" success="True" time="0.000" asserts="0" />
+                          <test-case name="NUnit.Mocks.Tests.MockTests.VerifyNewMock" executed="True" success="True" time="0.000" asserts="0" />
+                        </results>
+                      </test-suite>
+                    </results>
+                  </test-suite>
+                </results>
+              </test-suite>
+            </results>
+          </test-suite>
+        </results>
+      </test-suite>
+      <test-suite name="C:\Program Files\NUnit-Net-2.0 2.2.10\bin\nunit.uikit.tests.dll" success="True" time="2.188" asserts="0">
+        <results>
+          <test-suite name="NUnit" success="True" time="2.156" asserts="0">
+            <results>
+              <test-suite name="UiKit" success="True" time="2.156" asserts="0">
+                <results>
+                  <test-suite name="Tests" success="True" time="2.141" asserts="0">
+                    <results>
+                      <test-suite name="AddConfigurationDialogTests" success="True" time="1.094" asserts="0">
+                        <results>
+                          <test-case name="NUnit.UiKit.Tests.AddConfigurationDialogTests.CheckComboBox" executed="True" success="True" time="0.859" asserts="5" />
+                          <test-case name="NUnit.UiKit.Tests.AddConfigurationDialogTests.CheckForControls" executed="True" success="True" time="0.016" asserts="0" />
+                          <test-case name="NUnit.UiKit.Tests.AddConfigurationDialogTests.CheckTextBox" executed="True" success="True" time="0.031" asserts="1" />
+                          <test-case name="NUnit.UiKit.Tests.AddConfigurationDialogTests.TestComplexEntry" executed="True" success="True" time="0.125" asserts="2" />
+                          <test-case name="NUnit.UiKit.Tests.AddConfigurationDialogTests.TestSimpleEntry" executed="True" success="True" time="0.047" asserts="2" />
+                        </results>
+                      </test-suite>
+                      <test-suite name="ProgressBarTests" success="True" time="0.078" asserts="0">
+                        <results>
+                          <test-case name="NUnit.UiKit.Tests.ProgressBarTests.TestProgressDisplay" executed="True" success="True" time="0.063" asserts="16" />
+                        </results>
+                      </test-suite>
+                      <test-suite name="RecentFileMenuHandlerTests" success="True" time="0.016" asserts="0">
+                        <results>
+                          <test-case name="NUnit.UiKit.Tests.RecentFileMenuHandlerTests.DisableOnLoadWhenEmpty" executed="True" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.UiKit.Tests.RecentFileMenuHandlerTests.EnableOnLoadWhenNotEmpty" executed="True" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.UiKit.Tests.RecentFileMenuHandlerTests.LoadMenuItems" executed="True" success="True" time="0.000" asserts="2" />
+                        </results>
+                      </test-suite>
+                      <test-suite name="StatusBarTests" success="True" time="0.234" asserts="0">
+                        <results>
+                          <test-case name="NUnit.UiKit.Tests.StatusBarTests.TestConstruction" executed="True" success="True" time="0.063" asserts="5" />
+                          <test-case name="NUnit.UiKit.Tests.StatusBarTests.TestFinalDisplay" executed="True" success="True" time="0.047" asserts="6" />
+                          <test-case name="NUnit.UiKit.Tests.StatusBarTests.TestInitialization" executed="True" success="True" time="0.047" asserts="10" />
+                          <test-case name="NUnit.UiKit.Tests.StatusBarTests.TestProgressDisplay" executed="True" success="True" time="0.078" asserts="71" />
+                        </results>
+                      </test-suite>
+                      <test-suite name="TestSuiteTreeNodeTests" success="True" time="0.047" asserts="0">
+                        <results>
+                          <test-case name="NUnit.UiKit.Tests.TestSuiteTreeNodeTests.ClearResult" executed="True" success="True" time="0.016" asserts="5" />
+                          <test-case name="NUnit.UiKit.Tests.TestSuiteTreeNodeTests.ClearResults" executed="True" success="True" time="0.016" asserts="8" />
+                          <test-case name="NUnit.UiKit.Tests.TestSuiteTreeNodeTests.ConstructFromTestInfo" executed="True" success="True" time="0.000" asserts="3" />
+                          <test-case name="NUnit.UiKit.Tests.TestSuiteTreeNodeTests.SetResult" executed="True" success="True" time="0.000" asserts="7" />
+                          <test-case name="NUnit.UiKit.Tests.TestSuiteTreeNodeTests.SetResultForWrongTest" executed="True" success="True" time="0.000" asserts="0" />
+                          <test-case name="NUnit.UiKit.Tests.TestSuiteTreeNodeTests.UpdateTest" executed="True" success="True" time="0.000" asserts="4" />
+                          <test-case name="NUnit.UiKit.Tests.TestSuiteTreeNodeTests.UpdateUsingWrongTest" executed="True" success="True" time="0.000" asserts="0" />
+                        </results>
+                      </test-suite>
+                      <test-suite name="TestSuiteTreeViewFixture" success="True" time="0.609" asserts="0">
+                        <results>
+                          <test-case name="NUnit.UiKit.Tests.TestSuiteTreeViewFixture.BuildFromResult" executed="True" success="True" time="0.141" asserts="15" />
+                          <test-case name="NUnit.UiKit.Tests.TestSuiteTreeViewFixture.BuildTreeView" executed="True" success="True" time="0.063" asserts="5" />
+                          <test-case name="NUnit.UiKit.Tests.TestSuiteTreeViewFixture.ClearTree" executed="True" success="True" time="0.047" asserts="1" />
+                          <test-case name="NUnit.UiKit.Tests.TestSuiteTreeViewFixture.LoadSuite" executed="True" success="True" time="0.031" asserts="1" />
+                          <test-case name="NUnit.UiKit.Tests.TestSuiteTreeViewFixture.ProcessChecks" executed="True" success="True" time="0.063" asserts="7" />
+                          <test-case name="NUnit.UiKit.Tests.TestSuiteTreeViewFixture.ReloadTree" executed="True" success="True" time="0.078" asserts="6" />
+                          <test-case name="NUnit.UiKit.Tests.TestSuiteTreeViewFixture.ReloadTreeWithWrongTest" executed="True" success="True" time="0.063" asserts="0" />
+                          <test-case name="NUnit.UiKit.Tests.TestSuiteTreeViewFixture.SetTestResult" executed="True" success="True" time="0.063" asserts="3" />
+                        </results>
+                      </test-suite>
+                      <test-suite name="TextBoxWriterTests" success="True" time="0.063" asserts="0">
+                        <results>
+                          <test-case name="NUnit.UiKit.Tests.TextBoxWriterTests.CreateWriter" executed="True" success="True" time="0.047" asserts="4" />
+                          <test-case name="NUnit.UiKit.Tests.TextBoxWriterTests.MixedWrites" executed="True" success="True" time="0.016" asserts="2" />
+                          <test-case name="NUnit.UiKit.Tests.TextBoxWriterTests.Write" executed="True" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.UiKit.Tests.TextBoxWriterTests.WriteLines" executed="True" success="True" time="0.000" asserts="1" />
+                        </results>
+                      </test-suite>
+                    </results>
+                  </test-suite>
+                </results>
+              </test-suite>
+            </results>
+          </test-suite>
+        </results>
+      </test-suite>
+      <test-suite name="C:\Program Files\NUnit-Net-2.0 2.2.10\bin\nunit.util.tests.dll" success="False" time="17.609" asserts="0">
+        <results>
+          <test-suite name="NUnit" success="False" time="17.594" asserts="0">
+            <results>
+              <test-suite name="Util" success="False" time="17.547" asserts="0">
+                <results>
+                  <test-suite name="Tests" success="False" time="17.531" asserts="0">
+                    <results>
+                      <test-suite name="AssemblyListTests" success="True" time="0.016" asserts="0">
+                        <results>
+                          <test-case name="NUnit.Util.Tests.AssemblyListTests.AddMarksConfigurationDirty" executed="True" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Util.Tests.AssemblyListTests.CanAddAssemblies" executed="True" success="True" time="0.000" asserts="3" />
+                          <test-case name="NUnit.Util.Tests.AssemblyListTests.CanRemoveAssemblies" executed="True" success="True" time="0.000" asserts="3" />
+                          <test-case name="NUnit.Util.Tests.AssemblyListTests.EmptyList" executed="True" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Util.Tests.AssemblyListTests.MustAddAbsolutePath" executed="True" success="True" time="0.000" asserts="0" />
+                          <test-case name="NUnit.Util.Tests.AssemblyListTests.RemoveAtMarksConfigurationDirty" executed="True" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Util.Tests.AssemblyListTests.RemoveMarksConfigurationDirty" executed="True" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Util.Tests.AssemblyListTests.SettingFullPathMarksConfigurationDirty" executed="True" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Util.Tests.AssemblyListTests.SettingHasTestsMarksConfigurationDirty" executed="True" success="True" time="0.000" asserts="1" />
+                        </results>
+                      </test-suite>
+                      <test-suite name="EventDispatcherTests" success="True" time="0.016" asserts="0">
+                        <results>
+                          <test-case name="NUnit.Util.Tests.EventDispatcherTests.ProjectLoaded" executed="True" success="True" time="0.000" asserts="3" />
+                          <test-case name="NUnit.Util.Tests.EventDispatcherTests.ProjectLoadFailed" executed="True" success="True" time="0.016" asserts="4" />
+                          <test-case name="NUnit.Util.Tests.EventDispatcherTests.ProjectLoading" executed="True" success="True" time="0.000" asserts="3" />
+                          <test-case name="NUnit.Util.Tests.EventDispatcherTests.ProjectUnloaded" executed="True" success="True" time="0.000" asserts="3" />
+                          <test-case name="NUnit.Util.Tests.EventDispatcherTests.ProjectUnloadFailed" executed="True" success="True" time="0.000" asserts="4" />
+                          <test-case name="NUnit.Util.Tests.EventDispatcherTests.ProjectUnloading" executed="True" success="True" time="0.000" asserts="3" />
+                          <test-case name="NUnit.Util.Tests.EventDispatcherTests.RunFailed" executed="True" success="True" time="0.000" asserts="3" />
+                          <test-case name="NUnit.Util.Tests.EventDispatcherTests.RunFinished" executed="True" success="True" time="0.000" asserts="3" />
+                          <test-case name="NUnit.Util.Tests.EventDispatcherTests.RunStarting" executed="True" success="True" time="0.000" asserts="3" />
+                          <test-case name="NUnit.Util.Tests.EventDispatcherTests.SuiteFinished" executed="True" success="True" time="0.000" asserts="3" />
+                          <test-case name="NUnit.Util.Tests.EventDispatcherTests.SuiteStarting" executed="True" success="True" time="0.000" asserts="3" />
+                          <test-case name="NUnit.Util.Tests.EventDispatcherTests.TestFinished" executed="True" success="True" time="0.000" asserts="3" />
+                          <test-case name="NUnit.Util.Tests.EventDispatcherTests.TestLoaded" executed="True" success="True" time="0.000" asserts="4" />
+                          <test-case name="NUnit.Util.Tests.EventDispatcherTests.TestLoadFailed" executed="True" success="True" time="0.000" asserts="4" />
+                          <test-case name="NUnit.Util.Tests.EventDispatcherTests.TestLoading" executed="True" success="True" time="0.000" asserts="3" />
+                          <test-case name="NUnit.Util.Tests.EventDispatcherTests.TestReloaded" executed="True" success="True" time="0.000" asserts="4" />
+                          <test-case name="NUnit.Util.Tests.EventDispatcherTests.TestReloadFailed" executed="True" success="True" time="0.000" asserts="4" />
+                          <test-case name="NUnit.Util.Tests.EventDispatcherTests.TestReloading" executed="True" success="True" time="0.000" asserts="3" />
+                          <test-case name="NUnit.Util.Tests.EventDispatcherTests.TestStarting" executed="True" success="True" time="0.000" asserts="3" />
+                          <test-case name="NUnit.Util.Tests.EventDispatcherTests.TestUnloaded" executed="True" success="True" time="0.000" asserts="4" />
+                          <test-case name="NUnit.Util.Tests.EventDispatcherTests.TestUnloadFailed" executed="True" success="True" time="0.000" asserts="4" />
+                          <test-case name="NUnit.Util.Tests.EventDispatcherTests.TestUnloading" executed="True" success="True" time="0.000" asserts="3" />
+                        </results>
+                      </test-suite>
+                      <test-suite name="FileWatcherTest" success="True" time="1.016" asserts="0">
+                        <results>
+                          <test-case name="NUnit.Util.Tests.FileWatcherTest.ChangingAttributesDoesNotTriggerWatcher" executed="True" success="True" time="0.281" asserts="1" />
+                          <test-case name="NUnit.Util.Tests.FileWatcherTest.ChangingFileTriggersWatcher" executed="True" success="True" time="0.219" asserts="2" />
+                          <test-case name="NUnit.Util.Tests.FileWatcherTest.CopyingFileDoesNotTriggerWatcher" executed="True" success="True" time="0.203" asserts="1" />
+                          <test-case name="NUnit.Util.Tests.FileWatcherTest.MultipleCloselySpacedChangesTriggerWatcherOnlyOnce" executed="True" success="True" time="0.297" asserts="2" />
+                        </results>
+                      </test-suite>
+                      <test-suite name="MemorySettingsStorageTests" success="True" time="0.016" asserts="0">
+                        <results>
+                          <test-case name="NUnit.Util.Tests.MemorySettingsStorageTests.BadSetting1" executed="True" success="True" time="0.000" asserts="0" />
+                          <test-case name="NUnit.Util.Tests.MemorySettingsStorageTests.BadSetting2" executed="True" success="True" time="0.016" asserts="0" />
+                          <test-case name="NUnit.Util.Tests.MemorySettingsStorageTests.DefaultSettings" executed="True" success="True" time="0.000" asserts="7" />
+                          <test-case name="NUnit.Util.Tests.MemorySettingsStorageTests.MakeStorage" executed="True" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Util.Tests.MemorySettingsStorageTests.MakeSubStorages" executed="True" success="True" time="0.000" asserts="2" />
+                          <test-case name="NUnit.Util.Tests.MemorySettingsStorageTests.RemoveSettings" executed="True" success="True" time="0.000" asserts="3" />
+                          <test-case name="NUnit.Util.Tests.MemorySettingsStorageTests.SaveAndLoadSettings" executed="True" success="True" time="0.000" asserts="4" />
+                          <test-case name="NUnit.Util.Tests.MemorySettingsStorageTests.SubstorageSettings" executed="True" success="True" time="0.000" asserts="5" />
+                          <test-case name="NUnit.Util.Tests.MemorySettingsStorageTests.TypeSafeSettings" executed="True" success="True" time="0.000" asserts="8" />
+                        </results>
+                      </test-suite>
+                      <test-suite name="NUnitProjectLoad" success="True" time="0.500" asserts="0">
+                        <results>
+                          <test-case name="NUnit.Util.Tests.NUnitProjectLoad.FromAssembly" executed="True" success="True" time="0.016" asserts="5" />
+                          <test-case name="NUnit.Util.Tests.NUnitProjectLoad.FromCppProject" executed="True" success="True" time="0.203" asserts="5" />
+                          <test-case name="NUnit.Util.Tests.NUnitProjectLoad.FromCSharpProject" executed="True" success="True" time="0.016" asserts="5" />
+                          <test-case name="NUnit.Util.Tests.NUnitProjectLoad.FromJsharpProject" executed="True" success="True" time="0.016" asserts="5" />
+                          <test-case name="NUnit.Util.Tests.NUnitProjectLoad.FromMakefileProject" executed="True" success="True" time="0.000" asserts="5" />
+                          <test-case name="NUnit.Util.Tests.NUnitProjectLoad.FromProjectWithHebrewFileIncluded" executed="True" success="True" time="0.000" asserts="5" />
+                          <test-case name="NUnit.Util.Tests.NUnitProjectLoad.FromVBProject" executed="True" success="True" time="0.016" asserts="5" />
+                          <test-case name="NUnit.Util.Tests.NUnitProjectLoad.FromVSSolution2003" executed="True" success="True" time="0.063" asserts="7" />
+                          <test-case name="NUnit.Util.Tests.NUnitProjectLoad.FromVSSolution2005" executed="True" success="True" time="0.063" asserts="7" />
+                          <test-case name="NUnit.Util.Tests.NUnitProjectLoad.FromWebApplication" executed="True" success="True" time="0.000" asserts="3" />
+                          <test-case name="NUnit.Util.Tests.NUnitProjectLoad.LoadEmptyConfigs" executed="True" success="True" time="0.016" asserts="3" />
+                          <test-case name="NUnit.Util.Tests.NUnitProjectLoad.LoadEmptyProject" executed="True" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Util.Tests.NUnitProjectLoad.LoadNormalProject" executed="True" success="True" time="0.000" asserts="7" />
+                          <test-case name="NUnit.Util.Tests.NUnitProjectLoad.LoadProjectWithManualBinPath" executed="True" success="True" time="0.000" asserts="2" />
+                          <test-case name="NUnit.Util.Tests.NUnitProjectLoad.SaveClearsAssemblyWrapper" executed="True" success="True" time="0.016" asserts="1" />
+                          <test-case name="NUnit.Util.Tests.NUnitProjectLoad.WithUnmanagedCpp" executed="True" success="True" time="0.047" asserts="9" />
+                        </results>
+                      </test-suite>
+                      <test-suite name="NUnitProjectSave" success="True" time="0.047" asserts="0">
+                        <results>
+                          <test-case name="NUnit.Util.Tests.NUnitProjectSave.SaveEmptyConfigs" executed="True" success="True" time="0.031" asserts="1" />
+                          <test-case name="NUnit.Util.Tests.NUnitProjectSave.SaveEmptyProject" executed="True" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Util.Tests.NUnitProjectSave.SaveNormalProject" executed="True" success="True" time="0.016" asserts="1" />
+                        </results>
+                      </test-suite>
+                      <test-suite name="NUnitProjectTests" success="True" time="0.094" asserts="0">
+                        <results>
+                          <test-case name="NUnit.Util.Tests.NUnitProjectTests.AddConfigMakesProjectDirty" executed="True" success="True" time="0.000" asserts="2" />
+                          <test-case name="NUnit.Util.Tests.NUnitProjectTests.CanAddAssemblies" executed="True" success="True" time="0.000" asserts="3" />
+                          <test-case name="NUnit.Util.Tests.NUnitProjectTests.CanAddConfigs" executed="True" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Util.Tests.NUnitProjectTests.CanSetActiveConfig" executed="True" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Util.Tests.NUnitProjectTests.CanSetAppBase" executed="True" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Util.Tests.NUnitProjectTests.ConfigurationFileFromAssemblies" executed="True" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Util.Tests.NUnitProjectTests.ConfigurationFileFromAssembly" executed="True" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Util.Tests.NUnitProjectTests.DefaultActiveConfig" executed="True" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Util.Tests.NUnitProjectTests.DefaultApplicationBase" executed="True" success="True" time="0.016" asserts="1" />
+                          <test-case name="NUnit.Util.Tests.NUnitProjectTests.DefaultConfigurationFile" executed="True" success="True" time="0.000" asserts="2" />
+                          <test-case name="NUnit.Util.Tests.NUnitProjectTests.DefaultProjectName" executed="True" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Util.Tests.NUnitProjectTests.IsProjectFile" executed="True" success="True" time="0.000" asserts="2" />
+                          <test-case name="NUnit.Util.Tests.NUnitProjectTests.LoadMakesProjectNotDirty" executed="True" success="True" time="0.016" asserts="1" />
+                          <test-case name="NUnit.Util.Tests.NUnitProjectTests.NewProjectDefaultPath" executed="True" success="True" time="0.000" asserts="3" />
+                          <test-case name="NUnit.Util.Tests.NUnitProjectTests.NewProjectIsEmpty" executed="True" success="True" time="0.000" asserts="2" />
+                          <test-case name="NUnit.Util.Tests.NUnitProjectTests.NewProjectIsNotDirty" executed="True" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Util.Tests.NUnitProjectTests.NewProjectNotLoadable" executed="True" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Util.Tests.NUnitProjectTests.RemoveActiveConfig" executed="True" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Util.Tests.NUnitProjectTests.RemoveConfigMakesProjectDirty" executed="True" success="True" time="0.000" asserts="2" />
+                          <test-case name="NUnit.Util.Tests.NUnitProjectTests.RenameActiveConfig" executed="True" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Util.Tests.NUnitProjectTests.RenameConfigMakesProjectDirty" executed="True" success="True" time="0.000" asserts="2" />
+                          <test-case name="NUnit.Util.Tests.NUnitProjectTests.SaveAndLoadConfigsWithAssemblies" executed="True" success="True" time="0.016" asserts="8" />
+                          <test-case name="NUnit.Util.Tests.NUnitProjectTests.SaveAndLoadEmptyConfigs" executed="True" success="True" time="0.016" asserts="4" />
+                          <test-case name="NUnit.Util.Tests.NUnitProjectTests.SaveAndLoadEmptyProject" executed="True" success="True" time="0.000" asserts="2" />
+                          <test-case name="NUnit.Util.Tests.NUnitProjectTests.SaveMakesProjectNotDirty" executed="True" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Util.Tests.NUnitProjectTests.SaveSetsProjectPath" executed="True" success="True" time="0.016" asserts="2" />
+                          <test-case name="NUnit.Util.Tests.NUnitProjectTests.SettingActiveConfigMakesProjectDirty" executed="True" success="True" time="0.000" asserts="2" />
+                        </results>
+                      </test-suite>
+                      <test-suite name="NUnitRegistryTests" success="True" time="0.031" asserts="0">
+                        <results>
+                          <test-case name="NUnit.Util.Tests.NUnitRegistryTests.CurrentUser" executed="True" success="True" time="0.000" asserts="2" />
+                          <test-case name="NUnit.Util.Tests.NUnitRegistryTests.CurrentUserTestMode" executed="True" success="True" time="0.000" asserts="2" />
+                          <test-case name="NUnit.Util.Tests.NUnitRegistryTests.LocalMachine" executed="True" success="True" time="0.000" asserts="2" />
+                          <test-case name="NUnit.Util.Tests.NUnitRegistryTests.LocalMachineTestMode" executed="True" success="True" time="0.000" asserts="2" />
+                          <test-case name="NUnit.Util.Tests.NUnitRegistryTests.TestClearRoutines" executed="True" success="True" time="0.016" asserts="2" />
+                        </results>
+                      </test-suite>
+                      <test-suite name="PathUtilTests" success="True" time="0.000" asserts="0">
+                        <results>
+                          <test-case name="NUnit.Util.Tests.PathUtilTests.CheckDefaults" executed="True" success="True" time="0.000" asserts="2" />
+                        </results>
+                      </test-suite>
+                      <test-suite name="PathUtilTests_Unix" success="True" time="0.000" asserts="0">
+                        <results>
+                          <test-case name="NUnit.Util.Tests.PathUtilTests_Unix.Canonicalize" executed="True" success="True" time="0.000" asserts="5" />
+                          <test-case name="NUnit.Util.Tests.PathUtilTests_Unix.IsAssemblyFileType" executed="True" success="True" time="0.000" asserts="3" />
+                          <test-case name="NUnit.Util.Tests.PathUtilTests_Unix.RelativePath" executed="True" success="True" time="0.000" asserts="5" />
+                          <test-case name="NUnit.Util.Tests.PathUtilTests_Unix.SamePath" executed="True" success="True" time="0.000" asserts="4" />
+                          <test-case name="NUnit.Util.Tests.PathUtilTests_Unix.SamePathOrUnder" executed="True" success="True" time="0.000" asserts="7" />
+                        </results>
+                      </test-suite>
+                      <test-suite name="PathUtilTests_Windows" success="True" time="0.000" asserts="0">
+                        <results>
+                          <test-case name="NUnit.Util.Tests.PathUtilTests_Windows.Canonicalize" executed="True" success="True" time="0.000" asserts="5" />
+                          <test-case name="NUnit.Util.Tests.PathUtilTests_Windows.IsAssemblyFileType" executed="True" success="True" time="0.000" asserts="3" />
+                          <test-case name="NUnit.Util.Tests.PathUtilTests_Windows.RelativePath" executed="True" success="True" time="0.000" asserts="4" />
+                          <test-case name="NUnit.Util.Tests.PathUtilTests_Windows.SamePath" executed="True" success="True" time="0.000" asserts="4" />
+                          <test-case name="NUnit.Util.Tests.PathUtilTests_Windows.SamePathOrUnder" executed="True" success="True" time="0.000" asserts="9" />
+                        </results>
+                      </test-suite>
+                      <test-suite name="ProjectConfigCollectionTests" success="True" time="0.000" asserts="0">
+                        <results>
+                          <test-case name="NUnit.Util.Tests.ProjectConfigCollectionTests.AddConfig" executed="True" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Util.Tests.ProjectConfigCollectionTests.AddMakesProjectDirty" executed="True" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Util.Tests.ProjectConfigCollectionTests.AddTwoConfigs" executed="True" success="True" time="0.000" asserts="3" />
+                          <test-case name="NUnit.Util.Tests.ProjectConfigCollectionTests.BuildConfigAndAdd" executed="True" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Util.Tests.ProjectConfigCollectionTests.EmptyCollection" executed="True" success="True" time="0.000" asserts="1" />
+                        </results>
+                      </test-suite>
+                      <test-suite name="ProjectConfigTests" success="True" time="0.016" asserts="0">
+                        <results>
+                          <test-case name="NUnit.Util.Tests.ProjectConfigTests.AbsoluteBasePath" executed="True" success="True" time="0.000" asserts="2" />
+                          <test-case name="NUnit.Util.Tests.ProjectConfigTests.AbsoluteConfigurationFile" executed="True" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Util.Tests.ProjectConfigTests.AddMarksProjectDirty" executed="True" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Util.Tests.ProjectConfigTests.AutoPrivateBinPath" executed="True" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Util.Tests.ProjectConfigTests.CanAddAssemblies" executed="True" success="True" time="0.016" asserts="3" />
+                          <test-case name="NUnit.Util.Tests.ProjectConfigTests.DefaultConfigurationFile" executed="True" success="True" time="0.000" asserts="2" />
+                          <test-case name="NUnit.Util.Tests.ProjectConfigTests.EmptyConfig" executed="True" success="True" time="0.000" asserts="2" />
+                          <test-case name="NUnit.Util.Tests.ProjectConfigTests.GetAbsolutePaths" executed="True" success="True" time="0.000" asserts="2" />
+                          <test-case name="NUnit.Util.Tests.ProjectConfigTests.GetPrivateBinPath" executed="True" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Util.Tests.ProjectConfigTests.GetRelativePaths" executed="True" success="True" time="0.000" asserts="2" />
+                          <test-case name="NUnit.Util.Tests.ProjectConfigTests.GetTestAssemblies" executed="True" success="True" time="0.000" asserts="3" />
+                          <test-case name="NUnit.Util.Tests.ProjectConfigTests.ManualPrivateBinPath" executed="True" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Util.Tests.ProjectConfigTests.NoBasePathSet" executed="True" success="True" time="0.000" asserts="2" />
+                          <test-case name="NUnit.Util.Tests.ProjectConfigTests.NoPrivateBinPath" executed="True" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Util.Tests.ProjectConfigTests.RelativeBasePath" executed="True" success="True" time="0.000" asserts="2" />
+                          <test-case name="NUnit.Util.Tests.ProjectConfigTests.RelativeConfigurationFile" executed="True" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Util.Tests.ProjectConfigTests.RemoveMarksProjectDirty" executed="True" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Util.Tests.ProjectConfigTests.RenameMarksProjectDirty" executed="True" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Util.Tests.ProjectConfigTests.SettingApplicationBaseMarksProjectDirty" executed="True" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Util.Tests.ProjectConfigTests.SettingBinPathTypeMarksProjectDirty" executed="True" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Util.Tests.ProjectConfigTests.SettingConfigurationFileMarksProjectDirty" executed="True" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Util.Tests.ProjectConfigTests.SettingPrivateBinPathMarksProjectDirty" executed="True" success="True" time="0.000" asserts="1" />
+                        </results>
+                      </test-suite>
+                      <test-suite name="RegistrySettingsStorageTests" success="True" time="0.125" asserts="0">
+                        <results>
+                          <test-case name="NUnit.Util.Tests.RegistrySettingsStorageTests.BadSetting1" executed="True" success="True" time="0.000" asserts="0" />
+                          <test-case name="NUnit.Util.Tests.RegistrySettingsStorageTests.BadSetting2" executed="True" success="True" time="0.000" asserts="0" />
+                          <test-case name="NUnit.Util.Tests.RegistrySettingsStorageTests.DefaultSettings" executed="True" success="True" time="0.000" asserts="7" />
+                          <test-case name="NUnit.Util.Tests.RegistrySettingsStorageTests.MakeSubStorages" executed="True" success="True" time="0.109" asserts="4" />
+                          <test-case name="NUnit.Util.Tests.RegistrySettingsStorageTests.RemoveSettings" executed="True" success="True" time="0.000" asserts="3" />
+                          <test-case name="NUnit.Util.Tests.RegistrySettingsStorageTests.SaveAndLoadSettings" executed="True" success="True" time="0.000" asserts="6" />
+                          <test-case name="NUnit.Util.Tests.RegistrySettingsStorageTests.StorageHasCorrectKey" executed="True" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Util.Tests.RegistrySettingsStorageTests.SubstorageSettings" executed="True" success="True" time="0.016" asserts="5" />
+                          <test-case name="NUnit.Util.Tests.RegistrySettingsStorageTests.TypeSafeSettings" executed="True" success="True" time="0.000" asserts="8" />
+                        </results>
+                      </test-suite>
+                      <test-suite name="RemoteTestResultTest" success="True" time="1.000" asserts="0">
+                        <results>
+                          <test-case name="NUnit.Util.Tests.RemoteTestResultTest.ResultStillValidAfterDomainUnload" executed="True" success="True" time="1.000" asserts="4" />
+                        </results>
+                      </test-suite>
+                      <test-suite name="SettingsGroupTests" success="True" time="0.016" asserts="0">
+                        <results>
+                          <test-case name="NUnit.Util.Tests.SettingsGroupTests.BadSetting1" executed="True" success="True" time="0.016" asserts="0" />
+                          <test-case name="NUnit.Util.Tests.SettingsGroupTests.BadSetting2" executed="True" success="True" time="0.000" asserts="0" />
+                          <test-case name="NUnit.Util.Tests.SettingsGroupTests.DefaultSettings" executed="True" success="True" time="0.000" asserts="7" />
+                          <test-case name="NUnit.Util.Tests.SettingsGroupTests.SubGroupSettings" executed="True" success="True" time="0.000" asserts="7" />
+                          <test-case name="NUnit.Util.Tests.SettingsGroupTests.TopLevelSettings" executed="True" success="True" time="0.000" asserts="5" />
+                          <test-case name="NUnit.Util.Tests.SettingsGroupTests.TypeSafeSettings" executed="True" success="True" time="0.000" asserts="8" />
+                        </results>
+                      </test-suite>
+                      <test-suite name="SummaryResultFixture" success="True" time="0.000" asserts="0">
+                        <results>
+                          <test-case name="NUnit.Util.Tests.SummaryResultFixture.Failure" executed="True" success="True" time="0.000" asserts="4" />
+                          <test-case name="NUnit.Util.Tests.SummaryResultFixture.TestCountNotRunSuites" executed="True" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Util.Tests.SummaryResultFixture.TestTime" executed="True" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Util.Tests.SummaryResultFixture.TotalCountSuccess" executed="True" success="True" time="0.000" asserts="5" />
+                        </results>
+                      </test-suite>
+                      <test-suite name="TestDomainFixture" success="True" time="0.953" asserts="0">
+                        <results>
+                          <test-case name="NUnit.Util.Tests.TestDomainFixture.AppDomainIsSetUpCorrectly" executed="True" success="True" time="0.000" asserts="8" />
+                          <test-case name="NUnit.Util.Tests.TestDomainFixture.AssemblyIsLoadedCorrectly" executed="True" success="True" time="0.000" asserts="2" />
+                          <test-case name="NUnit.Util.Tests.TestDomainFixture.CanRunMockAssemblyTests" executed="True" success="True" time="0.031" asserts="4" />
+                          <test-case name="NUnit.Util.Tests.TestDomainFixture.TurnOffShadowCopyFailsAfterLoad" executed="True" success="True" time="0.000" asserts="0" />
+                        </results>
+                      </test-suite>
+                      <test-suite name="TestDomainTests" success="True" time="6.422" asserts="0">
+                        <results>
+                          <test-case name="NUnit.Util.Tests.TestDomainTests.BinPath" executed="True" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Util.Tests.TestDomainTests.FileNotFound" executed="True" success="True" time="0.281" asserts="0" />
+                          <test-case name="NUnit.Util.Tests.TestDomainTests.InvalidTestFixture" executed="True" success="True" time="1.047" asserts="1" />
+                          <test-case name="NUnit.Util.Tests.TestDomainTests.ProjectBasePathOverrideIsHonored" executed="True" success="True" time="0.813" asserts="1" />
+                          <test-case name="NUnit.Util.Tests.TestDomainTests.ProjectBinPathOverrideIsHonored" executed="True" success="True" time="0.813" asserts="1" />
+                          <test-case name="NUnit.Util.Tests.TestDomainTests.ProjectConfigBasePathOverrideIsHonored" executed="True" success="True" time="1.344" asserts="1" />
+                          <test-case name="NUnit.Util.Tests.TestDomainTests.ProjectConfigFileOverrideIsHonored" executed="True" success="True" time="0.750" asserts="1" />
+                          <test-case name="NUnit.Util.Tests.TestDomainTests.SpecificTestFixture" executed="True" success="True" time="0.844" asserts="3" />
+                          <test-case name="NUnit.Util.Tests.TestDomainTests.TurnOffShadowCopy" executed="True" success="True" time="0.516" asserts="1" />
+                        </results>
+                      </test-suite>
+                      <test-suite name="TestDomainTests_Multiple" success="True" time="1.734" asserts="0">
+                        <results>
+                          <test-case name="NUnit.Util.Tests.TestDomainTests_Multiple.AssemblyNodes" executed="True" success="True" time="0.000" asserts="2" />
+                          <test-case name="NUnit.Util.Tests.TestDomainTests_Multiple.BuildSuite" executed="True" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Util.Tests.TestDomainTests_Multiple.RootNode" executed="True" success="True" time="0.000" asserts="2" />
+                          <test-case name="NUnit.Util.Tests.TestDomainTests_Multiple.RunMultipleAssemblies" executed="True" success="True" time="0.016" asserts="1" />
+                          <test-case name="NUnit.Util.Tests.TestDomainTests_Multiple.TestCaseCount" executed="True" success="True" time="0.000" asserts="1" />
+                        </results>
+                      </test-suite>
+                      <test-suite name="TestDomainTests_MultipleFixture" success="True" time="1.188" asserts="0">
+                        <results>
+                          <test-case name="NUnit.Util.Tests.TestDomainTests_MultipleFixture.LoadFixture" executed="True" success="True" time="1.188" asserts="2" />
+                        </results>
+                      </test-suite>
+                      <test-suite name="TestLoaderAssemblyTests" success="True" time="4.047" asserts="0">
+                        <results>
+                          <test-case name="NUnit.Util.Tests.TestLoaderAssemblyTests.AssemblyWithNoTests" executed="True" success="True" time="0.781" asserts="4" />
+                          <test-case name="NUnit.Util.Tests.TestLoaderAssemblyTests.FileNotFound" executed="True" success="True" time="0.000" asserts="5" />
+                          <test-case name="NUnit.Util.Tests.TestLoaderAssemblyTests.LoadProject" executed="True" success="True" time="0.000" asserts="5" />
+                          <test-case name="NUnit.Util.Tests.TestLoaderAssemblyTests.LoadTest" executed="True" success="True" time="0.984" asserts="6" />
+                          <test-case name="NUnit.Util.Tests.TestLoaderAssemblyTests.RunTest" executed="True" success="True" time="1.344" asserts="5" />
+                          <test-case name="NUnit.Util.Tests.TestLoaderAssemblyTests.UnloadProject" executed="True" success="True" time="0.000" asserts="5" />
+                          <test-case name="NUnit.Util.Tests.TestLoaderAssemblyTests.UnloadTest" executed="True" success="True" time="0.938" asserts="3" />
+                        </results>
+                      </test-suite>
+                      <test-suite name="UITestNodeTests" success="True" time="0.016" asserts="0">
+                        <results>
+                          <test-case name="NUnit.Util.Tests.UITestNodeTests.Construction" executed="True" success="True" time="0.000" asserts="24" />
+                          <test-case name="NUnit.Util.Tests.UITestNodeTests.Conversion" executed="True" success="True" time="0.000" asserts="21" />
+                          <test-case name="NUnit.Util.Tests.UITestNodeTests.PopulateTests" executed="True" success="True" time="0.000" asserts="8" />
+                        </results>
+                      </test-suite>
+                      <test-suite name="UtilTest" success="True" time="0.016" asserts="0">
+                        <results>
+                          <test-case name="NUnit.Util.Tests.UtilTest.CompareIdenticalTreesWithOneIgnored" executed="True" success="True" time="0.016" asserts="1" />
+                          <test-case name="NUnit.Util.Tests.UtilTest.CompareStructurallyDifferentTrees" executed="True" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Util.Tests.UtilTest.CompareStructurallyIdenticalTreesWithDifferentNames" executed="True" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Util.Tests.UtilTest.CompareTreeToSelf" executed="True" success="True" time="0.000" asserts="1" />
+                        </results>
+                      </test-suite>
+                      <test-suite name="VSProjectTests" success="False" time="0.109" asserts="0">
+                        <results>
+                          <test-case name="NUnit.Util.Tests.VSProjectTests.FileNotFoundError" executed="True" success="True" time="0.000" asserts="0" />
+                          <test-case name="NUnit.Util.Tests.VSProjectTests.GenerateCorrectExtensionsFromVCProjectVS2005" executed="True" success="False" time="0.016" asserts="0">
+                            <failure>
+                              <message><![CDATA[System.NullReferenceException : Object reference not set to an instance of an object.]]></message>
+                              <stack-trace><![CDATA[   at NUnit.TestUtilities.TempResourceFile..ctor(Type type, String name, String path)
+   at NUnit.Util.Tests.VSProjectTests.GenerateCorrectExtensionsFromVCProjectVS2005()
+]]></stack-trace>
+                            </failure>
+                          </test-case>
+                          <test-case name="NUnit.Util.Tests.VSProjectTests.InvalidProjectFormat" executed="True" success="True" time="0.000" asserts="0" />
+                          <test-case name="NUnit.Util.Tests.VSProjectTests.InvalidXmlFormat" executed="True" success="True" time="0.016" asserts="0" />
+                          <test-case name="NUnit.Util.Tests.VSProjectTests.LoadCppProject" executed="True" success="True" time="0.016" asserts="3" />
+                          <test-case name="NUnit.Util.Tests.VSProjectTests.LoadCppProjectVS2005" executed="True" success="True" time="0.000" asserts="3" />
+                          <test-case name="NUnit.Util.Tests.VSProjectTests.LoadCppProjectWithMacros" executed="True" success="True" time="0.000" asserts="4" />
+                          <test-case name="NUnit.Util.Tests.VSProjectTests.LoadCsharpProject" executed="True" success="True" time="0.000" asserts="3" />
+                          <test-case name="NUnit.Util.Tests.VSProjectTests.LoadCsharpProjectVS2005" executed="True" success="True" time="0.000" asserts="3" />
+                          <test-case name="NUnit.Util.Tests.VSProjectTests.LoadInvalidFileType" executed="True" success="True" time="0.000" asserts="0" />
+                          <test-case name="NUnit.Util.Tests.VSProjectTests.LoadJsharpProject" executed="True" success="True" time="0.000" asserts="3" />
+                          <test-case name="NUnit.Util.Tests.VSProjectTests.LoadJsharpProjectVS2005" executed="True" success="True" time="0.000" asserts="3" />
+                          <test-case name="NUnit.Util.Tests.VSProjectTests.LoadProjectWithHebrewFileIncluded" executed="True" success="True" time="0.016" asserts="3" />
+                          <test-case name="NUnit.Util.Tests.VSProjectTests.LoadVbProject" executed="True" success="True" time="0.000" asserts="3" />
+                          <test-case name="NUnit.Util.Tests.VSProjectTests.LoadVbProjectVS2005" executed="True" success="True" time="0.000" asserts="3" />
+                          <test-case name="NUnit.Util.Tests.VSProjectTests.MissingAttributes" executed="True" success="True" time="0.016" asserts="0" />
+                          <test-case name="NUnit.Util.Tests.VSProjectTests.NoConfigurations" executed="True" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Util.Tests.VSProjectTests.NotWebProject" executed="True" success="True" time="0.000" asserts="2" />
+                          <test-case name="NUnit.Util.Tests.VSProjectTests.ProjectExtensions" executed="True" success="True" time="0.000" asserts="4" />
+                          <test-case name="NUnit.Util.Tests.VSProjectTests.SolutionExtension" executed="True" success="True" time="0.000" asserts="2" />
+                        </results>
+                      </test-suite>
+                      <test-suite name="XmlResultVisitorTest" success="True" time="0.063" asserts="0">
+                        <results>
+                          <test-case name="NUnit.Util.Tests.XmlResultVisitorTest.HasMultipleCategories" executed="True" success="True" time="0.016" asserts="4" />
+                          <test-case name="NUnit.Util.Tests.XmlResultVisitorTest.HasSingleCategory" executed="True" success="True" time="0.000" asserts="3" />
+                          <test-case name="NUnit.Util.Tests.XmlResultVisitorTest.SuiteResultHasCategories" executed="True" success="True" time="0.000" asserts="3" />
+                          <test-case name="NUnit.Util.Tests.XmlResultVisitorTest.TestHasCultureInfo" executed="True" success="True" time="0.000" asserts="5" />
+                          <test-case name="NUnit.Util.Tests.XmlResultVisitorTest.TestHasEnvironmentInfo" executed="True" success="True" time="0.000" asserts="9" />
+                        </results>
+                      </test-suite>
+                    </results>
+                  </test-suite>
+                </results>
+              </test-suite>
+            </results>
+          </test-suite>
+        </results>
+      </test-suite>
+      <test-suite name="C:\Program Files\NUnit-Net-2.0 2.2.10\bin\nunit-console.tests.dll" success="True" time="8.484" asserts="0">
+        <results>
+          <test-suite name="NUnit" success="True" time="8.484" asserts="0">
+            <results>
+              <test-suite name="ConsoleRunner" success="True" time="8.469" asserts="0">
+                <results>
+                  <test-suite name="Tests" success="True" time="8.469" asserts="0">
+                    <results>
+                      <test-suite name="CommandLineTests" success="True" time="0.125" asserts="0">
+                        <results>
+                          <test-case name="NUnit.ConsoleRunner.Tests.CommandLineTests.AllowForwardSlashDefaultsCorrectly" executed="True" success="True" time="0.078" asserts="1" />
+                          <test-case name="NUnit.ConsoleRunner.Tests.CommandLineTests.AssemblyAloneIsValid" executed="True" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.ConsoleRunner.Tests.CommandLineTests.AssemblyName" executed="True" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.ConsoleRunner.Tests.CommandLineTests.ExcludeCategories" executed="True" success="True" time="0.000" asserts="8" />
+                          <test-case name="NUnit.ConsoleRunner.Tests.CommandLineTests.FileNameWithoutXmlParameterIsInvalid" executed="True" success="True" time="0.016" asserts="1" />
+                          <test-case name="NUnit.ConsoleRunner.Tests.CommandLineTests.FixtureNamePlusAssemblyIsValid" executed="True" success="True" time="0.000" asserts="3" />
+                          <test-case name="NUnit.ConsoleRunner.Tests.CommandLineTests.HelpTextUsesCorrectDelimiterForPlatform" executed="True" success="True" time="0.000" asserts="2" />
+                          <test-case name="NUnit.ConsoleRunner.Tests.CommandLineTests.IncludeAndExcludeAreInvalidTogether" executed="True" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.ConsoleRunner.Tests.CommandLineTests.IncludeCategories" executed="True" success="True" time="0.000" asserts="8" />
+                          <test-case name="NUnit.ConsoleRunner.Tests.CommandLineTests.InvalidCommandLineParms" executed="True" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.ConsoleRunner.Tests.CommandLineTests.InvalidOption" executed="True" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.ConsoleRunner.Tests.CommandLineTests.NoFixtureNameProvided" executed="True" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.ConsoleRunner.Tests.CommandLineTests.NoParametersCount" executed="True" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.ConsoleRunner.Tests.CommandLineTests.OptionsAreRecognized" executed="True" success="True" time="0.016" asserts="102" />
+                          <test-case name="NUnit.ConsoleRunner.Tests.CommandLineTests.TransformParameter" executed="True" success="True" time="0.000" asserts="4" />
+                          <test-case name="NUnit.ConsoleRunner.Tests.CommandLineTests.XmlParameter" executed="True" success="True" time="0.000" asserts="4" />
+                          <test-case name="NUnit.ConsoleRunner.Tests.CommandLineTests.XmlParameterWithFullPath" executed="True" success="True" time="0.000" asserts="4" />
+                          <test-case name="NUnit.ConsoleRunner.Tests.CommandLineTests.XmlParameterWithFullPathUsingEqualSign" executed="True" success="True" time="0.000" asserts="4" />
+                          <test-case name="NUnit.ConsoleRunner.Tests.CommandLineTests.XmlParameterWithoutFileNameIsInvalid" executed="True" success="True" time="0.000" asserts="1" />
+                        </results>
+                      </test-suite>
+                      <test-suite name="CommandLineTests_MultipleAssemblies" success="True" time="0.000" asserts="0">
+                        <results>
+                          <test-case name="NUnit.ConsoleRunner.Tests.CommandLineTests_MultipleAssemblies.CheckParameters" executed="True" success="True" time="0.000" asserts="2" />
+                          <test-case name="NUnit.ConsoleRunner.Tests.CommandLineTests_MultipleAssemblies.FixtureParameters" executed="True" success="True" time="0.000" asserts="3" />
+                          <test-case name="NUnit.ConsoleRunner.Tests.CommandLineTests_MultipleAssemblies.FixtureValidate" executed="True" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.ConsoleRunner.Tests.CommandLineTests_MultipleAssemblies.IsAssemblyTest" executed="True" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.ConsoleRunner.Tests.CommandLineTests_MultipleAssemblies.IsFixture" executed="True" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.ConsoleRunner.Tests.CommandLineTests_MultipleAssemblies.MultipleAssemblyValidate" executed="True" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.ConsoleRunner.Tests.CommandLineTests_MultipleAssemblies.ParameterCount" executed="True" success="True" time="0.000" asserts="1" />
+                        </results>
+                      </test-suite>
+                      <test-suite name="ConsoleRunnerTest" success="True" time="8.344" asserts="0">
+                        <results>
+                          <test-case name="NUnit.ConsoleRunner.Tests.ConsoleRunnerTest.Bug1073539Test" executed="True" success="True" time="1.359" asserts="1" />
+                          <test-case name="NUnit.ConsoleRunner.Tests.ConsoleRunnerTest.Bug1311644Test" executed="True" success="True" time="1.109" asserts="1" />
+                          <test-case name="NUnit.ConsoleRunner.Tests.ConsoleRunnerTest.FailureFixture" executed="True" success="True" time="1.125" asserts="1" />
+                          <test-case name="NUnit.ConsoleRunner.Tests.ConsoleRunnerTest.InvalidAssembly" executed="True" success="True" time="0.016" asserts="1" />
+                          <test-case name="NUnit.ConsoleRunner.Tests.ConsoleRunnerTest.InvalidFixture" executed="True" success="True" time="1.125" asserts="1" />
+                          <test-case name="NUnit.ConsoleRunner.Tests.ConsoleRunnerTest.SuccessFixture" executed="True" success="True" time="1.203" asserts="1" />
+                          <test-case name="NUnit.ConsoleRunner.Tests.ConsoleRunnerTest.XmlResult" executed="True" success="True" time="1.219" asserts="2" />
+                          <test-case name="NUnit.ConsoleRunner.Tests.ConsoleRunnerTest.XmlToConsole" executed="True" success="True" time="1.188" asserts="2" />
+                        </results>
+                      </test-suite>
+                    </results>
+                  </test-suite>
+                </results>
+              </test-suite>
+            </results>
+          </test-suite>
+        </results>
+      </test-suite>
+      <test-suite name="C:\Program Files\NUnit-Net-2.0 2.2.10\bin\nunit-gui.tests.dll" success="True" time="0.891" asserts="0">
+        <results>
+          <test-suite name="NUnit" success="True" time="0.891" asserts="0">
+            <results>
+              <test-suite name="Gui" success="True" time="0.875" asserts="0">
+                <results>
+                  <test-suite name="Tests" success="True" time="0.844" asserts="0">
+                    <results>
+                      <test-suite name="CommandLineTests" success="True" time="0.219" asserts="0">
+                        <results>
+                          <test-case name="NUnit.Gui.Tests.CommandLineTests.AssemblyName" executed="True" success="True" time="0.203" asserts="1" />
+                          <test-case name="NUnit.Gui.Tests.CommandLineTests.Help" executed="True" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Gui.Tests.CommandLineTests.HelpTextUsesCorrectDelimiterForPlatform" executed="True" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Gui.Tests.CommandLineTests.InvalidArgs" executed="True" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Gui.Tests.CommandLineTests.InvalidCommandLineParms" executed="True" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Gui.Tests.CommandLineTests.NoNameValuePairs" executed="True" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Gui.Tests.CommandLineTests.NoParametersCount" executed="True" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Gui.Tests.CommandLineTests.ShortHelp" executed="True" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Gui.Tests.CommandLineTests.ValidateSuccessful" executed="True" success="True" time="0.000" asserts="1" />
+                        </results>
+                      </test-suite>
+                      <test-suite name="FormSettingsTests" success="True" time="0.031" asserts="0">
+                        <results>
+                          <test-case name="NUnit.Gui.Tests.FormSettingsTests.BadTabSplitterPosition" executed="True" success="True" time="0.016" asserts="2" />
+                          <test-case name="NUnit.Gui.Tests.FormSettingsTests.BadTreeSplitterPosition" executed="True" success="True" time="0.000" asserts="2" />
+                          <test-case name="NUnit.Gui.Tests.FormSettingsTests.FormPosition" executed="True" success="True" time="0.000" asserts="2" />
+                          <test-case name="NUnit.Gui.Tests.FormSettingsTests.FormPositionDefaults" executed="True" success="True" time="0.000" asserts="2" />
+                          <test-case name="NUnit.Gui.Tests.FormSettingsTests.FormSizeTooSmall" executed="True" success="True" time="0.016" asserts="2" />
+                          <test-case name="NUnit.Gui.Tests.FormSettingsTests.PositionOutOfBounds" executed="True" success="True" time="0.000" asserts="2" />
+                          <test-case name="NUnit.Gui.Tests.FormSettingsTests.SplitterPosition" executed="True" success="True" time="0.000" asserts="2" />
+                        </results>
+                      </test-suite>
+                      <test-suite name="OptionSettingsTests" success="True" time="0.016" asserts="0">
+                        <results>
+                          <test-case name="NUnit.Gui.Tests.OptionSettingsTests.ClearResults" executed="True" success="True" time="0.000" asserts="3" />
+                          <test-case name="NUnit.Gui.Tests.OptionSettingsTests.LoadLastInitialTreeDisplay" executed="True" success="True" time="0.000" asserts="3" />
+                          <test-case name="NUnit.Gui.Tests.OptionSettingsTests.LoadLastProject" executed="True" success="True" time="0.000" asserts="3" />
+                          <test-case name="NUnit.Gui.Tests.OptionSettingsTests.ReloadOnChange" executed="True" success="True" time="0.016" asserts="3" />
+                          <test-case name="NUnit.Gui.Tests.OptionSettingsTests.ReloadOnRun" executed="True" success="True" time="0.000" asserts="3" />
+                          <test-case name="NUnit.Gui.Tests.OptionSettingsTests.VisualStudioSupport" executed="True" success="True" time="0.000" asserts="3" />
+                        </results>
+                      </test-suite>
+                      <test-suite name="ProjectEditorTests" success="True" time="0.516" asserts="0">
+                        <results>
+                          <test-case name="NUnit.Gui.Tests.ProjectEditorTests.CheckControls" executed="True" success="True" time="0.328" asserts="0" />
+                          <test-case name="NUnit.Gui.Tests.ProjectEditorTests.InitialFieldValues" executed="True" success="True" time="0.109" asserts="2" />
+                          <test-case name="NUnit.Gui.Tests.ProjectEditorTests.SetProjectBase" executed="True" success="True" time="0.078" asserts="1" />
+                        </results>
+                      </test-suite>
+                      <test-suite name="RecentProjectsFixture" success="True" time="0.063" asserts="0">
+                        <results>
+                          <test-case name="NUnit.Gui.Tests.RecentProjectsFixture.AddMaxItems" executed="True" success="True" time="0.016" asserts="7" />
+                          <test-case name="NUnit.Gui.Tests.RecentProjectsFixture.AddSingleItem" executed="True" success="True" time="0.000" asserts="3" />
+                          <test-case name="NUnit.Gui.Tests.RecentProjectsFixture.AddTooManyItems" executed="True" success="True" time="0.000" asserts="7" />
+                          <test-case name="NUnit.Gui.Tests.RecentProjectsFixture.DefaultRecentFilesCount" executed="True" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Gui.Tests.RecentProjectsFixture.EmptyList" executed="True" success="True" time="0.000" asserts="3" />
+                          <test-case name="NUnit.Gui.Tests.RecentProjectsFixture.IncreaseSize" executed="True" success="True" time="0.000" asserts="12" />
+                          <test-case name="NUnit.Gui.Tests.RecentProjectsFixture.IncreaseSizeAfterAdd" executed="True" success="True" time="0.000" asserts="8" />
+                          <test-case name="NUnit.Gui.Tests.RecentProjectsFixture.RecentFilesCount" executed="True" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Gui.Tests.RecentProjectsFixture.RecentFilesCountAtMax" executed="True" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Gui.Tests.RecentProjectsFixture.RecentFilesCountAtMin" executed="True" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Gui.Tests.RecentProjectsFixture.RecentFilesCountOverMax" executed="True" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Gui.Tests.RecentProjectsFixture.RecentFilesCountUnderMin" executed="True" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Gui.Tests.RecentProjectsFixture.ReduceSize" executed="True" success="True" time="0.000" asserts="5" />
+                          <test-case name="NUnit.Gui.Tests.RecentProjectsFixture.ReduceSizeAfterAdd" executed="True" success="True" time="0.000" asserts="4" />
+                          <test-case name="NUnit.Gui.Tests.RecentProjectsFixture.RemoveFirstProject" executed="True" success="True" time="0.016" asserts="3" />
+                          <test-case name="NUnit.Gui.Tests.RecentProjectsFixture.RemoveLastProject" executed="True" success="True" time="0.000" asserts="5" />
+                          <test-case name="NUnit.Gui.Tests.RecentProjectsFixture.RemoveMultipleProjects" executed="True" success="True" time="0.000" asserts="3" />
+                          <test-case name="NUnit.Gui.Tests.RecentProjectsFixture.RemoveOneProject" executed="True" success="True" time="0.000" asserts="4" />
+                          <test-case name="NUnit.Gui.Tests.RecentProjectsFixture.ReorderLastProject" executed="True" success="True" time="0.000" asserts="6" />
+                          <test-case name="NUnit.Gui.Tests.RecentProjectsFixture.ReorderMultipleProjects" executed="True" success="True" time="0.000" asserts="6" />
+                          <test-case name="NUnit.Gui.Tests.RecentProjectsFixture.ReorderSameProject" executed="True" success="True" time="0.000" asserts="6" />
+                          <test-case name="NUnit.Gui.Tests.RecentProjectsFixture.ReorderSingleProject" executed="True" success="True" time="0.016" asserts="6" />
+                          <test-case name="NUnit.Gui.Tests.RecentProjectsFixture.ReorderWithListNotFull" executed="True" success="True" time="0.000" asserts="4" />
+                          <test-case name="NUnit.Gui.Tests.RecentProjectsFixture.RetrieveSubKey" executed="True" success="True" time="0.000" asserts="1" />
+                        </results>
+                      </test-suite>
+                      <test-suite name="UserSettingsTests" success="True" time="0.000" asserts="0">
+                        <results>
+                          <test-case name="NUnit.Gui.Tests.UserSettingsTests.FormSettings" executed="True" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Gui.Tests.UserSettingsTests.OptionSettings" executed="True" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Gui.Tests.UserSettingsTests.RecentProjects" executed="True" success="True" time="0.000" asserts="1" />
+                        </results>
+                      </test-suite>
+                    </results>
+                  </test-suite>
+                </results>
+              </test-suite>
+            </results>
+          </test-suite>
+        </results>
+      </test-suite>
+    </results>
+  </test-suite>
+</test-results>

--- a/src/test-nunit-summary.exe/TestInput/TestResult-2.4.8.xml
+++ b/src/test-nunit-summary.exe/TestInput/TestResult-2.4.8.xml
@@ -1,0 +1,2129 @@
+﻿<?xml version="1.0" encoding="utf-8" standalone="no"?>
+<!--This file represents the results of running a test suite-->
+<test-results name="C:\Program Files\NUnit 2.4.8\bin\NUnitTests.nunit" total="1264" failures="0" not-run="2" date="2009-11-30" time="17:08:03">
+  <environment nunit-version="2.4.8.0" clr-version="2.0.50727.3053" os-version="Microsoft Windows NT 5.1.2600 Service Pack 2" platform="Win32NT" cwd="C:\Program Files\NUnit 2.4.8\bin" machine-name="FERRARI" user="Charlie" user-domain="FERRARI" />
+  <culture-info current-culture="en-US" current-uiculture="en-US" />
+  <test-suite name="C:\Program Files\NUnit 2.4.8\bin\NUnitTests.nunit" success="True" time="79.859" asserts="0">
+    <results>
+      <test-suite name="C:\Program Files\NUnit 2.4.8\bin\nunit.framework.tests.dll" success="True" time="1.875" asserts="0">
+        <results>
+          <test-suite name="NUnit" success="True" time="1.781" asserts="0">
+            <results>
+              <test-suite name="Framework" success="True" time="1.672" asserts="0">
+                <results>
+                  <test-suite name="Constraints" success="True" time="0.344" asserts="0">
+                    <results>
+                      <test-suite name="Tests" success="True" time="0.344" asserts="0">
+                        <results>
+                          <test-suite name="AllItemsTests" success="True" time="0.063" asserts="0">
+                            <results>
+                              <test-case name="NUnit.Framework.Constraints.Tests.AllItemsTests.AllItemsAreInRange" executed="True" success="True" time="0.016" asserts="1" />
+                              <test-case name="NUnit.Framework.Constraints.Tests.AllItemsTests.AllItemsAreInRangeFailureMessage" executed="True" success="True" time="0.016" asserts="2" />
+                              <test-case name="NUnit.Framework.Constraints.Tests.AllItemsTests.AllItemsAreInstancesOfType" executed="True" success="True" time="0.000" asserts="1" />
+                              <test-case name="NUnit.Framework.Constraints.Tests.AllItemsTests.AllItemsAreInstancesOfTypeFailureMessage" executed="True" success="True" time="0.016" asserts="2" />
+                              <test-case name="NUnit.Framework.Constraints.Tests.AllItemsTests.AllItemsAreNotNull" executed="True" success="True" time="0.000" asserts="1" />
+                              <test-case name="NUnit.Framework.Constraints.Tests.AllItemsTests.AllItemsAreNotNullFails" executed="True" success="True" time="0.000" asserts="2" />
+                            </results>
+                          </test-suite>
+                          <test-suite name="AndTest" success="True" time="0.016" asserts="0">
+                            <results>
+                              <test-case name="NUnit.Framework.Constraints.Tests.AndTest.CanCombineTestsWithAndOperator" executed="True" success="True" time="0.000" asserts="1" />
+                              <test-case name="NUnit.Framework.Constraints.Tests.AndTest.FailsOnBadValues" executed="True" success="True" time="0.000" asserts="2" />
+                              <test-case name="NUnit.Framework.Constraints.Tests.AndTest.ProvidesProperDescription" executed="True" success="True" time="0.000" asserts="1" />
+                              <test-case name="NUnit.Framework.Constraints.Tests.AndTest.ProvidesProperFailureMessage" executed="True" success="True" time="0.000" asserts="3" />
+                              <test-case name="NUnit.Framework.Constraints.Tests.AndTest.SucceedsOnGoodValues" executed="True" success="True" time="0.000" asserts="1" />
+                            </results>
+                          </test-suite>
+                          <test-suite name="AssignableFromTest" success="True" time="0.016" asserts="0">
+                            <results>
+                              <test-case name="NUnit.Framework.Constraints.Tests.AssignableFromTest.FailsOnBadValues" executed="True" success="True" time="0.000" asserts="1" />
+                              <test-case name="NUnit.Framework.Constraints.Tests.AssignableFromTest.ProvidesProperDescription" executed="True" success="True" time="0.000" asserts="1" />
+                              <test-case name="NUnit.Framework.Constraints.Tests.AssignableFromTest.ProvidesProperFailureMessage" executed="True" success="True" time="0.000" asserts="3" />
+                              <test-case name="NUnit.Framework.Constraints.Tests.AssignableFromTest.SucceedsOnGoodValues" executed="True" success="True" time="0.000" asserts="2" />
+                            </results>
+                          </test-suite>
+                          <test-suite name="CollectionContainsTests" success="True" time="0.031" asserts="0">
+                            <results>
+                              <test-case name="NUnit.Framework.Constraints.Tests.CollectionContainsTests.CanTestContentsOfArray" executed="True" success="True" time="0.000" asserts="1" />
+                              <test-case name="NUnit.Framework.Constraints.Tests.CollectionContainsTests.CanTestContentsOfArrayList" executed="True" success="True" time="0.000" asserts="1" />
+                              <test-case name="NUnit.Framework.Constraints.Tests.CollectionContainsTests.CanTestContentsOfCollectionNotImplementingIList" executed="True" success="True" time="0.031" asserts="1" />
+                              <test-case name="NUnit.Framework.Constraints.Tests.CollectionContainsTests.CanTestContentsOfSortedList" executed="True" success="True" time="0.000" asserts="2" />
+                            </results>
+                          </test-suite>
+                          <test-suite name="EmptyTest" success="True" time="0.016" asserts="0">
+                            <results>
+                              <test-case name="NUnit.Framework.Constraints.Tests.EmptyTest.FailsOnBadValues" executed="True" success="True" time="0.000" asserts="2" />
+                              <test-case name="NUnit.Framework.Constraints.Tests.EmptyTest.NullGivesArgumentException" executed="True" success="True" time="0.000" asserts="0" />
+                              <test-case name="NUnit.Framework.Constraints.Tests.EmptyTest.ProvidesProperDescription" executed="True" success="True" time="0.000" asserts="1" />
+                              <test-case name="NUnit.Framework.Constraints.Tests.EmptyTest.ProvidesProperFailureMessage" executed="True" success="True" time="0.000" asserts="3" />
+                              <test-case name="NUnit.Framework.Constraints.Tests.EmptyTest.SucceedsOnGoodValues" executed="True" success="True" time="0.000" asserts="3" />
+                            </results>
+                          </test-suite>
+                          <test-suite name="EndsWithTest" success="True" time="0.000" asserts="0">
+                            <results>
+                              <test-case name="NUnit.Framework.Constraints.Tests.EndsWithTest.FailsOnBadValues" executed="True" success="True" time="0.000" asserts="6" />
+                              <test-case name="NUnit.Framework.Constraints.Tests.EndsWithTest.ProvidesProperDescription" executed="True" success="True" time="0.000" asserts="1" />
+                              <test-case name="NUnit.Framework.Constraints.Tests.EndsWithTest.ProvidesProperFailureMessage" executed="True" success="True" time="0.000" asserts="3" />
+                              <test-case name="NUnit.Framework.Constraints.Tests.EndsWithTest.SucceedsOnGoodValues" executed="True" success="True" time="0.000" asserts="2" />
+                            </results>
+                          </test-suite>
+                          <test-suite name="EndsWithTestIgnoringCase" success="True" time="0.000" asserts="0">
+                            <results>
+                              <test-case name="NUnit.Framework.Constraints.Tests.EndsWithTestIgnoringCase.FailsOnBadValues" executed="True" success="True" time="0.000" asserts="6" />
+                              <test-case name="NUnit.Framework.Constraints.Tests.EndsWithTestIgnoringCase.ProvidesProperDescription" executed="True" success="True" time="0.000" asserts="1" />
+                              <test-case name="NUnit.Framework.Constraints.Tests.EndsWithTestIgnoringCase.ProvidesProperFailureMessage" executed="True" success="True" time="0.000" asserts="3" />
+                              <test-case name="NUnit.Framework.Constraints.Tests.EndsWithTestIgnoringCase.SucceedsOnGoodValues" executed="True" success="True" time="0.000" asserts="2" />
+                            </results>
+                          </test-suite>
+                          <test-suite name="EqualIgnoringCaseTest" success="True" time="0.000" asserts="0">
+                            <results>
+                              <test-case name="NUnit.Framework.Constraints.Tests.EqualIgnoringCaseTest.FailsOnBadValues" executed="True" success="True" time="0.000" asserts="4" />
+                              <test-case name="NUnit.Framework.Constraints.Tests.EqualIgnoringCaseTest.ProvidesProperDescription" executed="True" success="True" time="0.000" asserts="1" />
+                              <test-case name="NUnit.Framework.Constraints.Tests.EqualIgnoringCaseTest.ProvidesProperFailureMessage" executed="True" success="True" time="0.000" asserts="3" />
+                              <test-case name="NUnit.Framework.Constraints.Tests.EqualIgnoringCaseTest.SucceedsOnGoodValues" executed="True" success="True" time="0.000" asserts="3" />
+                            </results>
+                          </test-suite>
+                          <test-suite name="EqualTest" success="True" time="0.078" asserts="0">
+                            <results>
+                              <test-case name="NUnit.Framework.Constraints.Tests.EqualTest.CanCompareDates" executed="True" success="True" time="0.000" asserts="1" />
+                              <test-case name="NUnit.Framework.Constraints.Tests.EqualTest.CanCompareDatesWithinTolerance" executed="True" success="True" time="0.000" asserts="1" />
+                              <test-case name="NUnit.Framework.Constraints.Tests.EqualTest.FailedStringMatchShowsFailurePosition" executed="True" success="True" time="0.031" asserts="2" />
+                              <test-case name="NUnit.Framework.Constraints.Tests.EqualTest.FailsOnBadValues" executed="True" success="True" time="0.000" asserts="3" />
+                              <test-case name="NUnit.Framework.Constraints.Tests.EqualTest.LongStringsAreTruncated" executed="True" success="True" time="0.000" asserts="2" />
+                              <test-case name="NUnit.Framework.Constraints.Tests.EqualTest.LongStringsAreTruncatedAtBothEndsIfNecessary" executed="True" success="True" time="0.000" asserts="2" />
+                              <test-case name="NUnit.Framework.Constraints.Tests.EqualTest.LongStringsAreTruncatedAtFrontEndIfNecessary" executed="True" success="True" time="0.000" asserts="2" />
+                              <test-case name="NUnit.Framework.Constraints.Tests.EqualTest.NANsCompareAsEqual" executed="True" success="True" time="0.000" asserts="1" />
+                              <test-case name="NUnit.Framework.Constraints.Tests.EqualTest.ProvidesProperDescription" executed="True" success="True" time="0.000" asserts="1" />
+                              <test-case name="NUnit.Framework.Constraints.Tests.EqualTest.ProvidesProperFailureMessage" executed="True" success="True" time="0.000" asserts="3" />
+                              <test-case name="NUnit.Framework.Constraints.Tests.EqualTest.SucceedsOnGoodValues" executed="True" success="True" time="0.031" asserts="4" />
+                            </results>
+                          </test-suite>
+                          <test-suite name="ExactTypeTest" success="True" time="0.000" asserts="0">
+                            <results>
+                              <test-case name="NUnit.Framework.Constraints.Tests.ExactTypeTest.FailsOnBadValues" executed="True" success="True" time="0.000" asserts="2" />
+                              <test-case name="NUnit.Framework.Constraints.Tests.ExactTypeTest.ProvidesProperDescription" executed="True" success="True" time="0.000" asserts="1" />
+                              <test-case name="NUnit.Framework.Constraints.Tests.ExactTypeTest.ProvidesProperFailureMessage" executed="True" success="True" time="0.000" asserts="3" />
+                              <test-case name="NUnit.Framework.Constraints.Tests.ExactTypeTest.SucceedsOnGoodValues" executed="True" success="True" time="0.000" asserts="1" />
+                            </results>
+                          </test-suite>
+                          <test-suite name="GreaterThanOrEqualTest" success="True" time="0.016" asserts="0">
+                            <results>
+                              <test-case name="NUnit.Framework.Constraints.Tests.GreaterThanOrEqualTest.BadTypeGivesError" executed="True" success="True" time="0.000" asserts="1" />
+                              <test-case name="NUnit.Framework.Constraints.Tests.GreaterThanOrEqualTest.FailsOnBadValues" executed="True" success="True" time="0.000" asserts="1" />
+                              <test-case name="NUnit.Framework.Constraints.Tests.GreaterThanOrEqualTest.NullGivesError" executed="True" success="True" time="0.000" asserts="1" />
+                              <test-case name="NUnit.Framework.Constraints.Tests.GreaterThanOrEqualTest.ProvidesProperDescription" executed="True" success="True" time="0.000" asserts="1" />
+                              <test-case name="NUnit.Framework.Constraints.Tests.GreaterThanOrEqualTest.ProvidesProperFailureMessage" executed="True" success="True" time="0.000" asserts="3" />
+                              <test-case name="NUnit.Framework.Constraints.Tests.GreaterThanOrEqualTest.SucceedsOnGoodValues" executed="True" success="True" time="0.000" asserts="2" />
+                            </results>
+                          </test-suite>
+                          <test-suite name="GreaterThanTest" success="True" time="0.016" asserts="0">
+                            <results>
+                              <test-case name="NUnit.Framework.Constraints.Tests.GreaterThanTest.BadTypeGivesError" executed="True" success="True" time="0.000" asserts="1" />
+                              <test-case name="NUnit.Framework.Constraints.Tests.GreaterThanTest.FailsOnBadValues" executed="True" success="True" time="0.000" asserts="2" />
+                              <test-case name="NUnit.Framework.Constraints.Tests.GreaterThanTest.NullGivesError" executed="True" success="True" time="0.000" asserts="1" />
+                              <test-case name="NUnit.Framework.Constraints.Tests.GreaterThanTest.ProvidesProperDescription" executed="True" success="True" time="0.000" asserts="1" />
+                              <test-case name="NUnit.Framework.Constraints.Tests.GreaterThanTest.ProvidesProperFailureMessage" executed="True" success="True" time="0.000" asserts="3" />
+                              <test-case name="NUnit.Framework.Constraints.Tests.GreaterThanTest.SucceedsOnGoodValues" executed="True" success="True" time="0.000" asserts="1" />
+                            </results>
+                          </test-suite>
+                          <test-suite name="InstanceOfTypeTest" success="True" time="0.000" asserts="0">
+                            <results>
+                              <test-case name="NUnit.Framework.Constraints.Tests.InstanceOfTypeTest.FailsOnBadValues" executed="True" success="True" time="0.000" asserts="1" />
+                              <test-case name="NUnit.Framework.Constraints.Tests.InstanceOfTypeTest.ProvidesProperDescription" executed="True" success="True" time="0.000" asserts="1" />
+                              <test-case name="NUnit.Framework.Constraints.Tests.InstanceOfTypeTest.ProvidesProperFailureMessage" executed="True" success="True" time="0.000" asserts="3" />
+                              <test-case name="NUnit.Framework.Constraints.Tests.InstanceOfTypeTest.SucceedsOnGoodValues" executed="True" success="True" time="0.000" asserts="2" />
+                            </results>
+                          </test-suite>
+                          <test-suite name="LessThanOrEqualTest" success="True" time="0.016" asserts="0">
+                            <results>
+                              <test-case name="NUnit.Framework.Constraints.Tests.LessThanOrEqualTest.BadTypeGivesError" executed="True" success="True" time="0.000" asserts="1" />
+                              <test-case name="NUnit.Framework.Constraints.Tests.LessThanOrEqualTest.FailsOnBadValues" executed="True" success="True" time="0.000" asserts="1" />
+                              <test-case name="NUnit.Framework.Constraints.Tests.LessThanOrEqualTest.NullGivesError" executed="True" success="True" time="0.016" asserts="1" />
+                              <test-case name="NUnit.Framework.Constraints.Tests.LessThanOrEqualTest.ProvidesProperDescription" executed="True" success="True" time="0.000" asserts="1" />
+                              <test-case name="NUnit.Framework.Constraints.Tests.LessThanOrEqualTest.ProvidesProperFailureMessage" executed="True" success="True" time="0.000" asserts="3" />
+                              <test-case name="NUnit.Framework.Constraints.Tests.LessThanOrEqualTest.SucceedsOnGoodValues" executed="True" success="True" time="0.000" asserts="2" />
+                            </results>
+                          </test-suite>
+                          <test-suite name="LessThanTest" success="True" time="0.016" asserts="0">
+                            <results>
+                              <test-case name="NUnit.Framework.Constraints.Tests.LessThanTest.BadTypeGivesError" executed="True" success="True" time="0.000" asserts="1" />
+                              <test-case name="NUnit.Framework.Constraints.Tests.LessThanTest.FailsOnBadValues" executed="True" success="True" time="0.000" asserts="2" />
+                              <test-case name="NUnit.Framework.Constraints.Tests.LessThanTest.NullGivesError" executed="True" success="True" time="0.000" asserts="1" />
+                              <test-case name="NUnit.Framework.Constraints.Tests.LessThanTest.ProvidesProperDescription" executed="True" success="True" time="0.000" asserts="1" />
+                              <test-case name="NUnit.Framework.Constraints.Tests.LessThanTest.ProvidesProperFailureMessage" executed="True" success="True" time="0.000" asserts="3" />
+                              <test-case name="NUnit.Framework.Constraints.Tests.LessThanTest.SucceedsOnGoodValues" executed="True" success="True" time="0.000" asserts="1" />
+                            </results>
+                          </test-suite>
+                          <test-suite name="NotTest" success="True" time="0.016" asserts="0">
+                            <results>
+                              <test-case name="NUnit.Framework.Constraints.Tests.NotTest.CanUseNotOperator" executed="True" success="True" time="0.000" asserts="1" />
+                              <test-case name="NUnit.Framework.Constraints.Tests.NotTest.FailsOnBadValues" executed="True" success="True" time="0.000" asserts="1" />
+                              <test-case name="NUnit.Framework.Constraints.Tests.NotTest.NotHonorsIgnoreCaseUsingConstructors" executed="True" success="True" time="0.000" asserts="1" />
+                              <test-case name="NUnit.Framework.Constraints.Tests.NotTest.NotHonorsIgnoreCaseUsingPrefixNotation" executed="True" success="True" time="0.000" asserts="1" />
+                              <test-case name="NUnit.Framework.Constraints.Tests.NotTest.NotHonorsTolerance" executed="True" success="True" time="0.000" asserts="1" />
+                              <test-case name="NUnit.Framework.Constraints.Tests.NotTest.ProvidesProperDescription" executed="True" success="True" time="0.000" asserts="1" />
+                              <test-case name="NUnit.Framework.Constraints.Tests.NotTest.ProvidesProperFailureMessage" executed="True" success="True" time="0.000" asserts="3" />
+                              <test-case name="NUnit.Framework.Constraints.Tests.NotTest.SucceedsOnGoodValues" executed="True" success="True" time="0.000" asserts="2" />
+                            </results>
+                          </test-suite>
+                          <test-suite name="OrTest" success="True" time="0.031" asserts="0">
+                            <results>
+                              <test-case name="NUnit.Framework.Constraints.Tests.OrTest.CanCombineTestsWithOrOperator" executed="True" success="True" time="0.000" asserts="1" />
+                              <test-case name="NUnit.Framework.Constraints.Tests.OrTest.FailsOnBadValues" executed="True" success="True" time="0.000" asserts="1" />
+                              <test-case name="NUnit.Framework.Constraints.Tests.OrTest.ProvidesProperDescription" executed="True" success="True" time="0.000" asserts="1" />
+                              <test-case name="NUnit.Framework.Constraints.Tests.OrTest.ProvidesProperFailureMessage" executed="True" success="True" time="0.000" asserts="3" />
+                              <test-case name="NUnit.Framework.Constraints.Tests.OrTest.SucceedsOnGoodValues" executed="True" success="True" time="0.000" asserts="2" />
+                            </results>
+                          </test-suite>
+                          <test-suite name="SameAsTest" success="True" time="0.000" asserts="0">
+                            <results>
+                              <test-case name="NUnit.Framework.Constraints.Tests.SameAsTest.FailsOnBadValues" executed="True" success="True" time="0.000" asserts="3" />
+                              <test-case name="NUnit.Framework.Constraints.Tests.SameAsTest.ProvidesProperDescription" executed="True" success="True" time="0.000" asserts="1" />
+                              <test-case name="NUnit.Framework.Constraints.Tests.SameAsTest.ProvidesProperFailureMessage" executed="True" success="True" time="0.000" asserts="3" />
+                              <test-case name="NUnit.Framework.Constraints.Tests.SameAsTest.SucceedsOnGoodValues" executed="True" success="True" time="0.000" asserts="1" />
+                            </results>
+                          </test-suite>
+                          <test-suite name="StartsWithTest" success="True" time="0.016" asserts="0">
+                            <results>
+                              <test-case name="NUnit.Framework.Constraints.Tests.StartsWithTest.FailsOnBadValues" executed="True" success="True" time="0.000" asserts="6" />
+                              <test-case name="NUnit.Framework.Constraints.Tests.StartsWithTest.ProvidesProperDescription" executed="True" success="True" time="0.000" asserts="1" />
+                              <test-case name="NUnit.Framework.Constraints.Tests.StartsWithTest.ProvidesProperFailureMessage" executed="True" success="True" time="0.000" asserts="3" />
+                              <test-case name="NUnit.Framework.Constraints.Tests.StartsWithTest.SucceedsOnGoodValues" executed="True" success="True" time="0.000" asserts="2" />
+                            </results>
+                          </test-suite>
+                          <test-suite name="StartsWithTestIgnoringCase" success="True" time="0.000" asserts="0">
+                            <results>
+                              <test-case name="NUnit.Framework.Constraints.Tests.StartsWithTestIgnoringCase.FailsOnBadValues" executed="True" success="True" time="0.000" asserts="6" />
+                              <test-case name="NUnit.Framework.Constraints.Tests.StartsWithTestIgnoringCase.ProvidesProperDescription" executed="True" success="True" time="0.000" asserts="1" />
+                              <test-case name="NUnit.Framework.Constraints.Tests.StartsWithTestIgnoringCase.ProvidesProperFailureMessage" executed="True" success="True" time="0.000" asserts="3" />
+                              <test-case name="NUnit.Framework.Constraints.Tests.StartsWithTestIgnoringCase.SucceedsOnGoodValues" executed="True" success="True" time="0.000" asserts="2" />
+                            </results>
+                          </test-suite>
+                          <test-suite name="SubstringTest" success="True" time="0.000" asserts="0">
+                            <results>
+                              <test-case name="NUnit.Framework.Constraints.Tests.SubstringTest.FailsOnBadValues" executed="True" success="True" time="0.000" asserts="4" />
+                              <test-case name="NUnit.Framework.Constraints.Tests.SubstringTest.ProvidesProperDescription" executed="True" success="True" time="0.000" asserts="1" />
+                              <test-case name="NUnit.Framework.Constraints.Tests.SubstringTest.ProvidesProperFailureMessage" executed="True" success="True" time="0.000" asserts="3" />
+                              <test-case name="NUnit.Framework.Constraints.Tests.SubstringTest.SucceedsOnGoodValues" executed="True" success="True" time="0.000" asserts="4" />
+                            </results>
+                          </test-suite>
+                          <test-suite name="SubstringTestIgnoringCase" success="True" time="0.000" asserts="0">
+                            <results>
+                              <test-case name="NUnit.Framework.Constraints.Tests.SubstringTestIgnoringCase.FailsOnBadValues" executed="True" success="True" time="0.000" asserts="4" />
+                              <test-case name="NUnit.Framework.Constraints.Tests.SubstringTestIgnoringCase.ProvidesProperDescription" executed="True" success="True" time="0.000" asserts="1" />
+                              <test-case name="NUnit.Framework.Constraints.Tests.SubstringTestIgnoringCase.ProvidesProperFailureMessage" executed="True" success="True" time="0.000" asserts="3" />
+                              <test-case name="NUnit.Framework.Constraints.Tests.SubstringTestIgnoringCase.SucceedsOnGoodValues" executed="True" success="True" time="0.000" asserts="4" />
+                            </results>
+                          </test-suite>
+                        </results>
+                      </test-suite>
+                    </results>
+                  </test-suite>
+                  <test-suite name="Tests" success="True" time="1.297" asserts="0">
+                    <results>
+                      <test-suite name="ArrayEqualsFailureMessageFixture" success="True" time="0.109" asserts="0">
+                        <results>
+                          <test-case name="NUnit.Framework.Tests.ArrayEqualsFailureMessageFixture.ActualArrayIsLonger" executed="True" success="True" time="0.000" asserts="2" />
+                          <test-case name="NUnit.Framework.Tests.ArrayEqualsFailureMessageFixture.ArrayAndCollection_Failure" executed="True" success="True" time="0.031" asserts="1" />
+                          <test-case name="NUnit.Framework.Tests.ArrayEqualsFailureMessageFixture.ArraysDeclaredAsDifferentTypes" executed="True" success="True" time="0.000" asserts="2" />
+                          <test-case name="NUnit.Framework.Tests.ArrayEqualsFailureMessageFixture.ArraysHaveDifferentRanks" executed="True" success="True" time="0.000" asserts="2" />
+                          <test-case name="NUnit.Framework.Tests.ArrayEqualsFailureMessageFixture.ArraysWithDifferentDimensionsAsCollection" executed="True" success="True" time="0.000" asserts="2" />
+                          <test-case name="NUnit.Framework.Tests.ArrayEqualsFailureMessageFixture.ArraysWithDifferentRanksAsCollection" executed="True" success="True" time="0.000" asserts="2" />
+                          <test-case name="NUnit.Framework.Tests.ArrayEqualsFailureMessageFixture.DifferentArrayTypesEqualFails" executed="True" success="True" time="0.000" asserts="2" />
+                          <test-case name="NUnit.Framework.Tests.ArrayEqualsFailureMessageFixture.DoubleDimensionedArrays" executed="True" success="True" time="0.000" asserts="2" />
+                          <test-case name="NUnit.Framework.Tests.ArrayEqualsFailureMessageFixture.ExpectedArrayIsLonger" executed="True" success="True" time="0.000" asserts="2" />
+                          <test-case name="NUnit.Framework.Tests.ArrayEqualsFailureMessageFixture.FailureOnSingleDimensionedArrays" executed="True" success="True" time="0.000" asserts="2" />
+                          <test-case name="NUnit.Framework.Tests.ArrayEqualsFailureMessageFixture.FiveDimensionedArrays" executed="True" success="True" time="0.000" asserts="2" />
+                          <test-case name="NUnit.Framework.Tests.ArrayEqualsFailureMessageFixture.JaggedArrayComparedToSimpleArray" executed="True" success="True" time="0.000" asserts="2" />
+                          <test-case name="NUnit.Framework.Tests.ArrayEqualsFailureMessageFixture.JaggedArrays" executed="True" success="True" time="0.016" asserts="2" />
+                          <test-case name="NUnit.Framework.Tests.ArrayEqualsFailureMessageFixture.SameLengthDifferentContent" executed="True" success="True" time="0.000" asserts="2" />
+                          <test-case name="NUnit.Framework.Tests.ArrayEqualsFailureMessageFixture.TripleDimensionedArrays" executed="True" success="True" time="0.000" asserts="2" />
+                        </results>
+                      </test-suite>
+                      <test-suite name="ArrayEqualsFixture" success="True" time="0.031" asserts="0">
+                        <results>
+                          <test-case name="NUnit.Framework.Tests.ArrayEqualsFixture.ArrayAndCollection" executed="True" success="True" time="0.000" asserts="4" />
+                          <test-case name="NUnit.Framework.Tests.ArrayEqualsFixture.ArrayIsEqualToItself" executed="True" success="True" time="0.000" asserts="3" />
+                          <test-case name="NUnit.Framework.Tests.ArrayEqualsFixture.ArrayOfIntAndArrayOfDouble" executed="True" success="True" time="0.000" asserts="4" />
+                          <test-case name="NUnit.Framework.Tests.ArrayEqualsFixture.ArraysDeclaredAsDifferentTypes" executed="True" success="True" time="0.016" asserts="4" />
+                          <test-case name="NUnit.Framework.Tests.ArrayEqualsFixture.ArraysOfArrays" executed="True" success="True" time="0.000" asserts="4" />
+                          <test-case name="NUnit.Framework.Tests.ArrayEqualsFixture.ArraysOfDecimal" executed="True" success="True" time="0.000" asserts="4" />
+                          <test-case name="NUnit.Framework.Tests.ArrayEqualsFixture.ArraysOfDouble" executed="True" success="True" time="0.000" asserts="4" />
+                          <test-case name="NUnit.Framework.Tests.ArrayEqualsFixture.ArraysOfInt" executed="True" success="True" time="0.000" asserts="4" />
+                          <test-case name="NUnit.Framework.Tests.ArrayEqualsFixture.ArraysOfMixedTypes" executed="True" success="True" time="0.000" asserts="4" />
+                          <test-case name="NUnit.Framework.Tests.ArrayEqualsFixture.ArraysOfString" executed="True" success="True" time="0.000" asserts="5" />
+                          <test-case name="NUnit.Framework.Tests.ArrayEqualsFixture.ArraysPassedAsObjects" executed="True" success="True" time="0.000" asserts="4" />
+                          <test-case name="NUnit.Framework.Tests.ArrayEqualsFixture.ArraysWithDifferentDimensionsMatchedAsCollection" executed="True" success="True" time="0.000" asserts="3" />
+                          <test-case name="NUnit.Framework.Tests.ArrayEqualsFixture.ArraysWithDifferentRanksComparedAsCollection" executed="True" success="True" time="0.000" asserts="3" />
+                          <test-case name="NUnit.Framework.Tests.ArrayEqualsFixture.DoubleDimensionedArrays" executed="True" success="True" time="0.000" asserts="4" />
+                          <test-case name="NUnit.Framework.Tests.ArrayEqualsFixture.FiveDimensionedArrays" executed="True" success="True" time="0.000" asserts="2" />
+                          <test-case name="NUnit.Framework.Tests.ArrayEqualsFixture.JaggedArrays" executed="True" success="True" time="0.000" asserts="2" />
+                          <test-case name="NUnit.Framework.Tests.ArrayEqualsFixture.TripleDimensionedArrays" executed="True" success="True" time="0.000" asserts="2" />
+                        </results>
+                      </test-suite>
+                      <test-suite name="ArrayNotEqualFixture" success="True" time="0.016" asserts="0">
+                        <results>
+                          <test-case name="NUnit.Framework.Tests.ArrayNotEqualFixture.ArraysDeclaredAsDifferentTypes" executed="True" success="True" time="0.000" asserts="3" />
+                          <test-case name="NUnit.Framework.Tests.ArrayNotEqualFixture.DifferentLengthArrays" executed="True" success="True" time="0.000" asserts="4" />
+                          <test-case name="NUnit.Framework.Tests.ArrayNotEqualFixture.SameLengthDifferentContent" executed="True" success="True" time="0.000" asserts="4" />
+                        </results>
+                      </test-suite>
+                      <test-suite name="AssertExtensionTests" success="True" time="0.000" asserts="0">
+                        <results>
+                          <test-case name="NUnit.Framework.Tests.AssertExtensionTests.OddNumber" executed="True" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Framework.Tests.AssertExtensionTests.OddNumberFails" executed="True" success="True" time="0.000" asserts="2" />
+                        </results>
+                      </test-suite>
+                      <test-suite name="AssertionTest" success="True" time="0.047" asserts="0">
+                        <results>
+                          <test-case name="NUnit.Framework.Tests.AssertionTest.AssertByte" executed="True" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Framework.Tests.AssertionTest.AssertEquals" executed="True" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Framework.Tests.AssertionTest.AssertEqualsFail" executed="True" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Framework.Tests.AssertionTest.AssertEqualsNaNFails" executed="True" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Framework.Tests.AssertionTest.AssertEqualsNull" executed="True" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Framework.Tests.AssertionTest.AssertEqualsSameTypes" executed="True" success="True" time="0.000" asserts="21" />
+                          <test-case name="NUnit.Framework.Tests.AssertionTest.AssertEqualsTestCaseFail" executed="True" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Framework.Tests.AssertionTest.AssertNanEqualsFails" executed="True" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Framework.Tests.AssertionTest.AssertNanEqualsNaNSucceeds" executed="True" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Framework.Tests.AssertionTest.AssertNegInfinityEqualsInfinity" executed="True" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Framework.Tests.AssertionTest.AssertNull" executed="True" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Framework.Tests.AssertionTest.AssertNullNotEqualsNull" executed="True" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Framework.Tests.AssertionTest.AssertPosInfinityEqualsInfinity" executed="True" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Framework.Tests.AssertionTest.AssertPosInfinityNotEquals" executed="True" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Framework.Tests.AssertionTest.AssertPosInfinityNotEqualsNegInfinity" executed="True" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Framework.Tests.AssertionTest.AssertSame" executed="True" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Framework.Tests.AssertionTest.AssertSameFails" executed="True" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Framework.Tests.AssertionTest.AssertShort" executed="True" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Framework.Tests.AssertionTest.AssertSingle" executed="True" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Framework.Tests.AssertionTest.AssertSinglePosInfinityNotEqualsNegInfinity" executed="True" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Framework.Tests.AssertionTest.AssertString" executed="True" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Framework.Tests.AssertionTest.Bug1076043AreEqualsNotTransitiveForDecimal" executed="True" success="True" time="0.047" asserts="9" />
+                          <test-case name="NUnit.Framework.Tests.AssertionTest.Bug561909FailInheritsFromSystemException" executed="True" success="True" time="0.000" asserts="0" />
+                          <test-case name="NUnit.Framework.Tests.AssertionTest.Bug575936Int32Int64Comparison" executed="True" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Framework.Tests.AssertionTest.Fail" executed="True" success="True" time="0.000" asserts="0" />
+                          <test-case name="NUnit.Framework.Tests.AssertionTest.FailAssertFalse" executed="True" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Framework.Tests.AssertionTest.FailAssertNotNull" executed="True" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Framework.Tests.AssertionTest.IntegerLongComparison" executed="True" success="True" time="0.000" asserts="2" />
+                          <test-case name="NUnit.Framework.Tests.AssertionTest.SucceedAssertFail" executed="True" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Framework.Tests.AssertionTest.SucceedAssertNotNull" executed="True" success="True" time="0.000" asserts="1" />
+                        </results>
+                      </test-suite>
+                      <test-suite name="AssertSyntaxTests" success="True" time="0.266" asserts="0">
+                        <results>
+                          <test-case name="NUnit.Framework.Tests.AssertSyntaxTests.AllItemsTests" executed="True" success="True" time="0.000" asserts="33" />
+                          <test-case name="NUnit.Framework.Tests.AssertSyntaxTests.AndOperator" executed="True" success="True" time="0.000" asserts="2" />
+                          <test-case name="NUnit.Framework.Tests.AssertSyntaxTests.AssignableFromTypeTests" executed="True" success="True" time="0.016" asserts="6" />
+                          <test-case name="NUnit.Framework.Tests.AssertSyntaxTests.CollectionContainsTests" executed="True" success="True" time="0.000" asserts="27" />
+                          <test-case name="NUnit.Framework.Tests.AssertSyntaxTests.CollectionEquivalenceTests" executed="True" success="True" time="0.000" asserts="13" />
+                          <test-case name="NUnit.Framework.Tests.AssertSyntaxTests.ComparisonTests" executed="True" success="True" time="0.000" asserts="26" />
+                          <test-case name="NUnit.Framework.Tests.AssertSyntaxTests.ComplexTests" executed="True" success="True" time="0.000" asserts="6" />
+                          <test-case name="NUnit.Framework.Tests.AssertSyntaxTests.EmptyCollectionTests" executed="True" success="True" time="0.000" asserts="6" />
+                          <test-case name="NUnit.Framework.Tests.AssertSyntaxTests.EmptyStringTests" executed="True" success="True" time="0.031" asserts="6" />
+                          <test-case name="NUnit.Framework.Tests.AssertSyntaxTests.EndsWithTests" executed="True" success="True" time="0.000" asserts="9" />
+                          <test-case name="NUnit.Framework.Tests.AssertSyntaxTests.EqualIgnoringCaseTests" executed="True" success="True" time="0.000" asserts="9" />
+                          <test-case name="NUnit.Framework.Tests.AssertSyntaxTests.EqualityTests" executed="True" success="True" time="0.000" asserts="14" />
+                          <test-case name="NUnit.Framework.Tests.AssertSyntaxTests.EqualityTestsUsingDefaultFloatingPointTolerance" executed="True" success="True" time="0.016" asserts="5" />
+                          <test-case name="NUnit.Framework.Tests.AssertSyntaxTests.EqualityTestsWithTolerance" executed="True" success="True" time="0.000" asserts="18" />
+                          <test-case name="NUnit.Framework.Tests.AssertSyntaxTests.EqualityTestsWithTolerance_MixedFloatAndDouble" executed="True" success="True" time="0.000" asserts="6" />
+                          <test-case name="NUnit.Framework.Tests.AssertSyntaxTests.EqualityTestsWithTolerance_MixingTypesGenerally" executed="True" success="True" time="0.000" asserts="7" />
+                          <test-case name="NUnit.Framework.Tests.AssertSyntaxTests.ExactTypeTests" executed="True" success="True" time="0.000" asserts="8" />
+                          <test-case name="NUnit.Framework.Tests.AssertSyntaxTests.InstanceOfTypeTests" executed="True" success="True" time="0.000" asserts="6" />
+                          <test-case name="NUnit.Framework.Tests.AssertSyntaxTests.IsFalse" executed="True" success="True" time="0.000" asserts="3" />
+                          <test-case name="NUnit.Framework.Tests.AssertSyntaxTests.IsNaN" executed="True" success="True" time="0.000" asserts="6" />
+                          <test-case name="NUnit.Framework.Tests.AssertSyntaxTests.IsNotNull" executed="True" success="True" time="0.000" asserts="3" />
+                          <test-case name="NUnit.Framework.Tests.AssertSyntaxTests.IsNull" executed="True" success="True" time="0.000" asserts="3" />
+                          <test-case name="NUnit.Framework.Tests.AssertSyntaxTests.IsTrue" executed="True" success="True" time="0.000" asserts="5" />
+                          <test-case name="NUnit.Framework.Tests.AssertSyntaxTests.NoItemTests" executed="True" success="True" time="0.000" asserts="8" />
+                          <test-case name="NUnit.Framework.Tests.AssertSyntaxTests.NotOperator" executed="True" success="True" time="0.000" asserts="2" />
+                          <test-case name="NUnit.Framework.Tests.AssertSyntaxTests.NotTests" executed="True" success="True" time="0.000" asserts="14" />
+                          <test-case name="NUnit.Framework.Tests.AssertSyntaxTests.OrOperator" executed="True" success="True" time="0.000" asserts="2" />
+                          <test-case name="NUnit.Framework.Tests.AssertSyntaxTests.PropertyTests" executed="True" success="True" time="0.000" asserts="50" />
+                          <test-case name="NUnit.Framework.Tests.AssertSyntaxTests.PropertyTests_DoesNotExistFails" executed="True" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Framework.Tests.AssertSyntaxTests.RegularExpressionTests" executed="True" success="True" time="0.125" asserts="12" />
+                          <test-case name="NUnit.Framework.Tests.AssertSyntaxTests.SomeItemTests" executed="True" success="True" time="0.000" asserts="10" />
+                          <test-case name="NUnit.Framework.Tests.AssertSyntaxTests.StartsWithTests" executed="True" success="True" time="0.016" asserts="11" />
+                          <test-case name="NUnit.Framework.Tests.AssertSyntaxTests.SubsetTests" executed="True" success="True" time="0.000" asserts="10" />
+                          <test-case name="NUnit.Framework.Tests.AssertSyntaxTests.SubstringTests" executed="True" success="True" time="0.000" asserts="11" />
+                        </results>
+                      </test-suite>
+                      <test-suite name="CollectionAssertTest" success="True" time="0.078" asserts="0">
+                        <results>
+                          <test-case name="NUnit.Framework.Tests.CollectionAssertTest.AreEqual" executed="True" success="True" time="0.016" asserts="3" />
+                          <test-case name="NUnit.Framework.Tests.CollectionAssertTest.AreEqual_HandlesNull" executed="True" success="True" time="0.000" asserts="2" />
+                          <test-case name="NUnit.Framework.Tests.CollectionAssertTest.AreEqualFail" executed="True" success="True" time="0.000" asserts="2" />
+                          <test-case name="NUnit.Framework.Tests.CollectionAssertTest.AreEqualFailCount" executed="True" success="True" time="0.000" asserts="2" />
+                          <test-case name="NUnit.Framework.Tests.CollectionAssertTest.AreEquivalentHandlesNull" executed="True" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Framework.Tests.CollectionAssertTest.AreNotEqual" executed="True" success="True" time="0.000" asserts="6" />
+                          <test-case name="NUnit.Framework.Tests.CollectionAssertTest.AreNotEqual_Fails" executed="True" success="True" time="0.000" asserts="2" />
+                          <test-case name="NUnit.Framework.Tests.CollectionAssertTest.AreNotEqual_HandlesNull" executed="True" success="True" time="0.000" asserts="2" />
+                          <test-case name="NUnit.Framework.Tests.CollectionAssertTest.Contains_ICollection" executed="True" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Framework.Tests.CollectionAssertTest.Contains_IList" executed="True" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Framework.Tests.CollectionAssertTest.ContainsFails_EmptyICollection" executed="True" success="True" time="0.000" asserts="2" />
+                          <test-case name="NUnit.Framework.Tests.CollectionAssertTest.ContainsFails_EmptyIList" executed="True" success="True" time="0.000" asserts="2" />
+                          <test-case name="NUnit.Framework.Tests.CollectionAssertTest.ContainsFails_ICollection" executed="True" success="True" time="0.000" asserts="2" />
+                          <test-case name="NUnit.Framework.Tests.CollectionAssertTest.ContainsFails_ILIst" executed="True" success="True" time="0.000" asserts="2" />
+                          <test-case name="NUnit.Framework.Tests.CollectionAssertTest.ContainsNull_ICollection" executed="True" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Framework.Tests.CollectionAssertTest.ContainsNull_IList" executed="True" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Framework.Tests.CollectionAssertTest.DoesNotContain" executed="True" success="True" time="0.016" asserts="1" />
+                          <test-case name="NUnit.Framework.Tests.CollectionAssertTest.DoesNotContain_Empty" executed="True" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Framework.Tests.CollectionAssertTest.DoesNotContain_Fails" executed="True" success="True" time="0.000" asserts="2" />
+                          <test-case name="NUnit.Framework.Tests.CollectionAssertTest.EnsureComparerIsUsed" executed="True" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Framework.Tests.CollectionAssertTest.Equivalent" executed="True" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Framework.Tests.CollectionAssertTest.EquivalentFailOne" executed="True" success="True" time="0.000" asserts="2" />
+                          <test-case name="NUnit.Framework.Tests.CollectionAssertTest.EquivalentFailTwo" executed="True" success="True" time="0.000" asserts="2" />
+                          <test-case name="NUnit.Framework.Tests.CollectionAssertTest.IsNotSubsetOf" executed="True" success="True" time="0.000" asserts="2" />
+                          <test-case name="NUnit.Framework.Tests.CollectionAssertTest.IsNotSubsetOf_Fails" executed="True" success="True" time="0.000" asserts="2" />
+                          <test-case name="NUnit.Framework.Tests.CollectionAssertTest.IsNotSubsetOfHandlesNull" executed="True" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Framework.Tests.CollectionAssertTest.IsSubsetOf" executed="True" success="True" time="0.000" asserts="2" />
+                          <test-case name="NUnit.Framework.Tests.CollectionAssertTest.IsSubsetOf_Fails" executed="True" success="True" time="0.000" asserts="2" />
+                          <test-case name="NUnit.Framework.Tests.CollectionAssertTest.IsSubsetOfHandlesNull" executed="True" success="True" time="0.000" asserts="2" />
+                          <test-case name="NUnit.Framework.Tests.CollectionAssertTest.ItemsNotNull" executed="True" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Framework.Tests.CollectionAssertTest.ItemsNotNullFailure" executed="True" success="True" time="0.000" asserts="2" />
+                          <test-case name="NUnit.Framework.Tests.CollectionAssertTest.ItemsOfType" executed="True" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Framework.Tests.CollectionAssertTest.ItemsOfTypeFailure" executed="True" success="True" time="0.000" asserts="2" />
+                          <test-case name="NUnit.Framework.Tests.CollectionAssertTest.NotEquivalent" executed="True" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Framework.Tests.CollectionAssertTest.NotEquivalent_Fails" executed="True" success="True" time="0.000" asserts="2" />
+                          <test-case name="NUnit.Framework.Tests.CollectionAssertTest.NotEquivalentHandlesNull" executed="True" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Framework.Tests.CollectionAssertTest.Unique_WithNull" executed="True" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Framework.Tests.CollectionAssertTest.Unique_WithObjects" executed="True" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Framework.Tests.CollectionAssertTest.Unique_WithStrings" executed="True" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Framework.Tests.CollectionAssertTest.UniqueFailure" executed="True" success="True" time="0.000" asserts="2" />
+                          <test-case name="NUnit.Framework.Tests.CollectionAssertTest.UniqueFailure_WithTwoNulls" executed="True" success="True" time="0.000" asserts="1" />
+                        </results>
+                      </test-suite>
+                      <test-suite name="ConditionAssertTests" success="True" time="0.047" asserts="0">
+                        <results>
+                          <test-case name="NUnit.Framework.Tests.ConditionAssertTests.IsEmpty" executed="True" success="True" time="0.000" asserts="4" />
+                          <test-case name="NUnit.Framework.Tests.ConditionAssertTests.IsEmptyFailsOnNonEmptyArray" executed="True" success="True" time="0.000" asserts="2" />
+                          <test-case name="NUnit.Framework.Tests.ConditionAssertTests.IsEmptyFailsOnNullString" executed="True" success="True" time="0.000" asserts="2" />
+                          <test-case name="NUnit.Framework.Tests.ConditionAssertTests.IsEmptyFailsOnString" executed="True" success="True" time="0.000" asserts="2" />
+                          <test-case name="NUnit.Framework.Tests.ConditionAssertTests.IsFalse" executed="True" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Framework.Tests.ConditionAssertTests.IsFalseFails" executed="True" success="True" time="0.000" asserts="2" />
+                          <test-case name="NUnit.Framework.Tests.ConditionAssertTests.IsNaN" executed="True" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Framework.Tests.ConditionAssertTests.IsNaNFails" executed="True" success="True" time="0.000" asserts="2" />
+                          <test-case name="NUnit.Framework.Tests.ConditionAssertTests.IsNotEmpty" executed="True" success="True" time="0.000" asserts="4" />
+                          <test-case name="NUnit.Framework.Tests.ConditionAssertTests.IsNotEmptyFailsOnEmptyArray" executed="True" success="True" time="0.000" asserts="2" />
+                          <test-case name="NUnit.Framework.Tests.ConditionAssertTests.IsNotEmptyFailsOnEmptyArrayList" executed="True" success="True" time="0.000" asserts="2" />
+                          <test-case name="NUnit.Framework.Tests.ConditionAssertTests.IsNotEmptyFailsOnEmptyHashTable" executed="True" success="True" time="0.016" asserts="2" />
+                          <test-case name="NUnit.Framework.Tests.ConditionAssertTests.IsNotEmptyFailsOnEmptyString" executed="True" success="True" time="0.000" asserts="2" />
+                          <test-case name="NUnit.Framework.Tests.ConditionAssertTests.IsNotNull" executed="True" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Framework.Tests.ConditionAssertTests.IsNotNullFails" executed="True" success="True" time="0.000" asserts="2" />
+                          <test-case name="NUnit.Framework.Tests.ConditionAssertTests.IsNull" executed="True" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Framework.Tests.ConditionAssertTests.IsNullFails" executed="True" success="True" time="0.000" asserts="2" />
+                          <test-case name="NUnit.Framework.Tests.ConditionAssertTests.IsTrue" executed="True" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Framework.Tests.ConditionAssertTests.IsTrueFails" executed="True" success="True" time="0.000" asserts="2" />
+                        </results>
+                      </test-suite>
+                      <test-suite name="EqualsFixture" success="True" time="0.063" asserts="0">
+                        <results>
+                          <test-case name="NUnit.Framework.Tests.EqualsFixture.Bug575936Int32Int64Comparison" executed="True" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Framework.Tests.EqualsFixture.Byte" executed="True" success="True" time="0.000" asserts="2" />
+                          <test-case name="NUnit.Framework.Tests.EqualsFixture.DateTimeEqual" executed="True" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Framework.Tests.EqualsFixture.DateTimeNotEqual" executed="True" success="True" time="0.000" asserts="2" />
+                          <test-case name="NUnit.Framework.Tests.EqualsFixture.Decimal" executed="True" success="True" time="0.000" asserts="6" />
+                          <test-case name="NUnit.Framework.Tests.EqualsFixture.DoubleNotEqualMessageDisplaysAllDigits" executed="True" success="True" time="0.000" asserts="2" />
+                          <test-case name="NUnit.Framework.Tests.EqualsFixture.DoubleNotEqualMessageDisplaysDefaultTolerance" executed="True" success="True" time="0.000" asserts="2" />
+                          <test-case name="NUnit.Framework.Tests.EqualsFixture.DoubleNotEqualMessageDisplaysTolerance" executed="True" success="True" time="0.000" asserts="2" />
+                          <test-case name="NUnit.Framework.Tests.EqualsFixture.DoubleNotEqualWithNanDoesNotDisplayDefaultTolerance" executed="True" success="True" time="0.000" asserts="2" />
+                          <test-case name="NUnit.Framework.Tests.EqualsFixture.EnumsEqual" executed="True" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Framework.Tests.EqualsFixture.EnumsNotEqual" executed="True" success="True" time="0.000" asserts="2" />
+                          <test-case name="NUnit.Framework.Tests.EqualsFixture.Equals" executed="True" success="True" time="0.000" asserts="2" />
+                          <test-case name="NUnit.Framework.Tests.EqualsFixture.EqualsFail" executed="True" success="True" time="0.000" asserts="2" />
+                          <test-case name="NUnit.Framework.Tests.EqualsFixture.EqualsNaNFails" executed="True" success="True" time="0.000" asserts="2" />
+                          <test-case name="NUnit.Framework.Tests.EqualsFixture.EqualsNull" executed="True" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Framework.Tests.EqualsFixture.EqualsSameTypes" executed="True" success="True" time="0.000" asserts="21" />
+                          <test-case name="NUnit.Framework.Tests.EqualsFixture.EqualsThrowsException" executed="True" success="True" time="0.000" asserts="0" />
+                          <test-case name="NUnit.Framework.Tests.EqualsFixture.Float" executed="True" success="True" time="0.000" asserts="2" />
+                          <test-case name="NUnit.Framework.Tests.EqualsFixture.FloatNotEqualMessageDisplaysAllDigits" executed="True" success="True" time="0.000" asserts="2" />
+                          <test-case name="NUnit.Framework.Tests.EqualsFixture.FloatNotEqualMessageDisplaysTolerance" executed="True" success="True" time="0.000" asserts="2" />
+                          <test-case name="NUnit.Framework.Tests.EqualsFixture.Int" executed="True" success="True" time="0.000" asserts="2" />
+                          <test-case name="NUnit.Framework.Tests.EqualsFixture.IntegerEquals" executed="True" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Framework.Tests.EqualsFixture.IntegerLongComparison" executed="True" success="True" time="0.000" asserts="2" />
+                          <test-case name="NUnit.Framework.Tests.EqualsFixture.NanEqualsFails" executed="True" success="True" time="0.000" asserts="2" />
+                          <test-case name="NUnit.Framework.Tests.EqualsFixture.NanEqualsNaNSucceeds" executed="True" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Framework.Tests.EqualsFixture.NegInfinityEqualsInfinity" executed="True" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Framework.Tests.EqualsFixture.PosInfinityEqualsInfinity" executed="True" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Framework.Tests.EqualsFixture.PosInfinityNotEquals" executed="True" success="True" time="0.000" asserts="2" />
+                          <test-case name="NUnit.Framework.Tests.EqualsFixture.PosInfinityNotEqualsNegInfinity" executed="True" success="True" time="0.016" asserts="2" />
+                          <test-case name="NUnit.Framework.Tests.EqualsFixture.ReferenceEqualsThrowsException" executed="True" success="True" time="0.000" asserts="0" />
+                          <test-case name="NUnit.Framework.Tests.EqualsFixture.Short" executed="True" success="True" time="0.000" asserts="2" />
+                          <test-case name="NUnit.Framework.Tests.EqualsFixture.SinglePosInfinityNotEqualsNegInfinity" executed="True" success="True" time="0.000" asserts="2" />
+                          <test-case name="NUnit.Framework.Tests.EqualsFixture.String" executed="True" success="True" time="0.000" asserts="2" />
+                          <test-case name="NUnit.Framework.Tests.EqualsFixture.UInt" executed="True" success="True" time="0.000" asserts="2" />
+                        </results>
+                      </test-suite>
+                      <test-suite name="FileAssertTests" success="True" time="0.203" asserts="0">
+                        <results>
+                          <test-case name="NUnit.Framework.Tests.FileAssertTests.AreEqualFailsWhenOneIsNull" executed="True" success="True" time="0.000" asserts="2" />
+                          <test-case name="NUnit.Framework.Tests.FileAssertTests.AreEqualFailsWithFileInfos" executed="True" success="True" time="0.016" asserts="2" />
+                          <test-case name="NUnit.Framework.Tests.FileAssertTests.AreEqualFailsWithFiles" executed="True" success="True" time="0.000" asserts="2" />
+                          <test-case name="NUnit.Framework.Tests.FileAssertTests.AreEqualFailsWithStreams" executed="True" success="True" time="0.016" asserts="2" />
+                          <test-case name="NUnit.Framework.Tests.FileAssertTests.AreEqualFailsWithTextFilesAfterReadingBothFiles" executed="True" success="True" time="0.016" asserts="2" />
+                          <test-case name="NUnit.Framework.Tests.FileAssertTests.AreEqualPassesUsingSameFileTwice" executed="True" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Framework.Tests.FileAssertTests.AreEqualPassesWhenBothAreNull" executed="True" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Framework.Tests.FileAssertTests.AreEqualPassesWithFileInfos" executed="True" success="True" time="0.016" asserts="2" />
+                          <test-case name="NUnit.Framework.Tests.FileAssertTests.AreEqualPassesWithFiles" executed="True" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Framework.Tests.FileAssertTests.AreEqualPassesWithStreams" executed="True" success="True" time="0.016" asserts="1" />
+                          <test-case name="NUnit.Framework.Tests.FileAssertTests.AreEqualPassesWithTextFiles" executed="True" success="True" time="0.016" asserts="1" />
+                          <test-case name="NUnit.Framework.Tests.FileAssertTests.AreNotEqualFailsWhenBothAreNull" executed="True" success="True" time="0.000" asserts="2" />
+                          <test-case name="NUnit.Framework.Tests.FileAssertTests.AreNotEqualFailsWithFileInfos" executed="True" success="True" time="0.016" asserts="2" />
+                          <test-case name="NUnit.Framework.Tests.FileAssertTests.AreNotEqualFailsWithFiles" executed="True" success="True" time="0.000" asserts="2" />
+                          <test-case name="NUnit.Framework.Tests.FileAssertTests.AreNotEqualFailsWithStreams" executed="True" success="True" time="0.016" asserts="2" />
+                          <test-case name="NUnit.Framework.Tests.FileAssertTests.AreNotEqualIteratesOverTheEntireFile" executed="True" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Framework.Tests.FileAssertTests.AreNotEqualIteratesOverTheEntireFileAndFails" executed="True" success="True" time="0.016" asserts="2" />
+                          <test-case name="NUnit.Framework.Tests.FileAssertTests.AreNotEqualPassesIfOneIsNull" executed="True" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Framework.Tests.FileAssertTests.AreNotEqualPassesWithFileInfos" executed="True" success="True" time="0.016" asserts="1" />
+                          <test-case name="NUnit.Framework.Tests.FileAssertTests.AreNotEqualPassesWithFiles" executed="True" success="True" time="0.031" asserts="1" />
+                          <test-case name="NUnit.Framework.Tests.FileAssertTests.AreNotEqualPassesWithStreams" executed="True" success="True" time="0.000" asserts="1" />
+                        </results>
+                      </test-suite>
+                      <test-suite name="GreaterEqualFixture" success="True" time="0.078" asserts="0">
+                        <results>
+                          <test-case name="NUnit.Framework.Tests.GreaterEqualFixture.FailureMessage" executed="True" success="True" time="0.000" asserts="3" />
+                          <test-case name="NUnit.Framework.Tests.GreaterEqualFixture.GreaterOrEqual_Decimal" executed="True" success="True" time="0.000" asserts="2" />
+                          <test-case name="NUnit.Framework.Tests.GreaterEqualFixture.GreaterOrEqual_Double" executed="True" success="True" time="0.000" asserts="2" />
+                          <test-case name="NUnit.Framework.Tests.GreaterEqualFixture.GreaterOrEqual_Float" executed="True" success="True" time="0.000" asserts="2" />
+                          <test-case name="NUnit.Framework.Tests.GreaterEqualFixture.GreaterOrEqual_Int32" executed="True" success="True" time="0.000" asserts="2" />
+                          <test-case name="NUnit.Framework.Tests.GreaterEqualFixture.GreaterOrEqual_Long" executed="True" success="True" time="0.000" asserts="2" />
+                          <test-case name="NUnit.Framework.Tests.GreaterEqualFixture.GreaterOrEqual_UInt32" executed="True" success="True" time="0.000" asserts="2" />
+                          <test-case name="NUnit.Framework.Tests.GreaterEqualFixture.GreaterOrEqual_ULong" executed="True" success="True" time="0.000" asserts="2" />
+                          <test-case name="NUnit.Framework.Tests.GreaterEqualFixture.MixedTypes" executed="True" success="True" time="0.000" asserts="42" />
+                          <test-case name="NUnit.Framework.Tests.GreaterEqualFixture.NotGreaterEqualIComparable" executed="True" success="True" time="0.016" asserts="2" />
+                          <test-case name="NUnit.Framework.Tests.GreaterEqualFixture.NotGreaterOrEqual" executed="True" success="True" time="0.000" asserts="2" />
+                        </results>
+                      </test-suite>
+                      <test-suite name="GreaterFixture" success="True" time="0.016" asserts="0">
+                        <results>
+                          <test-case name="NUnit.Framework.Tests.GreaterFixture.FailureMessage" executed="True" success="True" time="0.000" asserts="2" />
+                          <test-case name="NUnit.Framework.Tests.GreaterFixture.Greater" executed="True" success="True" time="0.000" asserts="7" />
+                          <test-case name="NUnit.Framework.Tests.GreaterFixture.MixedTypes" executed="True" success="True" time="0.000" asserts="42" />
+                          <test-case name="NUnit.Framework.Tests.GreaterFixture.NotGreater" executed="True" success="True" time="0.000" asserts="2" />
+                          <test-case name="NUnit.Framework.Tests.GreaterFixture.NotGreaterIComparable" executed="True" success="True" time="0.000" asserts="2" />
+                          <test-case name="NUnit.Framework.Tests.GreaterFixture.NotGreaterWhenEqual" executed="True" success="True" time="0.000" asserts="2" />
+                        </results>
+                      </test-suite>
+                      <test-suite name="LessEqualFixture" success="True" time="0.031" asserts="0">
+                        <results>
+                          <test-case name="NUnit.Framework.Tests.LessEqualFixture.FailureMessage" executed="True" success="True" time="0.016" asserts="2" />
+                          <test-case name="NUnit.Framework.Tests.LessEqualFixture.LessOrEqual" executed="True" success="True" time="0.000" asserts="42" />
+                          <test-case name="NUnit.Framework.Tests.LessEqualFixture.MixedTypes" executed="True" success="True" time="0.000" asserts="42" />
+                          <test-case name="NUnit.Framework.Tests.LessEqualFixture.NotLessEqualIComparable" executed="True" success="True" time="0.000" asserts="2" />
+                          <test-case name="NUnit.Framework.Tests.LessEqualFixture.NotLessOrEqual" executed="True" success="True" time="0.000" asserts="2" />
+                        </results>
+                      </test-suite>
+                      <test-suite name="LessFixture" success="True" time="0.016" asserts="0">
+                        <results>
+                          <test-case name="NUnit.Framework.Tests.LessFixture.FailureMessage" executed="True" success="True" time="0.000" asserts="3" />
+                          <test-case name="NUnit.Framework.Tests.LessFixture.Less" executed="True" success="True" time="0.000" asserts="18" />
+                          <test-case name="NUnit.Framework.Tests.LessFixture.MixedTypes" executed="True" success="True" time="0.000" asserts="42" />
+                          <test-case name="NUnit.Framework.Tests.LessFixture.NotLess" executed="True" success="True" time="0.016" asserts="2" />
+                          <test-case name="NUnit.Framework.Tests.LessFixture.NotLessIComparable" executed="True" success="True" time="0.000" asserts="2" />
+                          <test-case name="NUnit.Framework.Tests.LessFixture.NotLessWhenEqual" executed="True" success="True" time="0.000" asserts="2" />
+                        </results>
+                      </test-suite>
+                      <test-suite name="ListContentsTests" success="True" time="0.016" asserts="0">
+                        <results>
+                          <test-case name="NUnit.Framework.Tests.ListContentsTests.ArrayFails" executed="True" success="True" time="0.000" asserts="2" />
+                          <test-case name="NUnit.Framework.Tests.ListContentsTests.ArrayListFails" executed="True" success="True" time="0.000" asserts="2" />
+                          <test-case name="NUnit.Framework.Tests.ListContentsTests.ArrayListSucceeds" executed="True" success="True" time="0.000" asserts="3" />
+                          <test-case name="NUnit.Framework.Tests.ListContentsTests.ArraySucceeds" executed="True" success="True" time="0.000" asserts="3" />
+                          <test-case name="NUnit.Framework.Tests.ListContentsTests.DifferentTypesFail" executed="True" success="True" time="0.000" asserts="2" />
+                          <test-case name="NUnit.Framework.Tests.ListContentsTests.EmptyArrayFails" executed="True" success="True" time="0.000" asserts="2" />
+                          <test-case name="NUnit.Framework.Tests.ListContentsTests.NullArrayIsError" executed="True" success="True" time="0.000" asserts="1" />
+                        </results>
+                      </test-suite>
+                      <test-suite name="MsgUtilTests" success="True" time="0.000" asserts="0">
+                        <results>
+                          <test-case name="NUnit.Framework.Tests.MsgUtilTests.ClipExpectedAndActual_StringsDoNotFitInLine" executed="True" success="True" time="0.000" asserts="4" />
+                          <test-case name="NUnit.Framework.Tests.MsgUtilTests.ClipExpectedAndActual_StringsFitInLine" executed="True" success="True" time="0.000" asserts="4" />
+                          <test-case name="NUnit.Framework.Tests.MsgUtilTests.ClipExpectedAndActual_StringTailsFitInLine" executed="True" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Framework.Tests.MsgUtilTests.TestClipString" executed="True" success="True" time="0.000" asserts="4" />
+                          <test-case name="NUnit.Framework.Tests.MsgUtilTests.TestConvertWhitespace" executed="True" success="True" time="0.000" asserts="14" />
+                        </results>
+                      </test-suite>
+                      <test-suite name="MyAssertionFailureMessage+FailureMessageFixture" success="True" time="0.094" asserts="0">
+                        <results>
+                          <test-case name="NUnit.Framework.Tests.MyAssertionFailureMessage+FailureMessageFixture.DisplayListElements" executed="True" success="True" time="0.000" asserts="6" />
+                          <test-case name="NUnit.Framework.Tests.MyAssertionFailureMessage+FailureMessageFixture.TestClipAroundPosition" executed="True" success="True" time="0.000" asserts="26" />
+                          <test-case name="NUnit.Framework.Tests.MyAssertionFailureMessage+FailureMessageFixture.TestClipAroundPosition2" executed="True" success="True" time="0.000" asserts="80" />
+                          <test-case name="NUnit.Framework.Tests.MyAssertionFailureMessage+FailureMessageFixture.TestConvertWhitespace" executed="True" success="True" time="0.000" asserts="14" />
+                          <test-case name="NUnit.Framework.Tests.MyAssertionFailureMessage+FailureMessageFixture.TestFormatMessageForArraysNotEqual" executed="True" success="True" time="0.047" asserts="5" />
+                          <test-case name="NUnit.Framework.Tests.MyAssertionFailureMessage+FailureMessageFixture.TestFormatMessageForFailNotEquals" executed="True" success="True" time="0.016" asserts="13" />
+                          <test-case name="NUnit.Framework.Tests.MyAssertionFailureMessage+FailureMessageFixture.TestFormatMessageForFailNotEqualsIgnoringCase" executed="True" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Framework.Tests.MyAssertionFailureMessage+FailureMessageFixture.TestFormatMessageForFailNotEqualsNewlines2" executed="True" success="True" time="0.000" asserts="3" />
+                          <test-case name="NUnit.Framework.Tests.MyAssertionFailureMessage+FailureMessageFixture.TestInputsAreStrings" executed="True" success="True" time="0.000" asserts="8" />
+                          <test-case name="NUnit.Framework.Tests.MyAssertionFailureMessage+FailureMessageFixture.TestStringLengthsDiffer" executed="True" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Framework.Tests.MyAssertionFailureMessage+FailureMessageFixture.TestStringLengthsDiffer2" executed="True" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Framework.Tests.MyAssertionFailureMessage+FailureMessageFixture.TestStringLengthsDiffer3" executed="True" success="True" time="0.031" asserts="995" />
+                        </results>
+                      </test-suite>
+                      <test-suite name="NotEqualFixture" success="True" time="0.016" asserts="0">
+                        <results>
+                          <test-case name="NUnit.Framework.Tests.NotEqualFixture.ArraysNotEqual" executed="True" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Framework.Tests.NotEqualFixture.ArraysNotEqualFails" executed="True" success="True" time="0.000" asserts="2" />
+                          <test-case name="NUnit.Framework.Tests.NotEqualFixture.NotEqual" executed="True" success="True" time="0.016" asserts="1" />
+                          <test-case name="NUnit.Framework.Tests.NotEqualFixture.NotEqualFails" executed="True" success="True" time="0.000" asserts="2" />
+                          <test-case name="NUnit.Framework.Tests.NotEqualFixture.NotEqualSameTypes" executed="True" success="True" time="0.000" asserts="21" />
+                          <test-case name="NUnit.Framework.Tests.NotEqualFixture.NullEqualsNull" executed="True" success="True" time="0.000" asserts="2" />
+                          <test-case name="NUnit.Framework.Tests.NotEqualFixture.NullNotEqualToNonNull" executed="True" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Framework.Tests.NotEqualFixture.UInt" executed="True" success="True" time="0.000" asserts="1" />
+                        </results>
+                      </test-suite>
+                      <test-suite name="NotSameFixture" success="True" time="0.000" asserts="0">
+                        <results>
+                          <test-case name="NUnit.Framework.Tests.NotSameFixture.NotSame" executed="True" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Framework.Tests.NotSameFixture.NotSameFails" executed="True" success="True" time="0.000" asserts="2" />
+                        </results>
+                      </test-suite>
+                      <test-suite name="SameFixture" success="True" time="0.000" asserts="0">
+                        <results>
+                          <test-case name="NUnit.Framework.Tests.SameFixture.Same" executed="True" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Framework.Tests.SameFixture.SameFails" executed="True" success="True" time="0.000" asserts="2" />
+                          <test-case name="NUnit.Framework.Tests.SameFixture.SameValueTypes" executed="True" success="True" time="0.000" asserts="2" />
+                        </results>
+                      </test-suite>
+                      <test-suite name="StringAssertTests" success="True" time="0.031" asserts="0">
+                        <results>
+                          <test-case name="NUnit.Framework.Tests.StringAssertTests.CaseInsensitiveCompare" executed="True" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Framework.Tests.StringAssertTests.CaseInsensitiveCompareFails" executed="True" success="True" time="0.000" asserts="2" />
+                          <test-case name="NUnit.Framework.Tests.StringAssertTests.Contains" executed="True" success="True" time="0.000" asserts="3" />
+                          <test-case name="NUnit.Framework.Tests.StringAssertTests.ContainsFails" executed="True" success="True" time="0.000" asserts="2" />
+                          <test-case name="NUnit.Framework.Tests.StringAssertTests.EndsWith" executed="True" success="True" time="0.000" asserts="2" />
+                          <test-case name="NUnit.Framework.Tests.StringAssertTests.EndsWithFails" executed="True" success="True" time="0.000" asserts="2" />
+                          <test-case name="NUnit.Framework.Tests.StringAssertTests.IsMatch" executed="True" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Framework.Tests.StringAssertTests.IsMatchFails" executed="True" success="True" time="0.000" asserts="2" />
+                          <test-case name="NUnit.Framework.Tests.StringAssertTests.StartsWith" executed="True" success="True" time="0.000" asserts="2" />
+                          <test-case name="NUnit.Framework.Tests.StringAssertTests.StartsWithFails" executed="True" success="True" time="0.000" asserts="2" />
+                        </results>
+                      </test-suite>
+                      <test-suite name="TextMessageWriterTests" success="True" time="0.031" asserts="0">
+                        <results>
+                          <test-case name="NUnit.Framework.Tests.TextMessageWriterTests.ConnectorIsWrittenWithSurroundingSpaces" executed="True" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Framework.Tests.TextMessageWriterTests.DateTimeTest" executed="True" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Framework.Tests.TextMessageWriterTests.DecimalIsWrittenToTwentyNineDigits" executed="True" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Framework.Tests.TextMessageWriterTests.DecimalIsWrittenWithTrailingM" executed="True" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Framework.Tests.TextMessageWriterTests.DisplayStringDifferences" executed="True" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Framework.Tests.TextMessageWriterTests.DisplayStringDifferences_NoClipping" executed="True" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Framework.Tests.TextMessageWriterTests.DoubleIsWrittenToSeventeenDigits" executed="True" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Framework.Tests.TextMessageWriterTests.DoubleIsWrittenWithTrailingD" executed="True" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Framework.Tests.TextMessageWriterTests.FloatIsWrittenToNineDigits" executed="True" success="True" time="0.000" asserts="2" />
+                          <test-case name="NUnit.Framework.Tests.TextMessageWriterTests.FloatIsWrittenWithTrailingF" executed="True" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Framework.Tests.TextMessageWriterTests.IntegerIsWrittenAsIs" executed="True" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Framework.Tests.TextMessageWriterTests.PredicateIsWrittenWithTrailingSpace" executed="True" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Framework.Tests.TextMessageWriterTests.StringIsWrittenWithQuotes" executed="True" success="True" time="0.000" asserts="1" />
+                        </results>
+                      </test-suite>
+                      <test-suite name="TypeAssertTests" success="True" time="0.016" asserts="0">
+                        <results>
+                          <test-case name="NUnit.Framework.Tests.TypeAssertTests.ExactType" executed="True" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Framework.Tests.TypeAssertTests.ExactTypeFails" executed="True" success="True" time="0.000" asserts="2" />
+                          <test-case name="NUnit.Framework.Tests.TypeAssertTests.IsAssignableFrom" executed="True" success="True" time="0.000" asserts="4" />
+                          <test-case name="NUnit.Framework.Tests.TypeAssertTests.IsAssignableFromFails" executed="True" success="True" time="0.000" asserts="2" />
+                          <test-case name="NUnit.Framework.Tests.TypeAssertTests.IsInstanceOfType" executed="True" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Framework.Tests.TypeAssertTests.IsInstanceOfTypeFails" executed="True" success="True" time="0.000" asserts="2" />
+                          <test-case name="NUnit.Framework.Tests.TypeAssertTests.IsNotAssignableFrom" executed="True" success="True" time="0.000" asserts="4" />
+                          <test-case name="NUnit.Framework.Tests.TypeAssertTests.IsNotAssignableFromFails" executed="True" success="True" time="0.000" asserts="2" />
+                          <test-case name="NUnit.Framework.Tests.TypeAssertTests.IsNotInstanceOfType" executed="True" success="True" time="0.000" asserts="2" />
+                          <test-case name="NUnit.Framework.Tests.TypeAssertTests.IsNotInstanceOfTypeFails" executed="True" success="True" time="0.000" asserts="2" />
+                        </results>
+                      </test-suite>
+                    </results>
+                  </test-suite>
+                </results>
+              </test-suite>
+            </results>
+          </test-suite>
+        </results>
+      </test-suite>
+      <test-suite name="C:\Program Files\NUnit 2.4.8\bin\nunit.core.tests.dll" success="True" time="10.297" asserts="0">
+        <results>
+          <test-suite name="NUnit" success="True" time="10.188" asserts="0">
+            <results>
+              <test-suite name="Core" success="True" time="10.109" asserts="0">
+                <results>
+                  <test-suite name="Tests" success="True" time="10.047" asserts="0">
+                    <results>
+                      <test-suite name="AssemblyReaderTests" success="True" time="0.172" asserts="0">
+                        <results>
+                          <test-case name="NUnit.Core.Tests.AssemblyReaderTests.CreateFromAssembly" executed="True" success="True" time="0.125" asserts="1" />
+                          <test-case name="NUnit.Core.Tests.AssemblyReaderTests.CreateFromPath" executed="True" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Core.Tests.AssemblyReaderTests.ImageRuntimeVersion" executed="True" success="True" time="0.016" asserts="1" />
+                          <test-case name="NUnit.Core.Tests.AssemblyReaderTests.IsDotNetFile" executed="True" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Core.Tests.AssemblyReaderTests.IsValidPeFile" executed="True" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Core.Tests.AssemblyReaderTests.IsValidPeFile_Fails" executed="True" success="True" time="0.016" asserts="1" />
+                        </results>
+                      </test-suite>
+                      <test-suite name="AssemblyResolverTests" success="True" time="0.469" asserts="0">
+                        <results>
+                          <test-case name="NUnit.Core.Tests.AssemblyResolverTests.AddFile" executed="True" success="True" time="0.453" asserts="0" />
+                        </results>
+                      </test-suite>
+                      <test-suite name="AssemblyTests" success="True" time="0.625" asserts="0">
+                        <results>
+                          <test-case name="NUnit.Core.Tests.AssemblyTests.AppSettingsLoaded" executed="True" success="True" time="0.078" asserts="3" />
+                          <test-case name="NUnit.Core.Tests.AssemblyTests.LoadAssembly" executed="True" success="True" time="0.375" asserts="2" />
+                          <test-case name="NUnit.Core.Tests.AssemblyTests.LoadAssemblyNotFound" executed="True" success="True" time="0.000" asserts="0" />
+                          <test-case name="NUnit.Core.Tests.AssemblyTests.LoadAssemblyWithoutTestFixtures" executed="True" success="True" time="0.125" asserts="4" />
+                          <test-case name="NUnit.Core.Tests.AssemblyTests.LoadTestFixtureFromAssembly" executed="True" success="True" time="0.016" asserts="1" />
+                          <test-case name="NUnit.Core.Tests.AssemblyTests.NUnitTraceIsEnabled" executed="True" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Core.Tests.AssemblyTests.RunSetsCurrentDirectory" executed="True" success="True" time="0.000" asserts="1" />
+                        </results>
+                      </test-suite>
+                      <test-suite name="AssemblyVersionFixture" success="True" time="0.016" asserts="0">
+                        <results>
+                          <test-case name="NUnit.Core.Tests.AssemblyVersionFixture.Version" executed="True" success="True" time="0.016" asserts="1" />
+                        </results>
+                      </test-suite>
+                      <test-suite name="CallContextTests" success="True" time="0.000" asserts="0">
+                        <results>
+                          <test-case name="NUnit.Core.Tests.CallContextTests.GenericPrincipalTest" executed="True" success="True" time="0.000" asserts="0" />
+                          <test-case name="NUnit.Core.Tests.CallContextTests.ILogicalThreadAffinativeTest" executed="True" success="True" time="0.000" asserts="0" />
+                          <test-case name="NUnit.Core.Tests.CallContextTests.ILogicalThreadAffinativeTestConsole" executed="True" success="True" time="0.000" asserts="0" />
+                          <test-case name="NUnit.Core.Tests.CallContextTests.SetCustomPrincipalOnThread" executed="True" success="True" time="0.000" asserts="0" />
+                          <test-case name="NUnit.Core.Tests.CallContextTests.SetGenericPrincipalOnThread" executed="True" success="True" time="0.000" asserts="0" />
+                          <test-case name="NUnit.Core.Tests.CallContextTests.UseCustomIdentity" executed="True" success="True" time="0.000" asserts="0" />
+                        </results>
+                      </test-suite>
+                      <test-suite name="CategoryAttributeTests" success="True" time="0.156" asserts="0">
+                        <results>
+                          <test-case name="NUnit.Core.Tests.CategoryAttributeTests.CanDeriveFromCategoryAttribute" executed="True" success="True" time="0.141" asserts="1" />
+                          <test-case name="NUnit.Core.Tests.CategoryAttributeTests.CategoryOnFixture" executed="True" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Core.Tests.CategoryAttributeTests.CategoryOnTestCase" executed="True" success="True" time="0.000" asserts="1" />
+                        </results>
+                      </test-suite>
+                      <test-suite name="CoreExtensionsTests" success="True" time="0.016" asserts="0">
+                        <results>
+                          <test-case name="NUnit.Core.Tests.CoreExtensionsTests.CanAddDecorator" executed="True" success="True" time="0.000" asserts="2" />
+                          <test-case name="NUnit.Core.Tests.CoreExtensionsTests.CanAddEventListener" executed="True" success="True" time="0.000" asserts="4" />
+                          <test-case name="NUnit.Core.Tests.CoreExtensionsTests.CanAddSuiteBuilder" executed="True" success="True" time="0.016" asserts="4" />
+                          <test-case name="NUnit.Core.Tests.CoreExtensionsTests.CanAddTestCaseBuilder" executed="True" success="True" time="0.000" asserts="4" />
+                          <test-case name="NUnit.Core.Tests.CoreExtensionsTests.HasEventListenerExtensionPoint" executed="True" success="True" time="0.000" asserts="3" />
+                          <test-case name="NUnit.Core.Tests.CoreExtensionsTests.HasSuiteBuildersExtensionPoint" executed="True" success="True" time="0.000" asserts="3" />
+                          <test-case name="NUnit.Core.Tests.CoreExtensionsTests.HasTestCaseBuildersExtensionPoint" executed="True" success="True" time="0.000" asserts="3" />
+                          <test-case name="NUnit.Core.Tests.CoreExtensionsTests.HasTestDecoratorsExtensionPoint" executed="True" success="True" time="0.000" asserts="3" />
+                          <test-case name="NUnit.Core.Tests.CoreExtensionsTests.HasTestFrameworkRegistry" executed="True" success="True" time="0.000" asserts="1" />
+                        </results>
+                      </test-suite>
+                      <test-suite name="CultureSettingAndDetectionTests" success="True" time="0.094" asserts="0">
+                        <results>
+                          <test-case name="NUnit.Core.Tests.CultureSettingAndDetectionTests.CanMatchAttributeWithExclude" executed="True" success="True" time="0.000" asserts="2" />
+                          <test-case name="NUnit.Core.Tests.CultureSettingAndDetectionTests.CanMatchAttributeWithInclude" executed="True" success="True" time="0.000" asserts="2" />
+                          <test-case name="NUnit.Core.Tests.CultureSettingAndDetectionTests.CanMatchAttributeWithIncludeAndExclude" executed="True" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Core.Tests.CultureSettingAndDetectionTests.CanMatchStrings" executed="True" success="True" time="0.000" asserts="5" />
+                          <test-case name="NUnit.Core.Tests.CultureSettingAndDetectionTests.LoadWithFrenchCanadianCulture" executed="True" success="True" time="0.016" asserts="5">
+                            <properties>
+                              <property name="_SETCULTURE" value="fr-CA" />
+                            </properties>
+                          </test-case>
+                          <test-case name="NUnit.Core.Tests.CultureSettingAndDetectionTests.LoadWithFrenchCulture" executed="True" success="True" time="0.016" asserts="5">
+                            <properties>
+                              <property name="_SETCULTURE" value="fr-FR" />
+                            </properties>
+                          </test-case>
+                          <test-case name="NUnit.Core.Tests.CultureSettingAndDetectionTests.LoadWithRussianCulture" executed="True" success="True" time="0.000" asserts="5">
+                            <properties>
+                              <property name="_SETCULTURE" value="ru-RU" />
+                            </properties>
+                          </test-case>
+                          <test-case name="NUnit.Core.Tests.CultureSettingAndDetectionTests.SettingInvalidCultureGivesError" executed="True" success="True" time="0.047" asserts="3" />
+                        </results>
+                      </test-suite>
+                      <test-suite name="CultureSettingAndDetectionTests+NestedFixture" success="True" time="0.000" asserts="0">
+                        <properties>
+                          <property name="_SETCULTURE" value="en-GB" />
+                        </properties>
+                        <results>
+                          <test-case name="NUnit.Core.Tests.CultureSettingAndDetectionTests+NestedFixture.CanSetCultureOnFixture" executed="True" success="True" time="0.000" asserts="1" />
+                        </results>
+                      </test-suite>
+                      <test-suite name="DirectorySwapperTests" success="True" time="0.000" asserts="0">
+                        <results>
+                          <test-case name="NUnit.Core.Tests.DirectorySwapperTests.ChangeAndRestore" executed="True" success="True" time="0.000" asserts="3" />
+                          <test-case name="NUnit.Core.Tests.DirectorySwapperTests.SwapAndRestore" executed="True" success="True" time="0.000" asserts="2" />
+                        </results>
+                      </test-suite>
+                      <test-suite name="EventQueueTests" success="True" time="0.016" asserts="0">
+                        <results>
+                          <test-case name="NUnit.Core.Tests.EventQueueTests.PumpAutoStopsOnRunFinished" executed="True" success="True" time="0.000" asserts="3" />
+                          <test-case name="NUnit.Core.Tests.EventQueueTests.PumpEvents" executed="True" success="True" time="0.000" asserts="9" />
+                          <test-case name="NUnit.Core.Tests.EventQueueTests.PumpEventsWithAutoStop" executed="True" success="True" time="0.000" asserts="7" />
+                          <test-case name="NUnit.Core.Tests.EventQueueTests.QueueEvents" executed="True" success="True" time="0.000" asserts="6" />
+                          <test-case name="NUnit.Core.Tests.EventQueueTests.SendEvents" executed="True" success="True" time="0.000" asserts="6" />
+                          <test-case name="NUnit.Core.Tests.EventQueueTests.StartAndStopPumpOnEmptyQueue" executed="True" success="True" time="0.000" asserts="2" />
+                        </results>
+                      </test-suite>
+                      <test-suite name="EventTestFixture" description="Tests that proper events are generated when running  test" success="True" time="0.172" asserts="0">
+                        <results>
+                          <test-case name="NUnit.Core.Tests.EventTestFixture.CheckEventListening" executed="True" success="True" time="0.156" asserts="4" />
+                        </results>
+                      </test-suite>
+                      <test-suite name="ExpectExceptionTest" success="True" time="0.266" asserts="0">
+                        <results>
+                          <test-case name="NUnit.Core.Tests.ExpectExceptionTest.AssertFailBeforeException" executed="True" success="True" time="0.000" asserts="2" />
+                          <test-case name="NUnit.Core.Tests.ExpectExceptionTest.CanExpectUnspecifiedException" executed="True" success="True" time="0.000" asserts="0" />
+                          <test-case name="NUnit.Core.Tests.ExpectExceptionTest.ExceptionHandlerIsCalledWhenExceptionMatches" executed="True" success="True" time="0.000" asserts="2" />
+                          <test-case name="NUnit.Core.Tests.ExpectExceptionTest.ExceptionHandlerIsCalledWhenExceptionMatches_AlternateHandler" executed="True" success="True" time="0.000" asserts="2" />
+                          <test-case name="NUnit.Core.Tests.ExpectExceptionTest.ExceptionHandlerIsNotCalledWhenExceptionDoesNotMatch" executed="True" success="True" time="0.000" asserts="2" />
+                          <test-case name="NUnit.Core.Tests.ExpectExceptionTest.ExceptionHandlerIsNotCalledWhenExceptionDoesNotMatch_AlternateHandler" executed="True" success="True" time="0.000" asserts="2" />
+                          <test-case name="NUnit.Core.Tests.ExpectExceptionTest.MethodThrowsArgumentOutOfRange" executed="True" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Core.Tests.ExpectExceptionTest.MethodThrowsException" executed="True" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Core.Tests.ExpectExceptionTest.MethodThrowsRightExceptionMessage" executed="True" success="True" time="0.016" asserts="1" />
+                          <test-case name="NUnit.Core.Tests.ExpectExceptionTest.MethodThrowsWrongExceptionMessage" executed="True" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Core.Tests.ExpectExceptionTest.SetUpThrowsSameException" executed="True" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Core.Tests.ExpectExceptionTest.TearDownThrowsSameException" executed="True" success="True" time="0.016" asserts="1" />
+                          <test-case name="NUnit.Core.Tests.ExpectExceptionTest.TestExceptionNameNotThrown" executed="True" success="True" time="0.000" asserts="2" />
+                          <test-case name="NUnit.Core.Tests.ExpectExceptionTest.TestExceptionNameNotThrownWithUserMessage" executed="True" success="True" time="0.000" asserts="2" />
+                          <test-case name="NUnit.Core.Tests.ExpectExceptionTest.TestExceptionTypeNotThrown" executed="True" success="True" time="0.000" asserts="2" />
+                          <test-case name="NUnit.Core.Tests.ExpectExceptionTest.TestExceptionTypeNotThrownWithUserMessage" executed="True" success="True" time="0.000" asserts="2" />
+                          <test-case name="NUnit.Core.Tests.ExpectExceptionTest.TestFailsWhenBaseExceptionIsThrown" executed="True" success="True" time="0.000" asserts="2" />
+                          <test-case name="NUnit.Core.Tests.ExpectExceptionTest.TestFailsWhenDerivedExceptionIsThrown" executed="True" success="True" time="0.000" asserts="2" />
+                          <test-case name="NUnit.Core.Tests.ExpectExceptionTest.TestIsNotRunnableWhenAlternateHandlerIsNotFound" executed="True" success="True" time="0.000" asserts="2" />
+                          <test-case name="NUnit.Core.Tests.ExpectExceptionTest.TestMismatchedExceptionMessage" executed="True" success="True" time="0.000" asserts="2" />
+                          <test-case name="NUnit.Core.Tests.ExpectExceptionTest.TestMismatchedExceptionMessageWithUserMessage" executed="True" success="True" time="0.000" asserts="2" />
+                          <test-case name="NUnit.Core.Tests.ExpectExceptionTest.TestMismatchedExceptionName" executed="True" success="True" time="0.000" asserts="2" />
+                          <test-case name="NUnit.Core.Tests.ExpectExceptionTest.TestMismatchedExceptionNameWithUserMessage" executed="True" success="True" time="0.000" asserts="2" />
+                          <test-case name="NUnit.Core.Tests.ExpectExceptionTest.TestMismatchedExceptionType" executed="True" success="True" time="0.016" asserts="2" />
+                          <test-case name="NUnit.Core.Tests.ExpectExceptionTest.TestMismatchedExceptionTypeWithUserMessage" executed="True" success="True" time="0.000" asserts="2" />
+                          <test-case name="NUnit.Core.Tests.ExpectExceptionTest.TestSucceedsWhenSpecifiedExceptionNameAndContainsMatch" executed="True" success="True" time="0.000" asserts="0" />
+                          <test-case name="NUnit.Core.Tests.ExpectExceptionTest.TestSucceedsWhenSpecifiedExceptionNameAndRegexMatch" executed="True" success="True" time="0.109" asserts="0" />
+                          <test-case name="NUnit.Core.Tests.ExpectExceptionTest.TestSucceedsWithSpecifiedExceptionName" executed="True" success="True" time="0.000" asserts="0" />
+                          <test-case name="NUnit.Core.Tests.ExpectExceptionTest.TestSucceedsWithSpecifiedExceptionNameAndExactMatch" executed="True" success="True" time="0.000" asserts="0" />
+                          <test-case name="NUnit.Core.Tests.ExpectExceptionTest.TestSucceedsWithSpecifiedExceptionNameAndMessage_NewFormat" executed="True" success="True" time="0.000" asserts="0" />
+                          <test-case name="NUnit.Core.Tests.ExpectExceptionTest.TestSucceedsWithSpecifiedExceptionNameAndMessage_OldFormat" executed="True" success="True" time="0.000" asserts="0" />
+                          <test-case name="NUnit.Core.Tests.ExpectExceptionTest.TestSucceedsWithSpecifiedExceptionType" executed="True" success="True" time="0.016" asserts="0" />
+                          <test-case name="NUnit.Core.Tests.ExpectExceptionTest.TestSucceedsWithSpecifiedExceptionTypeAndContainsMatch" executed="True" success="True" time="0.000" asserts="0" />
+                          <test-case name="NUnit.Core.Tests.ExpectExceptionTest.TestSucceedsWithSpecifiedExceptionTypeAndExactMatch" executed="True" success="True" time="0.000" asserts="0" />
+                          <test-case name="NUnit.Core.Tests.ExpectExceptionTest.TestSucceedsWithSpecifiedExceptionTypeAndMessage" executed="True" success="True" time="0.000" asserts="0" />
+                          <test-case name="NUnit.Core.Tests.ExpectExceptionTest.TestSucceedsWithSpecifiedExceptionTypeAndRegexMatch" executed="True" success="True" time="0.000" asserts="0" />
+                          <test-case name="NUnit.Core.Tests.ExpectExceptionTest.TestUnspecifiedExceptionNotThrown" executed="True" success="True" time="0.016" asserts="2" />
+                          <test-case name="NUnit.Core.Tests.ExpectExceptionTest.TestUnspecifiedExceptionNotThrownWithUserMessage" executed="True" success="True" time="0.000" asserts="2" />
+                          <test-case name="NUnit.Core.Tests.ExpectExceptionTest.ThrowingMyAppException" executed="True" success="True" time="0.000" asserts="0" />
+                          <test-case name="NUnit.Core.Tests.ExpectExceptionTest.ThrowingMyAppExceptionWithMessage" executed="True" success="True" time="0.000" asserts="0" />
+                          <test-case name="NUnit.Core.Tests.ExpectExceptionTest.ThrowNUnitException" executed="True" success="True" time="0.000" asserts="0" />
+                        </results>
+                      </test-suite>
+                      <test-suite name="FailFixture" success="True" time="0.016" asserts="0">
+                        <results>
+                          <test-case name="NUnit.Core.Tests.FailFixture.BadStackTraceIsHandled" executed="True" success="True" time="0.000" asserts="3" />
+                          <test-case name="NUnit.Core.Tests.FailFixture.CustomExceptionIsHandled" executed="True" success="True" time="0.000" asserts="2" />
+                          <test-case name="NUnit.Core.Tests.FailFixture.FailInheritsFromSystemException" executed="True" success="True" time="0.000" asserts="0" />
+                          <test-case name="NUnit.Core.Tests.FailFixture.FailRecordsInnerException" executed="True" success="True" time="0.016" asserts="2" />
+                          <test-case name="NUnit.Core.Tests.FailFixture.FailThrowsAssertionException" executed="True" success="True" time="0.000" asserts="0" />
+                          <test-case name="NUnit.Core.Tests.FailFixture.VerifyAssertionFailWorks" executed="True" success="True" time="0.000" asserts="2" />
+                          <test-case name="NUnit.Core.Tests.FailFixture.VerifyFailWorks" executed="True" success="True" time="0.000" asserts="2" />
+                        </results>
+                      </test-suite>
+                      <test-suite name="FixtureSetupTearDownTest" success="True" time="0.078" asserts="0">
+                        <results>
+                          <test-case name="NUnit.Core.Tests.FixtureSetupTearDownTest.CheckInheritedSetUpAndTearDownAreCalled" executed="True" success="True" time="0.016" asserts="2" />
+                          <test-case name="NUnit.Core.Tests.FixtureSetupTearDownTest.CheckInheritedSetUpAndTearDownAreNotCalled" executed="True" success="True" time="0.000" asserts="4" />
+                          <test-case name="NUnit.Core.Tests.FixtureSetupTearDownTest.DisposeCalledWhenFixtureImplementsIDisposable" executed="True" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Core.Tests.FixtureSetupTearDownTest.FixtureWithNoTestsShouldNotCallFixtureSetUpOrTearDown" executed="True" success="True" time="0.016" asserts="2" />
+                          <test-case name="NUnit.Core.Tests.FixtureSetupTearDownTest.HandleErrorInFixtureSetup" executed="True" success="True" time="0.000" asserts="13" />
+                          <test-case name="NUnit.Core.Tests.FixtureSetupTearDownTest.HandleErrorInFixtureTearDown" executed="True" success="True" time="0.000" asserts="10" />
+                          <test-case name="NUnit.Core.Tests.FixtureSetupTearDownTest.HandleExceptionInFixtureConstructor" executed="True" success="True" time="0.000" asserts="11" />
+                          <test-case name="NUnit.Core.Tests.FixtureSetupTearDownTest.HandleIgnoreInFixtureSetup" executed="True" success="True" time="0.000" asserts="8" />
+                          <test-case name="NUnit.Core.Tests.FixtureSetupTearDownTest.HandleSetUpAndTearDownWithTestInName" executed="True" success="True" time="0.000" asserts="2" />
+                          <test-case name="NUnit.Core.Tests.FixtureSetupTearDownTest.IgnoredFixtureShouldNotCallFixtureSetUpOrTearDown" executed="True" success="True" time="0.000" asserts="2" />
+                          <test-case name="NUnit.Core.Tests.FixtureSetupTearDownTest.MakeSureSetUpAndTearDownAreCalled" executed="True" success="True" time="0.000" asserts="2" />
+                          <test-case name="NUnit.Core.Tests.FixtureSetupTearDownTest.MakeSureSetUpAndTearDownAreCalledOnExplicitFixture" executed="True" success="True" time="0.000" asserts="2" />
+                          <test-case name="NUnit.Core.Tests.FixtureSetupTearDownTest.RerunFixtureAfterSetUpFixed" executed="True" success="True" time="0.000" asserts="5" />
+                          <test-case name="NUnit.Core.Tests.FixtureSetupTearDownTest.RerunFixtureAfterTearDownFixed" executed="True" success="True" time="0.016" asserts="5" />
+                          <test-case name="NUnit.Core.Tests.FixtureSetupTearDownTest.RunningSingleMethodCallsSetUpAndTearDown" executed="True" success="True" time="0.000" asserts="2" />
+                        </results>
+                      </test-suite>
+                      <test-suite name="IgnoreFixture" success="True" time="0.016" asserts="0">
+                        <results>
+                          <test-case name="NUnit.Core.Tests.IgnoreFixture.IgnoreThrowsIgnoreException" executed="True" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Core.Tests.IgnoreFixture.IgnoreWithUserMessage" executed="True" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Core.Tests.IgnoreFixture.IgnoreWithUserMessage_ArrayOfArgs" executed="True" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Core.Tests.IgnoreFixture.IgnoreWithUserMessage_OneArg" executed="True" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Core.Tests.IgnoreFixture.IgnoreWithUserMessage_ThreeArgs" executed="True" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Core.Tests.IgnoreFixture.IgnoreWorksForTestCase" executed="True" success="True" time="0.000" asserts="2" />
+                          <test-case name="NUnit.Core.Tests.IgnoreFixture.IgnoreWorksForTestSuite" executed="True" success="True" time="0.016" asserts="3" />
+                          <test-case name="NUnit.Core.Tests.IgnoreFixture.IgnoreWorksFromSetUp" executed="True" success="True" time="0.000" asserts="3" />
+                        </results>
+                      </test-suite>
+                      <test-suite name="LegacySuiteTests" success="True" time="0.125" asserts="0">
+                        <results>
+                          <test-case name="NUnit.Core.Tests.LegacySuiteTests.SetUpAndTearDownAreCalled" executed="True" success="True" time="0.000" asserts="3" />
+                          <test-case name="NUnit.Core.Tests.LegacySuiteTests.SuitePropertyWithInvalidType" executed="True" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Core.Tests.LegacySuiteTests.SuiteReturningFixtures" executed="True" success="True" time="0.094" asserts="3" />
+                          <test-case name="NUnit.Core.Tests.LegacySuiteTests.SuiteReturningTestSuite" executed="True" success="True" time="0.016" asserts="3" />
+                          <test-case name="NUnit.Core.Tests.LegacySuiteTests.SuiteReturningTypes" executed="True" success="True" time="0.000" asserts="3" />
+                        </results>
+                      </test-suite>
+                      <test-suite name="NameFilterTest" success="True" time="0.094" asserts="0">
+                        <results>
+                          <test-case name="NUnit.Core.Tests.NameFilterTest.ExplicitTestCaseDoesNotMatchWhenNotSelectedDirectly" executed="True" success="True" time="0.016" asserts="1" />
+                          <test-case name="NUnit.Core.Tests.NameFilterTest.ExplicitTestCaseMatchesWhenSelectedDirectly" executed="True" success="True" time="0.016" asserts="2" />
+                          <test-case name="NUnit.Core.Tests.NameFilterTest.ExplicitTestSuiteDoesNotMatchWhenNotSelectedDirectly" executed="True" success="True" time="0.000" asserts="2" />
+                          <test-case name="NUnit.Core.Tests.NameFilterTest.ExplicitTestSuiteMatchesWhenSelectedDirectly" executed="True" success="True" time="0.016" asserts="3" />
+                          <test-case name="NUnit.Core.Tests.NameFilterTest.HighLevelSuite" executed="True" success="True" time="0.000" asserts="3" />
+                          <test-case name="NUnit.Core.Tests.NameFilterTest.MultipleNameMatch" executed="True" success="True" time="0.016" asserts="3" />
+                          <test-case name="NUnit.Core.Tests.NameFilterTest.SingleNameMatch" executed="True" success="True" time="0.016" asserts="4" />
+                          <test-case name="NUnit.Core.Tests.NameFilterTest.SuiteNameMatch" executed="True" success="True" time="0.000" asserts="3" />
+                          <test-case name="NUnit.Core.Tests.NameFilterTest.TestDoesNotMatch" executed="True" success="True" time="0.016" asserts="2" />
+                        </results>
+                      </test-suite>
+                      <test-suite name="NamespaceAssemblyTests" success="True" time="0.188" asserts="0">
+                        <results>
+                          <test-case name="NUnit.Core.Tests.NamespaceAssemblyTests.Hierarchy" executed="True" success="True" time="0.031" asserts="20" />
+                          <test-case name="NUnit.Core.Tests.NamespaceAssemblyTests.LoadTestFixtureFromAssembly" executed="True" success="True" time="0.063" asserts="1" />
+                          <test-case name="NUnit.Core.Tests.NamespaceAssemblyTests.NoNamespaceInAssembly" executed="True" success="True" time="0.031" asserts="5" />
+                          <test-case name="NUnit.Core.Tests.NamespaceAssemblyTests.TestRoot" executed="True" success="True" time="0.047" asserts="1" />
+                        </results>
+                      </test-suite>
+                      <test-suite name="PlatformDetectionTests" success="True" time="0.047" asserts="0">
+                        <results>
+                          <test-case name="NUnit.Core.Tests.PlatformDetectionTests.ArrayOfPlatforms" executed="True" success="True" time="0.000" asserts="2" />
+                          <test-case name="NUnit.Core.Tests.PlatformDetectionTests.DetectExactVersion" executed="True" success="True" time="0.000" asserts="4" />
+                          <test-case name="NUnit.Core.Tests.PlatformDetectionTests.DetectMono10" executed="True" success="True" time="0.000" asserts="8" />
+                          <test-case name="NUnit.Core.Tests.PlatformDetectionTests.DetectMono20" executed="True" success="True" time="0.000" asserts="8" />
+                          <test-case name="NUnit.Core.Tests.PlatformDetectionTests.DetectNet10" executed="True" success="True" time="0.000" asserts="8" />
+                          <test-case name="NUnit.Core.Tests.PlatformDetectionTests.DetectNet11" executed="True" success="True" time="0.000" asserts="8" />
+                          <test-case name="NUnit.Core.Tests.PlatformDetectionTests.DetectNet20" executed="True" success="True" time="0.000" asserts="8" />
+                          <test-case name="NUnit.Core.Tests.PlatformDetectionTests.DetectNetCF" executed="True" success="True" time="0.000" asserts="9" />
+                          <test-case name="NUnit.Core.Tests.PlatformDetectionTests.DetectNT3" executed="True" success="True" time="0.000" asserts="16" />
+                          <test-case name="NUnit.Core.Tests.PlatformDetectionTests.DetectNT4" executed="True" success="True" time="0.000" asserts="16" />
+                          <test-case name="NUnit.Core.Tests.PlatformDetectionTests.DetectSSCLI" executed="True" success="True" time="0.000" asserts="8" />
+                          <test-case name="NUnit.Core.Tests.PlatformDetectionTests.DetectUnixUnderMicrosoftDotNet" executed="True" success="True" time="0.000" asserts="18" />
+                          <test-case name="NUnit.Core.Tests.PlatformDetectionTests.DetectUnixUnderMono" executed="False">
+                            <reason>
+                              <message><![CDATA[Not supported on Net]]></message>
+                            </reason>
+                          </test-case>
+                          <test-case name="NUnit.Core.Tests.PlatformDetectionTests.DetectWin2003Server" executed="True" success="True" time="0.000" asserts="15" />
+                          <test-case name="NUnit.Core.Tests.PlatformDetectionTests.DetectWin2K" executed="True" success="True" time="0.000" asserts="15" />
+                          <test-case name="NUnit.Core.Tests.PlatformDetectionTests.DetectWin95" executed="True" success="True" time="0.016" asserts="16" />
+                          <test-case name="NUnit.Core.Tests.PlatformDetectionTests.DetectWin98" executed="True" success="True" time="0.000" asserts="16" />
+                          <test-case name="NUnit.Core.Tests.PlatformDetectionTests.DetectWinCE" executed="True" success="True" time="0.000" asserts="17" />
+                          <test-case name="NUnit.Core.Tests.PlatformDetectionTests.DetectWinMe" executed="True" success="True" time="0.000" asserts="16" />
+                          <test-case name="NUnit.Core.Tests.PlatformDetectionTests.DetectWinXP" executed="True" success="True" time="0.000" asserts="15" />
+                          <test-case name="NUnit.Core.Tests.PlatformDetectionTests.PlatformAttribute_Exclude" executed="True" success="True" time="0.000" asserts="3" />
+                          <test-case name="NUnit.Core.Tests.PlatformDetectionTests.PlatformAttribute_Include" executed="True" success="True" time="0.000" asserts="3" />
+                          <test-case name="NUnit.Core.Tests.PlatformDetectionTests.PlatformAttribute_IncludeAndExclude" executed="True" success="True" time="0.000" asserts="7" />
+                          <test-case name="NUnit.Core.Tests.PlatformDetectionTests.PlatformAttribute_InvalidPlatform" executed="True" success="True" time="0.000" asserts="2" />
+                        </results>
+                      </test-suite>
+                      <test-suite name="PropertyAttributeTests" success="True" time="0.000" asserts="0">
+                        <results>
+                          <test-case name="NUnit.Core.Tests.PropertyAttributeTests.CanDeriveFromPropertyAttribute" executed="True" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Core.Tests.PropertyAttributeTests.PropertiesWithNumericValues" executed="True" success="True" time="0.000" asserts="2" />
+                          <test-case name="NUnit.Core.Tests.PropertyAttributeTests.PropertyWithStringValue" executed="True" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Core.Tests.PropertyAttributeTests.PropertyWorksOnFixtures" executed="True" success="True" time="0.000" asserts="1" />
+                        </results>
+                      </test-suite>
+                      <test-suite name="ReflectTests" success="True" time="0.016" asserts="0">
+                        <results>
+                          <test-case name="NUnit.Core.Tests.ReflectTests.CanDetectAttributes" executed="True" success="True" time="0.000" asserts="3" />
+                          <test-case name="NUnit.Core.Tests.ReflectTests.CanDetectInheritedAttributes" executed="True" success="True" time="0.016" asserts="3" />
+                          <test-case name="NUnit.Core.Tests.ReflectTests.Construct" executed="True" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Core.Tests.ReflectTests.CountMethodsWithAttribute" executed="True" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Core.Tests.ReflectTests.GetAttribute" executed="True" success="True" time="0.000" asserts="3" />
+                          <test-case name="NUnit.Core.Tests.ReflectTests.GetAttributes" executed="True" success="True" time="0.000" asserts="4" />
+                          <test-case name="NUnit.Core.Tests.ReflectTests.GetConstructor" executed="True" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Core.Tests.ReflectTests.GetInheritedAttribute" executed="True" success="True" time="0.000" asserts="3" />
+                          <test-case name="NUnit.Core.Tests.ReflectTests.GetInheritedAttributes" executed="True" success="True" time="0.000" asserts="4" />
+                          <test-case name="NUnit.Core.Tests.ReflectTests.GetMethodWithAttribute" executed="True" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Core.Tests.ReflectTests.GetNamedMethod" executed="True" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Core.Tests.ReflectTests.GetNamedMethodWithArgs" executed="True" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Core.Tests.ReflectTests.GetNamedProperty" executed="True" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Core.Tests.ReflectTests.GetPropertyValue" executed="True" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Core.Tests.ReflectTests.GetPropertyWithAttribute" executed="True" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Core.Tests.ReflectTests.HasInterface" executed="True" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Core.Tests.ReflectTests.InheritsFrom" executed="True" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Core.Tests.ReflectTests.InvokeMethod" executed="True" success="True" time="0.000" asserts="1" />
+                        </results>
+                      </test-suite>
+                      <test-suite name="RemoteRunnerTests" success="True" time="0.938" asserts="1">
+                        <results>
+                          <test-case name="NUnit.Core.Tests.RemoteRunnerTests.CheckRunnerID" executed="True" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Core.Tests.RemoteRunnerTests.CountTestCases" executed="True" success="True" time="0.094" asserts="1" />
+                          <test-case name="NUnit.Core.Tests.RemoteRunnerTests.CountTestCasesAcrossMultipleAssemblies" executed="True" success="True" time="0.109" asserts="1" />
+                          <test-case name="NUnit.Core.Tests.RemoteRunnerTests.LoadAssembly" executed="True" success="True" time="0.063" asserts="1" />
+                          <test-case name="NUnit.Core.Tests.RemoteRunnerTests.LoadAssemblyWithFixture" executed="True" success="True" time="0.031" asserts="1" />
+                          <test-case name="NUnit.Core.Tests.RemoteRunnerTests.LoadAssemblyWithoutNamespaces" executed="True" success="True" time="0.047" asserts="4" />
+                          <test-case name="NUnit.Core.Tests.RemoteRunnerTests.LoadAssemblyWithSuite" executed="True" success="True" time="0.047" asserts="1" />
+                          <test-case name="NUnit.Core.Tests.RemoteRunnerTests.LoadMultipleAssemblies" executed="True" success="True" time="0.063" asserts="1" />
+                          <test-case name="NUnit.Core.Tests.RemoteRunnerTests.LoadMultipleAssembliesWithFixture" executed="True" success="True" time="0.063" asserts="1" />
+                          <test-case name="NUnit.Core.Tests.RemoteRunnerTests.LoadMultipleAssembliesWithSuite" executed="True" success="True" time="0.063" asserts="1" />
+                          <test-case name="NUnit.Core.Tests.RemoteRunnerTests.RunAssembly" executed="True" success="True" time="0.047" asserts="1" />
+                          <test-case name="NUnit.Core.Tests.RemoteRunnerTests.RunAssemblyUsingBeginAndEndRun" executed="True" success="True" time="0.078" asserts="2" />
+                          <test-case name="NUnit.Core.Tests.RemoteRunnerTests.RunMultipleAssemblies" executed="True" success="True" time="0.078" asserts="1" />
+                          <test-case name="NUnit.Core.Tests.RemoteRunnerTests.RunMultipleAssembliesUsingBeginAndEndRun" executed="True" success="True" time="0.141" asserts="2" />
+                        </results>
+                      </test-suite>
+                      <test-suite name="SerializationBug" success="True" time="0.016" asserts="0">
+                        <results>
+                          <test-case name="NUnit.Core.Tests.SerializationBug.SaveAndLoad" executed="True" success="True" time="0.016" asserts="3" />
+                        </results>
+                      </test-suite>
+                      <test-suite name="SetUpFixtureTests" success="True" time="0.672" asserts="0">
+                        <results>
+                          <test-case name="NUnit.Core.Tests.SetUpFixtureTests.AssemblySetUpFixtureReplacesAssemblyNodeInTree" executed="True" success="True" time="0.281" asserts="4" />
+                          <test-case name="NUnit.Core.Tests.SetUpFixtureTests.AssemblySetupFixtureWrapsExecutionOfTest" executed="True" success="True" time="0.141" asserts="5" />
+                          <test-case name="NUnit.Core.Tests.SetUpFixtureTests.NamespaceSetUpFixtureReplacesNamespaceNodeInTree" executed="True" success="True" time="0.031" asserts="14" />
+                          <test-case name="NUnit.Core.Tests.SetUpFixtureTests.NamespaceSetUpFixtureWrapsExecutionOfSingleTest" executed="True" success="True" time="0.063" asserts="8" />
+                          <test-case name="NUnit.Core.Tests.SetUpFixtureTests.NamespaceSetUpFixtureWrapsExecutionOfTwoTests" executed="True" success="True" time="0.047" asserts="13" />
+                          <test-case name="NUnit.Core.Tests.SetUpFixtureTests.NamespaceSetUpFixtureWrapsNestedNamespaceSetUpFixture" executed="True" success="True" time="0.063" asserts="15" />
+                          <test-case name="NUnit.Core.Tests.SetUpFixtureTests.WithTwoSetUpFixtuesOnlyOneIsUsed" executed="True" success="True" time="0.031" asserts="8" />
+                        </results>
+                      </test-suite>
+                      <test-suite name="SetUpTest" success="True" time="0.016" asserts="0">
+                        <results>
+                          <test-case name="NUnit.Core.Tests.SetUpTest.CheckInheritedSetUpAndTearDownAreCalled" executed="True" success="True" time="0.016" asserts="2" />
+                          <test-case name="NUnit.Core.Tests.SetUpTest.CheckInheritedSetUpAndTearDownAreNotCalled" executed="True" success="True" time="0.000" asserts="4" />
+                          <test-case name="NUnit.Core.Tests.SetUpTest.MakeSureSetUpAndTearDownAreCalled" executed="True" success="True" time="0.000" asserts="2" />
+                          <test-case name="NUnit.Core.Tests.SetUpTest.SetUpAndTearDownCounter" executed="True" success="True" time="0.000" asserts="2" />
+                        </results>
+                      </test-suite>
+                      <test-suite name="SimpleNameFilterTests" success="True" time="0.094" asserts="0">
+                        <results>
+                          <test-case name="NUnit.Core.Tests.SimpleNameFilterTests.ExplicitTestCaseDoesNotMatchWhenNotSelectedDirectly" executed="True" success="True" time="0.016" asserts="1" />
+                          <test-case name="NUnit.Core.Tests.SimpleNameFilterTests.ExplicitTestCaseMatchesWhenSelectedDirectly" executed="True" success="True" time="0.000" asserts="2" />
+                          <test-case name="NUnit.Core.Tests.SimpleNameFilterTests.ExplicitTestSuiteDoesNotMatchWhenNotSelectedDirectly" executed="True" success="True" time="0.016" asserts="2" />
+                          <test-case name="NUnit.Core.Tests.SimpleNameFilterTests.ExplicitTestSuiteMatchesWhenSelectedDirectly" executed="True" success="True" time="0.016" asserts="3" />
+                          <test-case name="NUnit.Core.Tests.SimpleNameFilterTests.HighLevelSuite" executed="True" success="True" time="0.000" asserts="3" />
+                          <test-case name="NUnit.Core.Tests.SimpleNameFilterTests.MultipleNameMatch" executed="True" success="True" time="0.016" asserts="3" />
+                          <test-case name="NUnit.Core.Tests.SimpleNameFilterTests.SingleNameMatch" executed="True" success="True" time="0.000" asserts="4" />
+                          <test-case name="NUnit.Core.Tests.SimpleNameFilterTests.SuiteNameMatch" executed="True" success="True" time="0.016" asserts="3" />
+                          <test-case name="NUnit.Core.Tests.SimpleNameFilterTests.TestDoesNotMatch" executed="True" success="True" time="0.016" asserts="2" />
+                        </results>
+                      </test-suite>
+                      <test-suite name="SimpleTestRunnerTests" success="True" time="0.953" asserts="1">
+                        <results>
+                          <test-case name="NUnit.Core.Tests.SimpleTestRunnerTests.CheckRunnerID" executed="True" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Core.Tests.SimpleTestRunnerTests.CountTestCases" executed="True" success="True" time="0.031" asserts="1" />
+                          <test-case name="NUnit.Core.Tests.SimpleTestRunnerTests.CountTestCasesAcrossMultipleAssemblies" executed="True" success="True" time="0.094" asserts="1" />
+                          <test-case name="NUnit.Core.Tests.SimpleTestRunnerTests.LoadAssembly" executed="True" success="True" time="0.141" asserts="1" />
+                          <test-case name="NUnit.Core.Tests.SimpleTestRunnerTests.LoadAssemblyWithFixture" executed="True" success="True" time="0.047" asserts="1" />
+                          <test-case name="NUnit.Core.Tests.SimpleTestRunnerTests.LoadAssemblyWithoutNamespaces" executed="True" success="True" time="0.063" asserts="4" />
+                          <test-case name="NUnit.Core.Tests.SimpleTestRunnerTests.LoadAssemblyWithSuite" executed="True" success="True" time="0.031" asserts="1" />
+                          <test-case name="NUnit.Core.Tests.SimpleTestRunnerTests.LoadMultipleAssemblies" executed="True" success="True" time="0.094" asserts="1" />
+                          <test-case name="NUnit.Core.Tests.SimpleTestRunnerTests.LoadMultipleAssembliesWithFixture" executed="True" success="True" time="0.078" asserts="1" />
+                          <test-case name="NUnit.Core.Tests.SimpleTestRunnerTests.LoadMultipleAssembliesWithSuite" executed="True" success="True" time="0.078" asserts="1" />
+                          <test-case name="NUnit.Core.Tests.SimpleTestRunnerTests.RunAssembly" executed="True" success="True" time="0.047" asserts="1" />
+                          <test-case name="NUnit.Core.Tests.SimpleTestRunnerTests.RunAssemblyUsingBeginAndEndRun" executed="True" success="True" time="0.078" asserts="2" />
+                          <test-case name="NUnit.Core.Tests.SimpleTestRunnerTests.RunMultipleAssemblies" executed="True" success="True" time="0.078" asserts="1" />
+                          <test-case name="NUnit.Core.Tests.SimpleTestRunnerTests.RunMultipleAssembliesUsingBeginAndEndRun" executed="True" success="True" time="0.078" asserts="2" />
+                        </results>
+                      </test-suite>
+                      <test-suite name="StackOverflowTestFixture" success="True" time="0.016" asserts="0">
+                        <results>
+                          <test-case name="NUnit.Core.Tests.StackOverflowTestFixture.SimpleOverflow" executed="False">
+                            <reason>
+                              <message><![CDATA[Cannot handle StackOverflowException in managed code]]></message>
+                            </reason>
+                          </test-case>
+                        </results>
+                      </test-suite>
+                      <test-suite name="SuiteBuilderTests" success="True" time="1.750" asserts="0">
+                        <results>
+                          <test-case name="NUnit.Core.Tests.SuiteBuilderTests.DiscoverSuite" executed="True" success="True" time="0.031" asserts="1" />
+                          <test-case name="NUnit.Core.Tests.SuiteBuilderTests.FileNotFound" executed="True" success="True" time="0.000" asserts="0" />
+                          <test-case name="NUnit.Core.Tests.SuiteBuilderTests.FixtureNotFound" executed="True" success="True" time="0.031" asserts="1" />
+                          <test-case name="NUnit.Core.Tests.SuiteBuilderTests.InvalidAssembly" executed="True" success="True" time="0.078" asserts="0" />
+                          <test-case name="NUnit.Core.Tests.SuiteBuilderTests.LoadAssembly" executed="True" success="True" time="0.500" asserts="3" />
+                          <test-case name="NUnit.Core.Tests.SuiteBuilderTests.LoadAssemblyWithoutNamespaces" executed="True" success="True" time="0.469" asserts="3" />
+                          <test-case name="NUnit.Core.Tests.SuiteBuilderTests.LoadFixture" executed="True" success="True" time="0.063" asserts="1" />
+                          <test-case name="NUnit.Core.Tests.SuiteBuilderTests.LoadNamespaceAsSuite" executed="True" success="True" time="0.469" asserts="3" />
+                          <test-case name="NUnit.Core.Tests.SuiteBuilderTests.LoadSuite" executed="True" success="True" time="0.047" asserts="2" />
+                          <test-case name="NUnit.Core.Tests.SuiteBuilderTests.WrongReturnTypeSuite" executed="True" success="True" time="0.031" asserts="1" />
+                        </results>
+                      </test-suite>
+                      <test-suite name="SuiteBuilderTests_Multiple" success="True" time="0.422" asserts="0">
+                        <results>
+                          <test-case name="NUnit.Core.Tests.SuiteBuilderTests_Multiple.BuildSuite" executed="True" success="True" time="0.063" asserts="1" />
+                          <test-case name="NUnit.Core.Tests.SuiteBuilderTests_Multiple.LoadFixture" executed="True" success="True" time="0.156" asserts="2" />
+                          <test-case name="NUnit.Core.Tests.SuiteBuilderTests_Multiple.RootNode" executed="True" success="True" time="0.109" asserts="1" />
+                          <test-case name="NUnit.Core.Tests.SuiteBuilderTests_Multiple.TestCaseCount" executed="True" success="True" time="0.078" asserts="1" />
+                        </results>
+                      </test-suite>
+                      <test-suite name="TestAssemblyBuilderTests" success="True" time="0.094" asserts="0">
+                        <results>
+                          <test-case name="NUnit.Core.Tests.TestAssemblyBuilderTests.CanLoadAssemblyAtRelativeDirectoryLocation" executed="True" success="True" time="0.047" asserts="1" />
+                          <test-case name="NUnit.Core.Tests.TestAssemblyBuilderTests.CanLoadAssemblyInCurrentDirectory" executed="True" success="True" time="0.047" asserts="1" />
+                        </results>
+                      </test-suite>
+                      <test-suite name="TestAttributeFixture" success="True" time="0.031" asserts="0">
+                        <results>
+                          <test-case name="NUnit.Core.Tests.TestAttributeFixture.Description" executed="True" success="True" time="0.016" asserts="1" />
+                          <test-case name="NUnit.Core.Tests.TestAttributeFixture.DescriptionInResult" executed="True" success="True" time="0.000" asserts="0" />
+                          <test-case name="NUnit.Core.Tests.TestAttributeFixture.FixtureDescription" executed="True" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Core.Tests.TestAttributeFixture.FixtureDescriptionInResult" executed="True" success="True" time="0.016" asserts="1" />
+                          <test-case name="NUnit.Core.Tests.TestAttributeFixture.NoDescription" executed="True" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Core.Tests.TestAttributeFixture.ReflectionTest" executed="True" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Core.Tests.TestAttributeFixture.SeparateDescriptionAttribute" executed="True" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Core.Tests.TestAttributeFixture.SeparateDescriptionInResult" executed="True" success="True" time="0.000" asserts="0" />
+                        </results>
+                      </test-suite>
+                      <test-suite name="TestCaseResultFixture" success="True" time="0.000" asserts="0">
+                        <results>
+                          <test-case name="NUnit.Core.Tests.TestCaseResultFixture.TestCaseDefault" executed="True" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Core.Tests.TestCaseResultFixture.TestCaseFailure" executed="True" success="True" time="0.000" asserts="4" />
+                          <test-case name="NUnit.Core.Tests.TestCaseResultFixture.TestCaseNotRun" executed="True" success="True" time="0.000" asserts="2" />
+                          <test-case name="NUnit.Core.Tests.TestCaseResultFixture.TestCaseSuccess" executed="True" success="True" time="0.000" asserts="1" />
+                        </results>
+                      </test-suite>
+                      <test-suite name="TestCaseTest" success="True" time="0.000" asserts="0">
+                        <results>
+                          <test-case name="NUnit.Core.Tests.TestCaseTest.CreateIgnoredTestCase" executed="True" success="True" time="0.000" asserts="3" />
+                          <test-case name="NUnit.Core.Tests.TestCaseTest.LoadMethodCategories" executed="True" success="True" time="0.000" asserts="3" />
+                          <test-case name="NUnit.Core.Tests.TestCaseTest.RunIgnoredTestCase" executed="True" success="True" time="0.000" asserts="3" />
+                        </results>
+                      </test-suite>
+                      <test-suite name="TestConsole" success="True" time="0.016" asserts="0">
+                        <results>
+                          <test-case name="NUnit.Core.Tests.TestConsole.ConsoleWrite" executed="True" success="True" time="0.016" asserts="0" />
+                          <test-case name="NUnit.Core.Tests.TestConsole.ConsoleWriteLine" executed="True" success="True" time="0.000" asserts="0" />
+                        </results>
+                      </test-suite>
+                      <test-suite name="TestContextTests" success="True" time="0.031" asserts="0">
+                        <results>
+                          <test-case name="NUnit.Core.Tests.TestContextTests.SetAndRestoreCurrentCulture" executed="True" success="True" time="0.000" asserts="5" />
+                          <test-case name="NUnit.Core.Tests.TestContextTests.SetAndRestoreCurrentDirectory" executed="True" success="True" time="0.031" asserts="5" />
+                        </results>
+                      </test-suite>
+                      <test-suite name="TestDelegateFixture" success="True" time="0.000" asserts="0">
+                        <results>
+                          <test-case name="NUnit.Core.Tests.TestDelegateFixture.DelegateTest" executed="True" success="True" time="0.000" asserts="1" />
+                        </results>
+                      </test-suite>
+                      <test-suite name="TestFixtureBuilderTests" success="True" time="0.000" asserts="0">
+                        <results>
+                          <test-case name="NUnit.Core.Tests.TestFixtureBuilderTests.GoodSignature" executed="True" success="True" time="0.000" asserts="2" />
+                          <test-case name="NUnit.Core.Tests.TestFixtureBuilderTests.LoadCategories" executed="True" success="True" time="0.000" asserts="2" />
+                        </results>
+                      </test-suite>
+                      <test-suite name="TestFixtureExtension" success="True" time="0.156" asserts="0">
+                        <results>
+                          <test-case name="NUnit.Core.Tests.TestFixtureExtension.CheckMultipleSetUp" executed="True" success="True" time="0.047" asserts="1" />
+                          <test-case name="NUnit.Core.Tests.TestFixtureExtension.DerivedTest" executed="True" success="True" time="0.031" asserts="1" />
+                          <test-case name="NUnit.Core.Tests.TestFixtureExtension.InheritSetup" executed="True" success="True" time="0.031" asserts="1" />
+                          <test-case name="NUnit.Core.Tests.TestFixtureExtension.InheritTearDown" executed="True" success="True" time="0.047" asserts="1" />
+                        </results>
+                      </test-suite>
+                      <test-suite name="TestFixtureTests" success="True" time="0.078" asserts="0">
+                        <results>
+                          <test-case name="NUnit.Core.Tests.TestFixtureTests.CannotRunAbstractDerivedFixture" executed="True" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Core.Tests.TestFixtureTests.CannotRunAbstractFixture" executed="True" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Core.Tests.TestFixtureTests.CannotRunBadConstructor" executed="True" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Core.Tests.TestFixtureTests.CannotRunFixtureSetupWithParameters" executed="True" success="True" time="0.016" asserts="1" />
+                          <test-case name="NUnit.Core.Tests.TestFixtureTests.CannotRunFixtureSetupWithReturnValue" executed="True" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Core.Tests.TestFixtureTests.CannotRunFixtureTearDownWithParameters" executed="True" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Core.Tests.TestFixtureTests.CannotRunFixtureTearDownWithReturnValue" executed="True" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Core.Tests.TestFixtureTests.CannotRunIgnoredFixture" executed="True" success="True" time="0.000" asserts="2" />
+                          <test-case name="NUnit.Core.Tests.TestFixtureTests.CannotRunMultipleSetUp" executed="True" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Core.Tests.TestFixtureTests.CannotRunMultipleTearDown" executed="True" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Core.Tests.TestFixtureTests.CannotRunMultipleTestFixtureSetUp" executed="True" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Core.Tests.TestFixtureTests.CannotRunMultipleTestFixtureTearDown" executed="True" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Core.Tests.TestFixtureTests.CannotRunNoDefaultConstructor" executed="True" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Core.Tests.TestFixtureTests.CannotRunPrivateFixtureSetUp" executed="True" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Core.Tests.TestFixtureTests.CannotRunPrivateFixtureTearDown" executed="True" success="True" time="0.016" asserts="1" />
+                          <test-case name="NUnit.Core.Tests.TestFixtureTests.CannotRunPrivateSetUp" executed="True" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Core.Tests.TestFixtureTests.CannotRunPrivateTearDown" executed="True" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Core.Tests.TestFixtureTests.CannotRunProtectedFixtureSetUp" executed="True" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Core.Tests.TestFixtureTests.CannotRunProtectedFixtureTearDown" executed="True" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Core.Tests.TestFixtureTests.CannotRunProtectedSetUp" executed="True" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Core.Tests.TestFixtureTests.CannotRunProtectedTearDown" executed="True" success="True" time="0.016" asserts="1" />
+                          <test-case name="NUnit.Core.Tests.TestFixtureTests.CannotRunSetupWithParameters" executed="True" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Core.Tests.TestFixtureTests.CannotRunSetupWithReturnValue" executed="True" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Core.Tests.TestFixtureTests.CannotRunStaticFixtureSetUp" executed="True" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Core.Tests.TestFixtureTests.CannotRunStaticFixtureTearDown" executed="True" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Core.Tests.TestFixtureTests.CannotRunStaticSetUp" executed="True" success="True" time="0.016" asserts="1" />
+                          <test-case name="NUnit.Core.Tests.TestFixtureTests.CannotRunStaticTearDown" executed="True" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Core.Tests.TestFixtureTests.CannotRunTearDownWithParameters" executed="True" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Core.Tests.TestFixtureTests.CannotRunTearDownWithReturnValue" executed="True" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Core.Tests.TestFixtureTests.ConstructFromDoublyNestedType" executed="True" success="True" time="0.000" asserts="2" />
+                          <test-case name="NUnit.Core.Tests.TestFixtureTests.ConstructFromNestedType" executed="True" success="True" time="0.000" asserts="2" />
+                          <test-case name="NUnit.Core.Tests.TestFixtureTests.ConstructFromType" executed="True" success="True" time="0.000" asserts="2" />
+                          <test-case name="NUnit.Core.Tests.TestFixtureTests.ConstructFromTypeWithoutNamespace" executed="True" success="True" time="0.000" asserts="2" />
+                        </results>
+                      </test-suite>
+                      <test-suite name="TestFrameworkTests" success="True" time="0.016" asserts="0">
+                        <results>
+                          <test-case name="NUnit.Core.Tests.TestFrameworkTests.NUnitFrameworkIsKnownAndReferenced" executed="True" success="True" time="0.016" asserts="0" />
+                        </results>
+                      </test-suite>
+                      <test-suite name="TestIDTests" success="True" time="0.000" asserts="0">
+                        <results>
+                          <test-case name="NUnit.Core.Tests.TestIDTests.ClonedTestIDsAreEqual" executed="True" success="True" time="0.000" asserts="3" />
+                          <test-case name="NUnit.Core.Tests.TestIDTests.DifferentTestIDsAreNotEqual" executed="True" success="True" time="0.000" asserts="3" />
+                          <test-case name="NUnit.Core.Tests.TestIDTests.DifferentTestIDsDisplayDifferentStrings" executed="True" success="True" time="0.000" asserts="1" />
+                        </results>
+                      </test-suite>
+                      <test-suite name="TestInfoTests" success="True" time="0.047" asserts="0">
+                        <results>
+                          <test-case name="NUnit.Core.Tests.TestInfoTests.ConstructFromFixture" executed="True" success="True" time="0.000" asserts="8" />
+                          <test-case name="NUnit.Core.Tests.TestInfoTests.ConstructFromSuite" executed="True" success="True" time="0.047" asserts="7" />
+                          <test-case name="NUnit.Core.Tests.TestInfoTests.ConstructFromTestCase" executed="True" success="True" time="0.000" asserts="7" />
+                        </results>
+                      </test-suite>
+                      <test-suite name="TestNameTests" success="True" time="0.000" asserts="0">
+                        <results>
+                          <test-case name="NUnit.Core.Tests.TestNameTests.CanCompareStrongTestNames" executed="True" success="True" time="0.000" asserts="9" />
+                          <test-case name="NUnit.Core.Tests.TestNameTests.CanCompareWeakAndStrongTestNames" executed="True" success="True" time="0.000" asserts="3" />
+                          <test-case name="NUnit.Core.Tests.TestNameTests.CanCompareWeakTestNames" executed="True" success="True" time="0.000" asserts="6" />
+                          <test-case name="NUnit.Core.Tests.TestNameTests.CanDisplayUniqueNames" executed="True" success="True" time="0.000" asserts="2" />
+                          <test-case name="NUnit.Core.Tests.TestNameTests.CanParseSimpleTestNames" executed="True" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Core.Tests.TestNameTests.CanParseStrongTestNames" executed="True" success="True" time="0.000" asserts="2" />
+                          <test-case name="NUnit.Core.Tests.TestNameTests.CanParseWeakTestNames" executed="True" success="True" time="0.000" asserts="2" />
+                          <test-case name="NUnit.Core.Tests.TestNameTests.ClonedTestNamesAreEqual" executed="True" success="True" time="0.000" asserts="6" />
+                          <test-case name="NUnit.Core.Tests.TestNameTests.TestNamesWithDifferentRunnerIDsAreNotEqual" executed="True" success="True" time="0.000" asserts="7" />
+                        </results>
+                      </test-suite>
+                      <test-suite name="TestNodeTests" success="True" time="0.016" asserts="0">
+                        <results>
+                          <test-case name="NUnit.Core.Tests.TestNodeTests.ConstructFromMultipleTests" executed="True" success="True" time="0.016" asserts="8" />
+                          <test-case name="NUnit.Core.Tests.TestNodeTests.ConstructFromSuite" executed="True" success="True" time="0.000" asserts="3" />
+                          <test-case name="NUnit.Core.Tests.TestNodeTests.ConstructFromTestCase" executed="True" success="True" time="0.000" asserts="1" />
+                        </results>
+                      </test-suite>
+                      <test-suite name="TestRunnerThreadTests" success="True" time="0.031" asserts="0">
+                        <results>
+                          <test-case name="NUnit.Core.Tests.TestRunnerThreadTests.RunMultipleTests" executed="True" success="True" time="0.031" asserts="2" />
+                          <test-case name="NUnit.Core.Tests.TestRunnerThreadTests.RunNamedTest" executed="True" success="True" time="0.000" asserts="2" />
+                          <test-case name="NUnit.Core.Tests.TestRunnerThreadTests.RunTestSuite" executed="True" success="True" time="0.000" asserts="2" />
+                        </results>
+                      </test-suite>
+                      <test-suite name="TestSuiteResultFixture" success="True" time="0.000" asserts="0">
+                        <results>
+                          <test-case name="NUnit.Core.Tests.TestSuiteResultFixture.EmptySuite" executed="True" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Core.Tests.TestSuiteResultFixture.SuiteSuccess" executed="True" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Core.Tests.TestSuiteResultFixture.TestSuiteFailure" executed="True" success="True" time="0.000" asserts="4" />
+                        </results>
+                      </test-suite>
+                      <test-suite name="TestSuiteTest" success="True" time="0.219" asserts="0">
+                        <results>
+                          <test-case name="NUnit.Core.Tests.TestSuiteTest.CanSortUsingExternalComparer" executed="True" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Core.Tests.TestSuiteTest.CountTestCasesFilteredByName" executed="True" success="True" time="0.016" asserts="4" />
+                          <test-case name="NUnit.Core.Tests.TestSuiteTest.DefaultSortIsByName" executed="True" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Core.Tests.TestSuiteTest.ExcludingCategoryDoesNotRunExplicitTestCases" executed="True" success="True" time="0.016" asserts="1" />
+                          <test-case name="NUnit.Core.Tests.TestSuiteTest.ExcludingCategoryDoesNotRunExplicitTestFixtures" executed="True" success="True" time="0.047" asserts="1" />
+                          <test-case name="NUnit.Core.Tests.TestSuiteTest.InheritedTestCount" executed="True" success="True" time="0.016" asserts="1" />
+                          <test-case name="NUnit.Core.Tests.TestSuiteTest.RunExplicitTestByCategory" executed="True" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Core.Tests.TestSuiteTest.RunExplicitTestByName" executed="True" success="True" time="0.016" asserts="1" />
+                          <test-case name="NUnit.Core.Tests.TestSuiteTest.RunExplicitTestDirectly" executed="True" success="True" time="0.016" asserts="1" />
+                          <test-case name="NUnit.Core.Tests.TestSuiteTest.RunNoTestSuite" executed="True" success="True" time="0.000" asserts="4" />
+                          <test-case name="NUnit.Core.Tests.TestSuiteTest.RunSingleTest" executed="True" success="True" time="0.016" asserts="1" />
+                          <test-case name="NUnit.Core.Tests.TestSuiteTest.RunSuiteByCategory" executed="True" success="True" time="0.016" asserts="1" />
+                          <test-case name="NUnit.Core.Tests.TestSuiteTest.RunSuiteByName" executed="True" success="True" time="0.000" asserts="2" />
+                          <test-case name="NUnit.Core.Tests.TestSuiteTest.RunTestByCategory" executed="True" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Core.Tests.TestSuiteTest.RunTestByName" executed="True" success="True" time="0.016" asserts="2" />
+                          <test-case name="NUnit.Core.Tests.TestSuiteTest.RunTestExcludingCategory" executed="True" success="True" time="0.016" asserts="1" />
+                          <test-case name="NUnit.Core.Tests.TestSuiteTest.RunTestsInFixture" executed="True" success="True" time="0.000" asserts="3" />
+                          <test-case name="NUnit.Core.Tests.TestSuiteTest.SuiteRunInitialized" executed="True" success="True" time="0.016" asserts="1" />
+                          <test-case name="NUnit.Core.Tests.TestSuiteTest.SuiteWithNoTests" executed="True" success="True" time="0.000" asserts="3" />
+                        </results>
+                      </test-suite>
+                      <test-suite name="ThreadedTestRunnerTests" success="True" time="0.844" asserts="1">
+                        <results>
+                          <test-case name="NUnit.Core.Tests.ThreadedTestRunnerTests.CheckRunnerID" executed="True" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Core.Tests.ThreadedTestRunnerTests.CountTestCases" executed="True" success="True" time="0.047" asserts="1" />
+                          <test-case name="NUnit.Core.Tests.ThreadedTestRunnerTests.CountTestCasesAcrossMultipleAssemblies" executed="True" success="True" time="0.078" asserts="1" />
+                          <test-case name="NUnit.Core.Tests.ThreadedTestRunnerTests.LoadAssembly" executed="True" success="True" time="0.047" asserts="1" />
+                          <test-case name="NUnit.Core.Tests.ThreadedTestRunnerTests.LoadAssemblyWithFixture" executed="True" success="True" time="0.047" asserts="1" />
+                          <test-case name="NUnit.Core.Tests.ThreadedTestRunnerTests.LoadAssemblyWithoutNamespaces" executed="True" success="True" time="0.031" asserts="4" />
+                          <test-case name="NUnit.Core.Tests.ThreadedTestRunnerTests.LoadAssemblyWithSuite" executed="True" success="True" time="0.016" asserts="1" />
+                          <test-case name="NUnit.Core.Tests.ThreadedTestRunnerTests.LoadMultipleAssemblies" executed="True" success="True" time="0.078" asserts="1" />
+                          <test-case name="NUnit.Core.Tests.ThreadedTestRunnerTests.LoadMultipleAssembliesWithFixture" executed="True" success="True" time="0.063" asserts="1" />
+                          <test-case name="NUnit.Core.Tests.ThreadedTestRunnerTests.LoadMultipleAssembliesWithSuite" executed="True" success="True" time="0.078" asserts="1" />
+                          <test-case name="NUnit.Core.Tests.ThreadedTestRunnerTests.RunAssembly" executed="True" success="True" time="0.063" asserts="1" />
+                          <test-case name="NUnit.Core.Tests.ThreadedTestRunnerTests.RunAssemblyUsingBeginAndEndRun" executed="True" success="True" time="0.078" asserts="2" />
+                          <test-case name="NUnit.Core.Tests.ThreadedTestRunnerTests.RunMultipleAssemblies" executed="True" success="True" time="0.109" asserts="1" />
+                          <test-case name="NUnit.Core.Tests.ThreadedTestRunnerTests.RunMultipleAssembliesUsingBeginAndEndRun" executed="True" success="True" time="0.078" asserts="2" />
+                        </results>
+                      </test-suite>
+                      <test-suite name="XmlTest" success="True" time="0.766" asserts="0">
+                        <results>
+                          <test-case name="NUnit.Core.Tests.XmlTest.removeTime" executed="True" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Core.Tests.XmlTest.TestSchemaValidatorFrenchCulture" executed="True" success="True" time="0.531" asserts="1">
+                            <properties>
+                              <property name="_SETCULTURE" value="fr-FR" />
+                            </properties>
+                          </test-case>
+                          <test-case name="NUnit.Core.Tests.XmlTest.TestSchemaValidatorInvariantCulture" executed="True" success="True" time="0.063" asserts="1">
+                            <properties>
+                              <property name="_SETCULTURE" value="" />
+                            </properties>
+                          </test-case>
+                          <test-case name="NUnit.Core.Tests.XmlTest.TestSchemaValidatorUnitedStatesCulture" executed="True" success="True" time="0.063" asserts="1">
+                            <properties>
+                              <property name="_SETCULTURE" value="en-US" />
+                            </properties>
+                          </test-case>
+                          <test-case name="NUnit.Core.Tests.XmlTest.TestStream" executed="True" success="True" time="0.094" asserts="1">
+                            <properties>
+                              <property name="_SETCULTURE" value="en-US" />
+                            </properties>
+                          </test-case>
+                        </results>
+                      </test-suite>
+                    </results>
+                  </test-suite>
+                </results>
+              </test-suite>
+            </results>
+          </test-suite>
+        </results>
+      </test-suite>
+      <test-suite name="C:\Program Files\NUnit 2.4.8\bin\nunit.util.tests.dll" success="True" time="33.594" asserts="0">
+        <results>
+          <test-suite name="NUnit" success="True" time="33.563" asserts="0">
+            <results>
+              <test-suite name="Util" success="True" time="33.516" asserts="0">
+                <results>
+                  <test-suite name="Tests" success="True" time="33.453" asserts="0">
+                    <results>
+                      <test-suite name="AssemblyListTests" success="True" time="0.047" asserts="0">
+                        <results>
+                          <test-case name="NUnit.Util.Tests.AssemblyListTests.AddFiresChangedEvent" executed="True" success="True" time="0.016" asserts="1" />
+                          <test-case name="NUnit.Util.Tests.AssemblyListTests.CanAddAssemblies" executed="True" success="True" time="0.000" asserts="3" />
+                          <test-case name="NUnit.Util.Tests.AssemblyListTests.CanRemoveAssemblies" executed="True" success="True" time="0.000" asserts="3" />
+                          <test-case name="NUnit.Util.Tests.AssemblyListTests.EmptyList" executed="True" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Util.Tests.AssemblyListTests.MustAddAbsolutePath" executed="True" success="True" time="0.000" asserts="0" />
+                          <test-case name="NUnit.Util.Tests.AssemblyListTests.RemoveAtFiresChangedEvent" executed="True" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Util.Tests.AssemblyListTests.RemoveFiresChangedEvent" executed="True" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Util.Tests.AssemblyListTests.SettingFullPathFiresChangedEvent" executed="True" success="True" time="0.000" asserts="1" />
+                        </results>
+                      </test-suite>
+                      <test-suite name="CategoryManagerTest" success="True" time="0.281" asserts="0">
+                        <results>
+                          <test-case name="NUnit.Util.Tests.CategoryManagerTest.CanAddAllAvailableCategoriesInTestTree" executed="True" success="True" time="0.172" asserts="1" />
+                          <test-case name="NUnit.Util.Tests.CategoryManagerTest.CanAddStrings" executed="True" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Util.Tests.CategoryManagerTest.CanAddStringsWithoutDuplicating" executed="True" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Util.Tests.CategoryManagerTest.CanAddTestCategories" executed="True" success="True" time="0.109" asserts="1" />
+                          <test-case name="NUnit.Util.Tests.CategoryManagerTest.CanClearEntries" executed="True" success="True" time="0.000" asserts="1" />
+                        </results>
+                      </test-suite>
+                      <test-suite name="CategoryParseTests" success="True" time="0.031" asserts="0">
+                        <results>
+                          <test-case name="NUnit.Util.Tests.CategoryParseTests.CanParseCompoundCategory" executed="True" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Util.Tests.CategoryParseTests.CanParseExcludedCategories" executed="True" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Util.Tests.CategoryParseTests.CanParseMultipleAlternatives" executed="True" success="True" time="0.000" asserts="4" />
+                          <test-case name="NUnit.Util.Tests.CategoryParseTests.CanParseMultipleCategoriesWithAnd" executed="True" success="True" time="0.000" asserts="4" />
+                          <test-case name="NUnit.Util.Tests.CategoryParseTests.CanParseSimpleCategory" executed="True" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Util.Tests.CategoryParseTests.EmptyStringReturnsEmptyFilter" executed="True" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Util.Tests.CategoryParseTests.OrAndMinusCombined" executed="True" success="True" time="0.000" asserts="5" />
+                          <test-case name="NUnit.Util.Tests.CategoryParseTests.PlusAndMinusCombined" executed="True" success="True" time="0.000" asserts="6" />
+                          <test-case name="NUnit.Util.Tests.CategoryParseTests.PrecedenceTest" executed="True" success="True" time="0.000" asserts="4" />
+                          <test-case name="NUnit.Util.Tests.CategoryParseTests.PrecedenceTestWithParentheses" executed="True" success="True" time="0.000" asserts="5" />
+                        </results>
+                      </test-suite>
+                      <test-suite name="EventDispatcherTests" success="True" time="0.031" asserts="0">
+                        <results>
+                          <test-case name="NUnit.Util.Tests.EventDispatcherTests.ProjectLoaded" executed="True" success="True" time="0.016" asserts="3" />
+                          <test-case name="NUnit.Util.Tests.EventDispatcherTests.ProjectLoadFailed" executed="True" success="True" time="0.000" asserts="4" />
+                          <test-case name="NUnit.Util.Tests.EventDispatcherTests.ProjectLoading" executed="True" success="True" time="0.000" asserts="3" />
+                          <test-case name="NUnit.Util.Tests.EventDispatcherTests.ProjectUnloaded" executed="True" success="True" time="0.000" asserts="3" />
+                          <test-case name="NUnit.Util.Tests.EventDispatcherTests.ProjectUnloadFailed" executed="True" success="True" time="0.000" asserts="4" />
+                          <test-case name="NUnit.Util.Tests.EventDispatcherTests.ProjectUnloading" executed="True" success="True" time="0.000" asserts="3" />
+                          <test-case name="NUnit.Util.Tests.EventDispatcherTests.RunFailed" executed="True" success="True" time="0.000" asserts="3" />
+                          <test-case name="NUnit.Util.Tests.EventDispatcherTests.RunFinished" executed="True" success="True" time="0.000" asserts="3" />
+                          <test-case name="NUnit.Util.Tests.EventDispatcherTests.RunStarting" executed="True" success="True" time="0.000" asserts="4" />
+                          <test-case name="NUnit.Util.Tests.EventDispatcherTests.SuiteFinished" executed="True" success="True" time="0.000" asserts="3" />
+                          <test-case name="NUnit.Util.Tests.EventDispatcherTests.SuiteStarting" executed="True" success="True" time="0.000" asserts="3" />
+                          <test-case name="NUnit.Util.Tests.EventDispatcherTests.TestFinished" executed="True" success="True" time="0.000" asserts="3" />
+                          <test-case name="NUnit.Util.Tests.EventDispatcherTests.TestLoaded" executed="True" success="True" time="0.000" asserts="4" />
+                          <test-case name="NUnit.Util.Tests.EventDispatcherTests.TestLoadFailed" executed="True" success="True" time="0.000" asserts="4" />
+                          <test-case name="NUnit.Util.Tests.EventDispatcherTests.TestLoading" executed="True" success="True" time="0.000" asserts="3" />
+                          <test-case name="NUnit.Util.Tests.EventDispatcherTests.TestReloaded" executed="True" success="True" time="0.000" asserts="4" />
+                          <test-case name="NUnit.Util.Tests.EventDispatcherTests.TestReloadFailed" executed="True" success="True" time="0.000" asserts="4" />
+                          <test-case name="NUnit.Util.Tests.EventDispatcherTests.TestReloading" executed="True" success="True" time="0.000" asserts="3" />
+                          <test-case name="NUnit.Util.Tests.EventDispatcherTests.TestStarting" executed="True" success="True" time="0.000" asserts="3" />
+                          <test-case name="NUnit.Util.Tests.EventDispatcherTests.TestUnloaded" executed="True" success="True" time="0.000" asserts="3" />
+                          <test-case name="NUnit.Util.Tests.EventDispatcherTests.TestUnloadFailed" executed="True" success="True" time="0.000" asserts="4" />
+                          <test-case name="NUnit.Util.Tests.EventDispatcherTests.TestUnloading" executed="True" success="True" time="0.000" asserts="3" />
+                        </results>
+                      </test-suite>
+                      <test-suite name="FileWatcherTest" success="True" time="0.984" asserts="0">
+                        <results>
+                          <test-case name="NUnit.Util.Tests.FileWatcherTest.ChangingAttributesDoesNotTriggerWatcher" executed="True" success="True" time="0.250" asserts="1" />
+                          <test-case name="NUnit.Util.Tests.FileWatcherTest.ChangingFileTriggersWatcher" executed="True" success="True" time="0.219" asserts="2" />
+                          <test-case name="NUnit.Util.Tests.FileWatcherTest.CopyingFileDoesNotTriggerWatcher" executed="True" success="True" time="0.219" asserts="1" />
+                          <test-case name="NUnit.Util.Tests.FileWatcherTest.MultipleCloselySpacedChangesTriggerWatcherOnlyOnce" executed="True" success="True" time="0.297" asserts="2" />
+                        </results>
+                      </test-suite>
+                      <test-suite name="MemorySettingsStorageTests" success="True" time="0.031" asserts="0">
+                        <results>
+                          <test-case name="NUnit.Util.Tests.MemorySettingsStorageTests.MakeStorage" executed="True" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Util.Tests.MemorySettingsStorageTests.MakeSubStorages" executed="True" success="True" time="0.000" asserts="2" />
+                          <test-case name="NUnit.Util.Tests.MemorySettingsStorageTests.RemoveSettings" executed="True" success="True" time="0.000" asserts="3" />
+                          <test-case name="NUnit.Util.Tests.MemorySettingsStorageTests.SaveAndLoadSettings" executed="True" success="True" time="0.000" asserts="4" />
+                          <test-case name="NUnit.Util.Tests.MemorySettingsStorageTests.SubstorageSettings" executed="True" success="True" time="0.016" asserts="5" />
+                          <test-case name="NUnit.Util.Tests.MemorySettingsStorageTests.TypeSafeSettings" executed="True" success="True" time="0.000" asserts="3" />
+                        </results>
+                      </test-suite>
+                      <test-suite name="NUnitProjectLoad" success="True" time="0.422" asserts="0">
+                        <results>
+                          <test-case name="NUnit.Util.Tests.NUnitProjectLoad.FromAssembly" executed="True" success="True" time="0.016" asserts="5" />
+                          <test-case name="NUnit.Util.Tests.NUnitProjectLoad.FromCppProject" executed="True" success="True" time="0.156" asserts="5" />
+                          <test-case name="NUnit.Util.Tests.NUnitProjectLoad.FromCSharpProject" executed="True" success="True" time="0.016" asserts="5" />
+                          <test-case name="NUnit.Util.Tests.NUnitProjectLoad.FromJsharpProject" executed="True" success="True" time="0.000" asserts="5" />
+                          <test-case name="NUnit.Util.Tests.NUnitProjectLoad.FromMakefileProject" executed="True" success="True" time="0.000" asserts="3" />
+                          <test-case name="NUnit.Util.Tests.NUnitProjectLoad.FromProjectWithHebrewFileIncluded" executed="True" success="True" time="0.016" asserts="5" />
+                          <test-case name="NUnit.Util.Tests.NUnitProjectLoad.FromVBProject" executed="True" success="True" time="0.000" asserts="5" />
+                          <test-case name="NUnit.Util.Tests.NUnitProjectLoad.FromVSSolution2003" executed="True" success="True" time="0.047" asserts="7" />
+                          <test-case name="NUnit.Util.Tests.NUnitProjectLoad.FromVSSolution2005" executed="True" success="True" time="0.063" asserts="7" />
+                          <test-case name="NUnit.Util.Tests.NUnitProjectLoad.FromWebApplication" executed="True" success="True" time="0.016" asserts="3" />
+                          <test-case name="NUnit.Util.Tests.NUnitProjectLoad.LoadEmptyConfigs" executed="True" success="True" time="0.016" asserts="3" />
+                          <test-case name="NUnit.Util.Tests.NUnitProjectLoad.LoadEmptyProject" executed="True" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Util.Tests.NUnitProjectLoad.LoadNormalProject" executed="True" success="True" time="0.016" asserts="7" />
+                          <test-case name="NUnit.Util.Tests.NUnitProjectLoad.LoadProjectWithManualBinPath" executed="True" success="True" time="0.000" asserts="2" />
+                          <test-case name="NUnit.Util.Tests.NUnitProjectLoad.SaveClearsAssemblyWrapper" executed="True" success="True" time="0.031" asserts="1" />
+                          <test-case name="NUnit.Util.Tests.NUnitProjectLoad.WithUnmanagedCpp" executed="True" success="True" time="0.016" asserts="5" />
+                        </results>
+                      </test-suite>
+                      <test-suite name="NUnitProjectSave" success="True" time="0.016" asserts="0">
+                        <results>
+                          <test-case name="NUnit.Util.Tests.NUnitProjectSave.SaveEmptyConfigs" executed="True" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Util.Tests.NUnitProjectSave.SaveEmptyProject" executed="True" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Util.Tests.NUnitProjectSave.SaveNormalProject" executed="True" success="True" time="0.016" asserts="1" />
+                        </results>
+                      </test-suite>
+                      <test-suite name="NUnitProjectTests" success="True" time="0.094" asserts="0">
+                        <results>
+                          <test-case name="NUnit.Util.Tests.NUnitProjectTests.AddConfigMakesProjectDirty" executed="True" success="True" time="0.000" asserts="2" />
+                          <test-case name="NUnit.Util.Tests.NUnitProjectTests.CanAddAssemblies" executed="True" success="True" time="0.000" asserts="3" />
+                          <test-case name="NUnit.Util.Tests.NUnitProjectTests.CanAddConfigs" executed="True" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Util.Tests.NUnitProjectTests.CanSetActiveConfig" executed="True" success="True" time="0.016" asserts="1" />
+                          <test-case name="NUnit.Util.Tests.NUnitProjectTests.CanSetAppBase" executed="True" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Util.Tests.NUnitProjectTests.ConfigurationFileFromAssemblies" executed="True" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Util.Tests.NUnitProjectTests.ConfigurationFileFromAssembly" executed="True" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Util.Tests.NUnitProjectTests.DefaultActiveConfig" executed="True" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Util.Tests.NUnitProjectTests.DefaultApplicationBase" executed="True" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Util.Tests.NUnitProjectTests.DefaultConfigurationFile" executed="True" success="True" time="0.016" asserts="2" />
+                          <test-case name="NUnit.Util.Tests.NUnitProjectTests.DefaultProjectName" executed="True" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Util.Tests.NUnitProjectTests.IsProjectFile" executed="True" success="True" time="0.000" asserts="2" />
+                          <test-case name="NUnit.Util.Tests.NUnitProjectTests.LoadMakesProjectNotDirty" executed="True" success="True" time="0.016" asserts="1" />
+                          <test-case name="NUnit.Util.Tests.NUnitProjectTests.NewProjectDefaultPath" executed="True" success="True" time="0.000" asserts="3" />
+                          <test-case name="NUnit.Util.Tests.NUnitProjectTests.NewProjectIsEmpty" executed="True" success="True" time="0.000" asserts="2" />
+                          <test-case name="NUnit.Util.Tests.NUnitProjectTests.NewProjectIsNotDirty" executed="True" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Util.Tests.NUnitProjectTests.NewProjectNotLoadable" executed="True" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Util.Tests.NUnitProjectTests.RemoveActiveConfig" executed="True" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Util.Tests.NUnitProjectTests.RemoveConfigMakesProjectDirty" executed="True" success="True" time="0.000" asserts="2" />
+                          <test-case name="NUnit.Util.Tests.NUnitProjectTests.RenameActiveConfig" executed="True" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Util.Tests.NUnitProjectTests.RenameConfigMakesProjectDirty" executed="True" success="True" time="0.000" asserts="2" />
+                          <test-case name="NUnit.Util.Tests.NUnitProjectTests.SaveAndLoadConfigsWithAssemblies" executed="True" success="True" time="0.000" asserts="8" />
+                          <test-case name="NUnit.Util.Tests.NUnitProjectTests.SaveAndLoadEmptyConfigs" executed="True" success="True" time="0.000" asserts="4" />
+                          <test-case name="NUnit.Util.Tests.NUnitProjectTests.SaveAndLoadEmptyProject" executed="True" success="True" time="0.000" asserts="2" />
+                          <test-case name="NUnit.Util.Tests.NUnitProjectTests.SaveMakesProjectNotDirty" executed="True" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Util.Tests.NUnitProjectTests.SaveSetsProjectPath" executed="True" success="True" time="0.000" asserts="2" />
+                          <test-case name="NUnit.Util.Tests.NUnitProjectTests.SettingActiveConfigMakesProjectDirty" executed="True" success="True" time="0.000" asserts="2" />
+                        </results>
+                      </test-suite>
+                      <test-suite name="NUnitRegistryTests" success="True" time="0.016" asserts="0">
+                        <results>
+                          <test-case name="NUnit.Util.Tests.NUnitRegistryTests.CurrentUser" executed="True" success="True" time="0.000" asserts="2" />
+                          <test-case name="NUnit.Util.Tests.NUnitRegistryTests.CurrentUserTestMode" executed="True" success="True" time="0.000" asserts="2" />
+                          <test-case name="NUnit.Util.Tests.NUnitRegistryTests.LocalMachine" executed="True" success="True" time="0.000" asserts="2" />
+                          <test-case name="NUnit.Util.Tests.NUnitRegistryTests.LocalMachineTestMode" executed="True" success="True" time="0.000" asserts="2" />
+                          <test-case name="NUnit.Util.Tests.NUnitRegistryTests.TestClearRoutines" executed="True" success="True" time="0.016" asserts="2" />
+                        </results>
+                      </test-suite>
+                      <test-suite name="PathUtilTests" success="True" time="0.000" asserts="0">
+                        <results>
+                          <test-case name="NUnit.Util.Tests.PathUtilTests.CheckDefaults" executed="True" success="True" time="0.000" asserts="2" />
+                        </results>
+                      </test-suite>
+                      <test-suite name="PathUtilTests_Unix" success="True" time="0.016" asserts="0">
+                        <results>
+                          <test-case name="NUnit.Util.Tests.PathUtilTests_Unix.Canonicalize" executed="True" success="True" time="0.000" asserts="5" />
+                          <test-case name="NUnit.Util.Tests.PathUtilTests_Unix.IsAssemblyFileType" executed="True" success="True" time="0.000" asserts="3" />
+                          <test-case name="NUnit.Util.Tests.PathUtilTests_Unix.PathFromUri" executed="True" success="True" time="0.000" asserts="2" />
+                          <test-case name="NUnit.Util.Tests.PathUtilTests_Unix.RelativePath" executed="True" success="True" time="0.000" asserts="5" />
+                          <test-case name="NUnit.Util.Tests.PathUtilTests_Unix.SamePath" executed="True" success="True" time="0.016" asserts="4" />
+                          <test-case name="NUnit.Util.Tests.PathUtilTests_Unix.SamePathOrUnder" executed="True" success="True" time="0.000" asserts="7" />
+                        </results>
+                      </test-suite>
+                      <test-suite name="PathUtilTests_Windows" success="True" time="0.000" asserts="0">
+                        <results>
+                          <test-case name="NUnit.Util.Tests.PathUtilTests_Windows.Canonicalize" executed="True" success="True" time="0.000" asserts="5" />
+                          <test-case name="NUnit.Util.Tests.PathUtilTests_Windows.IsAssemblyFileType" executed="True" success="True" time="0.000" asserts="3" />
+                          <test-case name="NUnit.Util.Tests.PathUtilTests_Windows.PathFromUri" executed="True" success="True" time="0.000" asserts="2" />
+                          <test-case name="NUnit.Util.Tests.PathUtilTests_Windows.RelativePath" executed="True" success="True" time="0.000" asserts="4" />
+                          <test-case name="NUnit.Util.Tests.PathUtilTests_Windows.SamePath" executed="True" success="True" time="0.000" asserts="4" />
+                          <test-case name="NUnit.Util.Tests.PathUtilTests_Windows.SamePathOrUnder" executed="True" success="True" time="0.000" asserts="9" />
+                        </results>
+                      </test-suite>
+                      <test-suite name="ProjectConfigCollectionTests" success="True" time="0.031" asserts="0">
+                        <results>
+                          <test-case name="NUnit.Util.Tests.ProjectConfigCollectionTests.AddConfig" executed="True" success="True" time="0.031" asserts="1" />
+                          <test-case name="NUnit.Util.Tests.ProjectConfigCollectionTests.AddMakesProjectDirty" executed="True" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Util.Tests.ProjectConfigCollectionTests.AddTwoConfigs" executed="True" success="True" time="0.000" asserts="3" />
+                          <test-case name="NUnit.Util.Tests.ProjectConfigCollectionTests.BuildConfigAndAdd" executed="True" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Util.Tests.ProjectConfigCollectionTests.EmptyCollection" executed="True" success="True" time="0.000" asserts="1" />
+                        </results>
+                      </test-suite>
+                      <test-suite name="ProjectConfigTests" success="True" time="0.047" asserts="0">
+                        <results>
+                          <test-case name="NUnit.Util.Tests.ProjectConfigTests.AbsoluteBasePath" executed="True" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Util.Tests.ProjectConfigTests.AbsoluteConfigurationFile" executed="True" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Util.Tests.ProjectConfigTests.AddMarksProjectDirty" executed="True" success="True" time="0.016" asserts="1" />
+                          <test-case name="NUnit.Util.Tests.ProjectConfigTests.CanAddAssemblies" executed="True" success="True" time="0.000" asserts="3" />
+                          <test-case name="NUnit.Util.Tests.ProjectConfigTests.DefaultConfigurationFile" executed="True" success="True" time="0.000" asserts="2" />
+                          <test-case name="NUnit.Util.Tests.ProjectConfigTests.EmptyConfig" executed="True" success="True" time="0.000" asserts="2" />
+                          <test-case name="NUnit.Util.Tests.ProjectConfigTests.ManualPrivateBinPath" executed="True" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Util.Tests.ProjectConfigTests.NoBasePathSet" executed="True" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Util.Tests.ProjectConfigTests.NoPrivateBinPath" executed="True" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Util.Tests.ProjectConfigTests.RelativeBasePath" executed="True" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Util.Tests.ProjectConfigTests.RelativeConfigurationFile" executed="True" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Util.Tests.ProjectConfigTests.RemoveMarksProjectDirty" executed="True" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Util.Tests.ProjectConfigTests.RenameMarksProjectDirty" executed="True" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Util.Tests.ProjectConfigTests.SettingApplicationBaseMarksProjectDirty" executed="True" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Util.Tests.ProjectConfigTests.SettingBinPathTypeMarksProjectDirty" executed="True" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Util.Tests.ProjectConfigTests.SettingConfigurationFileMarksProjectDirty" executed="True" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Util.Tests.ProjectConfigTests.SettingPrivateBinPathMarksProjectDirty" executed="True" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Util.Tests.ProjectConfigTests.ToArray" executed="True" success="True" time="0.000" asserts="2" />
+                        </results>
+                      </test-suite>
+                      <test-suite name="RecentFileEntryTests" success="True" time="0.000" asserts="0">
+                        <results>
+                          <test-case name="NUnit.Util.Tests.RecentFileEntryTests.CanCreateFromFileNameAndVersion" executed="True" success="True" time="0.000" asserts="2" />
+                          <test-case name="NUnit.Util.Tests.RecentFileEntryTests.CanCreateFromSimpleFileName" executed="True" success="True" time="0.000" asserts="2" />
+                          <test-case name="NUnit.Util.Tests.RecentFileEntryTests.CanParseFileNamePlusVersionString" executed="True" success="True" time="0.000" asserts="2" />
+                          <test-case name="NUnit.Util.Tests.RecentFileEntryTests.CanParseFileNameWithCommaPlusVersionString" executed="True" success="True" time="0.000" asserts="2" />
+                          <test-case name="NUnit.Util.Tests.RecentFileEntryTests.CanParseSimpleFileName" executed="True" success="True" time="0.000" asserts="2" />
+                          <test-case name="NUnit.Util.Tests.RecentFileEntryTests.CanParseSimpleFileNameWithComma" executed="True" success="True" time="0.000" asserts="2" />
+                          <test-case name="NUnit.Util.Tests.RecentFileEntryTests.EntryCanDisplayItself" executed="True" success="True" time="0.000" asserts="1" />
+                        </results>
+                      </test-suite>
+                      <test-suite name="RecentFilesTests" success="True" time="0.016" asserts="0">
+                        <results>
+                          <test-case name="NUnit.Util.Tests.RecentFilesTests.AddMaxItems" executed="True" success="True" time="0.000" asserts="7" />
+                          <test-case name="NUnit.Util.Tests.RecentFilesTests.AddSingleItem" executed="True" success="True" time="0.000" asserts="3" />
+                          <test-case name="NUnit.Util.Tests.RecentFilesTests.AddTooManyItems" executed="True" success="True" time="0.000" asserts="7" />
+                          <test-case name="NUnit.Util.Tests.RecentFilesTests.CountAtMax" executed="True" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Util.Tests.RecentFilesTests.CountAtMin" executed="True" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Util.Tests.RecentFilesTests.CountDefault" executed="True" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Util.Tests.RecentFilesTests.CountOverMax" executed="True" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Util.Tests.RecentFilesTests.CountUnderMin" executed="True" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Util.Tests.RecentFilesTests.EmptyList" executed="True" success="True" time="0.000" asserts="3" />
+                          <test-case name="NUnit.Util.Tests.RecentFilesTests.IncreaseSize" executed="True" success="True" time="0.000" asserts="12" />
+                          <test-case name="NUnit.Util.Tests.RecentFilesTests.IncreaseSizeAfterAdd" executed="True" success="True" time="0.000" asserts="8" />
+                          <test-case name="NUnit.Util.Tests.RecentFilesTests.ReduceSize" executed="True" success="True" time="0.000" asserts="5" />
+                          <test-case name="NUnit.Util.Tests.RecentFilesTests.ReduceSizeAfterAdd" executed="True" success="True" time="0.000" asserts="4" />
+                          <test-case name="NUnit.Util.Tests.RecentFilesTests.RemoveFirstProject" executed="True" success="True" time="0.000" asserts="3" />
+                          <test-case name="NUnit.Util.Tests.RecentFilesTests.RemoveLastProject" executed="True" success="True" time="0.000" asserts="5" />
+                          <test-case name="NUnit.Util.Tests.RecentFilesTests.RemoveMultipleProjects" executed="True" success="True" time="0.000" asserts="3" />
+                          <test-case name="NUnit.Util.Tests.RecentFilesTests.RemoveOneProject" executed="True" success="True" time="0.000" asserts="4" />
+                          <test-case name="NUnit.Util.Tests.RecentFilesTests.ReorderLastProject" executed="True" success="True" time="0.000" asserts="6" />
+                          <test-case name="NUnit.Util.Tests.RecentFilesTests.ReorderMultipleProjects" executed="True" success="True" time="0.000" asserts="6" />
+                          <test-case name="NUnit.Util.Tests.RecentFilesTests.ReorderSameProject" executed="True" success="True" time="0.016" asserts="6" />
+                          <test-case name="NUnit.Util.Tests.RecentFilesTests.ReorderSingleProject" executed="True" success="True" time="0.000" asserts="6" />
+                          <test-case name="NUnit.Util.Tests.RecentFilesTests.ReorderWithListNotFull" executed="True" success="True" time="0.000" asserts="4" />
+                        </results>
+                      </test-suite>
+                      <test-suite name="RegistrySettingsStorageTests" success="True" time="0.000" asserts="0">
+                        <results>
+                          <test-case name="NUnit.Util.Tests.RegistrySettingsStorageTests.MakeSubStorages" executed="True" success="True" time="0.000" asserts="4" />
+                          <test-case name="NUnit.Util.Tests.RegistrySettingsStorageTests.RemoveSettings" executed="True" success="True" time="0.000" asserts="3" />
+                          <test-case name="NUnit.Util.Tests.RegistrySettingsStorageTests.SaveAndLoadSettings" executed="True" success="True" time="0.000" asserts="6" />
+                          <test-case name="NUnit.Util.Tests.RegistrySettingsStorageTests.StorageHasCorrectKey" executed="True" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Util.Tests.RegistrySettingsStorageTests.SubstorageSettings" executed="True" success="True" time="0.000" asserts="5" />
+                          <test-case name="NUnit.Util.Tests.RegistrySettingsStorageTests.TypeSafeSettings" executed="True" success="True" time="0.000" asserts="3" />
+                        </results>
+                      </test-suite>
+                      <test-suite name="RemoteTestResultTest" success="True" time="1.219" asserts="0">
+                        <results>
+                          <test-case name="NUnit.Util.Tests.RemoteTestResultTest.ResultStillValidAfterDomainUnload" executed="True" success="True" time="1.219" asserts="4" />
+                        </results>
+                      </test-suite>
+                      <test-suite name="ServerUtilityTests" success="True" time="0.031" asserts="0">
+                        <results>
+                          <test-case name="NUnit.Util.Tests.ServerUtilityTests.CanGetTcpChannelOnSpecifiedPort" executed="True" success="True" time="0.016" asserts="5" />
+                          <test-case name="NUnit.Util.Tests.ServerUtilityTests.CanGetTcpChannelOnUnpecifiedPort" executed="True" success="True" time="0.000" asserts="4" />
+                        </results>
+                      </test-suite>
+                      <test-suite name="SettingsGroupTests" success="True" time="0.016" asserts="0">
+                        <results>
+                          <test-case name="NUnit.Util.Tests.SettingsGroupTests.BadSetting" executed="True" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Util.Tests.SettingsGroupTests.DefaultSettings" executed="True" success="True" time="0.016" asserts="7" />
+                          <test-case name="NUnit.Util.Tests.SettingsGroupTests.SubGroupSettings" executed="True" success="True" time="0.000" asserts="7" />
+                          <test-case name="NUnit.Util.Tests.SettingsGroupTests.TopLevelSettings" executed="True" success="True" time="0.000" asserts="5" />
+                          <test-case name="NUnit.Util.Tests.SettingsGroupTests.TypeSafeSettings" executed="True" success="True" time="0.000" asserts="3" />
+                        </results>
+                      </test-suite>
+                      <test-suite name="SummaryResultFixture" success="True" time="0.000" asserts="0">
+                        <results>
+                          <test-case name="NUnit.Util.Tests.SummaryResultFixture.Failure" executed="True" success="True" time="0.000" asserts="4" />
+                          <test-case name="NUnit.Util.Tests.SummaryResultFixture.TestCountNotRunSuites" executed="True" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Util.Tests.SummaryResultFixture.TestTime" executed="True" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Util.Tests.SummaryResultFixture.TotalCountSuccess" executed="True" success="True" time="0.000" asserts="5" />
+                        </results>
+                      </test-suite>
+                      <test-suite name="TestDomainFixture" success="True" time="0.984" asserts="0">
+                        <results>
+                          <test-case name="NUnit.Util.Tests.TestDomainFixture.AppDomainIsSetUpCorrectly" executed="True" success="True" time="0.000" asserts="8" />
+                          <test-case name="NUnit.Util.Tests.TestDomainFixture.AssemblyIsLoadedCorrectly" executed="True" success="True" time="0.000" asserts="2" />
+                          <test-case name="NUnit.Util.Tests.TestDomainFixture.CanRunMockAssemblyTests" executed="True" success="True" time="0.109" asserts="4" />
+                        </results>
+                      </test-suite>
+                      <test-suite name="TestDomainRunnerTests" success="True" time="15.266" asserts="1">
+                        <results>
+                          <test-case name="NUnit.Util.Tests.TestDomainRunnerTests.CheckRunnerID" executed="True" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Util.Tests.TestDomainRunnerTests.CountTestCases" executed="True" success="True" time="0.953" asserts="1" />
+                          <test-case name="NUnit.Util.Tests.TestDomainRunnerTests.CountTestCasesAcrossMultipleAssemblies" executed="True" success="True" time="1.344" asserts="1" />
+                          <test-case name="NUnit.Util.Tests.TestDomainRunnerTests.LoadAssembly" executed="True" success="True" time="1.063" asserts="1" />
+                          <test-case name="NUnit.Util.Tests.TestDomainRunnerTests.LoadAssemblyWithFixture" executed="True" success="True" time="0.938" asserts="1" />
+                          <test-case name="NUnit.Util.Tests.TestDomainRunnerTests.LoadAssemblyWithoutNamespaces" executed="True" success="True" time="1.047" asserts="4" />
+                          <test-case name="NUnit.Util.Tests.TestDomainRunnerTests.LoadAssemblyWithSuite" executed="True" success="True" time="0.984" asserts="1" />
+                          <test-case name="NUnit.Util.Tests.TestDomainRunnerTests.LoadMultipleAssemblies" executed="True" success="True" time="1.359" asserts="1" />
+                          <test-case name="NUnit.Util.Tests.TestDomainRunnerTests.LoadMultipleAssembliesWithFixture" executed="True" success="True" time="1.156" asserts="1" />
+                          <test-case name="NUnit.Util.Tests.TestDomainRunnerTests.LoadMultipleAssembliesWithSuite" executed="True" success="True" time="1.141" asserts="1" />
+                          <test-case name="NUnit.Util.Tests.TestDomainRunnerTests.RunAssembly" executed="True" success="True" time="1.266" asserts="1" />
+                          <test-case name="NUnit.Util.Tests.TestDomainRunnerTests.RunAssemblyUsingBeginAndEndRun" executed="True" success="True" time="1.109" asserts="2" />
+                          <test-case name="NUnit.Util.Tests.TestDomainRunnerTests.RunMultipleAssemblies" executed="True" success="True" time="1.203" asserts="1" />
+                          <test-case name="NUnit.Util.Tests.TestDomainRunnerTests.RunMultipleAssembliesUsingBeginAndEndRun" executed="True" success="True" time="1.688" asserts="2" />
+                        </results>
+                      </test-suite>
+                      <test-suite name="TestDomainTests" success="True" time="6.531" asserts="0">
+                        <results>
+                          <test-case name="NUnit.Util.Tests.TestDomainTests.BasePathOverrideIsHonored" executed="True" success="True" time="0.969" asserts="1" />
+                          <test-case name="NUnit.Util.Tests.TestDomainTests.BinPathOverrideIsHonored" executed="True" success="True" time="0.984" asserts="1" />
+                          <test-case name="NUnit.Util.Tests.TestDomainTests.ConfigFileOverrideIsHonored" executed="True" success="True" time="1.094" asserts="1" />
+                          <test-case name="NUnit.Util.Tests.TestDomainTests.FileNotFound" executed="True" success="True" time="0.719" asserts="0" />
+                          <test-case name="NUnit.Util.Tests.TestDomainTests.InvalidTestFixture" executed="True" success="True" time="1.078" asserts="1" />
+                          <test-case name="NUnit.Util.Tests.TestDomainTests.SpecificTestFixture" executed="True" success="True" time="1.109" asserts="3" />
+                          <test-case name="NUnit.Util.Tests.TestDomainTests.TurnOffShadowCopy" executed="True" success="True" time="0.578" asserts="1" />
+                        </results>
+                      </test-suite>
+                      <test-suite name="TestDomainTests_Multiple" success="True" time="1.094" asserts="0">
+                        <results>
+                          <test-case name="NUnit.Util.Tests.TestDomainTests_Multiple.AssemblyNodes" executed="True" success="True" time="0.000" asserts="2" />
+                          <test-case name="NUnit.Util.Tests.TestDomainTests_Multiple.BuildSuite" executed="True" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Util.Tests.TestDomainTests_Multiple.RootNode" executed="True" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Util.Tests.TestDomainTests_Multiple.RunMultipleAssemblies" executed="True" success="True" time="0.094" asserts="1" />
+                          <test-case name="NUnit.Util.Tests.TestDomainTests_Multiple.TestCaseCount" executed="True" success="True" time="0.000" asserts="1" />
+                        </results>
+                      </test-suite>
+                      <test-suite name="TestDomainTests_MultipleFixture" success="True" time="1.172" asserts="0">
+                        <results>
+                          <test-case name="NUnit.Util.Tests.TestDomainTests_MultipleFixture.LoadFixture" executed="True" success="True" time="1.172" asserts="1" />
+                        </results>
+                      </test-suite>
+                      <test-suite name="TestLoaderAssemblyTests" success="True" time="4.406" asserts="0">
+                        <results>
+                          <test-case name="NUnit.Util.Tests.TestLoaderAssemblyTests.AssemblyWithNoTests" executed="True" success="True" time="0.891" asserts="4" />
+                          <test-case name="NUnit.Util.Tests.TestLoaderAssemblyTests.FileNotFound" executed="True" success="True" time="0.000" asserts="5" />
+                          <test-case name="NUnit.Util.Tests.TestLoaderAssemblyTests.LoadProject" executed="True" success="True" time="0.000" asserts="5" />
+                          <test-case name="NUnit.Util.Tests.TestLoaderAssemblyTests.LoadTest" executed="True" success="True" time="0.891" asserts="6" />
+                          <test-case name="NUnit.Util.Tests.TestLoaderAssemblyTests.RunTest" executed="True" success="True" time="1.516" asserts="5" />
+                          <test-case name="NUnit.Util.Tests.TestLoaderAssemblyTests.UnloadProject" executed="True" success="True" time="0.000" asserts="5" />
+                          <test-case name="NUnit.Util.Tests.TestLoaderAssemblyTests.UnloadTest" executed="True" success="True" time="1.109" asserts="3" />
+                        </results>
+                      </test-suite>
+                      <test-suite name="VSProjectTests" success="True" time="0.156" asserts="0">
+                        <results>
+                          <test-case name="NUnit.Util.Tests.VSProjectTests.FileNotFoundError" executed="True" success="True" time="0.000" asserts="0" />
+                          <test-case name="NUnit.Util.Tests.VSProjectTests.GenerateCorrectExtensionsFromVCProjectVS2005" executed="True" success="True" time="0.031" asserts="4" />
+                          <test-case name="NUnit.Util.Tests.VSProjectTests.InvalidProjectFormat" executed="True" success="True" time="0.000" asserts="0" />
+                          <test-case name="NUnit.Util.Tests.VSProjectTests.InvalidXmlFormat" executed="True" success="True" time="0.031" asserts="0" />
+                          <test-case name="NUnit.Util.Tests.VSProjectTests.LoadCppProject" executed="True" success="True" time="0.016" asserts="6" />
+                          <test-case name="NUnit.Util.Tests.VSProjectTests.LoadCppProjectVS2005" executed="True" success="True" time="0.000" asserts="6" />
+                          <test-case name="NUnit.Util.Tests.VSProjectTests.LoadCppProjectWithMacros" executed="True" success="True" time="0.000" asserts="4" />
+                          <test-case name="NUnit.Util.Tests.VSProjectTests.LoadCsharpProject" executed="True" success="True" time="0.000" asserts="6" />
+                          <test-case name="NUnit.Util.Tests.VSProjectTests.LoadCsharpProjectVS2005" executed="True" success="True" time="0.000" asserts="6" />
+                          <test-case name="NUnit.Util.Tests.VSProjectTests.LoadCsharpProjectVS2005WithoutPlatforms" executed="True" success="True" time="0.016" asserts="6" />
+                          <test-case name="NUnit.Util.Tests.VSProjectTests.LoadCsharpProjectWithMultiplePlatforms" executed="True" success="True" time="0.000" asserts="10" />
+                          <test-case name="NUnit.Util.Tests.VSProjectTests.LoadInvalidFileType" executed="True" success="True" time="0.000" asserts="0" />
+                          <test-case name="NUnit.Util.Tests.VSProjectTests.LoadJsharpProject" executed="True" success="True" time="0.000" asserts="6" />
+                          <test-case name="NUnit.Util.Tests.VSProjectTests.LoadJsharpProjectVS2005" executed="True" success="True" time="0.000" asserts="6" />
+                          <test-case name="NUnit.Util.Tests.VSProjectTests.LoadProjectWithHebrewFileIncluded" executed="True" success="True" time="0.000" asserts="6" />
+                          <test-case name="NUnit.Util.Tests.VSProjectTests.LoadVbProject" executed="True" success="True" time="0.016" asserts="6" />
+                          <test-case name="NUnit.Util.Tests.VSProjectTests.LoadVbProjectVS2005" executed="True" success="True" time="0.000" asserts="6" />
+                          <test-case name="NUnit.Util.Tests.VSProjectTests.LoadXNAWindowsProject" executed="True" success="True" time="0.000" asserts="6" />
+                          <test-case name="NUnit.Util.Tests.VSProjectTests.MissingAttributes" executed="True" success="True" time="0.016" asserts="0" />
+                          <test-case name="NUnit.Util.Tests.VSProjectTests.NoConfigurations" executed="True" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Util.Tests.VSProjectTests.NotWebProject" executed="True" success="True" time="0.000" asserts="2" />
+                          <test-case name="NUnit.Util.Tests.VSProjectTests.ProjectExtensions" executed="True" success="True" time="0.000" asserts="4" />
+                          <test-case name="NUnit.Util.Tests.VSProjectTests.SolutionExtension" executed="True" success="True" time="0.000" asserts="2" />
+                        </results>
+                      </test-suite>
+                      <test-suite name="XmlResultVisitorTest" success="True" time="0.047" asserts="0">
+                        <results>
+                          <test-case name="NUnit.Util.Tests.XmlResultVisitorTest.HasMultipleCategories" executed="True" success="True" time="0.016" asserts="4" />
+                          <test-case name="NUnit.Util.Tests.XmlResultVisitorTest.HasMultipleProperties" executed="True" success="True" time="0.000" asserts="5" />
+                          <test-case name="NUnit.Util.Tests.XmlResultVisitorTest.HasSingleCategory" executed="True" success="True" time="0.000" asserts="3" />
+                          <test-case name="NUnit.Util.Tests.XmlResultVisitorTest.HasSingleProperty" executed="True" success="True" time="0.000" asserts="4" />
+                          <test-case name="NUnit.Util.Tests.XmlResultVisitorTest.SuiteResultHasCategories" executed="True" success="True" time="0.000" asserts="3" />
+                          <test-case name="NUnit.Util.Tests.XmlResultVisitorTest.TestHasCultureInfo" executed="True" success="True" time="0.000" asserts="5" />
+                          <test-case name="NUnit.Util.Tests.XmlResultVisitorTest.TestHasEnvironmentInfo" executed="True" success="True" time="0.000" asserts="9" />
+                        </results>
+                      </test-suite>
+                    </results>
+                  </test-suite>
+                </results>
+              </test-suite>
+            </results>
+          </test-suite>
+        </results>
+      </test-suite>
+      <test-suite name="C:\Program Files\NUnit 2.4.8\bin\nunit.mocks.tests.dll" success="True" time="0.219" asserts="0">
+        <results>
+          <test-suite name="NUnit" success="True" time="0.219" asserts="0">
+            <results>
+              <test-suite name="Mocks" success="True" time="0.203" asserts="0">
+                <results>
+                  <test-suite name="Tests" success="True" time="0.203" asserts="0">
+                    <results>
+                      <test-suite name="DynamicMockTests" success="True" time="0.063" asserts="0">
+                        <results>
+                          <test-case name="NUnit.Mocks.Tests.DynamicMockTests.CallMethod" executed="True" success="True" time="0.016" asserts="0" />
+                          <test-case name="NUnit.Mocks.Tests.DynamicMockTests.CallMethodWithArgs" executed="True" success="True" time="0.000" asserts="0" />
+                          <test-case name="NUnit.Mocks.Tests.DynamicMockTests.CreateMockForMBRClass" executed="True" success="True" time="0.016" asserts="13" />
+                          <test-case name="NUnit.Mocks.Tests.DynamicMockTests.CreateMockForNonMBRClassFails" executed="True" success="True" time="0.016" asserts="0" />
+                          <test-case name="NUnit.Mocks.Tests.DynamicMockTests.DefaultReturnValues" executed="True" success="True" time="0.000" asserts="5" />
+                          <test-case name="NUnit.Mocks.Tests.DynamicMockTests.ExpectedMethod" executed="True" success="True" time="0.000" asserts="2" />
+                          <test-case name="NUnit.Mocks.Tests.DynamicMockTests.ExpectedMethodNotCalled" executed="True" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Mocks.Tests.DynamicMockTests.MethodWithReturnValue" executed="True" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Mocks.Tests.DynamicMockTests.MockHasDefaultName" executed="True" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Mocks.Tests.DynamicMockTests.MockHasNonDefaultName" executed="True" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Mocks.Tests.DynamicMockTests.OverrideMethodOnDynamicMock" executed="True" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Mocks.Tests.DynamicMockTests.RefParameter" executed="True" success="True" time="0.000" asserts="2" />
+                          <test-case name="NUnit.Mocks.Tests.DynamicMockTests.WrongReturnType" executed="True" success="True" time="0.000" asserts="0" />
+                        </results>
+                      </test-suite>
+                      <test-suite name="MockTests" success="True" time="0.109" asserts="0">
+                        <results>
+                          <test-case name="NUnit.Mocks.Tests.MockTests.CallMultipleMethodsInDifferentOrder" executed="True" success="True" time="0.000" asserts="6" />
+                          <test-case name="NUnit.Mocks.Tests.MockTests.CallMultipleMethodsSomeWithoutExpectations" executed="True" success="True" time="0.000" asserts="5" />
+                          <test-case name="NUnit.Mocks.Tests.MockTests.ChangeExpectAndReturnToFixedReturn" executed="True" success="True" time="0.000" asserts="8" />
+                          <test-case name="NUnit.Mocks.Tests.MockTests.ChangeFixedReturnToExpectAndReturn" executed="True" success="True" time="0.000" asserts="9" />
+                          <test-case name="NUnit.Mocks.Tests.MockTests.ConstraintArgumentSucceeds" executed="True" success="True" time="0.000" asserts="3" />
+                          <test-case name="NUnit.Mocks.Tests.MockTests.ConstraintArgumentThatFails" executed="True" success="True" time="0.016" asserts="3" />
+                          <test-case name="NUnit.Mocks.Tests.MockTests.ExpectAndReturn" executed="True" success="True" time="0.000" asserts="4" />
+                          <test-case name="NUnit.Mocks.Tests.MockTests.ExpectAndReturnNull" executed="True" success="True" time="0.000" asserts="4" />
+                          <test-case name="NUnit.Mocks.Tests.MockTests.ExpectAndReturnWithArgument" executed="True" success="True" time="0.000" asserts="5" />
+                          <test-case name="NUnit.Mocks.Tests.MockTests.ExpectAndReturnWithWrongArgument" executed="True" success="True" time="0.000" asserts="3" />
+                          <test-case name="NUnit.Mocks.Tests.MockTests.ExpectAndThrowException" executed="True" success="True" time="0.000" asserts="2" />
+                          <test-case name="NUnit.Mocks.Tests.MockTests.ExpectNoCallFails" executed="True" success="True" time="0.016" asserts="0" />
+                          <test-case name="NUnit.Mocks.Tests.MockTests.ExpectNoCallSucceeds" executed="True" success="True" time="0.000" asserts="0" />
+                          <test-case name="NUnit.Mocks.Tests.MockTests.FailWithParametersSpecified" executed="True" success="True" time="0.000" asserts="2" />
+                          <test-case name="NUnit.Mocks.Tests.MockTests.IgnoreArguments" executed="True" success="True" time="0.000" asserts="2" />
+                          <test-case name="NUnit.Mocks.Tests.MockTests.MethodNotCalled" executed="True" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Mocks.Tests.MockTests.MockHasName" executed="True" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Mocks.Tests.MockTests.MultipleCallsToSameMethod" executed="True" success="True" time="0.000" asserts="4" />
+                          <test-case name="NUnit.Mocks.Tests.MockTests.MultipleExpectAndReturn" executed="True" success="True" time="0.000" asserts="10" />
+                          <test-case name="NUnit.Mocks.Tests.MockTests.MultipleExpectations" executed="True" success="True" time="0.000" asserts="12" />
+                          <test-case name="NUnit.Mocks.Tests.MockTests.NotEnoughCalls" executed="True" success="True" time="0.000" asserts="3" />
+                          <test-case name="NUnit.Mocks.Tests.MockTests.OneExpectation" executed="True" success="True" time="0.000" asserts="2" />
+                          <test-case name="NUnit.Mocks.Tests.MockTests.RequireArguments" executed="True" success="True" time="0.000" asserts="2" />
+                          <test-case name="NUnit.Mocks.Tests.MockTests.SetReturnValue" executed="True" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Mocks.Tests.MockTests.SetReturnValueMultipleTimesOnMultipleMethods" executed="True" success="True" time="0.000" asserts="7" />
+                          <test-case name="NUnit.Mocks.Tests.MockTests.SetReturnValueRepeatedCalls" executed="True" success="True" time="0.000" asserts="3" />
+                          <test-case name="NUnit.Mocks.Tests.MockTests.SetReturnValueWithoutCalling" executed="True" success="True" time="0.000" asserts="0" />
+                          <test-case name="NUnit.Mocks.Tests.MockTests.StrictDefaultsToFalse" executed="True" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Mocks.Tests.MockTests.StrictMode" executed="True" success="True" time="0.000" asserts="2" />
+                          <test-case name="NUnit.Mocks.Tests.MockTests.TooManyCalls" executed="True" success="True" time="0.000" asserts="3" />
+                          <test-case name="NUnit.Mocks.Tests.MockTests.UnexpectedCallsIgnored" executed="True" success="True" time="0.000" asserts="0" />
+                          <test-case name="NUnit.Mocks.Tests.MockTests.VerifyNewMock" executed="True" success="True" time="0.000" asserts="0" />
+                        </results>
+                      </test-suite>
+                    </results>
+                  </test-suite>
+                </results>
+              </test-suite>
+            </results>
+          </test-suite>
+        </results>
+      </test-suite>
+      <test-suite name="C:\Program Files\NUnit 2.4.8\bin\nunit.extensions.tests.dll" success="True" time="0.375" asserts="0">
+        <results>
+          <test-suite name="NUnit" success="True" time="0.375" asserts="0">
+            <results>
+              <test-suite name="Core" success="True" time="0.375" asserts="0">
+                <results>
+                  <test-suite name="Extensions" success="True" time="0.375" asserts="0">
+                    <results>
+                      <test-suite name="RepeatedTestFixture" success="True" time="0.141" asserts="0">
+                        <results>
+                          <test-case name="NUnit.Core.Extensions.RepeatedTestFixture.CategoryWorksWithRepeatedTest" executed="True" success="True" time="0.109" asserts="3" />
+                          <test-case name="NUnit.Core.Extensions.RepeatedTestFixture.IgnoreWorksWithRepeatedTest" executed="True" success="True" time="0.000" asserts="3" />
+                          <test-case name="NUnit.Core.Extensions.RepeatedTestFixture.RepeatedTestIsBuiltCorrectly" executed="True" success="True" time="0.000" asserts="6" />
+                          <test-case name="NUnit.Core.Extensions.RepeatedTestFixture.RepeatFailOnFirst" executed="True" success="True" time="0.016" asserts="4" />
+                          <test-case name="NUnit.Core.Extensions.RepeatedTestFixture.RepeatFailOnThird" executed="True" success="True" time="0.016" asserts="4" />
+                          <test-case name="NUnit.Core.Extensions.RepeatedTestFixture.RepeatSuccess" executed="True" success="True" time="0.000" asserts="6" />
+                        </results>
+                      </test-suite>
+                      <test-suite name="RowTest" success="True" time="0.219" asserts="0">
+                        <results>
+                          <test-suite name="OrderedTest" success="True" time="0.000" asserts="0">
+                            <results>
+                              <test-case name="NUnit.Core.Extensions.RowTest.OrderedTest.Test1_SomeTest" executed="True" success="True" time="0.000" asserts="1" />
+                              <test-suite name="Test2_OtherTest" success="True" time="0.000" asserts="0">
+                                <results>
+                                  <test-case name="NUnit.Core.Extensions.RowTest.OrderedTest.Test2_OtherTest(100)" executed="True" success="True" time="0.000" asserts="1" />
+                                  <test-case name="NUnit.Core.Extensions.RowTest.OrderedTest.Test2_OtherTest(200)" executed="True" success="True" time="0.000" asserts="1" />
+                                </results>
+                              </test-suite>
+                              <test-case name="NUnit.Core.Extensions.RowTest.OrderedTest.Test3_OneMoreTest" executed="True" success="True" time="0.000" asserts="1" />
+                            </results>
+                          </test-suite>
+                          <test-suite name="RowTests" success="True" time="0.031" asserts="0">
+                            <results>
+                              <test-suite name="AddTest" success="True" time="0.016" asserts="0">
+                                <categories>
+                                  <category name="Category - 2" />
+                                </categories>
+                                <results>
+                                  <test-case name="NUnit.Core.Extensions.RowTest.RowTests.AddTest(1, 2, 3)" executed="True" success="True" time="0.000" asserts="1" />
+                                  <test-case name="NUnit.Core.Extensions.RowTest.RowTests.AddTest(2, 3, 5)" executed="True" success="True" time="0.000" asserts="1" />
+                                  <test-case name="NUnit.Core.Extensions.RowTest.RowTests.AddTest(4, 5, 9)" executed="True" success="True" time="0.000" asserts="1" />
+                                  <test-case name="NUnit.Core.Extensions.RowTest.RowTests.ExceptionTest1(10, 10, 0)" executed="True" success="True" time="0.000" asserts="0" />
+                                  <test-case name="NUnit.Core.Extensions.RowTest.RowTests.ExceptionTest2(1, 1, 0)" executed="True" success="True" time="0.000" asserts="0" />
+                                  <test-case name="NUnit.Core.Extensions.RowTest.RowTests.Special case(3, 4, 8)" executed="True" success="True" time="0.000" asserts="1" />
+                                </results>
+                              </test-suite>
+                              <test-suite name="DivisionTest" success="True" time="0.000" asserts="0">
+                                <categories>
+                                  <category name="Category - 1" />
+                                </categories>
+                                <results>
+                                  <test-case name="NUnit.Core.Extensions.RowTest.RowTests.DivisionTest(1000, 0, 0)" executed="True" success="True" time="0.000" asserts="0" />
+                                  <test-case name="NUnit.Core.Extensions.RowTest.RowTests.DivisionTest(1000, 10, 100)" executed="True" success="True" time="0.000" asserts="1" />
+                                  <test-case name="NUnit.Core.Extensions.RowTest.RowTests.DivisionTest(-1000, 10, -100)" executed="True" success="True" time="0.000" asserts="1" />
+                                  <test-case name="NUnit.Core.Extensions.RowTest.RowTests.DivisionTest(1000, 1E-05, 100000000)" executed="True" success="True" time="0.000" asserts="1" />
+                                  <test-case name="NUnit.Core.Extensions.RowTest.RowTests.DivisionTest(1000, 7, 142.85715)" executed="True" success="True" time="0.000" asserts="1" />
+                                  <test-case name="NUnit.Core.Extensions.RowTest.RowTests.DivisionTest(4195835, 3145729, 1.3338196)" executed="True" success="True" time="0.000" asserts="1" />
+                                </results>
+                              </test-suite>
+                              <test-suite name="NullArgument" success="True" time="0.016" asserts="0">
+                                <results>
+                                  <test-case name="NUnit.Core.Extensions.RowTest.RowTests.NullArgument(null)" executed="True" success="True" time="0.000" asserts="1" />
+                                </results>
+                              </test-suite>
+                              <test-suite name="SpecialValueNullArgument" success="True" time="0.000" asserts="0">
+                                <results>
+                                  <test-case name="NUnit.Core.Extensions.RowTest.RowTests.SpecialValueNullArgument(null)" executed="True" success="True" time="0.000" asserts="1" />
+                                </results>
+                              </test-suite>
+                              <test-suite name="StaticFieldTest" success="True" time="0.000" asserts="0">
+                                <results>
+                                  <test-case name="NUnit.Core.Extensions.RowTest.RowTests.StaticFieldTest(Class Member, Other string)" executed="True" success="True" time="0.000" asserts="1" />
+                                  <test-case name="NUnit.Core.Extensions.RowTest.RowTests.StaticFieldTest(Other string, Class Member)" executed="True" success="True" time="0.000" asserts="1" />
+                                </results>
+                              </test-suite>
+                            </results>
+                          </test-suite>
+                          <test-suite name="SetUpMethodsTestFixture" success="True" time="0.000" asserts="0">
+                            <results>
+                              <test-suite name="ClassMemberTest" success="True" time="0.000" asserts="0">
+                                <results>
+                                  <test-case name="NUnit.Core.Extensions.RowTest.SetUpMethodsTestFixture.ClassMemberTest(So Long,, and Thanks for All the Fish)" executed="True" success="True" time="0.000" asserts="4" />
+                                </results>
+                              </test-suite>
+                              <test-case name="NUnit.Core.Extensions.RowTest.SetUpMethodsTestFixture.PrivateClassMemberTest" executed="True" success="True" time="0.000" asserts="2" />
+                            </results>
+                          </test-suite>
+                          <test-suite name="UnitTests" success="True" time="0.156" asserts="0">
+                            <results>
+                              <test-suite name="RowTestAddInTest" success="True" time="0.109" asserts="0">
+                                <results>
+                                  <test-case name="NUnit.Core.Extensions.RowTest.UnitTests.RowTestAddInTest.BuildFrom_SetsCommonNUnitAttributes" executed="True" success="True" time="0.000" asserts="3" />
+                                  <test-case name="NUnit.Core.Extensions.RowTest.UnitTests.RowTestAddInTest.BuildFrom_SetsNameCorrectly" executed="True" success="True" time="0.000" asserts="3" />
+                                  <test-case name="NUnit.Core.Extensions.RowTest.UnitTests.RowTestAddInTest.BuildFrom_WithExpectedException" executed="True" success="True" time="0.000" asserts="5" />
+                                  <test-case name="NUnit.Core.Extensions.RowTest.UnitTests.RowTestAddInTest.BuildFrom_WithExpectedExceptionAndExceptionMessage" executed="True" success="True" time="0.000" asserts="6" />
+                                  <test-case name="NUnit.Core.Extensions.RowTest.UnitTests.RowTestAddInTest.BuildFrom_WithNull" executed="True" success="True" time="0.000" asserts="4" />
+                                  <test-case name="NUnit.Core.Extensions.RowTest.UnitTests.RowTestAddInTest.BuildFrom_WithoutRows" executed="True" success="True" time="0.000" asserts="2" />
+                                  <test-case name="NUnit.Core.Extensions.RowTest.UnitTests.RowTestAddInTest.BuildFrom_WithRows" executed="True" success="True" time="0.000" asserts="6" />
+                                  <test-case name="NUnit.Core.Extensions.RowTest.UnitTests.RowTestAddInTest.BuildFrom_WithSpecialValueNull" executed="True" success="True" time="0.000" asserts="5" />
+                                  <test-case name="NUnit.Core.Extensions.RowTest.UnitTests.RowTestAddInTest.BuildFrom_WithTestName" executed="True" success="True" time="0.000" asserts="4" />
+                                  <test-case name="NUnit.Core.Extensions.RowTest.UnitTests.RowTestAddInTest.CanBuildFrom_False" executed="True" success="True" time="0.000" asserts="1" />
+                                  <test-case name="NUnit.Core.Extensions.RowTest.UnitTests.RowTestAddInTest.CanBuildFrom_True" executed="True" success="True" time="0.000" asserts="1" />
+                                  <test-case name="NUnit.Core.Extensions.RowTest.UnitTests.RowTestAddInTest.Install_Failure" executed="True" success="True" time="0.094" asserts="5" />
+                                  <test-case name="NUnit.Core.Extensions.RowTest.UnitTests.RowTestAddInTest.Install_Successful" executed="True" success="True" time="0.000" asserts="9" />
+                                </results>
+                              </test-suite>
+                              <test-suite name="RowTestCaseTest" success="True" time="0.031" asserts="0">
+                                <results>
+                                  <test-case name="NUnit.Core.Extensions.RowTest.UnitTests.RowTestCaseTest.Initialize" executed="True" success="True" time="0.016" asserts="3" />
+                                  <test-case name="NUnit.Core.Extensions.RowTest.UnitTests.RowTestCaseTest.Initialize_TestNameIsMethodName" executed="True" success="True" time="0.000" asserts="2" />
+                                  <test-case name="NUnit.Core.Extensions.RowTest.UnitTests.RowTestCaseTest.Initialize_TestNameIsProvided" executed="True" success="True" time="0.000" asserts="2" />
+                                  <test-case name="NUnit.Core.Extensions.RowTest.UnitTests.RowTestCaseTest.RunTestMethod_WithArguments" executed="True" success="True" time="0.000" asserts="3" />
+                                  <test-case name="NUnit.Core.Extensions.RowTest.UnitTests.RowTestCaseTest.RunTestMethod_WithNullArgument" executed="True" success="True" time="0.000" asserts="2" />
+                                </results>
+                              </test-suite>
+                              <test-suite name="RowTestFrameworkTest" success="True" time="0.000" asserts="0">
+                                <results>
+                                  <test-case name="NUnit.Core.Extensions.RowTest.UnitTests.RowTestFrameworkTest.GetExpectedExceptionMessage" executed="True" success="True" time="0.000" asserts="1" />
+                                  <test-case name="NUnit.Core.Extensions.RowTest.UnitTests.RowTestFrameworkTest.GetExpectedExceptionType" executed="True" success="True" time="0.000" asserts="1" />
+                                  <test-case name="NUnit.Core.Extensions.RowTest.UnitTests.RowTestFrameworkTest.GetRowArguments" executed="True" success="True" time="0.000" asserts="1" />
+                                  <test-case name="NUnit.Core.Extensions.RowTest.UnitTests.RowTestFrameworkTest.GetRowAttributes_NoRows" executed="True" success="True" time="0.000" asserts="1" />
+                                  <test-case name="NUnit.Core.Extensions.RowTest.UnitTests.RowTestFrameworkTest.GetRowAttributes_TwoRows" executed="True" success="True" time="0.000" asserts="1" />
+                                  <test-case name="NUnit.Core.Extensions.RowTest.UnitTests.RowTestFrameworkTest.GetTestName" executed="True" success="True" time="0.000" asserts="1" />
+                                  <test-case name="NUnit.Core.Extensions.RowTest.UnitTests.RowTestFrameworkTest.IsRowTest_False" executed="True" success="True" time="0.000" asserts="1" />
+                                  <test-case name="NUnit.Core.Extensions.RowTest.UnitTests.RowTestFrameworkTest.IsRowTest_MethodIsNull" executed="True" success="True" time="0.000" asserts="1" />
+                                  <test-case name="NUnit.Core.Extensions.RowTest.UnitTests.RowTestFrameworkTest.IsRowTest_True" executed="True" success="True" time="0.000" asserts="1" />
+                                  <test-case name="NUnit.Core.Extensions.RowTest.UnitTests.RowTestFrameworkTest.IsSpecialValue_False" executed="True" success="True" time="0.000" asserts="1" />
+                                  <test-case name="NUnit.Core.Extensions.RowTest.UnitTests.RowTestFrameworkTest.IsSpecialValue_Null" executed="True" success="True" time="0.000" asserts="1" />
+                                  <test-case name="NUnit.Core.Extensions.RowTest.UnitTests.RowTestFrameworkTest.IsSpecialValue_True" executed="True" success="True" time="0.000" asserts="1" />
+                                </results>
+                              </test-suite>
+                              <test-suite name="RowTestNameBuilderTest" success="True" time="0.000" asserts="0">
+                                <results>
+                                  <test-case name="NUnit.Core.Extensions.RowTest.UnitTests.RowTestNameBuilderTest.FullTestName" executed="True" success="True" time="0.000" asserts="1" />
+                                  <test-case name="NUnit.Core.Extensions.RowTest.UnitTests.RowTestNameBuilderTest.Initialize" executed="True" success="True" time="0.000" asserts="3" />
+                                  <test-case name="NUnit.Core.Extensions.RowTest.UnitTests.RowTestNameBuilderTest.TestName_IsMethodName" executed="True" success="True" time="0.000" asserts="1" />
+                                  <test-case name="NUnit.Core.Extensions.RowTest.UnitTests.RowTestNameBuilderTest.TestName_IsProvided" executed="True" success="True" time="0.000" asserts="1" />
+                                  <test-case name="NUnit.Core.Extensions.RowTest.UnitTests.RowTestNameBuilderTest.TestName_NullArgument" executed="True" success="True" time="0.000" asserts="1" />
+                                  <test-case name="NUnit.Core.Extensions.RowTest.UnitTests.RowTestNameBuilderTest.TestName_ProvidedTestNameIsEmpty" executed="True" success="True" time="0.000" asserts="1" />
+                                </results>
+                              </test-suite>
+                              <test-suite name="RowTestSuiteTest" success="True" time="0.016" asserts="0">
+                                <results>
+                                  <test-case name="NUnit.Core.Extensions.RowTest.UnitTests.RowTestSuiteTest.Initialize" executed="True" success="True" time="0.000" asserts="1" />
+                                  <test-case name="NUnit.Core.Extensions.RowTest.UnitTests.RowTestSuiteTest.Run" executed="True" success="True" time="0.000" asserts="1" />
+                                  <test-case name="NUnit.Core.Extensions.RowTest.UnitTests.RowTestSuiteTest.Run_WithoutParent" executed="True" success="True" time="0.000" asserts="1" />
+                                  <test-case name="NUnit.Core.Extensions.RowTest.UnitTests.RowTestSuiteTest.Run_WithTestFilter" executed="True" success="True" time="0.016" asserts="1" />
+                                </results>
+                              </test-suite>
+                            </results>
+                          </test-suite>
+                        </results>
+                      </test-suite>
+                    </results>
+                  </test-suite>
+                </results>
+              </test-suite>
+            </results>
+          </test-suite>
+        </results>
+      </test-suite>
+      <test-suite name="C:\Program Files\NUnit 2.4.8\bin\nunit-console.tests.dll" success="True" time="23.234" asserts="0">
+        <results>
+          <test-suite name="NUnit" success="True" time="23.203" asserts="0">
+            <results>
+              <test-suite name="ConsoleRunner" success="True" time="23.203" asserts="0">
+                <results>
+                  <test-suite name="Tests" success="True" time="23.188" asserts="0">
+                    <results>
+                      <test-suite name="CommandLineTests" success="True" time="0.250" asserts="0">
+                        <results>
+                          <test-case name="NUnit.ConsoleRunner.Tests.CommandLineTests.AllowForwardSlashDefaultsCorrectly" executed="True" success="True" time="0.188" asserts="1" />
+                          <test-case name="NUnit.ConsoleRunner.Tests.CommandLineTests.AssemblyAloneIsValid" executed="True" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.ConsoleRunner.Tests.CommandLineTests.AssemblyName" executed="True" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.ConsoleRunner.Tests.CommandLineTests.FileNameWithoutXmlParameterIsInvalid" executed="True" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.ConsoleRunner.Tests.CommandLineTests.FixtureNamePlusAssemblyIsValid" executed="True" success="True" time="0.000" asserts="3" />
+                          <test-case name="NUnit.ConsoleRunner.Tests.CommandLineTests.HelpTextUsesCorrectDelimiterForPlatform" executed="True" success="True" time="0.000" asserts="2" />
+                          <test-case name="NUnit.ConsoleRunner.Tests.CommandLineTests.InvalidCommandLineParms" executed="True" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.ConsoleRunner.Tests.CommandLineTests.InvalidOption" executed="True" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.ConsoleRunner.Tests.CommandLineTests.NoFixtureNameProvided" executed="True" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.ConsoleRunner.Tests.CommandLineTests.NoParametersCount" executed="True" success="True" time="0.016" asserts="1" />
+                          <test-case name="NUnit.ConsoleRunner.Tests.CommandLineTests.OptionsAreRecognized" executed="True" success="True" time="0.016" asserts="104" />
+                          <test-case name="NUnit.ConsoleRunner.Tests.CommandLineTests.TransformParameter" executed="True" success="True" time="0.000" asserts="3" />
+                          <test-case name="NUnit.ConsoleRunner.Tests.CommandLineTests.XmlParameter" executed="True" success="True" time="0.000" asserts="3" />
+                          <test-case name="NUnit.ConsoleRunner.Tests.CommandLineTests.XmlParameterWithFullPath" executed="True" success="True" time="0.000" asserts="3" />
+                          <test-case name="NUnit.ConsoleRunner.Tests.CommandLineTests.XmlParameterWithFullPathUsingEqualSign" executed="True" success="True" time="0.000" asserts="3" />
+                          <test-case name="NUnit.ConsoleRunner.Tests.CommandLineTests.XmlParameterWithoutFileNameIsInvalid" executed="True" success="True" time="0.000" asserts="1" />
+                        </results>
+                      </test-suite>
+                      <test-suite name="CommandLineTests_MultipleAssemblies" success="True" time="0.016" asserts="0">
+                        <results>
+                          <test-case name="NUnit.ConsoleRunner.Tests.CommandLineTests_MultipleAssemblies.CheckParameters" executed="True" success="True" time="0.000" asserts="2" />
+                          <test-case name="NUnit.ConsoleRunner.Tests.CommandLineTests_MultipleAssemblies.FixtureParameters" executed="True" success="True" time="0.000" asserts="3" />
+                          <test-case name="NUnit.ConsoleRunner.Tests.CommandLineTests_MultipleAssemblies.FixtureValidate" executed="True" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.ConsoleRunner.Tests.CommandLineTests_MultipleAssemblies.MultipleAssemblyValidate" executed="True" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.ConsoleRunner.Tests.CommandLineTests_MultipleAssemblies.ParameterCount" executed="True" success="True" time="0.000" asserts="1" />
+                        </results>
+                      </test-suite>
+                      <test-suite name="ConsoleRunnerTest" success="True" time="22.906" asserts="0">
+                        <results>
+                          <test-case name="NUnit.ConsoleRunner.Tests.ConsoleRunnerTest.Bug1073539Test" executed="True" success="True" time="1.969" asserts="1" />
+                          <test-case name="NUnit.ConsoleRunner.Tests.ConsoleRunnerTest.Bug1311644Test" executed="True" success="True" time="1.281" asserts="1" />
+                          <test-case name="NUnit.ConsoleRunner.Tests.ConsoleRunnerTest.CanRunWithMultipleTestDomains" executed="True" success="True" time="2.234" asserts="2" />
+                          <test-case name="NUnit.ConsoleRunner.Tests.ConsoleRunnerTest.CanRunWithMultipleTestDomains_NoThread" executed="True" success="True" time="2.109" asserts="2" />
+                          <test-case name="NUnit.ConsoleRunner.Tests.ConsoleRunnerTest.CanRunWithoutTestDomain" executed="True" success="True" time="0.250" asserts="2" />
+                          <test-case name="NUnit.ConsoleRunner.Tests.ConsoleRunnerTest.CanRunWithoutTestDomain_NoThread" executed="True" success="True" time="0.094" asserts="2" />
+                          <test-case name="NUnit.ConsoleRunner.Tests.ConsoleRunnerTest.CanRunWithSingleTestDomain" executed="True" success="True" time="1.125" asserts="2" />
+                          <test-case name="NUnit.ConsoleRunner.Tests.ConsoleRunnerTest.CanRunWithSingleTestDomain_NoThread" executed="True" success="True" time="1.594" asserts="2" />
+                          <test-case name="NUnit.ConsoleRunner.Tests.ConsoleRunnerTest.FailureFixture" executed="True" success="True" time="2.500" asserts="1" />
+                          <test-case name="NUnit.ConsoleRunner.Tests.ConsoleRunnerTest.InvalidAssembly" executed="True" success="True" time="1.703" asserts="1" />
+                          <test-case name="NUnit.ConsoleRunner.Tests.ConsoleRunnerTest.InvalidFixture" executed="True" success="True" time="2.688" asserts="1" />
+                          <test-case name="NUnit.ConsoleRunner.Tests.ConsoleRunnerTest.MultiFailureFixture" executed="True" success="True" time="1.797" asserts="1" />
+                          <test-case name="NUnit.ConsoleRunner.Tests.ConsoleRunnerTest.SuccessFixture" executed="True" success="True" time="1.188" asserts="1" />
+                          <test-case name="NUnit.ConsoleRunner.Tests.ConsoleRunnerTest.XmlResult" executed="True" success="True" time="1.219" asserts="2" />
+                          <test-case name="NUnit.ConsoleRunner.Tests.ConsoleRunnerTest.XmlToConsole" executed="True" success="True" time="1.141" asserts="2" />
+                        </results>
+                      </test-suite>
+                    </results>
+                  </test-suite>
+                </results>
+              </test-suite>
+            </results>
+          </test-suite>
+        </results>
+      </test-suite>
+      <test-suite name="C:\Program Files\NUnit 2.4.8\bin\nunit.uikit.tests.dll" success="True" time="4.188" asserts="0">
+        <results>
+          <test-suite name="NUnit" success="True" time="4.188" asserts="0">
+            <results>
+              <test-suite name="UiKit" success="True" time="4.156" asserts="0">
+                <results>
+                  <test-suite name="Tests" success="True" time="4.156" asserts="0">
+                    <results>
+                      <test-suite name="AddConfigurationDialogTests" success="True" time="1.234" asserts="0">
+                        <results>
+                          <test-case name="NUnit.UiKit.Tests.AddConfigurationDialogTests.CheckComboBox" executed="True" success="True" time="1.078" asserts="5" />
+                          <test-case name="NUnit.UiKit.Tests.AddConfigurationDialogTests.CheckForControls" executed="True" success="True" time="0.000" asserts="0" />
+                          <test-case name="NUnit.UiKit.Tests.AddConfigurationDialogTests.CheckTextBox" executed="True" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.UiKit.Tests.AddConfigurationDialogTests.TestComplexEntry" executed="True" success="True" time="0.094" asserts="2" />
+                          <test-case name="NUnit.UiKit.Tests.AddConfigurationDialogTests.TestSimpleEntry" executed="True" success="True" time="0.016" asserts="2" />
+                        </results>
+                      </test-suite>
+                      <test-suite name="ErrorDisplayTests" success="True" time="0.047" asserts="0">
+                        <results>
+                          <test-case name="NUnit.UiKit.Tests.ErrorDisplayTests.ControlsArePositionedCorrectly" executed="True" success="True" time="0.000" asserts="0" />
+                          <test-case name="NUnit.UiKit.Tests.ErrorDisplayTests.ControlsExist" executed="True" success="True" time="0.000" asserts="0" />
+                        </results>
+                      </test-suite>
+                      <test-suite name="LongRunningOperationDisplayTests" success="True" time="0.031" asserts="0">
+                        <results>
+                          <test-case name="NUnit.UiKit.Tests.LongRunningOperationDisplayTests.CreateDisplay" executed="True" success="True" time="0.031" asserts="2" />
+                        </results>
+                      </test-suite>
+                      <test-suite name="ProgressBarTests" success="True" time="0.156" asserts="0">
+                        <results>
+                          <test-case name="NUnit.UiKit.Tests.ProgressBarTests.TestProgressDisplay" executed="True" success="True" time="0.156" asserts="19" />
+                        </results>
+                      </test-suite>
+                      <test-suite name="RecentFileMenuHandlerTests" success="True" time="0.016" asserts="0">
+                        <results>
+                          <test-case name="NUnit.UiKit.Tests.RecentFileMenuHandlerTests.DisableOnLoadWhenEmpty" executed="True" success="True" time="0.016" asserts="1" />
+                          <test-case name="NUnit.UiKit.Tests.RecentFileMenuHandlerTests.EnableOnLoadWhenNotEmpty" executed="True" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.UiKit.Tests.RecentFileMenuHandlerTests.LoadMenuItems" executed="True" success="True" time="0.000" asserts="2" />
+                        </results>
+                      </test-suite>
+                      <test-suite name="SimpleTextDisplayTests" success="True" time="0.234" asserts="0">
+                        <results>
+                          <test-case name="NUnit.UiKit.Tests.SimpleTextDisplayTests.AppendText_AfterCreation" executed="True" success="True" time="0.031" asserts="7" />
+                          <test-case name="NUnit.UiKit.Tests.SimpleTextDisplayTests.AppendText_BeforeAndAfterCreation" executed="True" success="True" time="0.000" asserts="2" />
+                          <test-case name="NUnit.UiKit.Tests.SimpleTextDisplayTests.AppendText_BeforeCreation" executed="True" success="True" time="0.000" asserts="2" />
+                          <test-case name="NUnit.UiKit.Tests.SimpleTextDisplayTests.ClearText_AfterCreation" executed="True" success="True" time="0.000" asserts="2" />
+                          <test-case name="NUnit.UiKit.Tests.SimpleTextDisplayTests.ClearText_BeforeCreation" executed="True" success="True" time="0.000" asserts="2" />
+                          <test-case name="NUnit.UiKit.Tests.SimpleTextDisplayTests.SetText_AfterCreation" executed="True" success="True" time="0.000" asserts="2" />
+                          <test-case name="NUnit.UiKit.Tests.SimpleTextDisplayTests.SetText_BeforeCreation" executed="True" success="True" time="0.016" asserts="4" />
+                          <test-case name="NUnit.UiKit.Tests.SimpleTextDisplayTests.StressTest" executed="True" success="True" time="0.188" asserts="2" />
+                        </results>
+                      </test-suite>
+                      <test-suite name="StatusBarTests" success="True" time="0.313" asserts="0">
+                        <results>
+                          <test-case name="NUnit.UiKit.Tests.StatusBarTests.TestConstruction" executed="True" success="True" time="0.078" asserts="5" />
+                          <test-case name="NUnit.UiKit.Tests.StatusBarTests.TestFinalDisplay" executed="True" success="True" time="0.078" asserts="6" />
+                          <test-case name="NUnit.UiKit.Tests.StatusBarTests.TestInitialization" executed="True" success="True" time="0.078" asserts="10" />
+                          <test-case name="NUnit.UiKit.Tests.StatusBarTests.TestProgressDisplay" executed="True" success="True" time="0.063" asserts="89" />
+                        </results>
+                      </test-suite>
+                      <test-suite name="TestSuiteTreeNodeTests" success="True" time="0.109" asserts="0">
+                        <results>
+                          <test-case name="NUnit.UiKit.Tests.TestSuiteTreeNodeTests.ClearResult" executed="True" success="True" time="0.016" asserts="5" />
+                          <test-case name="NUnit.UiKit.Tests.TestSuiteTreeNodeTests.ClearResults" executed="True" success="True" time="0.016" asserts="8" />
+                          <test-case name="NUnit.UiKit.Tests.TestSuiteTreeNodeTests.ConstructFromTestInfo" executed="True" success="True" time="0.000" asserts="6" />
+                          <test-case name="NUnit.UiKit.Tests.TestSuiteTreeNodeTests.SetResult_Failure" executed="True" success="True" time="0.016" asserts="3" />
+                          <test-case name="NUnit.UiKit.Tests.TestSuiteTreeNodeTests.SetResult_Ignore" executed="True" success="True" time="0.000" asserts="4" />
+                          <test-case name="NUnit.UiKit.Tests.TestSuiteTreeNodeTests.SetResult_Init" executed="True" success="True" time="0.047" asserts="4" />
+                          <test-case name="NUnit.UiKit.Tests.TestSuiteTreeNodeTests.SetResult_Skipped" executed="True" success="True" time="0.016" asserts="3" />
+                          <test-case name="NUnit.UiKit.Tests.TestSuiteTreeNodeTests.SetResult_Success" executed="True" success="True" time="0.000" asserts="3" />
+                        </results>
+                      </test-suite>
+                      <test-suite name="TestSuiteTreeViewFixture" success="True" time="1.156" asserts="0">
+                        <results>
+                          <test-case name="NUnit.UiKit.Tests.TestSuiteTreeViewFixture.BuildFromResult" executed="True" success="True" time="0.531" asserts="15" />
+                          <test-case name="NUnit.UiKit.Tests.TestSuiteTreeViewFixture.BuildTreeView" executed="True" success="True" time="0.078" asserts="5" />
+                          <test-case name="NUnit.UiKit.Tests.TestSuiteTreeViewFixture.ClearTree" executed="True" success="True" time="0.141" asserts="1" />
+                          <test-case name="NUnit.UiKit.Tests.TestSuiteTreeViewFixture.ProcessChecks" executed="True" success="True" time="0.094" asserts="7" />
+                          <test-case name="NUnit.UiKit.Tests.TestSuiteTreeViewFixture.ReloadTree" executed="True" success="True" time="0.094" asserts="235" />
+                          <test-case name="NUnit.UiKit.Tests.TestSuiteTreeViewFixture.ReloadTreeWithWrongTest" executed="True" success="True" time="0.063" asserts="0" />
+                          <test-case name="NUnit.UiKit.Tests.TestSuiteTreeViewFixture.SetTestResult" executed="True" success="True" time="0.156" asserts="3" />
+                        </results>
+                      </test-suite>
+                      <test-suite name="VisualStateTests" success="True" time="0.813" asserts="0">
+                        <results>
+                          <test-case name="NUnit.UiKit.Tests.VisualStateTests.SaveAndRestoreVisualState" executed="True" success="True" time="0.813" asserts="5" />
+                        </results>
+                      </test-suite>
+                    </results>
+                  </test-suite>
+                </results>
+              </test-suite>
+            </results>
+          </test-suite>
+        </results>
+      </test-suite>
+      <test-suite name="C:\Program Files\NUnit 2.4.8\bin\nunit-gui.tests.dll" success="True" time="3.547" asserts="0">
+        <results>
+          <test-suite name="NUnit" success="True" time="3.547" asserts="0">
+            <results>
+              <test-suite name="Gui" success="True" time="3.547" asserts="0">
+                <results>
+                  <test-suite name="Tests" success="True" time="3.531" asserts="0">
+                    <results>
+                      <test-suite name="CommandLineTests" success="True" time="0.234" asserts="0">
+                        <results>
+                          <test-case name="NUnit.Gui.Tests.CommandLineTests.AssemblyName" executed="True" success="True" time="0.219" asserts="1" />
+                          <test-case name="NUnit.Gui.Tests.CommandLineTests.Help" executed="True" success="True" time="0.016" asserts="1" />
+                          <test-case name="NUnit.Gui.Tests.CommandLineTests.HelpTextUsesCorrectDelimiterForPlatform" executed="True" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Gui.Tests.CommandLineTests.InvalidArgs" executed="True" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Gui.Tests.CommandLineTests.InvalidCommandLineParms" executed="True" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Gui.Tests.CommandLineTests.NoNameValuePairs" executed="True" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Gui.Tests.CommandLineTests.NoParametersCount" executed="True" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Gui.Tests.CommandLineTests.ShortHelp" executed="True" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Gui.Tests.CommandLineTests.ValidateSuccessful" executed="True" success="True" time="0.000" asserts="1" />
+                        </results>
+                      </test-suite>
+                      <test-suite name="ExceptionDetailsFormTests" success="True" time="0.594" asserts="0">
+                        <results>
+                          <test-case name="NUnit.Gui.Tests.ExceptionDetailsFormTests.ControlsArePositionedCorrectly" executed="True" success="True" time="0.000" asserts="0" />
+                          <test-case name="NUnit.Gui.Tests.ExceptionDetailsFormTests.ControlsExist" executed="True" success="True" time="0.000" asserts="0" />
+                          <test-case name="NUnit.Gui.Tests.ExceptionDetailsFormTests.MessageDisplaysCorrectly" executed="True" success="True" time="0.188" asserts="1" />
+                        </results>
+                      </test-suite>
+                      <test-suite name="ProjectEditorTests" success="True" time="0.797" asserts="0">
+                        <results>
+                          <test-case name="NUnit.Gui.Tests.ProjectEditorTests.CheckControls" executed="True" success="True" time="0.609" asserts="0" />
+                          <test-case name="NUnit.Gui.Tests.ProjectEditorTests.InitialFieldValues" executed="True" success="True" time="0.125" asserts="2" />
+                          <test-case name="NUnit.Gui.Tests.ProjectEditorTests.SetProjectBase" executed="True" success="True" time="0.063" asserts="1" />
+                        </results>
+                      </test-suite>
+                    </results>
+                  </test-suite>
+                </results>
+              </test-suite>
+            </results>
+          </test-suite>
+        </results>
+      </test-suite>
+      <test-suite name="C:\Program Files\NUnit 2.4.8\bin\nunit.fixtures.tests.dll" success="True" time="0.969" asserts="0">
+        <results>
+          <test-suite name="NUnit" success="True" time="0.953" asserts="0">
+            <results>
+              <test-suite name="Fixtures" success="True" time="0.953" asserts="0">
+                <results>
+                  <test-suite name="Tests" success="True" time="0.953" asserts="0">
+                    <results>
+                      <test-suite name="CompilationTests" success="True" time="0.938" asserts="0">
+                        <results>
+                          <test-case name="NUnit.Fixtures.Tests.CompilationTests.CheckDefaultSettings" executed="True" success="True" time="0.109" asserts="5" />
+                          <test-case name="NUnit.Fixtures.Tests.CompilationTests.CompileToFile" executed="True" success="True" time="0.344" asserts="3" />
+                          <test-case name="NUnit.Fixtures.Tests.CompilationTests.CompilingBadCodeGivesAnError" executed="True" success="True" time="0.281" asserts="1" />
+                          <test-case name="NUnit.Fixtures.Tests.CompilationTests.LoadTestsFromCompiledAssembly" executed="True" success="True" time="0.188" asserts="3" />
+                        </results>
+                      </test-suite>
+                      <test-suite name="TestTreeTests" success="True" time="0.000" asserts="0">
+                        <results>
+                          <test-case name="NUnit.Fixtures.Tests.TestTreeTests.MatchingTreesAreEqual" executed="True" success="True" time="0.000" asserts="3" />
+                          <test-case name="NUnit.Fixtures.Tests.TestTreeTests.NonMatchingTreesAreNotEqual" executed="True" success="True" time="0.000" asserts="3" />
+                        </results>
+                      </test-suite>
+                    </results>
+                  </test-suite>
+                </results>
+              </test-suite>
+            </results>
+          </test-suite>
+        </results>
+      </test-suite>
+    </results>
+  </test-suite>
+</test-results>

--- a/src/test-nunit-summary.exe/TestInput/TestResult-2.5.10.xml
+++ b/src/test-nunit-summary.exe/TestInput/TestResult-2.5.10.xml
@@ -1,0 +1,5971 @@
+﻿<?xml version="1.0" encoding="utf-8" standalone="no"?>
+<!--This file represents the results of running a test suite-->
+<test-results name="C:\Program Files\NUnit 2.5.10\bin\net-2.0\NUnitTests.nunit" total="3001" errors="0" failures="0" not-run="2" inconclusive="13" ignored="0" skipped="2" invalid="0" date="2013-09-28" time="16:20:35">
+  <environment nunit-version="2.5.10.11092" clr-version="2.0.50727.5472" os-version="Microsoft Windows NT 6.1.7601 Service Pack 1" platform="Win32NT" cwd="C:\Program Files\NUnit 2.5.10\bin\net-2.0" machine-name="CHARLIE-LAPTOP" user="charlie" user-domain="charlie-laptop" />
+  <culture-info current-culture="en-US" current-uiculture="en-US" />
+  <test-suite type="Test Project" name="C:\Program Files\NUnit 2.5.10\bin\net-2.0\NUnitTests.nunit" executed="True" result="Success" success="True" time="71.132" asserts="0">
+    <results>
+      <test-suite type="Assembly" name="C:\Program Files\NUnit 2.5.10\bin\net-2.0\tests/nunit.framework.tests.dll" executed="True" result="Success" success="True" time="14.877" asserts="0">
+        <results>
+          <test-suite type="Namespace" name="NUnit" executed="True" result="Success" success="True" time="14.873" asserts="0">
+            <results>
+              <test-suite type="Namespace" name="Framework" executed="True" result="Success" success="True" time="14.872" asserts="0">
+                <results>
+                  <test-suite type="Namespace" name="Constraints" executed="True" result="Success" success="True" time="9.210" asserts="0">
+                    <results>
+                      <test-suite type="TestFixture" name="AfterConstraintTest" executed="True" result="Success" success="True" time="6.344" asserts="0">
+                        <results>
+                          <test-case name="NUnit.Framework.Constraints.AfterConstraintTest.ConstraintTestBaseNoData.ProvidesProperDescription" executed="True" result="Success" success="True" time="0.012" asserts="1" />
+                          <test-case name="NUnit.Framework.Constraints.AfterConstraintTest.ConstraintTestBaseNoData.ProvidesProperStringRepresentation" executed="True" result="Success" success="True" time="0.001" asserts="1" />
+                          <test-suite type="ParameterizedTest" name="FailsWithBadDelegates" executed="True" result="Success" success="True" time="1.006" asserts="0">
+                            <results>
+                              <test-case name="NUnit.Framework.Constraints.AfterConstraintTest.FailsWithBadDelegates(NUnit.Framework.Constraints.ActualValueDelegate)" executed="True" result="Success" success="True" time="0.502" asserts="1" />
+                              <test-case name="NUnit.Framework.Constraints.AfterConstraintTest.FailsWithBadDelegates(NUnit.Framework.Constraints.ActualValueDelegate)" executed="True" result="Success" success="True" time="0.500" asserts="1" />
+                            </results>
+                          </test-suite>
+                          <test-suite type="ParameterizedTest" name="FailsWithBadValues" executed="True" result="Success" success="True" time="1.510" asserts="0">
+                            <results>
+                              <test-case name="NUnit.Framework.Constraints.AfterConstraintTest.FailsWithBadValues(False)" executed="True" result="Success" success="True" time="0.501" asserts="1" />
+                              <test-case name="NUnit.Framework.Constraints.AfterConstraintTest.FailsWithBadValues(0)" executed="True" result="Success" success="True" time="0.500" asserts="1" />
+                              <test-case name="NUnit.Framework.Constraints.AfterConstraintTest.FailsWithBadValues(null)" executed="True" result="Success" success="True" time="0.500" asserts="1" />
+                            </results>
+                          </test-suite>
+                          <test-suite type="ParameterizedTest" name="ProvidesProperFailureMessage" executed="True" result="Success" success="True" time="1.535" asserts="0">
+                            <results>
+                              <test-case name="NUnit.Framework.Constraints.AfterConstraintTest.ProvidesProperFailureMessage(False,&quot;False&quot;)" executed="True" result="Success" success="True" time="0.502" asserts="1" />
+                              <test-case name="NUnit.Framework.Constraints.AfterConstraintTest.ProvidesProperFailureMessage(0,&quot;0&quot;)" executed="True" result="Success" success="True" time="0.500" asserts="1" />
+                              <test-case name="NUnit.Framework.Constraints.AfterConstraintTest.ProvidesProperFailureMessage(null,&quot;null&quot;)" executed="True" result="Success" success="True" time="0.500" asserts="1" />
+                            </results>
+                          </test-suite>
+                          <test-case name="NUnit.Framework.Constraints.AfterConstraintTest.SimpleTest" executed="True" result="Success" success="True" time="0.602" asserts="1" />
+                          <test-case name="NUnit.Framework.Constraints.AfterConstraintTest.SimpleTestUsingReference" executed="True" result="Success" success="True" time="0.604" asserts="1" />
+                          <test-suite type="ParameterizedTest" name="SucceedsWithGoodDelegates" executed="True" result="Success" success="True" time="0.502" asserts="0">
+                            <results>
+                              <test-case name="NUnit.Framework.Constraints.AfterConstraintTest.SucceedsWithGoodDelegates(NUnit.Framework.Constraints.ActualValueDelegate)" executed="True" result="Success" success="True" time="0.501" asserts="1" />
+                            </results>
+                          </test-suite>
+                          <test-suite type="ParameterizedTest" name="SucceedsWithGoodValues" executed="True" result="Success" success="True" time="0.501" asserts="0">
+                            <results>
+                              <test-case name="NUnit.Framework.Constraints.AfterConstraintTest.SucceedsWithGoodValues(True)" executed="True" result="Success" success="True" time="0.500" asserts="1" />
+                            </results>
+                          </test-suite>
+                          <test-case name="NUnit.Framework.Constraints.AfterConstraintTest.ThatOverload_DoesNotAcceptNegativeDelayValues" executed="True" result="Success" success="True" time="0.006" asserts="0" />
+                          <test-case name="NUnit.Framework.Constraints.AfterConstraintTest.ThatOverload_ZeroDelayIsAllowed" executed="True" result="Success" success="True" time="0.003" asserts="1" />
+                        </results>
+                      </test-suite>
+                      <test-suite type="TestFixture" name="AllItemsTests" executed="True" result="Success" success="True" time="0.032" asserts="0">
+                        <results>
+                          <test-case name="NUnit.Framework.Constraints.AllItemsTests.AllItemsAreInRange" executed="True" result="Success" success="True" time="0.005" asserts="1" />
+                          <test-case name="NUnit.Framework.Constraints.AllItemsTests.AllItemsAreInRange_UsingComparisonOfT" executed="True" result="Success" success="True" time="0.001" asserts="1" />
+                          <test-case name="NUnit.Framework.Constraints.AllItemsTests.AllItemsAreInRange_UsingIComparer" executed="True" result="Success" success="True" time="0.001" asserts="1" />
+                          <test-case name="NUnit.Framework.Constraints.AllItemsTests.AllItemsAreInRange_UsingIComparerOfT" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Framework.Constraints.AllItemsTests.AllItemsAreInRangeFailureMessage" executed="True" result="Success" success="True" time="0.002" asserts="2" />
+                          <test-case name="NUnit.Framework.Constraints.AllItemsTests.AllItemsAreInstancesOfType" executed="True" result="Success" success="True" time="0.001" asserts="1" />
+                          <test-case name="NUnit.Framework.Constraints.AllItemsTests.AllItemsAreInstancesOfTypeFailureMessage" executed="True" result="Success" success="True" time="0.002" asserts="2" />
+                          <test-case name="NUnit.Framework.Constraints.AllItemsTests.AllItemsAreNotNull" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Framework.Constraints.AllItemsTests.AllItemsAreNotNullFails" executed="True" result="Success" success="True" time="0.001" asserts="2" />
+                        </results>
+                      </test-suite>
+                      <test-suite type="TestFixture" name="AndTest" executed="True" result="Success" success="True" time="0.024" asserts="0">
+                        <results>
+                          <test-case name="NUnit.Framework.Constraints.AndTest.CanCombineTestsWithAndOperator" executed="True" result="Success" success="True" time="0.002" asserts="1" />
+                          <test-case name="NUnit.Framework.Constraints.AndTest.ConstraintTestBaseNoData.ProvidesProperDescription" executed="True" result="Success" success="True" time="0.001" asserts="1" />
+                          <test-case name="NUnit.Framework.Constraints.AndTest.ConstraintTestBaseNoData.ProvidesProperStringRepresentation" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                          <test-suite type="ParameterizedTest" name="FailsWithBadValues" executed="True" result="Success" success="True" time="0.003" asserts="0">
+                            <results>
+                              <test-case name="NUnit.Framework.Constraints.AndTest.FailsWithBadValues(37)" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                              <test-case name="NUnit.Framework.Constraints.AndTest.FailsWithBadValues(53)" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                            </results>
+                          </test-suite>
+                          <test-suite type="ParameterizedTest" name="ProvidesProperFailureMessage" executed="True" result="Success" success="True" time="0.004" asserts="0">
+                            <results>
+                              <test-case name="NUnit.Framework.Constraints.AndTest.ProvidesProperFailureMessage(37,&quot;37&quot;)" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                              <test-case name="NUnit.Framework.Constraints.AndTest.ProvidesProperFailureMessage(53,&quot;53&quot;)" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                            </results>
+                          </test-suite>
+                          <test-suite type="ParameterizedTest" name="SucceedsWithGoodValues" executed="True" result="Success" success="True" time="0.001" asserts="0">
+                            <results>
+                              <test-case name="NUnit.Framework.Constraints.AndTest.SucceedsWithGoodValues(42)" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                            </results>
+                          </test-suite>
+                        </results>
+                      </test-suite>
+                      <test-suite type="TestFixture" name="AssignableFromTest" executed="True" result="Success" success="True" time="0.014" asserts="0">
+                        <results>
+                          <test-case name="NUnit.Framework.Constraints.AssignableFromTest.ConstraintTestBaseNoData.ProvidesProperDescription" executed="True" result="Success" success="True" time="0.001" asserts="1" />
+                          <test-case name="NUnit.Framework.Constraints.AssignableFromTest.ConstraintTestBaseNoData.ProvidesProperStringRepresentation" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                          <test-suite type="ParameterizedTest" name="FailsWithBadValues" executed="True" result="Success" success="True" time="0.001" asserts="0">
+                            <results>
+                              <test-case name="NUnit.Framework.Constraints.AssignableFromTest.FailsWithBadValues(NUnit.Framework.Constraints.D2)" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                            </results>
+                          </test-suite>
+                          <test-suite type="ParameterizedTest" name="ProvidesProperFailureMessage" executed="True" result="Success" success="True" time="0.002" asserts="0">
+                            <results>
+                              <test-case name="NUnit.Framework.Constraints.AssignableFromTest.ProvidesProperFailureMessage(NUnit.Framework.Constraints.D2,&quot;&lt;NUnit.Framework.Constraints.D2&gt;&quot;)" executed="True" result="Success" success="True" time="0.001" asserts="1" />
+                            </results>
+                          </test-suite>
+                          <test-suite type="ParameterizedTest" name="SucceedsWithGoodValues" executed="True" result="Success" success="True" time="0.002" asserts="0">
+                            <results>
+                              <test-case name="NUnit.Framework.Constraints.AssignableFromTest.SucceedsWithGoodValues(NUnit.Framework.Constraints.D1)" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                              <test-case name="NUnit.Framework.Constraints.AssignableFromTest.SucceedsWithGoodValues(NUnit.Framework.Constraints.B)" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                            </results>
+                          </test-suite>
+                        </results>
+                      </test-suite>
+                      <test-suite type="TestFixture" name="AssignableToTest" executed="True" result="Success" success="True" time="0.018" asserts="0">
+                        <results>
+                          <test-case name="NUnit.Framework.Constraints.AssignableToTest.ConstraintTestBaseNoData.ProvidesProperDescription" executed="True" result="Success" success="True" time="0.001" asserts="1" />
+                          <test-case name="NUnit.Framework.Constraints.AssignableToTest.ConstraintTestBaseNoData.ProvidesProperStringRepresentation" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                          <test-suite type="ParameterizedTest" name="FailsWithBadValues" executed="True" result="Success" success="True" time="0.001" asserts="0">
+                            <results>
+                              <test-case name="NUnit.Framework.Constraints.AssignableToTest.FailsWithBadValues(NUnit.Framework.Constraints.B)" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                            </results>
+                          </test-suite>
+                          <test-suite type="ParameterizedTest" name="ProvidesProperFailureMessage" executed="True" result="Success" success="True" time="0.000" asserts="0">
+                            <results>
+                              <test-case name="NUnit.Framework.Constraints.AssignableToTest.ProvidesProperFailureMessage(NUnit.Framework.Constraints.B,&quot;&lt;NUnit.Framework.Constraints.B&gt;&quot;)" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                            </results>
+                          </test-suite>
+                          <test-suite type="ParameterizedTest" name="SucceedsWithGoodValues" executed="True" result="Success" success="True" time="0.006" asserts="0">
+                            <results>
+                              <test-case name="NUnit.Framework.Constraints.AssignableToTest.SucceedsWithGoodValues(NUnit.Framework.Constraints.D1)" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                              <test-case name="NUnit.Framework.Constraints.AssignableToTest.SucceedsWithGoodValues(NUnit.Framework.Constraints.D2)" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                            </results>
+                          </test-suite>
+                        </results>
+                      </test-suite>
+                      <test-suite type="TestFixture" name="AttributeExistsConstraintTest" executed="True" result="Success" success="True" time="0.021" asserts="0">
+                        <results>
+                          <test-case name="NUnit.Framework.Constraints.AttributeExistsConstraintTest.AttributeExistsOnMethodInfo" executed="True" result="Success" success="True" time="0.001" asserts="1" />
+                          <test-case name="NUnit.Framework.Constraints.AttributeExistsConstraintTest.AttributeTestPropertyValueOnMethodInfo" description="my description" executed="True" result="Success" success="True" time="0.002" asserts="1" />
+                          <test-case name="NUnit.Framework.Constraints.AttributeExistsConstraintTest.ConstraintTestBaseNoData.ProvidesProperDescription" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Framework.Constraints.AttributeExistsConstraintTest.ConstraintTestBaseNoData.ProvidesProperStringRepresentation" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                          <test-suite type="ParameterizedTest" name="FailsWithBadValues" executed="True" result="Success" success="True" time="0.000" asserts="0">
+                            <results>
+                              <test-case name="NUnit.Framework.Constraints.AttributeExistsConstraintTest.FailsWithBadValues(NUnit.Framework.Constraints.D2)" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                            </results>
+                          </test-suite>
+                          <test-case name="NUnit.Framework.Constraints.AttributeExistsConstraintTest.NonAttributeThrowsException" executed="True" result="Success" success="True" time="0.001" asserts="0" />
+                          <test-suite type="ParameterizedTest" name="ProvidesProperFailureMessage" executed="True" result="Success" success="True" time="0.001" asserts="0">
+                            <results>
+                              <test-case name="NUnit.Framework.Constraints.AttributeExistsConstraintTest.ProvidesProperFailureMessage(NUnit.Framework.Constraints.D2,&quot;&lt;NUnit.Framework.Constraints.D2&gt;&quot;)" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                            </results>
+                          </test-suite>
+                          <test-suite type="ParameterizedTest" name="SucceedsWithGoodValues" executed="True" result="Success" success="True" time="0.001" asserts="0">
+                            <results>
+                              <test-case name="NUnit.Framework.Constraints.AttributeExistsConstraintTest.SucceedsWithGoodValues(NUnit.Framework.Constraints.AttributeExistsConstraintTest)" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                            </results>
+                          </test-suite>
+                        </results>
+                      </test-suite>
+                      <test-suite type="TestFixture" name="BinarySerializableTest" executed="True" result="Success" success="True" time="0.020" asserts="0">
+                        <results>
+                          <test-case name="NUnit.Framework.Constraints.BinarySerializableTest.ConstraintTestBaseNoData.ProvidesProperDescription" executed="True" result="Success" success="True" time="0.001" asserts="1" />
+                          <test-case name="NUnit.Framework.Constraints.BinarySerializableTest.ConstraintTestBaseNoData.ProvidesProperStringRepresentation" executed="True" result="Success" success="True" time="0.001" asserts="1" />
+                          <test-suite type="ParameterizedTest" name="FailsWithBadValues" executed="True" result="Success" success="True" time="0.001" asserts="0">
+                            <results>
+                              <test-case name="NUnit.Framework.Constraints.BinarySerializableTest.FailsWithBadValues(NUnit.Framework.Constraints.InternalClass)" executed="True" result="Success" success="True" time="0.001" asserts="1" />
+                            </results>
+                          </test-suite>
+                          <test-suite type="ParameterizedTest" name="InvalidDataThrowsArgumentException" executed="True" result="Success" success="True" time="0.001" asserts="0">
+                            <results>
+                              <test-case name="NUnit.Framework.Constraints.BinarySerializableTest.InvalidDataThrowsArgumentException(null)" executed="True" result="Success" success="True" time="0.001" asserts="0" />
+                            </results>
+                          </test-suite>
+                          <test-suite type="ParameterizedTest" name="ProvidesProperFailureMessage" executed="True" result="Success" success="True" time="0.001" asserts="0">
+                            <results>
+                              <test-case name="NUnit.Framework.Constraints.BinarySerializableTest.ProvidesProperFailureMessage(NUnit.Framework.Constraints.InternalClass,&quot;&lt;InternalClass&gt;&quot;)" executed="True" result="Success" success="True" time="0.001" asserts="1" />
+                            </results>
+                          </test-suite>
+                          <test-suite type="ParameterizedTest" name="SucceedsWithGoodValues" executed="True" result="Success" success="True" time="0.006" asserts="0">
+                            <results>
+                              <test-case name="NUnit.Framework.Constraints.BinarySerializableTest.SucceedsWithGoodValues(1)" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                              <test-case name="NUnit.Framework.Constraints.BinarySerializableTest.SucceedsWithGoodValues(&quot;a&quot;)" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                              <test-case name="NUnit.Framework.Constraints.BinarySerializableTest.SucceedsWithGoodValues(System.Collections.ArrayList)" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                              <test-case name="NUnit.Framework.Constraints.BinarySerializableTest.SucceedsWithGoodValues(NUnit.Framework.Constraints.InternalWithSerializableAttributeClass)" executed="True" result="Success" success="True" time="0.001" asserts="1" />
+                            </results>
+                          </test-suite>
+                        </results>
+                      </test-suite>
+                      <test-suite type="TestFixture" name="CollectionContainsTests" executed="True" result="Success" success="True" time="0.055" asserts="0">
+                        <results>
+                          <test-case name="NUnit.Framework.Constraints.CollectionContainsTests.CanTestContentsOfArray" executed="True" result="Success" success="True" time="0.001" asserts="1" />
+                          <test-case name="NUnit.Framework.Constraints.CollectionContainsTests.CanTestContentsOfArrayList" executed="True" result="Success" success="True" time="0.001" asserts="1" />
+                          <test-case name="NUnit.Framework.Constraints.CollectionContainsTests.CanTestContentsOfCollectionNotImplementingIList" executed="True" result="Success" success="True" time="0.001" asserts="1" />
+                          <test-case name="NUnit.Framework.Constraints.CollectionContainsTests.CanTestContentsOfSortedList" executed="True" result="Success" success="True" time="0.001" asserts="2" />
+                          <test-case name="NUnit.Framework.Constraints.CollectionContainsTests.IgnoreCaseIsHonored" executed="True" result="Success" success="True" time="0.001" asserts="1" />
+                          <test-case name="NUnit.Framework.Constraints.CollectionContainsTests.UsesProvidedComparerOfT" executed="True" result="Success" success="True" time="0.026" asserts="2" />
+                          <test-case name="NUnit.Framework.Constraints.CollectionContainsTests.UsesProvidedComparisonOfT" executed="True" result="Success" success="True" time="0.003" asserts="2" />
+                          <test-case name="NUnit.Framework.Constraints.CollectionContainsTests.UsesProvidedEqualityComparer" executed="True" result="Success" success="True" time="0.000" asserts="2" />
+                          <test-case name="NUnit.Framework.Constraints.CollectionContainsTests.UsesProvidedEqualityComparerOfT" executed="True" result="Success" success="True" time="0.003" asserts="2" />
+                          <test-case name="NUnit.Framework.Constraints.CollectionContainsTests.UsesProvidedIComparer" executed="True" result="Success" success="True" time="0.001" asserts="2" />
+                        </results>
+                      </test-suite>
+                      <test-suite type="TestFixture" name="CollectionEquivalentTests" executed="True" result="Success" success="True" time="0.020" asserts="0">
+                        <results>
+                          <test-case name="NUnit.Framework.Constraints.CollectionEquivalentTests.EqualCollectionsAreEquivalent" executed="True" result="Success" success="True" time="0.001" asserts="1" />
+                          <test-case name="NUnit.Framework.Constraints.CollectionEquivalentTests.EquivalentFailsWithDuplicateElementInActual" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Framework.Constraints.CollectionEquivalentTests.EquivalentFailsWithDuplicateElementInExpected" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Framework.Constraints.CollectionEquivalentTests.EquivalentHandlesNull" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Framework.Constraints.CollectionEquivalentTests.EquivalentHonorsIgnoreCase" executed="True" result="Success" success="True" time="0.001" asserts="1" />
+                          <test-case name="NUnit.Framework.Constraints.CollectionEquivalentTests.EquivalentIgnoresOrder" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Framework.Constraints.CollectionEquivalentTests.WorksWithCollectionsOfArrays" executed="True" result="Success" success="True" time="0.001" asserts="2" />
+                        </results>
+                      </test-suite>
+                      <test-suite type="TestFixture" name="CollectionOrderedTests" executed="True" result="Success" success="True" time="0.053" asserts="0">
+                        <results>
+                          <test-case name="NUnit.Framework.Constraints.CollectionOrderedTests.IsOrdered" executed="True" result="Success" success="True" time="0.001" asserts="1" />
+                          <test-case name="NUnit.Framework.Constraints.CollectionOrderedTests.IsOrdered_2" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Framework.Constraints.CollectionOrderedTests.IsOrdered_Allows_adjacent_equal_values" executed="True" result="Success" success="True" time="0.001" asserts="1" />
+                          <test-case name="NUnit.Framework.Constraints.CollectionOrderedTests.IsOrdered_AtLeastOneArgMustImplementIComparable" executed="True" result="Success" success="True" time="0.001" asserts="1" />
+                          <test-case name="NUnit.Framework.Constraints.CollectionOrderedTests.IsOrdered_Fails" executed="True" result="Success" success="True" time="0.001" asserts="2" />
+                          <test-case name="NUnit.Framework.Constraints.CollectionOrderedTests.IsOrdered_Handles_custom_comparison" executed="True" result="Success" success="True" time="0.001" asserts="2" />
+                          <test-case name="NUnit.Framework.Constraints.CollectionOrderedTests.IsOrdered_Handles_custom_comparison2" executed="True" result="Success" success="True" time="0.001" asserts="2" />
+                          <test-case name="NUnit.Framework.Constraints.CollectionOrderedTests.IsOrdered_Handles_null" executed="True" result="Success" success="True" time="0.001" asserts="1" />
+                          <test-case name="NUnit.Framework.Constraints.CollectionOrderedTests.IsOrdered_TypesMustBeComparable" executed="True" result="Success" success="True" time="0.001" asserts="1" />
+                          <test-case name="NUnit.Framework.Constraints.CollectionOrderedTests.IsOrderedBy" executed="True" result="Success" success="True" time="0.001" asserts="1" />
+                          <test-case name="NUnit.Framework.Constraints.CollectionOrderedTests.IsOrderedBy_Comparer" executed="True" result="Success" success="True" time="0.001" asserts="1" />
+                          <test-case name="NUnit.Framework.Constraints.CollectionOrderedTests.IsOrderedBy_Handles_heterogeneous_classes_as_long_as_the_property_is_of_same_type" executed="True" result="Success" success="True" time="0.001" asserts="1" />
+                          <test-case name="NUnit.Framework.Constraints.CollectionOrderedTests.IsOrderedDescending" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Framework.Constraints.CollectionOrderedTests.IsOrderedDescending_2" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Framework.Constraints.CollectionOrderedTests.UsesProvidedComparerOfT" executed="True" result="Success" success="True" time="0.002" asserts="2" />
+                          <test-case name="NUnit.Framework.Constraints.CollectionOrderedTests.UsesProvidedComparisonOfT" executed="True" result="Success" success="True" time="0.002" asserts="2" />
+                        </results>
+                      </test-suite>
+                      <test-suite type="TestFixture" name="ComparerTests" executed="True" result="Success" success="True" time="0.051" asserts="0">
+                        <results>
+                          <test-suite type="ParameterizedTest" name="EqualItems" executed="True" result="Success" success="True" time="0.020" asserts="0">
+                            <results>
+                              <test-case name="NUnit.Framework.Constraints.ComparerTests.EqualItems(4.0d,4)" executed="True" result="Success" success="True" time="0.003" asserts="3" />
+                              <test-case name="NUnit.Framework.Constraints.ComparerTests.EqualItems(4.0d,4.0f)" executed="True" result="Success" success="True" time="0.000" asserts="3" />
+                              <test-case name="NUnit.Framework.Constraints.ComparerTests.EqualItems(null,null)" executed="True" result="Success" success="True" time="0.000" asserts="3" />
+                              <test-case name="NUnit.Framework.Constraints.ComparerTests.EqualItems(4,4)" executed="True" result="Success" success="True" time="0.000" asserts="3" />
+                              <test-case name="NUnit.Framework.Constraints.ComparerTests.EqualItems(4.0d,4.0d)" executed="True" result="Success" success="True" time="0.000" asserts="3" />
+                              <test-case name="NUnit.Framework.Constraints.ComparerTests.EqualItems(4.0f,4.0f)" executed="True" result="Success" success="True" time="0.001" asserts="3" />
+                              <test-case name="NUnit.Framework.Constraints.ComparerTests.EqualItems(4,4.0d)" executed="True" result="Success" success="True" time="0.000" asserts="3" />
+                              <test-case name="NUnit.Framework.Constraints.ComparerTests.EqualItems(4,4.0f)" executed="True" result="Success" success="True" time="0.000" asserts="3" />
+                              <test-case name="NUnit.Framework.Constraints.ComparerTests.EqualItems(4.0f,4)" executed="True" result="Success" success="True" time="0.000" asserts="3" />
+                              <test-case name="NUnit.Framework.Constraints.ComparerTests.EqualItems(4.0f,4.0d)" executed="True" result="Success" success="True" time="0.001" asserts="3" />
+                              <test-case name="NUnit.Framework.Constraints.ComparerTests.EqualItems(null,null)" executed="True" result="Success" success="True" time="0.000" asserts="3" />
+                            </results>
+                          </test-suite>
+                          <test-suite type="ParameterizedTest" name="SpecialFloatingPointValues" executed="True" result="Success" success="True" time="0.009" asserts="0">
+                            <results>
+                              <test-case name="NUnit.Framework.Constraints.ComparerTests.SpecialFloatingPointValues(double.NaN)" executed="True" result="Success" success="True" time="0.000" asserts="2" />
+                              <test-case name="NUnit.Framework.Constraints.ComparerTests.SpecialFloatingPointValues(float.NegativeInfinity)" executed="True" result="Success" success="True" time="0.000" asserts="2" />
+                              <test-case name="NUnit.Framework.Constraints.ComparerTests.SpecialFloatingPointValues(float.NaN)" executed="True" result="Success" success="True" time="0.000" asserts="2" />
+                              <test-case name="NUnit.Framework.Constraints.ComparerTests.SpecialFloatingPointValues(double.PositiveInfinity)" executed="True" result="Success" success="True" time="0.000" asserts="2" />
+                              <test-case name="NUnit.Framework.Constraints.ComparerTests.SpecialFloatingPointValues(double.NegativeInfinity)" executed="True" result="Success" success="True" time="0.000" asserts="2" />
+                              <test-case name="NUnit.Framework.Constraints.ComparerTests.SpecialFloatingPointValues(float.PositiveInfinity)" executed="True" result="Success" success="True" time="0.000" asserts="2" />
+                            </results>
+                          </test-suite>
+                          <test-suite type="ParameterizedTest" name="UnequalItems" executed="True" result="Success" success="True" time="0.017" asserts="0">
+                            <results>
+                              <test-case name="NUnit.Framework.Constraints.ComparerTests.UnequalItems(4,null)" executed="True" result="Success" success="True" time="0.000" asserts="5" />
+                              <test-case name="NUnit.Framework.Constraints.ComparerTests.UnequalItems(4,2)" executed="True" result="Success" success="True" time="0.000" asserts="5" />
+                              <test-case name="NUnit.Framework.Constraints.ComparerTests.UnequalItems(4,null)" executed="True" result="Success" success="True" time="0.000" asserts="5" />
+                              <test-case name="NUnit.Framework.Constraints.ComparerTests.UnequalItems(4.0d,2.0d)" executed="True" result="Success" success="True" time="0.000" asserts="5" />
+                              <test-case name="NUnit.Framework.Constraints.ComparerTests.UnequalItems(4.0f,2.0f)" executed="True" result="Success" success="True" time="0.001" asserts="5" />
+                              <test-case name="NUnit.Framework.Constraints.ComparerTests.UnequalItems(4.0f,2.0d)" executed="True" result="Success" success="True" time="0.000" asserts="5" />
+                              <test-case name="NUnit.Framework.Constraints.ComparerTests.UnequalItems(4,2.0d)" executed="True" result="Success" success="True" time="0.001" asserts="5" />
+                              <test-case name="NUnit.Framework.Constraints.ComparerTests.UnequalItems(4,2.0f)" executed="True" result="Success" success="True" time="0.000" asserts="5" />
+                              <test-case name="NUnit.Framework.Constraints.ComparerTests.UnequalItems(4.0d,2)" executed="True" result="Success" success="True" time="0.000" asserts="5" />
+                              <test-case name="NUnit.Framework.Constraints.ComparerTests.UnequalItems(4.0d,2.0f)" executed="True" result="Success" success="True" time="0.000" asserts="5" />
+                              <test-case name="NUnit.Framework.Constraints.ComparerTests.UnequalItems(4.0f,2)" executed="True" result="Success" success="True" time="0.001" asserts="5" />
+                            </results>
+                          </test-suite>
+                        </results>
+                      </test-suite>
+                      <test-suite type="TestFixture" name="EmptyConstraintTest" executed="True" result="Success" success="True" time="0.025" asserts="0">
+                        <results>
+                          <test-case name="NUnit.Framework.Constraints.EmptyConstraintTest.ConstraintTestBaseNoData.ProvidesProperDescription" executed="True" result="Success" success="True" time="0.001" asserts="1" />
+                          <test-case name="NUnit.Framework.Constraints.EmptyConstraintTest.ConstraintTestBaseNoData.ProvidesProperStringRepresentation" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                          <test-suite type="ParameterizedTest" name="FailsWithBadValues" executed="True" result="Success" success="True" time="0.003" asserts="0">
+                            <results>
+                              <test-case name="NUnit.Framework.Constraints.EmptyConstraintTest.FailsWithBadValues(&quot;Hello&quot;)" executed="True" result="Success" success="True" time="0.001" asserts="1" />
+                              <test-case name="NUnit.Framework.Constraints.EmptyConstraintTest.FailsWithBadValues(System.Object[])" executed="True" result="Success" success="True" time="0.001" asserts="1" />
+                            </results>
+                          </test-suite>
+                          <test-suite type="ParameterizedTest" name="InvalidDataThrowsArgumentException" executed="True" result="Success" success="True" time="0.006" asserts="0">
+                            <results>
+                              <test-case name="NUnit.Framework.Constraints.EmptyConstraintTest.InvalidDataThrowsArgumentException(null)" executed="True" result="Success" success="True" time="0.001" asserts="0" />
+                              <test-case name="NUnit.Framework.Constraints.EmptyConstraintTest.InvalidDataThrowsArgumentException(5)" executed="True" result="Success" success="True" time="0.001" asserts="0" />
+                            </results>
+                          </test-suite>
+                          <test-suite type="ParameterizedTest" name="ProvidesProperFailureMessage" executed="True" result="Success" success="True" time="0.002" asserts="0">
+                            <results>
+                              <test-case name="NUnit.Framework.Constraints.EmptyConstraintTest.ProvidesProperFailureMessage(&quot;Hello&quot;,&quot;\&quot;Hello\&quot;&quot;)" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                              <test-case name="NUnit.Framework.Constraints.EmptyConstraintTest.ProvidesProperFailureMessage(System.Object[],&quot;&lt; 1, 2, 3 &gt;&quot;)" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                            </results>
+                          </test-suite>
+                          <test-suite type="ParameterizedTest" name="SucceedsWithGoodValues" executed="True" result="Success" success="True" time="0.005" asserts="0">
+                            <results>
+                              <test-case name="NUnit.Framework.Constraints.EmptyConstraintTest.SucceedsWithGoodValues(&quot;&quot;)" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                              <test-case name="NUnit.Framework.Constraints.EmptyConstraintTest.SucceedsWithGoodValues(System.Object[])" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                              <test-case name="NUnit.Framework.Constraints.EmptyConstraintTest.SucceedsWithGoodValues(System.Collections.ArrayList)" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                              <test-case name="NUnit.Framework.Constraints.EmptyConstraintTest.SucceedsWithGoodValues(System.Collections.Generic.List`1[System.Int32])" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                            </results>
+                          </test-suite>
+                        </results>
+                      </test-suite>
+                      <test-suite type="TestFixture" name="EndsWithTest" executed="True" result="Success" success="True" time="0.026" asserts="0">
+                        <results>
+                          <test-case name="NUnit.Framework.Constraints.EndsWithTest.ConstraintTestBaseNoData.ProvidesProperDescription" executed="True" result="Success" success="True" time="0.001" asserts="1" />
+                          <test-case name="NUnit.Framework.Constraints.EndsWithTest.ConstraintTestBaseNoData.ProvidesProperStringRepresentation" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                          <test-suite type="ParameterizedTest" name="FailsWithBadValues" executed="True" result="Success" success="True" time="0.007" asserts="0">
+                            <results>
+                              <test-case name="NUnit.Framework.Constraints.EndsWithTest.FailsWithBadValues(&quot;goodbye&quot;)" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                              <test-case name="NUnit.Framework.Constraints.EndsWithTest.FailsWithBadValues(&quot;What the hell?&quot;)" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                              <test-case name="NUnit.Framework.Constraints.EndsWithTest.FailsWithBadValues(&quot;hello there&quot;)" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                              <test-case name="NUnit.Framework.Constraints.EndsWithTest.FailsWithBadValues(&quot;say hello to fred&quot;)" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                              <test-case name="NUnit.Framework.Constraints.EndsWithTest.FailsWithBadValues(&quot;&quot;)" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                              <test-case name="NUnit.Framework.Constraints.EndsWithTest.FailsWithBadValues(null)" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                            </results>
+                          </test-suite>
+                          <test-suite type="ParameterizedTest" name="ProvidesProperFailureMessage" executed="True" result="Success" success="True" time="0.007" asserts="0">
+                            <results>
+                              <test-case name="NUnit.Framework.Constraints.EndsWithTest.ProvidesProperFailureMessage(&quot;goodbye&quot;,&quot;\&quot;goodbye\&quot;&quot;)" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                              <test-case name="NUnit.Framework.Constraints.EndsWithTest.ProvidesProperFailureMessage(&quot;What the hell?&quot;,&quot;\&quot;What the hell?\&quot;&quot;)" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                              <test-case name="NUnit.Framework.Constraints.EndsWithTest.ProvidesProperFailureMessage(&quot;hello there&quot;,&quot;\&quot;hello there\&quot;&quot;)" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                              <test-case name="NUnit.Framework.Constraints.EndsWithTest.ProvidesProperFailureMessage(&quot;say hello to fred&quot;,&quot;\&quot;say hello to fred\&quot;&quot;)" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                              <test-case name="NUnit.Framework.Constraints.EndsWithTest.ProvidesProperFailureMessage(&quot;&quot;,&quot;&lt;string.Empty&gt;&quot;)" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                              <test-case name="NUnit.Framework.Constraints.EndsWithTest.ProvidesProperFailureMessage(null,&quot;null&quot;)" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                            </results>
+                          </test-suite>
+                          <test-suite type="ParameterizedTest" name="SucceedsWithGoodValues" executed="True" result="Success" success="True" time="0.002" asserts="0">
+                            <results>
+                              <test-case name="NUnit.Framework.Constraints.EndsWithTest.SucceedsWithGoodValues(&quot;hello&quot;)" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                              <test-case name="NUnit.Framework.Constraints.EndsWithTest.SucceedsWithGoodValues(&quot;I said hello&quot;)" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                            </results>
+                          </test-suite>
+                        </results>
+                      </test-suite>
+                      <test-suite type="TestFixture" name="EndsWithTestIgnoringCase" executed="True" result="Success" success="True" time="0.024" asserts="0">
+                        <results>
+                          <test-case name="NUnit.Framework.Constraints.EndsWithTestIgnoringCase.ConstraintTestBaseNoData.ProvidesProperDescription" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Framework.Constraints.EndsWithTestIgnoringCase.ConstraintTestBaseNoData.ProvidesProperStringRepresentation" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                          <test-suite type="ParameterizedTest" name="FailsWithBadValues" executed="True" result="Success" success="True" time="0.008" asserts="0">
+                            <results>
+                              <test-case name="NUnit.Framework.Constraints.EndsWithTestIgnoringCase.FailsWithBadValues(&quot;goodbye&quot;)" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                              <test-case name="NUnit.Framework.Constraints.EndsWithTestIgnoringCase.FailsWithBadValues(&quot;What the hell?&quot;)" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                              <test-case name="NUnit.Framework.Constraints.EndsWithTestIgnoringCase.FailsWithBadValues(&quot;hello there&quot;)" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                              <test-case name="NUnit.Framework.Constraints.EndsWithTestIgnoringCase.FailsWithBadValues(&quot;say hello to fred&quot;)" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                              <test-case name="NUnit.Framework.Constraints.EndsWithTestIgnoringCase.FailsWithBadValues(&quot;&quot;)" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                              <test-case name="NUnit.Framework.Constraints.EndsWithTestIgnoringCase.FailsWithBadValues(null)" executed="True" result="Success" success="True" time="0.001" asserts="1" />
+                            </results>
+                          </test-suite>
+                          <test-suite type="ParameterizedTest" name="ProvidesProperFailureMessage" executed="True" result="Success" success="True" time="0.008" asserts="0">
+                            <results>
+                              <test-case name="NUnit.Framework.Constraints.EndsWithTestIgnoringCase.ProvidesProperFailureMessage(&quot;goodbye&quot;,&quot;\&quot;goodbye\&quot;&quot;)" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                              <test-case name="NUnit.Framework.Constraints.EndsWithTestIgnoringCase.ProvidesProperFailureMessage(&quot;What the hell?&quot;,&quot;\&quot;What the hell?\&quot;&quot;)" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                              <test-case name="NUnit.Framework.Constraints.EndsWithTestIgnoringCase.ProvidesProperFailureMessage(&quot;hello there&quot;,&quot;\&quot;hello there\&quot;&quot;)" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                              <test-case name="NUnit.Framework.Constraints.EndsWithTestIgnoringCase.ProvidesProperFailureMessage(&quot;say hello to fred&quot;,&quot;\&quot;say hello to fred\&quot;&quot;)" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                              <test-case name="NUnit.Framework.Constraints.EndsWithTestIgnoringCase.ProvidesProperFailureMessage(&quot;&quot;,&quot;&lt;string.Empty&gt;&quot;)" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                              <test-case name="NUnit.Framework.Constraints.EndsWithTestIgnoringCase.ProvidesProperFailureMessage(null,&quot;null&quot;)" executed="True" result="Success" success="True" time="0.001" asserts="1" />
+                            </results>
+                          </test-suite>
+                          <test-suite type="ParameterizedTest" name="SucceedsWithGoodValues" executed="True" result="Success" success="True" time="0.002" asserts="0">
+                            <results>
+                              <test-case name="NUnit.Framework.Constraints.EndsWithTestIgnoringCase.SucceedsWithGoodValues(&quot;HELLO&quot;)" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                              <test-case name="NUnit.Framework.Constraints.EndsWithTestIgnoringCase.SucceedsWithGoodValues(&quot;I said Hello&quot;)" executed="True" result="Success" success="True" time="0.001" asserts="1" />
+                            </results>
+                          </test-suite>
+                        </results>
+                      </test-suite>
+                      <test-suite type="TestFixture" name="EqualConstraintTest" executed="True" result="Success" success="True" time="0.143" asserts="0">
+                        <results>
+                          <test-case name="NUnit.Framework.Constraints.EqualConstraintTest.CanMatchDates" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Framework.Constraints.EqualConstraintTest.CanMatchDatesWithinDays" executed="True" result="Success" success="True" time="0.001" asserts="1" />
+                          <test-case name="NUnit.Framework.Constraints.EqualConstraintTest.CanMatchDatesWithinHours" executed="True" result="Success" success="True" time="0.001" asserts="1" />
+                          <test-case name="NUnit.Framework.Constraints.EqualConstraintTest.CanMatchDatesWithinMilliseconds" executed="True" result="Success" success="True" time="0.001" asserts="1" />
+                          <test-case name="NUnit.Framework.Constraints.EqualConstraintTest.CanMatchDatesWithinMinutes" executed="True" result="Success" success="True" time="0.001" asserts="1" />
+                          <test-case name="NUnit.Framework.Constraints.EqualConstraintTest.CanMatchDatesWithinSeconds" executed="True" result="Success" success="True" time="0.001" asserts="1" />
+                          <test-case name="NUnit.Framework.Constraints.EqualConstraintTest.CanMatchDatesWithinTicks" executed="True" result="Success" success="True" time="0.001" asserts="1" />
+                          <test-case name="NUnit.Framework.Constraints.EqualConstraintTest.CanMatchDatesWithinTimeSpan" executed="True" result="Success" success="True" time="0.001" asserts="1" />
+                          <test-suite type="ParameterizedTest" name="CanMatchDoublesWithRelativeTolerance" executed="True" result="Success" success="True" time="0.003" asserts="0">
+                            <results>
+                              <test-case name="NUnit.Framework.Constraints.EqualConstraintTest.CanMatchDoublesWithRelativeTolerance(10000.0d)" executed="True" result="Success" success="True" time="0.001" asserts="2" />
+                              <test-case name="NUnit.Framework.Constraints.EqualConstraintTest.CanMatchDoublesWithRelativeTolerance(9500.0d)" executed="True" result="Success" success="True" time="0.000" asserts="2" />
+                              <test-case name="NUnit.Framework.Constraints.EqualConstraintTest.CanMatchDoublesWithRelativeTolerance(10500.0d)" executed="True" result="Success" success="True" time="0.000" asserts="2" />
+                            </results>
+                          </test-suite>
+                          <test-suite type="ParameterizedTest" name="CanMatchDoublesWithUlpTolerance" executed="True" result="Success" success="True" time="0.003" asserts="0">
+                            <results>
+                              <test-case name="NUnit.Framework.Constraints.EqualConstraintTest.CanMatchDoublesWithUlpTolerance(2E+16.0d)" executed="True" result="Success" success="True" time="0.000" asserts="2" />
+                              <test-case name="NUnit.Framework.Constraints.EqualConstraintTest.CanMatchDoublesWithUlpTolerance(2E+16.0d)" executed="True" result="Success" success="True" time="0.000" asserts="2" />
+                            </results>
+                          </test-suite>
+                          <test-suite type="ParameterizedTest" name="CanMatchSinglesWithRelativeTolerance" executed="True" result="Success" success="True" time="0.004" asserts="0">
+                            <results>
+                              <test-case name="NUnit.Framework.Constraints.EqualConstraintTest.CanMatchSinglesWithRelativeTolerance(10000.0f)" executed="True" result="Success" success="True" time="0.000" asserts="2" />
+                              <test-case name="NUnit.Framework.Constraints.EqualConstraintTest.CanMatchSinglesWithRelativeTolerance(10500.0f)" executed="True" result="Success" success="True" time="0.000" asserts="2" />
+                              <test-case name="NUnit.Framework.Constraints.EqualConstraintTest.CanMatchSinglesWithRelativeTolerance(9500.0f)" executed="True" result="Success" success="True" time="0.000" asserts="2" />
+                            </results>
+                          </test-suite>
+                          <test-suite type="ParameterizedTest" name="CanMatchSinglesWithUlpTolerance" executed="True" result="Success" success="True" time="0.002" asserts="0">
+                            <results>
+                              <test-case name="NUnit.Framework.Constraints.EqualConstraintTest.CanMatchSinglesWithUlpTolerance(2E+07.0f)" executed="True" result="Success" success="True" time="0.000" asserts="2" />
+                              <test-case name="NUnit.Framework.Constraints.EqualConstraintTest.CanMatchSinglesWithUlpTolerance(2E+07.0f)" executed="True" result="Success" success="True" time="0.000" asserts="2" />
+                            </results>
+                          </test-suite>
+                          <test-suite type="ParameterizedTest" name="CanMatchSpecialFloatingPointValues" executed="True" result="Success" success="True" time="0.010" asserts="0">
+                            <results>
+                              <test-case name="NUnit.Framework.Constraints.EqualConstraintTest.CanMatchSpecialFloatingPointValues(double.PositiveInfinity)" executed="True" result="Success" success="True" time="0.000" asserts="2" />
+                              <test-case name="NUnit.Framework.Constraints.EqualConstraintTest.CanMatchSpecialFloatingPointValues(float.NegativeInfinity)" executed="True" result="Success" success="True" time="0.000" asserts="2" />
+                              <test-case name="NUnit.Framework.Constraints.EqualConstraintTest.CanMatchSpecialFloatingPointValues(float.PositiveInfinity)" executed="True" result="Success" success="True" time="0.000" asserts="2" />
+                              <test-case name="NUnit.Framework.Constraints.EqualConstraintTest.CanMatchSpecialFloatingPointValues(double.NaN)" executed="True" result="Success" success="True" time="0.000" asserts="2" />
+                              <test-case name="NUnit.Framework.Constraints.EqualConstraintTest.CanMatchSpecialFloatingPointValues(double.NegativeInfinity)" executed="True" result="Success" success="True" time="0.000" asserts="2" />
+                              <test-case name="NUnit.Framework.Constraints.EqualConstraintTest.CanMatchSpecialFloatingPointValues(float.NaN)" executed="True" result="Success" success="True" time="0.000" asserts="2" />
+                            </results>
+                          </test-suite>
+                          <test-case name="NUnit.Framework.Constraints.EqualConstraintTest.CanMatchTimeSpanWithinMinutes" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Framework.Constraints.EqualConstraintTest.ConstraintTestBaseNoData.ProvidesProperDescription" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Framework.Constraints.EqualConstraintTest.ConstraintTestBaseNoData.ProvidesProperStringRepresentation" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Framework.Constraints.EqualConstraintTest.ErrorIfDaysPrecedesWithin" executed="True" result="Success" success="True" time="0.001" asserts="0" />
+                          <test-case name="NUnit.Framework.Constraints.EqualConstraintTest.ErrorIfHoursPrecedesWithin" executed="True" result="Success" success="True" time="0.001" asserts="0" />
+                          <test-case name="NUnit.Framework.Constraints.EqualConstraintTest.ErrorIfMillisecondsPrecedesWithin" executed="True" result="Success" success="True" time="0.001" asserts="0" />
+                          <test-case name="NUnit.Framework.Constraints.EqualConstraintTest.ErrorIfMinutesPrecedesWithin" executed="True" result="Success" success="True" time="0.001" asserts="0" />
+                          <test-case name="NUnit.Framework.Constraints.EqualConstraintTest.ErrorIfPercentPrecedesWithin" executed="True" result="Success" success="True" time="0.000" asserts="0" />
+                          <test-case name="NUnit.Framework.Constraints.EqualConstraintTest.ErrorIfSecondsPrecedesWithin" executed="True" result="Success" success="True" time="0.000" asserts="0" />
+                          <test-case name="NUnit.Framework.Constraints.EqualConstraintTest.ErrorIfTicksPrecedesWithin" executed="True" result="Success" success="True" time="0.001" asserts="0" />
+                          <test-case name="NUnit.Framework.Constraints.EqualConstraintTest.ErrorIfUlpsIsUsedOnDecimal" executed="True" result="Success" success="True" time="0.001" asserts="1" />
+                          <test-suite type="ParameterizedTest" name="ErrorIfUlpsIsUsedOnIntegralType" executed="True" result="Success" success="True" time="0.007" asserts="0">
+                            <results>
+                              <test-case name="NUnit.Framework.Constraints.EqualConstraintTest.ErrorIfUlpsIsUsedOnIntegralType(1000,1010)" executed="True" result="Success" success="True" time="0.001" asserts="1" />
+                              <test-case name="NUnit.Framework.Constraints.EqualConstraintTest.ErrorIfUlpsIsUsedOnIntegralType(1000UL,1010UL)" executed="True" result="Success" success="True" time="0.001" asserts="1" />
+                              <test-case name="NUnit.Framework.Constraints.EqualConstraintTest.ErrorIfUlpsIsUsedOnIntegralType(1000,1010)" executed="True" result="Success" success="True" time="0.001" asserts="1" />
+                              <test-case name="NUnit.Framework.Constraints.EqualConstraintTest.ErrorIfUlpsIsUsedOnIntegralType(1000L,1010L)" executed="True" result="Success" success="True" time="0.001" asserts="1" />
+                            </results>
+                          </test-suite>
+                          <test-case name="NUnit.Framework.Constraints.EqualConstraintTest.ErrorIfUlpsPrecedesWithin" executed="True" result="Success" success="True" time="0.001" asserts="0" />
+                          <test-case name="NUnit.Framework.Constraints.EqualConstraintTest.ErrorWithPercentAndUlpsToleranceModes" executed="True" result="Success" success="True" time="0.001" asserts="0" />
+                          <test-case name="NUnit.Framework.Constraints.EqualConstraintTest.ErrorWithUlpsAndPercentToleranceModes" executed="True" result="Success" success="True" time="0.001" asserts="0" />
+                          <test-suite type="ParameterizedTest" name="FailsOnDoublesOutsideOfRelativeTolerance" executed="True" result="Success" success="True" time="0.004" asserts="0">
+                            <results>
+                              <test-case name="NUnit.Framework.Constraints.EqualConstraintTest.FailsOnDoublesOutsideOfRelativeTolerance(11500.0d)" executed="True" result="Success" success="True" time="0.002" asserts="1" />
+                              <test-case name="NUnit.Framework.Constraints.EqualConstraintTest.FailsOnDoublesOutsideOfRelativeTolerance(8500.0d)" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                            </results>
+                          </test-suite>
+                          <test-suite type="ParameterizedTest" name="FailsOnDoublesOutsideOfUlpTolerance" executed="True" result="Success" success="True" time="0.003" asserts="0">
+                            <results>
+                              <test-case name="NUnit.Framework.Constraints.EqualConstraintTest.FailsOnDoublesOutsideOfUlpTolerance(2E+16.0d)" executed="True" result="Success" success="True" time="0.001" asserts="1" />
+                              <test-case name="NUnit.Framework.Constraints.EqualConstraintTest.FailsOnDoublesOutsideOfUlpTolerance(2E+16.0d)" executed="True" result="Success" success="True" time="0.001" asserts="1" />
+                            </results>
+                          </test-suite>
+                          <test-suite type="ParameterizedTest" name="FailsOnSinglesOutsideOfRelativeTolerance" executed="True" result="Success" success="True" time="0.004" asserts="0">
+                            <results>
+                              <test-case name="NUnit.Framework.Constraints.EqualConstraintTest.FailsOnSinglesOutsideOfRelativeTolerance(8500.0f)" executed="True" result="Success" success="True" time="0.001" asserts="1" />
+                              <test-case name="NUnit.Framework.Constraints.EqualConstraintTest.FailsOnSinglesOutsideOfRelativeTolerance(11500.0f)" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                            </results>
+                          </test-suite>
+                          <test-suite type="ParameterizedTest" name="FailsOnSinglesOutsideOfUlpTolerance" executed="True" result="Success" success="True" time="0.003" asserts="0">
+                            <results>
+                              <test-case name="NUnit.Framework.Constraints.EqualConstraintTest.FailsOnSinglesOutsideOfUlpTolerance(2E+07.0f)" executed="True" result="Success" success="True" time="0.001" asserts="1" />
+                              <test-case name="NUnit.Framework.Constraints.EqualConstraintTest.FailsOnSinglesOutsideOfUlpTolerance(2E+07.0f)" executed="True" result="Success" success="True" time="0.001" asserts="1" />
+                            </results>
+                          </test-suite>
+                          <test-suite type="ParameterizedTest" name="FailsWithBadValues" executed="True" result="Success" success="True" time="0.006" asserts="0">
+                            <results>
+                              <test-case name="NUnit.Framework.Constraints.EqualConstraintTest.FailsWithBadValues(5)" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                              <test-case name="NUnit.Framework.Constraints.EqualConstraintTest.FailsWithBadValues(null)" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                              <test-case name="NUnit.Framework.Constraints.EqualConstraintTest.FailsWithBadValues(&quot;Hello&quot;)" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                              <test-case name="NUnit.Framework.Constraints.EqualConstraintTest.FailsWithBadValues(double.NaN)" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                              <test-case name="NUnit.Framework.Constraints.EqualConstraintTest.FailsWithBadValues(double.PositiveInfinity)" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                            </results>
+                          </test-suite>
+                          <test-suite type="ParameterizedTest" name="ProvidesProperFailureMessage" executed="True" result="Success" success="True" time="0.006" asserts="0">
+                            <results>
+                              <test-case name="NUnit.Framework.Constraints.EqualConstraintTest.ProvidesProperFailureMessage(5,&quot;5&quot;)" executed="True" result="Success" success="True" time="0.001" asserts="1" />
+                              <test-case name="NUnit.Framework.Constraints.EqualConstraintTest.ProvidesProperFailureMessage(null,&quot;null&quot;)" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                              <test-case name="NUnit.Framework.Constraints.EqualConstraintTest.ProvidesProperFailureMessage(&quot;Hello&quot;,&quot;\&quot;Hello\&quot;&quot;)" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                              <test-case name="NUnit.Framework.Constraints.EqualConstraintTest.ProvidesProperFailureMessage(double.NaN,&quot;NaN&quot;)" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                              <test-case name="NUnit.Framework.Constraints.EqualConstraintTest.ProvidesProperFailureMessage(double.PositiveInfinity,&quot;Infinity&quot;)" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                            </results>
+                          </test-suite>
+                          <test-suite type="ParameterizedTest" name="SucceedsWithGoodValues" executed="True" result="Success" success="True" time="0.006" asserts="0">
+                            <results>
+                              <test-case name="NUnit.Framework.Constraints.EqualConstraintTest.SucceedsWithGoodValues(4)" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                              <test-case name="NUnit.Framework.Constraints.EqualConstraintTest.SucceedsWithGoodValues(4.0f)" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                              <test-case name="NUnit.Framework.Constraints.EqualConstraintTest.SucceedsWithGoodValues(4.0d)" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                              <test-case name="NUnit.Framework.Constraints.EqualConstraintTest.SucceedsWithGoodValues(4.0000m)" executed="True" result="Success" success="True" time="0.002" asserts="1" />
+                            </results>
+                          </test-suite>
+                          <test-case name="NUnit.Framework.Constraints.EqualConstraintTest.UsesProvidedComparerOfT" executed="True" result="Success" success="True" time="0.001" asserts="2" />
+                          <test-case name="NUnit.Framework.Constraints.EqualConstraintTest.UsesProvidedComparisonOfT" executed="True" result="Success" success="True" time="0.001" asserts="2" />
+                          <test-case name="NUnit.Framework.Constraints.EqualConstraintTest.UsesProvidedEqualityComparer" executed="True" result="Success" success="True" time="0.000" asserts="2" />
+                          <test-case name="NUnit.Framework.Constraints.EqualConstraintTest.UsesProvidedEqualityComparerOfT" executed="True" result="Success" success="True" time="0.002" asserts="2" />
+                          <test-case name="NUnit.Framework.Constraints.EqualConstraintTest.UsesProvidedIComparer" executed="True" result="Success" success="True" time="0.001" asserts="2" />
+                        </results>
+                      </test-suite>
+                      <test-suite type="TestFixture" name="EqualityComparerTests" executed="True" result="Success" success="True" time="0.001" asserts="0">
+                        <results>
+                          <test-case name="NUnit.Framework.Constraints.EqualityComparerTests.CanCompareArrayContainingSelfToSelf" executed="True" result="Success" success="True" time="0.001" asserts="1" />
+                        </results>
+                      </test-suite>
+                      <test-suite type="TestFixture" name="EqualTest" executed="True" result="Success" success="True" time="0.014" asserts="0">
+                        <results>
+                          <test-case name="NUnit.Framework.Constraints.EqualTest.FailedStringMatchShowsFailurePosition" executed="True" result="Success" success="True" time="0.004" asserts="2" />
+                          <test-case name="NUnit.Framework.Constraints.EqualTest.LongStringsAreTruncated" executed="True" result="Success" success="True" time="0.001" asserts="2" />
+                          <test-case name="NUnit.Framework.Constraints.EqualTest.LongStringsAreTruncatedAtBothEndsIfNecessary" executed="True" result="Success" success="True" time="0.001" asserts="2" />
+                          <test-case name="NUnit.Framework.Constraints.EqualTest.LongStringsAreTruncatedAtFrontEndIfNecessary" executed="True" result="Success" success="True" time="0.001" asserts="2" />
+                          <test-case name="NUnit.Framework.Constraints.EqualTest.TestPropertyWithPrivateSetter" executed="True" result="Success" success="True" time="0.001" asserts="1" />
+                        </results>
+                      </test-suite>
+                      <test-suite type="TestFixture" name="ExactTypeTest" executed="True" result="Success" success="True" time="0.013" asserts="0">
+                        <results>
+                          <test-case name="NUnit.Framework.Constraints.ExactTypeTest.ConstraintTestBaseNoData.ProvidesProperDescription" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Framework.Constraints.ExactTypeTest.ConstraintTestBaseNoData.ProvidesProperStringRepresentation" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                          <test-suite type="ParameterizedTest" name="FailsWithBadValues" executed="True" result="Success" success="True" time="0.002" asserts="0">
+                            <results>
+                              <test-case name="NUnit.Framework.Constraints.ExactTypeTest.FailsWithBadValues(NUnit.Framework.Constraints.B)" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                              <test-case name="NUnit.Framework.Constraints.ExactTypeTest.FailsWithBadValues(NUnit.Framework.Constraints.D2)" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                            </results>
+                          </test-suite>
+                          <test-suite type="ParameterizedTest" name="ProvidesProperFailureMessage" executed="True" result="Success" success="True" time="0.003" asserts="0">
+                            <results>
+                              <test-case name="NUnit.Framework.Constraints.ExactTypeTest.ProvidesProperFailureMessage(NUnit.Framework.Constraints.B,&quot;&lt;NUnit.Framework.Constraints.B&gt;&quot;)" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                              <test-case name="NUnit.Framework.Constraints.ExactTypeTest.ProvidesProperFailureMessage(NUnit.Framework.Constraints.D2,&quot;&lt;NUnit.Framework.Constraints.D2&gt;&quot;)" executed="True" result="Success" success="True" time="0.001" asserts="1" />
+                            </results>
+                          </test-suite>
+                          <test-suite type="ParameterizedTest" name="SucceedsWithGoodValues" executed="True" result="Success" success="True" time="0.002" asserts="0">
+                            <results>
+                              <test-case name="NUnit.Framework.Constraints.ExactTypeTest.SucceedsWithGoodValues(NUnit.Framework.Constraints.D1)" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                            </results>
+                          </test-suite>
+                        </results>
+                      </test-suite>
+                      <test-suite type="TestFixture" name="FalseConstraintTest" executed="True" result="Success" success="True" time="0.017" asserts="0">
+                        <results>
+                          <test-case name="NUnit.Framework.Constraints.FalseConstraintTest.ConstraintTestBaseNoData.ProvidesProperDescription" executed="True" result="Success" success="True" time="0.001" asserts="1" />
+                          <test-case name="NUnit.Framework.Constraints.FalseConstraintTest.ConstraintTestBaseNoData.ProvidesProperStringRepresentation" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                          <test-suite type="ParameterizedTest" name="FailsWithBadValues" executed="True" result="Success" success="True" time="0.004" asserts="0">
+                            <results>
+                              <test-case name="NUnit.Framework.Constraints.FalseConstraintTest.FailsWithBadValues(null)" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                              <test-case name="NUnit.Framework.Constraints.FalseConstraintTest.FailsWithBadValues(&quot;hello&quot;)" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                              <test-case name="NUnit.Framework.Constraints.FalseConstraintTest.FailsWithBadValues(True)" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                              <test-case name="NUnit.Framework.Constraints.FalseConstraintTest.FailsWithBadValues(True)" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                            </results>
+                          </test-suite>
+                          <test-suite type="ParameterizedTest" name="ProvidesProperFailureMessage" executed="True" result="Success" success="True" time="0.004" asserts="0">
+                            <results>
+                              <test-case name="NUnit.Framework.Constraints.FalseConstraintTest.ProvidesProperFailureMessage(null,&quot;null&quot;)" executed="True" result="Success" success="True" time="0.001" asserts="1" />
+                              <test-case name="NUnit.Framework.Constraints.FalseConstraintTest.ProvidesProperFailureMessage(&quot;hello&quot;,&quot;\&quot;hello\&quot;&quot;)" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                              <test-case name="NUnit.Framework.Constraints.FalseConstraintTest.ProvidesProperFailureMessage(True,&quot;True&quot;)" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                              <test-case name="NUnit.Framework.Constraints.FalseConstraintTest.ProvidesProperFailureMessage(True,&quot;True&quot;)" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                            </results>
+                          </test-suite>
+                          <test-suite type="ParameterizedTest" name="SucceedsWithGoodValues" executed="True" result="Success" success="True" time="0.002" asserts="0">
+                            <results>
+                              <test-case name="NUnit.Framework.Constraints.FalseConstraintTest.SucceedsWithGoodValues(False)" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                              <test-case name="NUnit.Framework.Constraints.FalseConstraintTest.SucceedsWithGoodValues(False)" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                            </results>
+                          </test-suite>
+                        </results>
+                      </test-suite>
+                      <test-suite type="TestFixture" name="FloatingPointNumericsTest" executed="True" result="Success" success="True" time="0.010" asserts="0">
+                        <results>
+                          <test-case name="NUnit.Framework.Constraints.FloatingPointNumericsTest.DoubleEqualityWithUlps" executed="True" result="Success" success="True" time="0.000" asserts="4" />
+                          <test-case name="NUnit.Framework.Constraints.FloatingPointNumericsTest.FloatEqualityWithUlps" executed="True" result="Success" success="True" time="0.000" asserts="4" />
+                          <test-case name="NUnit.Framework.Constraints.FloatingPointNumericsTest.MirroredDoubleReinterpretation" executed="True" result="Success" success="True" time="0.001" asserts="1" />
+                          <test-case name="NUnit.Framework.Constraints.FloatingPointNumericsTest.MirroredFloatReinterpretation" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Framework.Constraints.FloatingPointNumericsTest.MirroredIntegerReinterpretation" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Framework.Constraints.FloatingPointNumericsTest.MirroredLongReinterpretation" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                        </results>
+                      </test-suite>
+                      <test-suite type="TestFixture" name="GreaterThanOrEqualTest" executed="True" result="Success" success="True" time="0.024" asserts="0">
+                        <results>
+                          <test-case name="NUnit.Framework.Constraints.GreaterThanOrEqualTest.CanCompareIComparables" executed="True" result="Success" success="True" time="0.001" asserts="1" />
+                          <test-case name="NUnit.Framework.Constraints.GreaterThanOrEqualTest.CanCompareIComparablesOfT" executed="True" result="Success" success="True" time="0.001" asserts="1" />
+                          <test-case name="NUnit.Framework.Constraints.GreaterThanOrEqualTest.ComparisonConstraintTest.UsesProvidedComparerOfT" executed="True" result="Success" success="True" time="0.001" asserts="1" />
+                          <test-case name="NUnit.Framework.Constraints.GreaterThanOrEqualTest.ComparisonConstraintTest.UsesProvidedComparisonOfT" executed="True" result="Success" success="True" time="0.001" asserts="1" />
+                          <test-case name="NUnit.Framework.Constraints.GreaterThanOrEqualTest.ComparisonConstraintTest.UsesProvidedIComparer" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Framework.Constraints.GreaterThanOrEqualTest.ConstraintTestBaseNoData.ProvidesProperDescription" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Framework.Constraints.GreaterThanOrEqualTest.ConstraintTestBaseNoData.ProvidesProperStringRepresentation" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                          <test-suite type="ParameterizedTest" name="FailsWithBadValues" executed="True" result="Success" success="True" time="0.001" asserts="0">
+                            <results>
+                              <test-case name="NUnit.Framework.Constraints.GreaterThanOrEqualTest.FailsWithBadValues(4)" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                            </results>
+                          </test-suite>
+                          <test-suite type="ParameterizedTest" name="InvalidDataThrowsArgumentException" executed="True" result="Success" success="True" time="0.003" asserts="0">
+                            <results>
+                              <test-case name="NUnit.Framework.Constraints.GreaterThanOrEqualTest.InvalidDataThrowsArgumentException(null)" executed="True" result="Success" success="True" time="0.000" asserts="0" />
+                              <test-case name="NUnit.Framework.Constraints.GreaterThanOrEqualTest.InvalidDataThrowsArgumentException(&quot;xxx&quot;)" executed="True" result="Success" success="True" time="0.000" asserts="0" />
+                            </results>
+                          </test-suite>
+                          <test-suite type="ParameterizedTest" name="ProvidesProperFailureMessage" executed="True" result="Success" success="True" time="0.000" asserts="0">
+                            <results>
+                              <test-case name="NUnit.Framework.Constraints.GreaterThanOrEqualTest.ProvidesProperFailureMessage(4,&quot;4&quot;)" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                            </results>
+                          </test-suite>
+                          <test-suite type="ParameterizedTest" name="SucceedsWithGoodValues" executed="True" result="Success" success="True" time="0.001" asserts="0">
+                            <results>
+                              <test-case name="NUnit.Framework.Constraints.GreaterThanOrEqualTest.SucceedsWithGoodValues(6)" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                              <test-case name="NUnit.Framework.Constraints.GreaterThanOrEqualTest.SucceedsWithGoodValues(5)" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                            </results>
+                          </test-suite>
+                        </results>
+                      </test-suite>
+                      <test-suite type="TestFixture" name="GreaterThanTest" executed="True" result="Success" success="True" time="0.027" asserts="0">
+                        <results>
+                          <test-case name="NUnit.Framework.Constraints.GreaterThanTest.CanCompareIComparables" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Framework.Constraints.GreaterThanTest.CanCompareIComparablesOfT" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Framework.Constraints.GreaterThanTest.ComparisonConstraintTest.UsesProvidedComparerOfT" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Framework.Constraints.GreaterThanTest.ComparisonConstraintTest.UsesProvidedComparisonOfT" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Framework.Constraints.GreaterThanTest.ComparisonConstraintTest.UsesProvidedIComparer" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Framework.Constraints.GreaterThanTest.ConstraintTestBaseNoData.ProvidesProperDescription" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Framework.Constraints.GreaterThanTest.ConstraintTestBaseNoData.ProvidesProperStringRepresentation" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                          <test-suite type="ParameterizedTest" name="FailsWithBadValues" executed="True" result="Success" success="True" time="0.004" asserts="0">
+                            <results>
+                              <test-case name="NUnit.Framework.Constraints.GreaterThanTest.FailsWithBadValues(4)" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                              <test-case name="NUnit.Framework.Constraints.GreaterThanTest.FailsWithBadValues(5)" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                            </results>
+                          </test-suite>
+                          <test-suite type="ParameterizedTest" name="InvalidDataThrowsArgumentException" executed="True" result="Success" success="True" time="0.003" asserts="0">
+                            <results>
+                              <test-case name="NUnit.Framework.Constraints.GreaterThanTest.InvalidDataThrowsArgumentException(null)" executed="True" result="Success" success="True" time="0.001" asserts="0" />
+                              <test-case name="NUnit.Framework.Constraints.GreaterThanTest.InvalidDataThrowsArgumentException(&quot;xxx&quot;)" executed="True" result="Success" success="True" time="0.001" asserts="0" />
+                            </results>
+                          </test-suite>
+                          <test-suite type="ParameterizedTest" name="ProvidesProperFailureMessage" executed="True" result="Success" success="True" time="0.002" asserts="0">
+                            <results>
+                              <test-case name="NUnit.Framework.Constraints.GreaterThanTest.ProvidesProperFailureMessage(4,&quot;4&quot;)" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                              <test-case name="NUnit.Framework.Constraints.GreaterThanTest.ProvidesProperFailureMessage(5,&quot;5&quot;)" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                            </results>
+                          </test-suite>
+                          <test-suite type="ParameterizedTest" name="SucceedsWithGoodValues" executed="True" result="Success" success="True" time="0.002" asserts="0">
+                            <results>
+                              <test-case name="NUnit.Framework.Constraints.GreaterThanTest.SucceedsWithGoodValues(6)" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                              <test-case name="NUnit.Framework.Constraints.GreaterThanTest.SucceedsWithGoodValues(5.001d)" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                            </results>
+                          </test-suite>
+                        </results>
+                      </test-suite>
+                      <test-suite type="TestFixture" name="InstanceOfTypeTest" executed="True" result="Success" success="True" time="0.010" asserts="0">
+                        <results>
+                          <test-case name="NUnit.Framework.Constraints.InstanceOfTypeTest.ConstraintTestBaseNoData.ProvidesProperDescription" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Framework.Constraints.InstanceOfTypeTest.ConstraintTestBaseNoData.ProvidesProperStringRepresentation" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                          <test-suite type="ParameterizedTest" name="FailsWithBadValues" executed="True" result="Success" success="True" time="0.000" asserts="0">
+                            <results>
+                              <test-case name="NUnit.Framework.Constraints.InstanceOfTypeTest.FailsWithBadValues(NUnit.Framework.Constraints.B)" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                            </results>
+                          </test-suite>
+                          <test-suite type="ParameterizedTest" name="ProvidesProperFailureMessage" executed="True" result="Success" success="True" time="0.000" asserts="0">
+                            <results>
+                              <test-case name="NUnit.Framework.Constraints.InstanceOfTypeTest.ProvidesProperFailureMessage(NUnit.Framework.Constraints.B,&quot;&lt;NUnit.Framework.Constraints.B&gt;&quot;)" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                            </results>
+                          </test-suite>
+                          <test-suite type="ParameterizedTest" name="SucceedsWithGoodValues" executed="True" result="Success" success="True" time="0.002" asserts="0">
+                            <results>
+                              <test-case name="NUnit.Framework.Constraints.InstanceOfTypeTest.SucceedsWithGoodValues(NUnit.Framework.Constraints.D1)" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                              <test-case name="NUnit.Framework.Constraints.InstanceOfTypeTest.SucceedsWithGoodValues(NUnit.Framework.Constraints.D2)" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                            </results>
+                          </test-suite>
+                        </results>
+                      </test-suite>
+                      <test-suite type="TestFixture" name="LessThanOrEqualTest" executed="True" result="Success" success="True" time="0.024" asserts="0">
+                        <results>
+                          <test-case name="NUnit.Framework.Constraints.LessThanOrEqualTest.CanCompareIComparables" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Framework.Constraints.LessThanOrEqualTest.CanCompareIComparablesOfT" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Framework.Constraints.LessThanOrEqualTest.ComparisonConstraintTest.UsesProvidedComparerOfT" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Framework.Constraints.LessThanOrEqualTest.ComparisonConstraintTest.UsesProvidedComparisonOfT" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Framework.Constraints.LessThanOrEqualTest.ComparisonConstraintTest.UsesProvidedIComparer" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Framework.Constraints.LessThanOrEqualTest.ConstraintTestBaseNoData.ProvidesProperDescription" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Framework.Constraints.LessThanOrEqualTest.ConstraintTestBaseNoData.ProvidesProperStringRepresentation" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                          <test-suite type="ParameterizedTest" name="FailsWithBadValues" executed="True" result="Success" success="True" time="0.000" asserts="0">
+                            <results>
+                              <test-case name="NUnit.Framework.Constraints.LessThanOrEqualTest.FailsWithBadValues(6)" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                            </results>
+                          </test-suite>
+                          <test-suite type="ParameterizedTest" name="InvalidDataThrowsArgumentException" executed="True" result="Success" success="True" time="0.003" asserts="0">
+                            <results>
+                              <test-case name="NUnit.Framework.Constraints.LessThanOrEqualTest.InvalidDataThrowsArgumentException(null)" executed="True" result="Success" success="True" time="0.001" asserts="0" />
+                              <test-case name="NUnit.Framework.Constraints.LessThanOrEqualTest.InvalidDataThrowsArgumentException(&quot;xxx&quot;)" executed="True" result="Success" success="True" time="0.001" asserts="0" />
+                            </results>
+                          </test-suite>
+                          <test-suite type="ParameterizedTest" name="ProvidesProperFailureMessage" executed="True" result="Success" success="True" time="0.001" asserts="0">
+                            <results>
+                              <test-case name="NUnit.Framework.Constraints.LessThanOrEqualTest.ProvidesProperFailureMessage(6,&quot;6&quot;)" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                            </results>
+                          </test-suite>
+                          <test-suite type="ParameterizedTest" name="SucceedsWithGoodValues" executed="True" result="Success" success="True" time="0.002" asserts="0">
+                            <results>
+                              <test-case name="NUnit.Framework.Constraints.LessThanOrEqualTest.SucceedsWithGoodValues(4)" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                              <test-case name="NUnit.Framework.Constraints.LessThanOrEqualTest.SucceedsWithGoodValues(5)" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                            </results>
+                          </test-suite>
+                        </results>
+                      </test-suite>
+                      <test-suite type="TestFixture" name="LessThanTest" executed="True" result="Success" success="True" time="0.025" asserts="0">
+                        <results>
+                          <test-case name="NUnit.Framework.Constraints.LessThanTest.CanCompareIComparables" executed="True" result="Success" success="True" time="0.001" asserts="1" />
+                          <test-case name="NUnit.Framework.Constraints.LessThanTest.CanCompareIComparablesOfT" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Framework.Constraints.LessThanTest.ComparisonConstraintTest.UsesProvidedComparerOfT" executed="True" result="Success" success="True" time="0.001" asserts="1" />
+                          <test-case name="NUnit.Framework.Constraints.LessThanTest.ComparisonConstraintTest.UsesProvidedComparisonOfT" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Framework.Constraints.LessThanTest.ComparisonConstraintTest.UsesProvidedIComparer" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Framework.Constraints.LessThanTest.ConstraintTestBaseNoData.ProvidesProperDescription" executed="True" result="Success" success="True" time="0.001" asserts="1" />
+                          <test-case name="NUnit.Framework.Constraints.LessThanTest.ConstraintTestBaseNoData.ProvidesProperStringRepresentation" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                          <test-suite type="ParameterizedTest" name="FailsWithBadValues" executed="True" result="Success" success="True" time="0.002" asserts="0">
+                            <results>
+                              <test-case name="NUnit.Framework.Constraints.LessThanTest.FailsWithBadValues(6)" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                              <test-case name="NUnit.Framework.Constraints.LessThanTest.FailsWithBadValues(5)" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                            </results>
+                          </test-suite>
+                          <test-suite type="ParameterizedTest" name="InvalidDataThrowsArgumentException" executed="True" result="Success" success="True" time="0.003" asserts="0">
+                            <results>
+                              <test-case name="NUnit.Framework.Constraints.LessThanTest.InvalidDataThrowsArgumentException(null)" executed="True" result="Success" success="True" time="0.001" asserts="0" />
+                              <test-case name="NUnit.Framework.Constraints.LessThanTest.InvalidDataThrowsArgumentException(&quot;xxx&quot;)" executed="True" result="Success" success="True" time="0.001" asserts="0" />
+                            </results>
+                          </test-suite>
+                          <test-suite type="ParameterizedTest" name="ProvidesProperFailureMessage" executed="True" result="Success" success="True" time="0.004" asserts="0">
+                            <results>
+                              <test-case name="NUnit.Framework.Constraints.LessThanTest.ProvidesProperFailureMessage(6,&quot;6&quot;)" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                              <test-case name="NUnit.Framework.Constraints.LessThanTest.ProvidesProperFailureMessage(5,&quot;5&quot;)" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                            </results>
+                          </test-suite>
+                          <test-suite type="ParameterizedTest" name="SucceedsWithGoodValues" executed="True" result="Success" success="True" time="0.002" asserts="0">
+                            <results>
+                              <test-case name="NUnit.Framework.Constraints.LessThanTest.SucceedsWithGoodValues(4)" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                              <test-case name="NUnit.Framework.Constraints.LessThanTest.SucceedsWithGoodValues(4.999d)" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                            </results>
+                          </test-suite>
+                        </results>
+                      </test-suite>
+                      <test-suite type="TestFixture" name="MsgUtilTests" executed="True" result="Success" success="True" time="0.042" asserts="0">
+                        <results>
+                          <test-case name="NUnit.Framework.Constraints.MsgUtilTests.ClipExpectedAndActual_StringsDoNotFitInLine" executed="True" result="Success" success="True" time="0.001" asserts="4" />
+                          <test-case name="NUnit.Framework.Constraints.MsgUtilTests.ClipExpectedAndActual_StringsFitInLine" executed="True" result="Success" success="True" time="0.000" asserts="4" />
+                          <test-case name="NUnit.Framework.Constraints.MsgUtilTests.ClipExpectedAndActual_StringTailsFitInLine" executed="True" result="Success" success="True" time="0.001" asserts="1" />
+                          <test-suite type="ParameterizedTest" name="EscapeControlCharsTest" executed="True" result="Success" success="True" time="0.029" asserts="0">
+                            <results>
+                              <test-case name="NUnit.Framework.Constraints.MsgUtilTests.EscapeControlCharsTest(&quot;\a&quot;,&quot;\\a&quot;)" executed="True" result="Success" success="True" time="0.000" asserts="2" />
+                              <test-case name="NUnit.Framework.Constraints.MsgUtilTests.EscapeControlCharsTest(&quot;\r\r\r&quot;,&quot;\\r\\r\\r&quot;)" executed="True" result="Success" success="True" time="0.001" asserts="2" />
+                              <test-case name="NUnit.Framework.Constraints.MsgUtilTests.EscapeControlCharsTest(&quot;\r\n&quot;,&quot;\\r\\n&quot;)" executed="True" result="Success" success="True" time="0.000" asserts="2" />
+                              <test-case name="NUnit.Framework.Constraints.MsgUtilTests.EscapeControlCharsTest(&quot;\n\r&quot;,&quot;\\n\\r&quot;)" executed="True" result="Success" success="True" time="0.000" asserts="2" />
+                              <test-case name="NUnit.Framework.Constraints.MsgUtilTests.EscapeControlCharsTest(&quot;This is a\rtest message&quot;,&quot;This is a\\rtest message&quot;)" executed="True" result="Success" success="True" time="0.000" asserts="2" />
+                              <test-case name="NUnit.Framework.Constraints.MsgUtilTests.EscapeControlCharsTest(&quot;&quot;,&quot;&quot;)" executed="True" result="Success" success="True" time="0.000" asserts="2" />
+                              <test-case name="NUnit.Framework.Constraints.MsgUtilTests.EscapeControlCharsTest(null,null)" executed="True" result="Success" success="True" time="0.000" asserts="2" />
+                              <test-case name="NUnit.Framework.Constraints.MsgUtilTests.EscapeControlCharsTest(&quot;\t&quot;,&quot;\\t&quot;)" executed="True" result="Success" success="True" time="0.001" asserts="2" />
+                              <test-case name="NUnit.Framework.Constraints.MsgUtilTests.EscapeControlCharsTest(&quot;\t\n&quot;,&quot;\\t\\n&quot;)" executed="True" result="Success" success="True" time="0.000" asserts="2" />
+                              <test-case name="NUnit.Framework.Constraints.MsgUtilTests.EscapeControlCharsTest(&quot;\\r\\n&quot;,&quot;\\\\r\\\\n&quot;)" executed="True" result="Success" success="True" time="0.001" asserts="2" />
+                              <test-case name="NUnit.Framework.Constraints.MsgUtilTests.EscapeControlCharsTest(&quot;\n&quot;,&quot;\\n&quot;)" executed="True" result="Success" success="True" time="0.000" asserts="2" />
+                              <test-case name="NUnit.Framework.Constraints.MsgUtilTests.EscapeControlCharsTest(&quot;\b&quot;,&quot;\\b&quot;)" executed="True" result="Success" success="True" time="0.000" asserts="2" />
+                              <test-case name="NUnit.Framework.Constraints.MsgUtilTests.EscapeControlCharsTest(&quot;\f&quot;,&quot;\\f&quot;)" executed="True" result="Success" success="True" time="0.000" asserts="2" />
+                              <test-case name="NUnit.Framework.Constraints.MsgUtilTests.EscapeControlCharsTest(&quot;\v&quot;,&quot;\\v&quot;)" executed="True" result="Success" success="True" time="0.000" asserts="2" />
+                              <test-case name="NUnit.Framework.Constraints.MsgUtilTests.EscapeControlCharsTest(&quot;\x0085&quot;,&quot;\\x0085&quot;)" description="Next line character" executed="True" result="Success" success="True" time="0.000" asserts="2" />
+                              <test-case name="NUnit.Framework.Constraints.MsgUtilTests.EscapeControlCharsTest(&quot;\x2028&quot;,&quot;\\x2028&quot;)" description="Line separator character" executed="True" result="Success" success="True" time="0.000" asserts="2" />
+                              <test-case name="NUnit.Framework.Constraints.MsgUtilTests.EscapeControlCharsTest(&quot;\x2029&quot;,&quot;\\x2029&quot;)" description="Paragraph separator character" executed="True" result="Success" success="True" time="0.000" asserts="2" />
+                              <test-case name="NUnit.Framework.Constraints.MsgUtilTests.EscapeControlCharsTest(&quot;\n\n&quot;,&quot;\\n\\n&quot;)" executed="True" result="Success" success="True" time="0.000" asserts="2" />
+                              <test-case name="NUnit.Framework.Constraints.MsgUtilTests.EscapeControlCharsTest(&quot;\n\n\n&quot;,&quot;\\n\\n\\n&quot;)" executed="True" result="Success" success="True" time="0.000" asserts="2" />
+                              <test-case name="NUnit.Framework.Constraints.MsgUtilTests.EscapeControlCharsTest(&quot;\r&quot;,&quot;\\r&quot;)" executed="True" result="Success" success="True" time="0.000" asserts="2" />
+                              <test-case name="NUnit.Framework.Constraints.MsgUtilTests.EscapeControlCharsTest(&quot;\r\r&quot;,&quot;\\r\\r&quot;)" executed="True" result="Success" success="True" time="0.000" asserts="2" />
+                            </results>
+                          </test-suite>
+                          <test-suite type="ParameterizedTest" name="TestClipString" executed="True" result="Success" success="True" time="0.005" asserts="0">
+                            <results>
+                              <test-case name="NUnit.Framework.Constraints.MsgUtilTests.ClipAtEnd" executed="True" result="Success" success="True" time="0.001" asserts="2" />
+                              <test-case name="NUnit.Framework.Constraints.MsgUtilTests.NoClippingNeeded" executed="True" result="Success" success="True" time="0.000" asserts="2" />
+                              <test-case name="NUnit.Framework.Constraints.MsgUtilTests.ClipAtStart" executed="True" result="Success" success="True" time="0.000" asserts="2" />
+                              <test-case name="NUnit.Framework.Constraints.MsgUtilTests.ClipAtStartAndEnd" executed="True" result="Success" success="True" time="0.000" asserts="2" />
+                            </results>
+                          </test-suite>
+                        </results>
+                      </test-suite>
+                      <test-suite type="TestFixture" name="NaNConstraintTest" executed="True" result="Success" success="True" time="0.031" asserts="0">
+                        <results>
+                          <test-case name="NUnit.Framework.Constraints.NaNConstraintTest.ConstraintTestBaseNoData.ProvidesProperDescription" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Framework.Constraints.NaNConstraintTest.ConstraintTestBaseNoData.ProvidesProperStringRepresentation" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                          <test-suite type="ParameterizedTest" name="FailsWithBadValues" executed="True" result="Success" success="True" time="0.008" asserts="0">
+                            <results>
+                              <test-case name="NUnit.Framework.Constraints.NaNConstraintTest.FailsWithBadValues(null)" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                              <test-case name="NUnit.Framework.Constraints.NaNConstraintTest.FailsWithBadValues(&quot;hello&quot;)" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                              <test-case name="NUnit.Framework.Constraints.NaNConstraintTest.FailsWithBadValues(42)" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                              <test-case name="NUnit.Framework.Constraints.NaNConstraintTest.FailsWithBadValues(double.PositiveInfinity)" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                              <test-case name="NUnit.Framework.Constraints.NaNConstraintTest.FailsWithBadValues(double.NegativeInfinity)" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                              <test-case name="NUnit.Framework.Constraints.NaNConstraintTest.FailsWithBadValues(float.PositiveInfinity)" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                              <test-case name="NUnit.Framework.Constraints.NaNConstraintTest.FailsWithBadValues(float.NegativeInfinity)" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                            </results>
+                          </test-suite>
+                          <test-suite type="ParameterizedTest" name="ProvidesProperFailureMessage" executed="True" result="Success" success="True" time="0.013" asserts="0">
+                            <results>
+                              <test-case name="NUnit.Framework.Constraints.NaNConstraintTest.ProvidesProperFailureMessage(null,&quot;null&quot;)" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                              <test-case name="NUnit.Framework.Constraints.NaNConstraintTest.ProvidesProperFailureMessage(&quot;hello&quot;,&quot;\&quot;hello\&quot;&quot;)" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                              <test-case name="NUnit.Framework.Constraints.NaNConstraintTest.ProvidesProperFailureMessage(42,&quot;42&quot;)" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                              <test-case name="NUnit.Framework.Constraints.NaNConstraintTest.ProvidesProperFailureMessage(double.PositiveInfinity,&quot;Infinity&quot;)" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                              <test-case name="NUnit.Framework.Constraints.NaNConstraintTest.ProvidesProperFailureMessage(double.NegativeInfinity,&quot;-Infinity&quot;)" executed="True" result="Success" success="True" time="0.001" asserts="1" />
+                              <test-case name="NUnit.Framework.Constraints.NaNConstraintTest.ProvidesProperFailureMessage(float.PositiveInfinity,&quot;Infinity&quot;)" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                              <test-case name="NUnit.Framework.Constraints.NaNConstraintTest.ProvidesProperFailureMessage(float.NegativeInfinity,&quot;-Infinity&quot;)" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                            </results>
+                          </test-suite>
+                          <test-suite type="ParameterizedTest" name="SucceedsWithGoodValues" executed="True" result="Success" success="True" time="0.002" asserts="0">
+                            <results>
+                              <test-case name="NUnit.Framework.Constraints.NaNConstraintTest.SucceedsWithGoodValues(double.NaN)" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                              <test-case name="NUnit.Framework.Constraints.NaNConstraintTest.SucceedsWithGoodValues(float.NaN)" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                            </results>
+                          </test-suite>
+                        </results>
+                      </test-suite>
+                      <test-suite type="TestFixture" name="NotTest" executed="True" result="Success" success="True" time="0.017" asserts="0">
+                        <results>
+                          <test-case name="NUnit.Framework.Constraints.NotTest.CanUseNotOperator" executed="True" result="Success" success="True" time="0.001" asserts="1" />
+                          <test-case name="NUnit.Framework.Constraints.NotTest.ConstraintTestBaseNoData.ProvidesProperDescription" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Framework.Constraints.NotTest.ConstraintTestBaseNoData.ProvidesProperStringRepresentation" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                          <test-suite type="ParameterizedTest" name="FailsWithBadValues" executed="True" result="Success" success="True" time="0.000" asserts="0">
+                            <results>
+                              <test-case name="NUnit.Framework.Constraints.NotTest.FailsWithBadValues(null)" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                            </results>
+                          </test-suite>
+                          <test-case name="NUnit.Framework.Constraints.NotTest.NotHonorsIgnoreCaseUsingConstructors" executed="True" result="Success" success="True" time="0.001" asserts="1" />
+                          <test-case name="NUnit.Framework.Constraints.NotTest.NotHonorsIgnoreCaseUsingPrefixNotation" executed="True" result="Success" success="True" time="0.001" asserts="1" />
+                          <test-case name="NUnit.Framework.Constraints.NotTest.NotHonorsTolerance" executed="True" result="Success" success="True" time="0.001" asserts="1" />
+                          <test-suite type="ParameterizedTest" name="ProvidesProperFailureMessage" executed="True" result="Success" success="True" time="0.000" asserts="0">
+                            <results>
+                              <test-case name="NUnit.Framework.Constraints.NotTest.ProvidesProperFailureMessage(null,&quot;null&quot;)" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                            </results>
+                          </test-suite>
+                          <test-suite type="ParameterizedTest" name="SucceedsWithGoodValues" executed="True" result="Success" success="True" time="0.002" asserts="0">
+                            <results>
+                              <test-case name="NUnit.Framework.Constraints.NotTest.SucceedsWithGoodValues(42)" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                              <test-case name="NUnit.Framework.Constraints.NotTest.SucceedsWithGoodValues(&quot;Hello&quot;)" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                            </results>
+                          </test-suite>
+                        </results>
+                      </test-suite>
+                      <test-suite type="TestFixture" name="NullConstraintTest" executed="True" result="Success" success="True" time="0.008" asserts="0">
+                        <results>
+                          <test-case name="NUnit.Framework.Constraints.NullConstraintTest.ConstraintTestBaseNoData.ProvidesProperDescription" executed="True" result="Success" success="True" time="0.001" asserts="1" />
+                          <test-case name="NUnit.Framework.Constraints.NullConstraintTest.ConstraintTestBaseNoData.ProvidesProperStringRepresentation" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                          <test-suite type="ParameterizedTest" name="FailsWithBadValues" executed="True" result="Success" success="True" time="0.001" asserts="0">
+                            <results>
+                              <test-case name="NUnit.Framework.Constraints.NullConstraintTest.FailsWithBadValues(&quot;hello&quot;)" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                            </results>
+                          </test-suite>
+                          <test-suite type="ParameterizedTest" name="ProvidesProperFailureMessage" executed="True" result="Success" success="True" time="0.001" asserts="0">
+                            <results>
+                              <test-case name="NUnit.Framework.Constraints.NullConstraintTest.ProvidesProperFailureMessage(&quot;hello&quot;,&quot;\&quot;hello\&quot;&quot;)" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                            </results>
+                          </test-suite>
+                          <test-suite type="ParameterizedTest" name="SucceedsWithGoodValues" executed="True" result="Success" success="True" time="0.001" asserts="0">
+                            <results>
+                              <test-case name="NUnit.Framework.Constraints.NullConstraintTest.SucceedsWithGoodValues(null)" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                            </results>
+                          </test-suite>
+                        </results>
+                      </test-suite>
+                      <test-suite type="TestFixture" name="NullOrEmptyStringConstraintTest" executed="True" result="Success" success="True" time="0.013" asserts="0">
+                        <results>
+                          <test-case name="NUnit.Framework.Constraints.NullOrEmptyStringConstraintTest.ConstraintTestBaseNoData.ProvidesProperDescription" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Framework.Constraints.NullOrEmptyStringConstraintTest.ConstraintTestBaseNoData.ProvidesProperStringRepresentation" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                          <test-suite type="ParameterizedTest" name="FailsWithBadValues" executed="True" result="Success" success="True" time="0.001" asserts="0">
+                            <results>
+                              <test-case name="NUnit.Framework.Constraints.NullOrEmptyStringConstraintTest.FailsWithBadValues(&quot;Hello&quot;)" executed="True" result="Success" success="True" time="0.001" asserts="1" />
+                            </results>
+                          </test-suite>
+                          <test-suite type="ParameterizedTest" name="InvalidDataThrowsArgumentException" executed="True" result="Success" success="True" time="0.001" asserts="0">
+                            <results>
+                              <test-case name="NUnit.Framework.Constraints.NullOrEmptyStringConstraintTest.InvalidDataThrowsArgumentException(5)" executed="True" result="Success" success="True" time="0.000" asserts="0" />
+                            </results>
+                          </test-suite>
+                          <test-suite type="ParameterizedTest" name="ProvidesProperFailureMessage" executed="True" result="Success" success="True" time="0.000" asserts="0">
+                            <results>
+                              <test-case name="NUnit.Framework.Constraints.NullOrEmptyStringConstraintTest.ProvidesProperFailureMessage(&quot;Hello&quot;,&quot;\&quot;Hello\&quot;&quot;)" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                            </results>
+                          </test-suite>
+                          <test-suite type="ParameterizedTest" name="SucceedsWithGoodValues" executed="True" result="Success" success="True" time="0.002" asserts="0">
+                            <results>
+                              <test-case name="NUnit.Framework.Constraints.NullOrEmptyStringConstraintTest.SucceedsWithGoodValues(&quot;&quot;)" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                              <test-case name="NUnit.Framework.Constraints.NullOrEmptyStringConstraintTest.SucceedsWithGoodValues(null)" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                            </results>
+                          </test-suite>
+                        </results>
+                      </test-suite>
+                      <test-suite type="TestFixture" name="NumericsTest" executed="True" result="Success" success="True" time="0.053" asserts="0">
+                        <results>
+                          <test-case name="NUnit.Framework.Constraints.NumericsTest.CanMatchDecimalWithoutToleranceMode" executed="True" result="Success" success="True" time="0.001" asserts="1" />
+                          <test-case name="NUnit.Framework.Constraints.NumericsTest.CanMatchDecimalWithPercentage" executed="True" result="Success" success="True" time="0.001" asserts="3" />
+                          <test-suite type="ParameterizedTest" name="CanMatchIntegralsWithPercentage" executed="True" result="Success" success="True" time="0.019" asserts="0">
+                            <results>
+                              <test-case name="NUnit.Framework.Constraints.NumericsTest.CanMatchIntegralsWithPercentage(10500)" executed="True" result="Success" success="True" time="0.000" asserts="2" />
+                              <test-case name="NUnit.Framework.Constraints.NumericsTest.CanMatchIntegralsWithPercentage(9500L)" executed="True" result="Success" success="True" time="0.000" asserts="2" />
+                              <test-case name="NUnit.Framework.Constraints.NumericsTest.CanMatchIntegralsWithPercentage(10500UL)" executed="True" result="Success" success="True" time="0.001" asserts="2" />
+                              <test-case name="NUnit.Framework.Constraints.NumericsTest.CanMatchIntegralsWithPercentage(9500UL)" executed="True" result="Success" success="True" time="0.001" asserts="2" />
+                              <test-case name="NUnit.Framework.Constraints.NumericsTest.CanMatchIntegralsWithPercentage(10000L)" executed="True" result="Success" success="True" time="0.000" asserts="2" />
+                              <test-case name="NUnit.Framework.Constraints.NumericsTest.CanMatchIntegralsWithPercentage(10000UL)" executed="True" result="Success" success="True" time="0.000" asserts="2" />
+                              <test-case name="NUnit.Framework.Constraints.NumericsTest.CanMatchIntegralsWithPercentage(10500L)" executed="True" result="Success" success="True" time="0.000" asserts="2" />
+                              <test-case name="NUnit.Framework.Constraints.NumericsTest.CanMatchIntegralsWithPercentage(10000)" executed="True" result="Success" success="True" time="0.000" asserts="2" />
+                              <test-case name="NUnit.Framework.Constraints.NumericsTest.CanMatchIntegralsWithPercentage(9500)" executed="True" result="Success" success="True" time="0.000" asserts="2" />
+                              <test-case name="NUnit.Framework.Constraints.NumericsTest.CanMatchIntegralsWithPercentage(10500)" executed="True" result="Success" success="True" time="0.000" asserts="2" />
+                              <test-case name="NUnit.Framework.Constraints.NumericsTest.CanMatchIntegralsWithPercentage(9500)" executed="True" result="Success" success="True" time="0.000" asserts="2" />
+                              <test-case name="NUnit.Framework.Constraints.NumericsTest.CanMatchIntegralsWithPercentage(10000)" executed="True" result="Success" success="True" time="0.001" asserts="2" />
+                            </results>
+                          </test-suite>
+                          <test-suite type="ParameterizedTest" name="CanMatchWithoutToleranceMode" executed="True" result="Success" success="True" time="0.007" asserts="0">
+                            <results>
+                              <test-case name="NUnit.Framework.Constraints.NumericsTest.CanMatchWithoutToleranceMode(123456789)" executed="True" result="Success" success="True" time="0.001" asserts="2" />
+                              <test-case name="NUnit.Framework.Constraints.NumericsTest.CanMatchWithoutToleranceMode(123456789UL)" executed="True" result="Success" success="True" time="0.000" asserts="2" />
+                              <test-case name="NUnit.Framework.Constraints.NumericsTest.CanMatchWithoutToleranceMode(123456789L)" executed="True" result="Success" success="True" time="0.000" asserts="2" />
+                              <test-case name="NUnit.Framework.Constraints.NumericsTest.CanMatchWithoutToleranceMode(123456789)" executed="True" result="Success" success="True" time="0.000" asserts="2" />
+                              <test-case name="NUnit.Framework.Constraints.NumericsTest.CanMatchWithoutToleranceMode(1234.568f)" executed="True" result="Success" success="True" time="0.000" asserts="2" />
+                              <test-case name="NUnit.Framework.Constraints.NumericsTest.CanMatchWithoutToleranceMode(1234.5678d)" executed="True" result="Success" success="True" time="0.000" asserts="2" />
+                            </results>
+                          </test-suite>
+                          <test-case name="NUnit.Framework.Constraints.NumericsTest.FailsOnDecimalAbovePercentage" executed="True" result="Success" success="True" time="0.001" asserts="1" />
+                          <test-case name="NUnit.Framework.Constraints.NumericsTest.FailsOnDecimalBelowPercentage" executed="True" result="Success" success="True" time="0.001" asserts="1" />
+                          <test-suite type="ParameterizedTest" name="FailsOnIntegralsOutsideOfPercentage" executed="True" result="Success" success="True" time="0.014" asserts="0">
+                            <results>
+                              <test-case name="NUnit.Framework.Constraints.NumericsTest.FailsOnIntegralsOutsideOfPercentage(8500)" executed="True" result="Success" success="True" time="0.001" asserts="1" />
+                              <test-case name="NUnit.Framework.Constraints.NumericsTest.FailsOnIntegralsOutsideOfPercentage(8500UL)" executed="True" result="Success" success="True" time="0.001" asserts="1" />
+                              <test-case name="NUnit.Framework.Constraints.NumericsTest.FailsOnIntegralsOutsideOfPercentage(11500)" executed="True" result="Success" success="True" time="0.001" asserts="1" />
+                              <test-case name="NUnit.Framework.Constraints.NumericsTest.FailsOnIntegralsOutsideOfPercentage(11500UL)" executed="True" result="Success" success="True" time="0.001" asserts="1" />
+                              <test-case name="NUnit.Framework.Constraints.NumericsTest.FailsOnIntegralsOutsideOfPercentage(8500L)" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                              <test-case name="NUnit.Framework.Constraints.NumericsTest.FailsOnIntegralsOutsideOfPercentage(11500)" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                              <test-case name="NUnit.Framework.Constraints.NumericsTest.FailsOnIntegralsOutsideOfPercentage(11500L)" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                              <test-case name="NUnit.Framework.Constraints.NumericsTest.FailsOnIntegralsOutsideOfPercentage(8500)" executed="True" result="Success" success="True" time="0.001" asserts="1" />
+                            </results>
+                          </test-suite>
+                        </results>
+                      </test-suite>
+                      <test-suite type="TestFixture" name="OrTest" executed="True" result="Success" success="True" time="0.011" asserts="0">
+                        <results>
+                          <test-case name="NUnit.Framework.Constraints.OrTest.CanCombineTestsWithOrOperator" executed="True" result="Success" success="True" time="0.001" asserts="1" />
+                          <test-case name="NUnit.Framework.Constraints.OrTest.ConstraintTestBaseNoData.ProvidesProperDescription" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Framework.Constraints.OrTest.ConstraintTestBaseNoData.ProvidesProperStringRepresentation" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                          <test-suite type="ParameterizedTest" name="FailsWithBadValues" executed="True" result="Success" success="True" time="0.001" asserts="0">
+                            <results>
+                              <test-case name="NUnit.Framework.Constraints.OrTest.FailsWithBadValues(37)" executed="True" result="Success" success="True" time="0.001" asserts="1" />
+                            </results>
+                          </test-suite>
+                          <test-suite type="ParameterizedTest" name="ProvidesProperFailureMessage" executed="True" result="Success" success="True" time="0.001" asserts="0">
+                            <results>
+                              <test-case name="NUnit.Framework.Constraints.OrTest.ProvidesProperFailureMessage(37,&quot;37&quot;)" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                            </results>
+                          </test-suite>
+                          <test-suite type="ParameterizedTest" name="SucceedsWithGoodValues" executed="True" result="Success" success="True" time="0.002" asserts="0">
+                            <results>
+                              <test-case name="NUnit.Framework.Constraints.OrTest.SucceedsWithGoodValues(99)" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                              <test-case name="NUnit.Framework.Constraints.OrTest.SucceedsWithGoodValues(42)" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                            </results>
+                          </test-suite>
+                        </results>
+                      </test-suite>
+                      <test-suite type="TestFixture" name="PropertyExistsTest" executed="True" result="Success" success="True" time="0.020" asserts="0">
+                        <results>
+                          <test-case name="NUnit.Framework.Constraints.PropertyExistsTest.ConstraintTestBaseNoData.ProvidesProperDescription" executed="True" result="Success" success="True" time="0.001" asserts="1" />
+                          <test-case name="NUnit.Framework.Constraints.PropertyExistsTest.ConstraintTestBaseNoData.ProvidesProperStringRepresentation" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                          <test-suite type="ParameterizedTest" name="FailsWithBadValues" executed="True" result="Success" success="True" time="0.004" asserts="0">
+                            <results>
+                              <test-case name="NUnit.Framework.Constraints.PropertyExistsTest.FailsWithBadValues(42)" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                              <test-case name="NUnit.Framework.Constraints.PropertyExistsTest.FailsWithBadValues(System.Collections.ArrayList)" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                              <test-case name="NUnit.Framework.Constraints.PropertyExistsTest.FailsWithBadValues(System.Int32)" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                            </results>
+                          </test-suite>
+                          <test-suite type="ParameterizedTest" name="InvalidDataThrowsException" executed="True" result="Success" success="True" time="0.002" asserts="0">
+                            <results>
+                              <test-case name="NUnit.Framework.Constraints.PropertyExistsTest.InvalidDataThrowsException(null)" executed="True" result="Success" success="True" time="0.001" asserts="0" />
+                            </results>
+                          </test-suite>
+                          <test-suite type="ParameterizedTest" name="ProvidesProperFailureMessage" executed="True" result="Success" success="True" time="0.004" asserts="0">
+                            <results>
+                              <test-case name="NUnit.Framework.Constraints.PropertyExistsTest.ProvidesProperFailureMessage(42,&quot;&lt;System.Int32&gt;&quot;)" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                              <test-case name="NUnit.Framework.Constraints.PropertyExistsTest.ProvidesProperFailureMessage(System.Collections.ArrayList,&quot;&lt;System.Collections.ArrayList&gt;&quot;)" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                              <test-case name="NUnit.Framework.Constraints.PropertyExistsTest.ProvidesProperFailureMessage(System.Int32,&quot;&lt;System.Int32&gt;&quot;)" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                            </results>
+                          </test-suite>
+                          <test-suite type="ParameterizedTest" name="SucceedsWithGoodValues" executed="True" result="Success" success="True" time="0.003" asserts="0">
+                            <results>
+                              <test-case name="NUnit.Framework.Constraints.PropertyExistsTest.SucceedsWithGoodValues(System.Int32[])" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                              <test-case name="NUnit.Framework.Constraints.PropertyExistsTest.SucceedsWithGoodValues(&quot;hello&quot;)" executed="True" result="Success" success="True" time="0.001" asserts="1" />
+                              <test-case name="NUnit.Framework.Constraints.PropertyExistsTest.SucceedsWithGoodValues(System.Array)" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                            </results>
+                          </test-suite>
+                        </results>
+                      </test-suite>
+                      <test-suite type="TestFixture" name="PropertyTest" executed="True" result="Success" success="True" time="0.022" asserts="0">
+                        <results>
+                          <test-case name="NUnit.Framework.Constraints.PropertyTest.ConstraintTestBaseNoData.ProvidesProperDescription" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Framework.Constraints.PropertyTest.ConstraintTestBaseNoData.ProvidesProperStringRepresentation" executed="True" result="Success" success="True" time="0.001" asserts="1" />
+                          <test-suite type="ParameterizedTest" name="FailsWithBadValues" executed="True" result="Success" success="True" time="0.002" asserts="0">
+                            <results>
+                              <test-case name="NUnit.Framework.Constraints.PropertyTest.FailsWithBadValues(System.Int32[])" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                              <test-case name="NUnit.Framework.Constraints.PropertyTest.FailsWithBadValues(&quot;goodbye&quot;)" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                            </results>
+                          </test-suite>
+                          <test-suite type="ParameterizedTest" name="InvalidDataThrowsException" executed="True" result="Success" success="True" time="0.005" asserts="0">
+                            <results>
+                              <test-case name="NUnit.Framework.Constraints.PropertyTest.InvalidDataThrowsException(null)" executed="True" result="Success" success="True" time="0.001" asserts="0" />
+                              <test-case name="NUnit.Framework.Constraints.PropertyTest.InvalidDataThrowsException(42)" executed="True" result="Success" success="True" time="0.000" asserts="0" />
+                              <test-case name="NUnit.Framework.Constraints.PropertyTest.InvalidDataThrowsException(System.Collections.ArrayList)" executed="True" result="Success" success="True" time="0.000" asserts="0" />
+                            </results>
+                          </test-suite>
+                          <test-case name="NUnit.Framework.Constraints.PropertyTest.PropertyEqualToValueWithTolerance" executed="True" result="Success" success="True" time="0.001" asserts="2" />
+                          <test-suite type="ParameterizedTest" name="ProvidesProperFailureMessage" executed="True" result="Success" success="True" time="0.002" asserts="0">
+                            <results>
+                              <test-case name="NUnit.Framework.Constraints.PropertyTest.ProvidesProperFailureMessage(System.Int32[],&quot;3&quot;)" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                              <test-case name="NUnit.Framework.Constraints.PropertyTest.ProvidesProperFailureMessage(&quot;goodbye&quot;,&quot;7&quot;)" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                            </results>
+                          </test-suite>
+                          <test-suite type="ParameterizedTest" name="SucceedsWithGoodValues" executed="True" result="Success" success="True" time="0.002" asserts="0">
+                            <results>
+                              <test-case name="NUnit.Framework.Constraints.PropertyTest.SucceedsWithGoodValues(System.Int32[])" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                              <test-case name="NUnit.Framework.Constraints.PropertyTest.SucceedsWithGoodValues(&quot;hello&quot;)" executed="True" result="Success" success="True" time="0.001" asserts="1" />
+                            </results>
+                          </test-suite>
+                        </results>
+                      </test-suite>
+                      <test-suite type="TestFixture" name="RangeConstraintTest" executed="True" result="Success" success="True" time="0.027" asserts="0">
+                        <results>
+                          <test-case name="NUnit.Framework.Constraints.RangeConstraintTest.ConstraintTestBaseNoData.ProvidesProperDescription" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Framework.Constraints.RangeConstraintTest.ConstraintTestBaseNoData.ProvidesProperStringRepresentation" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                          <test-suite type="ParameterizedTest" name="FailsWithBadValues" executed="True" result="Success" success="True" time="0.002" asserts="0">
+                            <results>
+                              <test-case name="NUnit.Framework.Constraints.RangeConstraintTest.FailsWithBadValues(4)" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                              <test-case name="NUnit.Framework.Constraints.RangeConstraintTest.FailsWithBadValues(43)" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                            </results>
+                          </test-suite>
+                          <test-suite type="ParameterizedTest" name="InvalidDataThrowsArgumentException" executed="True" result="Success" success="True" time="0.003" asserts="0">
+                            <results>
+                              <test-case name="NUnit.Framework.Constraints.RangeConstraintTest.InvalidDataThrowsArgumentException(null)" executed="True" result="Success" success="True" time="0.000" asserts="0" />
+                              <test-case name="NUnit.Framework.Constraints.RangeConstraintTest.InvalidDataThrowsArgumentException(&quot;xxx&quot;)" executed="True" result="Success" success="True" time="0.000" asserts="0" />
+                            </results>
+                          </test-suite>
+                          <test-suite type="ParameterizedTest" name="ProvidesProperFailureMessage" executed="True" result="Success" success="True" time="0.002" asserts="0">
+                            <results>
+                              <test-case name="NUnit.Framework.Constraints.RangeConstraintTest.ProvidesProperFailureMessage(4,&quot;4&quot;)" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                              <test-case name="NUnit.Framework.Constraints.RangeConstraintTest.ProvidesProperFailureMessage(43,&quot;43&quot;)" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                            </results>
+                          </test-suite>
+                          <test-suite type="ParameterizedTest" name="SucceedsWithGoodValues" executed="True" result="Success" success="True" time="0.003" asserts="0">
+                            <results>
+                              <test-case name="NUnit.Framework.Constraints.RangeConstraintTest.SucceedsWithGoodValues(5)" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                              <test-case name="NUnit.Framework.Constraints.RangeConstraintTest.SucceedsWithGoodValues(23)" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                              <test-case name="NUnit.Framework.Constraints.RangeConstraintTest.SucceedsWithGoodValues(42)" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                            </results>
+                          </test-suite>
+                          <test-case name="NUnit.Framework.Constraints.RangeConstraintTest.UsesProvidedComparerOfT" executed="True" result="Success" success="True" time="0.001" asserts="2" />
+                          <test-case name="NUnit.Framework.Constraints.RangeConstraintTest.UsesProvidedComparisonOfT" executed="True" result="Success" success="True" time="0.001" asserts="2" />
+                          <test-case name="NUnit.Framework.Constraints.RangeConstraintTest.UsesProvidedIComparer" executed="True" result="Success" success="True" time="0.000" asserts="2" />
+                        </results>
+                      </test-suite>
+                      <test-suite type="TestFixture" name="ReusableConstraintTests" executed="True" result="Success" success="True" time="0.008" asserts="0">
+                        <results>
+                          <test-case name="NUnit.Framework.Constraints.ReusableConstraintTests.CanCreateReusableConstraintByImplicitConversion" executed="True" result="Success" success="True" time="0.000" asserts="3" />
+                          <test-suite type="Theory" name="CanReuseReusableConstraintMultipleTimes" executed="True" result="Success" success="True" time="0.006" asserts="0">
+                            <results>
+                              <test-case name="NUnit.Framework.Constraints.ReusableConstraintTests.CanReuseReusableConstraintMultipleTimes(&lt;not &lt;empty&gt;&gt;)" executed="True" result="Success" success="True" time="0.000" asserts="3" />
+                              <test-case name="NUnit.Framework.Constraints.ReusableConstraintTests.CanReuseReusableConstraintMultipleTimes(&lt;not &lt;null&gt;&gt;)" executed="True" result="Success" success="True" time="0.000" asserts="3" />
+                              <test-case name="NUnit.Framework.Constraints.ReusableConstraintTests.CanReuseReusableConstraintMultipleTimes(&lt;property Length &lt;greaterthan 3&gt;&gt;)" executed="True" result="Success" success="True" time="0.000" asserts="3" />
+                              <test-case name="NUnit.Framework.Constraints.ReusableConstraintTests.CanReuseReusableConstraintMultipleTimes(&lt;and &lt;property Length &lt;equal 4&gt;&gt; &lt;startswith &quot;te&quot;&gt;&gt;)" executed="True" result="Success" success="True" time="0.001" asserts="3" />
+                            </results>
+                          </test-suite>
+                        </results>
+                      </test-suite>
+                      <test-suite type="TestFixture" name="SameAsTest" executed="True" result="Success" success="True" time="0.017" asserts="0">
+                        <results>
+                          <test-case name="NUnit.Framework.Constraints.SameAsTest.ConstraintTestBaseNoData.ProvidesProperDescription" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Framework.Constraints.SameAsTest.ConstraintTestBaseNoData.ProvidesProperStringRepresentation" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                          <test-suite type="ParameterizedTest" name="FailsWithBadValues" executed="True" result="Success" success="True" time="0.003" asserts="0">
+                            <results>
+                              <test-case name="NUnit.Framework.Constraints.SameAsTest.FailsWithBadValues(System.Object)" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                              <test-case name="NUnit.Framework.Constraints.SameAsTest.FailsWithBadValues(3)" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                              <test-case name="NUnit.Framework.Constraints.SameAsTest.FailsWithBadValues(&quot;Hello&quot;)" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                            </results>
+                          </test-suite>
+                          <test-suite type="ParameterizedTest" name="ProvidesProperFailureMessage" executed="True" result="Success" success="True" time="0.005" asserts="0">
+                            <results>
+                              <test-case name="NUnit.Framework.Constraints.SameAsTest.ProvidesProperFailureMessage(System.Object,&quot;&lt;System.Object&gt;&quot;)" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                              <test-case name="NUnit.Framework.Constraints.SameAsTest.ProvidesProperFailureMessage(3,&quot;3&quot;)" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                              <test-case name="NUnit.Framework.Constraints.SameAsTest.ProvidesProperFailureMessage(&quot;Hello&quot;,&quot;\&quot;Hello\&quot;&quot;)" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                            </results>
+                          </test-suite>
+                          <test-suite type="ParameterizedTest" name="SucceedsWithGoodValues" executed="True" result="Success" success="True" time="0.000" asserts="0">
+                            <results>
+                              <test-case name="NUnit.Framework.Constraints.SameAsTest.SucceedsWithGoodValues(System.Object)" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                            </results>
+                          </test-suite>
+                        </results>
+                      </test-suite>
+                      <test-suite type="TestFixture" name="SamePathOrUnderTest_Linux" executed="True" result="Success" success="True" time="0.040" asserts="0">
+                        <results>
+                          <test-case name="NUnit.Framework.Constraints.SamePathOrUnderTest_Linux.ConstraintTestBaseNoData.ProvidesProperDescription" executed="True" result="Success" success="True" time="0.001" asserts="1" />
+                          <test-case name="NUnit.Framework.Constraints.SamePathOrUnderTest_Linux.ConstraintTestBaseNoData.ProvidesProperStringRepresentation" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                          <test-suite type="ParameterizedTest" name="FailsWithBadValues" executed="True" result="Success" success="True" time="0.010" asserts="0">
+                            <results>
+                              <test-case name="NUnit.Framework.Constraints.SamePathOrUnderTest_Linux.FailsWithBadValues(123)" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                              <test-case name="NUnit.Framework.Constraints.SamePathOrUnderTest_Linux.FailsWithBadValues(&quot;/Folder1/Folder2&quot;)" executed="True" result="Success" success="True" time="0.001" asserts="1" />
+                              <test-case name="NUnit.Framework.Constraints.SamePathOrUnderTest_Linux.FailsWithBadValues(&quot;/FOLDER1/./junk/../Folder2&quot;)" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                              <test-case name="NUnit.Framework.Constraints.SamePathOrUnderTest_Linux.FailsWithBadValues(&quot;/FOLDER1/./junk/../Folder2/temp/../Folder3&quot;)" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                              <test-case name="NUnit.Framework.Constraints.SamePathOrUnderTest_Linux.FailsWithBadValues(&quot;/folder1/folder3&quot;)" executed="True" result="Success" success="True" time="0.001" asserts="1" />
+                              <test-case name="NUnit.Framework.Constraints.SamePathOrUnderTest_Linux.FailsWithBadValues(&quot;/folder1/./folder2/../folder3&quot;)" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                              <test-case name="NUnit.Framework.Constraints.SamePathOrUnderTest_Linux.FailsWithBadValues(&quot;/folder1&quot;)" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                            </results>
+                          </test-suite>
+                          <test-suite type="ParameterizedTest" name="ProvidesProperFailureMessage" executed="True" result="Success" success="True" time="0.009" asserts="0">
+                            <results>
+                              <test-case name="NUnit.Framework.Constraints.SamePathOrUnderTest_Linux.ProvidesProperFailureMessage(123,&quot;123&quot;)" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                              <test-case name="NUnit.Framework.Constraints.SamePathOrUnderTest_Linux.ProvidesProperFailureMessage(&quot;/Folder1/Folder2&quot;,&quot;\&quot;/Folder1/Folder2\&quot;&quot;)" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                              <test-case name="NUnit.Framework.Constraints.SamePathOrUnderTest_Linux.ProvidesProperFailureMessage(&quot;/FOLDER1/./junk/../Folder2&quot;,&quot;\&quot;/FOLDER1/./junk/../Folder2\&quot;&quot;)" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                              <test-case name="NUnit.Framework.Constraints.SamePathOrUnderTest_Linux.ProvidesProperFailureMessage(&quot;/FOLDER1/./junk/../Folder2/temp/../Folder3&quot;,&quot;\&quot;/FOLDER1/./junk/../Folder2/temp/../Folder3\&quot;&quot;)" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                              <test-case name="NUnit.Framework.Constraints.SamePathOrUnderTest_Linux.ProvidesProperFailureMessage(&quot;/folder1/folder3&quot;,&quot;\&quot;/folder1/folder3\&quot;&quot;)" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                              <test-case name="NUnit.Framework.Constraints.SamePathOrUnderTest_Linux.ProvidesProperFailureMessage(&quot;/folder1/./folder2/../folder3&quot;,&quot;\&quot;/folder1/./folder2/../folder3\&quot;&quot;)" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                              <test-case name="NUnit.Framework.Constraints.SamePathOrUnderTest_Linux.ProvidesProperFailureMessage(&quot;/folder1&quot;,&quot;\&quot;/folder1\&quot;&quot;)" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                            </results>
+                          </test-suite>
+                          <test-suite type="ParameterizedTest" name="SucceedsWithGoodValues" executed="True" result="Success" success="True" time="0.012" asserts="0">
+                            <results>
+                              <test-case name="NUnit.Framework.Constraints.SamePathOrUnderTest_Linux.SucceedsWithGoodValues(&quot;/folder1/folder2&quot;)" executed="True" result="Success" success="True" time="0.001" asserts="1" />
+                              <test-case name="NUnit.Framework.Constraints.SamePathOrUnderTest_Linux.SucceedsWithGoodValues(&quot;/folder1/./folder2&quot;)" executed="True" result="Success" success="True" time="0.001" asserts="1" />
+                              <test-case name="NUnit.Framework.Constraints.SamePathOrUnderTest_Linux.SucceedsWithGoodValues(&quot;/folder1/junk/../folder2&quot;)" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                              <test-case name="NUnit.Framework.Constraints.SamePathOrUnderTest_Linux.SucceedsWithGoodValues(&quot;\\folder1\\folder2&quot;)" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                              <test-case name="NUnit.Framework.Constraints.SamePathOrUnderTest_Linux.SucceedsWithGoodValues(&quot;/folder1/folder2/folder3&quot;)" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                              <test-case name="NUnit.Framework.Constraints.SamePathOrUnderTest_Linux.SucceedsWithGoodValues(&quot;/folder1/./folder2/folder3&quot;)" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                              <test-case name="NUnit.Framework.Constraints.SamePathOrUnderTest_Linux.SucceedsWithGoodValues(&quot;/folder1/junk/../folder2/folder3&quot;)" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                              <test-case name="NUnit.Framework.Constraints.SamePathOrUnderTest_Linux.SucceedsWithGoodValues(&quot;\\folder1\\folder2\\folder3&quot;)" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                            </results>
+                          </test-suite>
+                        </results>
+                      </test-suite>
+                      <test-suite type="TestFixture" name="SamePathOrUnderTest_Windows" executed="True" result="Success" success="True" time="0.030" asserts="0">
+                        <results>
+                          <test-case name="NUnit.Framework.Constraints.SamePathOrUnderTest_Windows.ConstraintTestBaseNoData.ProvidesProperDescription" executed="True" result="Success" success="True" time="0.001" asserts="1" />
+                          <test-case name="NUnit.Framework.Constraints.SamePathOrUnderTest_Windows.ConstraintTestBaseNoData.ProvidesProperStringRepresentation" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                          <test-suite type="ParameterizedTest" name="FailsWithBadValues" executed="True" result="Success" success="True" time="0.003" asserts="0">
+                            <results>
+                              <test-case name="NUnit.Framework.Constraints.SamePathOrUnderTest_Windows.FailsWithBadValues(123)" executed="True" result="Success" success="True" time="0.001" asserts="1" />
+                              <test-case name="NUnit.Framework.Constraints.SamePathOrUnderTest_Windows.FailsWithBadValues(&quot;C:\\folder1\\folder3&quot;)" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                              <test-case name="NUnit.Framework.Constraints.SamePathOrUnderTest_Windows.FailsWithBadValues(&quot;C:\\folder1\\.\\folder2\\..\\file.temp&quot;)" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                            </results>
+                          </test-suite>
+                          <test-suite type="ParameterizedTest" name="ProvidesProperFailureMessage" executed="True" result="Success" success="True" time="0.003" asserts="0">
+                            <results>
+                              <test-case name="NUnit.Framework.Constraints.SamePathOrUnderTest_Windows.ProvidesProperFailureMessage(123,&quot;123&quot;)" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                              <test-case name="NUnit.Framework.Constraints.SamePathOrUnderTest_Windows.ProvidesProperFailureMessage(&quot;C:\\folder1\\folder3&quot;,&quot;\&quot;C:\\folder1\\folder3\&quot;&quot;)" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                              <test-case name="NUnit.Framework.Constraints.SamePathOrUnderTest_Windows.ProvidesProperFailureMessage(&quot;C:\\folder1\\.\\folder2\\..\\file.temp&quot;,&quot;\&quot;C:\\folder1\\.\\folder2\\..\\file.temp\&quot;&quot;)" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                            </results>
+                          </test-suite>
+                          <test-suite type="ParameterizedTest" name="SucceedsWithGoodValues" executed="True" result="Success" success="True" time="0.016" asserts="0">
+                            <results>
+                              <test-case name="NUnit.Framework.Constraints.SamePathOrUnderTest_Windows.SucceedsWithGoodValues(&quot;C:\\folder1\\folder2&quot;)" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                              <test-case name="NUnit.Framework.Constraints.SamePathOrUnderTest_Windows.SucceedsWithGoodValues(&quot;C:\\Folder1\\Folder2&quot;)" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                              <test-case name="NUnit.Framework.Constraints.SamePathOrUnderTest_Windows.SucceedsWithGoodValues(&quot;C:\\folder1\\.\\folder2&quot;)" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                              <test-case name="NUnit.Framework.Constraints.SamePathOrUnderTest_Windows.SucceedsWithGoodValues(&quot;C:\\folder1\\junk\\..\\folder2&quot;)" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                              <test-case name="NUnit.Framework.Constraints.SamePathOrUnderTest_Windows.SucceedsWithGoodValues(&quot;C:\\FOLDER1\\.\\junk\\..\\Folder2&quot;)" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                              <test-case name="NUnit.Framework.Constraints.SamePathOrUnderTest_Windows.SucceedsWithGoodValues(&quot;C:/folder1/folder2&quot;)" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                              <test-case name="NUnit.Framework.Constraints.SamePathOrUnderTest_Windows.SucceedsWithGoodValues(&quot;C:\\folder1\\folder2\\folder3&quot;)" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                              <test-case name="NUnit.Framework.Constraints.SamePathOrUnderTest_Windows.SucceedsWithGoodValues(&quot;C:\\folder1\\.\\folder2\\folder3&quot;)" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                              <test-case name="NUnit.Framework.Constraints.SamePathOrUnderTest_Windows.SucceedsWithGoodValues(&quot;C:\\folder1\\junk\\..\\folder2\\folder3&quot;)" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                              <test-case name="NUnit.Framework.Constraints.SamePathOrUnderTest_Windows.SucceedsWithGoodValues(&quot;C:\\FOLDER1\\.\\junk\\..\\Folder2\\temp\\..\\Folder3&quot;)" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                              <test-case name="NUnit.Framework.Constraints.SamePathOrUnderTest_Windows.SucceedsWithGoodValues(&quot;C:/folder1/folder2/folder3&quot;)" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                            </results>
+                          </test-suite>
+                        </results>
+                      </test-suite>
+                      <test-suite type="TestFixture" name="SamePathTest_Linux" executed="True" result="Success" success="True" time="0.029" asserts="0">
+                        <results>
+                          <test-case name="NUnit.Framework.Constraints.SamePathTest_Linux.ConstraintTestBaseNoData.ProvidesProperDescription" executed="True" result="Success" success="True" time="0.001" asserts="1" />
+                          <test-case name="NUnit.Framework.Constraints.SamePathTest_Linux.ConstraintTestBaseNoData.ProvidesProperStringRepresentation" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                          <test-suite type="ParameterizedTest" name="FailsWithBadValues" executed="True" result="Success" success="True" time="0.006" asserts="0">
+                            <results>
+                              <test-case name="NUnit.Framework.Constraints.SamePathTest_Linux.FailsWithBadValues(123)" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                              <test-case name="NUnit.Framework.Constraints.SamePathTest_Linux.FailsWithBadValues(&quot;/folder2/file.tmp&quot;)" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                              <test-case name="NUnit.Framework.Constraints.SamePathTest_Linux.FailsWithBadValues(&quot;/folder1/./folder2/../file.temp&quot;)" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                              <test-case name="NUnit.Framework.Constraints.SamePathTest_Linux.FailsWithBadValues(&quot;/Folder1/File.TMP&quot;)" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                              <test-case name="NUnit.Framework.Constraints.SamePathTest_Linux.FailsWithBadValues(&quot;/FOLDER1/./folder2/../File.TMP&quot;)" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                            </results>
+                          </test-suite>
+                          <test-suite type="ParameterizedTest" name="ProvidesProperFailureMessage" executed="True" result="Success" success="True" time="0.006" asserts="0">
+                            <results>
+                              <test-case name="NUnit.Framework.Constraints.SamePathTest_Linux.ProvidesProperFailureMessage(123,&quot;123&quot;)" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                              <test-case name="NUnit.Framework.Constraints.SamePathTest_Linux.ProvidesProperFailureMessage(&quot;/folder2/file.tmp&quot;,&quot;\&quot;/folder2/file.tmp\&quot;&quot;)" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                              <test-case name="NUnit.Framework.Constraints.SamePathTest_Linux.ProvidesProperFailureMessage(&quot;/folder1/./folder2/../file.temp&quot;,&quot;\&quot;/folder1/./folder2/../file.temp\&quot;&quot;)" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                              <test-case name="NUnit.Framework.Constraints.SamePathTest_Linux.ProvidesProperFailureMessage(&quot;/Folder1/File.TMP&quot;,&quot;\&quot;/Folder1/File.TMP\&quot;&quot;)" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                              <test-case name="NUnit.Framework.Constraints.SamePathTest_Linux.ProvidesProperFailureMessage(&quot;/FOLDER1/./folder2/../File.TMP&quot;,&quot;\&quot;/FOLDER1/./folder2/../File.TMP\&quot;&quot;)" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                            </results>
+                          </test-suite>
+                          <test-case name="NUnit.Framework.Constraints.SamePathTest_Linux.RootPathEquality" executed="True" result="Success" success="True" time="0.001" asserts="1" />
+                          <test-suite type="ParameterizedTest" name="SucceedsWithGoodValues" executed="True" result="Success" success="True" time="0.007" asserts="0">
+                            <results>
+                              <test-case name="NUnit.Framework.Constraints.SamePathTest_Linux.SucceedsWithGoodValues(&quot;/folder1/file.tmp&quot;)" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                              <test-case name="NUnit.Framework.Constraints.SamePathTest_Linux.SucceedsWithGoodValues(&quot;/folder1/./file.tmp&quot;)" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                              <test-case name="NUnit.Framework.Constraints.SamePathTest_Linux.SucceedsWithGoodValues(&quot;/folder1/folder2/../file.tmp&quot;)" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                              <test-case name="NUnit.Framework.Constraints.SamePathTest_Linux.SucceedsWithGoodValues(&quot;/folder1/./folder2/../file.tmp&quot;)" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                              <test-case name="NUnit.Framework.Constraints.SamePathTest_Linux.SucceedsWithGoodValues(&quot;\\folder1\\file.tmp&quot;)" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                            </results>
+                          </test-suite>
+                        </results>
+                      </test-suite>
+                      <test-suite type="TestFixture" name="SamePathTest_Windows" executed="True" result="Success" success="True" time="0.022" asserts="0">
+                        <results>
+                          <test-case name="NUnit.Framework.Constraints.SamePathTest_Windows.ConstraintTestBaseNoData.ProvidesProperDescription" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Framework.Constraints.SamePathTest_Windows.ConstraintTestBaseNoData.ProvidesProperStringRepresentation" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                          <test-suite type="ParameterizedTest" name="FailsWithBadValues" executed="True" result="Success" success="True" time="0.003" asserts="0">
+                            <results>
+                              <test-case name="NUnit.Framework.Constraints.SamePathTest_Windows.FailsWithBadValues(123)" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                              <test-case name="NUnit.Framework.Constraints.SamePathTest_Windows.FailsWithBadValues(&quot;C:\\folder2\\file.tmp&quot;)" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                              <test-case name="NUnit.Framework.Constraints.SamePathTest_Windows.FailsWithBadValues(&quot;C:\\folder1\\.\\folder2\\..\\file.temp&quot;)" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                            </results>
+                          </test-suite>
+                          <test-suite type="ParameterizedTest" name="ProvidesProperFailureMessage" executed="True" result="Success" success="True" time="0.004" asserts="0">
+                            <results>
+                              <test-case name="NUnit.Framework.Constraints.SamePathTest_Windows.ProvidesProperFailureMessage(123,&quot;123&quot;)" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                              <test-case name="NUnit.Framework.Constraints.SamePathTest_Windows.ProvidesProperFailureMessage(&quot;C:\\folder2\\file.tmp&quot;,&quot;\&quot;C:\\folder2\\file.tmp\&quot;&quot;)" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                              <test-case name="NUnit.Framework.Constraints.SamePathTest_Windows.ProvidesProperFailureMessage(&quot;C:\\folder1\\.\\folder2\\..\\file.temp&quot;,&quot;\&quot;C:\\folder1\\.\\folder2\\..\\file.temp\&quot;&quot;)" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                            </results>
+                          </test-suite>
+                          <test-case name="NUnit.Framework.Constraints.SamePathTest_Windows.RootPathEquality" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                          <test-suite type="ParameterizedTest" name="SucceedsWithGoodValues" executed="True" result="Success" success="True" time="0.007" asserts="0">
+                            <results>
+                              <test-case name="NUnit.Framework.Constraints.SamePathTest_Windows.SucceedsWithGoodValues(&quot;C:\\folder1\\file.tmp&quot;)" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                              <test-case name="NUnit.Framework.Constraints.SamePathTest_Windows.SucceedsWithGoodValues(&quot;C:\\Folder1\\File.TMP&quot;)" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                              <test-case name="NUnit.Framework.Constraints.SamePathTest_Windows.SucceedsWithGoodValues(&quot;C:\\folder1\\.\\file.tmp&quot;)" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                              <test-case name="NUnit.Framework.Constraints.SamePathTest_Windows.SucceedsWithGoodValues(&quot;C:\\folder1\\folder2\\..\\file.tmp&quot;)" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                              <test-case name="NUnit.Framework.Constraints.SamePathTest_Windows.SucceedsWithGoodValues(&quot;C:\\FOLDER1\\.\\folder2\\..\\File.TMP&quot;)" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                              <test-case name="NUnit.Framework.Constraints.SamePathTest_Windows.SucceedsWithGoodValues(&quot;C:/folder1/file.tmp&quot;)" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                            </results>
+                          </test-suite>
+                        </results>
+                      </test-suite>
+                      <test-suite type="TestFixture" name="StartsWithTest" executed="True" result="Success" success="True" time="0.025" asserts="0">
+                        <results>
+                          <test-case name="NUnit.Framework.Constraints.StartsWithTest.ConstraintTestBaseNoData.ProvidesProperDescription" executed="True" result="Success" success="True" time="0.001" asserts="1" />
+                          <test-case name="NUnit.Framework.Constraints.StartsWithTest.ConstraintTestBaseNoData.ProvidesProperStringRepresentation" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                          <test-suite type="ParameterizedTest" name="FailsWithBadValues" executed="True" result="Success" success="True" time="0.007" asserts="0">
+                            <results>
+                              <test-case name="NUnit.Framework.Constraints.StartsWithTest.FailsWithBadValues(&quot;goodbye&quot;)" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                              <test-case name="NUnit.Framework.Constraints.StartsWithTest.FailsWithBadValues(&quot;HELLO THERE&quot;)" executed="True" result="Success" success="True" time="0.001" asserts="1" />
+                              <test-case name="NUnit.Framework.Constraints.StartsWithTest.FailsWithBadValues(&quot;I said hello&quot;)" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                              <test-case name="NUnit.Framework.Constraints.StartsWithTest.FailsWithBadValues(&quot;say hello to fred&quot;)" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                              <test-case name="NUnit.Framework.Constraints.StartsWithTest.FailsWithBadValues(&quot;&quot;)" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                              <test-case name="NUnit.Framework.Constraints.StartsWithTest.FailsWithBadValues(null)" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                            </results>
+                          </test-suite>
+                          <test-suite type="ParameterizedTest" name="ProvidesProperFailureMessage" executed="True" result="Success" success="True" time="0.007" asserts="0">
+                            <results>
+                              <test-case name="NUnit.Framework.Constraints.StartsWithTest.ProvidesProperFailureMessage(&quot;goodbye&quot;,&quot;\&quot;goodbye\&quot;&quot;)" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                              <test-case name="NUnit.Framework.Constraints.StartsWithTest.ProvidesProperFailureMessage(&quot;HELLO THERE&quot;,&quot;\&quot;HELLO THERE\&quot;&quot;)" executed="True" result="Success" success="True" time="0.001" asserts="1" />
+                              <test-case name="NUnit.Framework.Constraints.StartsWithTest.ProvidesProperFailureMessage(&quot;I said hello&quot;,&quot;\&quot;I said hello\&quot;&quot;)" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                              <test-case name="NUnit.Framework.Constraints.StartsWithTest.ProvidesProperFailureMessage(&quot;say hello to fred&quot;,&quot;\&quot;say hello to fred\&quot;&quot;)" executed="True" result="Success" success="True" time="0.001" asserts="1" />
+                              <test-case name="NUnit.Framework.Constraints.StartsWithTest.ProvidesProperFailureMessage(&quot;&quot;,&quot;&lt;string.Empty&gt;&quot;)" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                              <test-case name="NUnit.Framework.Constraints.StartsWithTest.ProvidesProperFailureMessage(null,&quot;null&quot;)" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                            </results>
+                          </test-suite>
+                          <test-suite type="ParameterizedTest" name="SucceedsWithGoodValues" executed="True" result="Success" success="True" time="0.002" asserts="0">
+                            <results>
+                              <test-case name="NUnit.Framework.Constraints.StartsWithTest.SucceedsWithGoodValues(&quot;hello&quot;)" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                              <test-case name="NUnit.Framework.Constraints.StartsWithTest.SucceedsWithGoodValues(&quot;hello there&quot;)" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                            </results>
+                          </test-suite>
+                        </results>
+                      </test-suite>
+                      <test-suite type="TestFixture" name="StartsWithTestIgnoringCase" executed="True" result="Success" success="True" time="0.028" asserts="0">
+                        <results>
+                          <test-case name="NUnit.Framework.Constraints.StartsWithTestIgnoringCase.ConstraintTestBaseNoData.ProvidesProperDescription" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Framework.Constraints.StartsWithTestIgnoringCase.ConstraintTestBaseNoData.ProvidesProperStringRepresentation" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                          <test-suite type="ParameterizedTest" name="FailsWithBadValues" executed="True" result="Success" success="True" time="0.008" asserts="0">
+                            <results>
+                              <test-case name="NUnit.Framework.Constraints.StartsWithTestIgnoringCase.FailsWithBadValues(&quot;goodbye&quot;)" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                              <test-case name="NUnit.Framework.Constraints.StartsWithTestIgnoringCase.FailsWithBadValues(&quot;What the hell?&quot;)" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                              <test-case name="NUnit.Framework.Constraints.StartsWithTestIgnoringCase.FailsWithBadValues(&quot;I said hello&quot;)" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                              <test-case name="NUnit.Framework.Constraints.StartsWithTestIgnoringCase.FailsWithBadValues(&quot;say Hello to fred&quot;)" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                              <test-case name="NUnit.Framework.Constraints.StartsWithTestIgnoringCase.FailsWithBadValues(&quot;&quot;)" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                              <test-case name="NUnit.Framework.Constraints.StartsWithTestIgnoringCase.FailsWithBadValues(null)" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                            </results>
+                          </test-suite>
+                          <test-suite type="ParameterizedTest" name="ProvidesProperFailureMessage" executed="True" result="Success" success="True" time="0.007" asserts="0">
+                            <results>
+                              <test-case name="NUnit.Framework.Constraints.StartsWithTestIgnoringCase.ProvidesProperFailureMessage(&quot;goodbye&quot;,&quot;\&quot;goodbye\&quot;&quot;)" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                              <test-case name="NUnit.Framework.Constraints.StartsWithTestIgnoringCase.ProvidesProperFailureMessage(&quot;What the hell?&quot;,&quot;\&quot;What the hell?\&quot;&quot;)" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                              <test-case name="NUnit.Framework.Constraints.StartsWithTestIgnoringCase.ProvidesProperFailureMessage(&quot;I said hello&quot;,&quot;\&quot;I said hello\&quot;&quot;)" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                              <test-case name="NUnit.Framework.Constraints.StartsWithTestIgnoringCase.ProvidesProperFailureMessage(&quot;say Hello to fred&quot;,&quot;\&quot;say Hello to fred\&quot;&quot;)" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                              <test-case name="NUnit.Framework.Constraints.StartsWithTestIgnoringCase.ProvidesProperFailureMessage(&quot;&quot;,&quot;&lt;string.Empty&gt;&quot;)" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                              <test-case name="NUnit.Framework.Constraints.StartsWithTestIgnoringCase.ProvidesProperFailureMessage(null,&quot;null&quot;)" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                            </results>
+                          </test-suite>
+                          <test-suite type="ParameterizedTest" name="SucceedsWithGoodValues" executed="True" result="Success" success="True" time="0.002" asserts="0">
+                            <results>
+                              <test-case name="NUnit.Framework.Constraints.StartsWithTestIgnoringCase.SucceedsWithGoodValues(&quot;Hello&quot;)" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                              <test-case name="NUnit.Framework.Constraints.StartsWithTestIgnoringCase.SucceedsWithGoodValues(&quot;HELLO there&quot;)" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                            </results>
+                          </test-suite>
+                        </results>
+                      </test-suite>
+                      <test-suite type="TestFixture" name="SubPathTest_Linux" executed="True" result="Success" success="True" time="0.045" asserts="0">
+                        <results>
+                          <test-case name="NUnit.Framework.Constraints.SubPathTest_Linux.ConstraintTestBaseNoData.ProvidesProperDescription" executed="True" result="Success" success="True" time="0.001" asserts="1" />
+                          <test-case name="NUnit.Framework.Constraints.SubPathTest_Linux.ConstraintTestBaseNoData.ProvidesProperStringRepresentation" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                          <test-suite type="ParameterizedTest" name="FailsWithBadValues" executed="True" result="Success" success="True" time="0.016" asserts="0">
+                            <results>
+                              <test-case name="NUnit.Framework.Constraints.SubPathTest_Linux.FailsWithBadValues(123)" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                              <test-case name="NUnit.Framework.Constraints.SubPathTest_Linux.FailsWithBadValues(&quot;/Folder1/Folder2&quot;)" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                              <test-case name="NUnit.Framework.Constraints.SubPathTest_Linux.FailsWithBadValues(&quot;/FOLDER1/./junk/../Folder2&quot;)" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                              <test-case name="NUnit.Framework.Constraints.SubPathTest_Linux.FailsWithBadValues(&quot;/FOLDER1/./junk/../Folder2/temp/../Folder3&quot;)" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                              <test-case name="NUnit.Framework.Constraints.SubPathTest_Linux.FailsWithBadValues(&quot;/folder1/folder3&quot;)" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                              <test-case name="NUnit.Framework.Constraints.SubPathTest_Linux.FailsWithBadValues(&quot;/folder1/./folder2/../folder3&quot;)" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                              <test-case name="NUnit.Framework.Constraints.SubPathTest_Linux.FailsWithBadValues(&quot;/folder1&quot;)" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                              <test-case name="NUnit.Framework.Constraints.SubPathTest_Linux.FailsWithBadValues(&quot;/folder1/folder2&quot;)" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                              <test-case name="NUnit.Framework.Constraints.SubPathTest_Linux.FailsWithBadValues(&quot;/folder1/./folder2&quot;)" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                              <test-case name="NUnit.Framework.Constraints.SubPathTest_Linux.FailsWithBadValues(&quot;/folder1/junk/../folder2&quot;)" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                              <test-case name="NUnit.Framework.Constraints.SubPathTest_Linux.FailsWithBadValues(&quot;\\folder1\\folder2&quot;)" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                            </results>
+                          </test-suite>
+                          <test-suite type="ParameterizedTest" name="ProvidesProperFailureMessage" executed="True" result="Success" success="True" time="0.015" asserts="0">
+                            <results>
+                              <test-case name="NUnit.Framework.Constraints.SubPathTest_Linux.ProvidesProperFailureMessage(123,&quot;123&quot;)" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                              <test-case name="NUnit.Framework.Constraints.SubPathTest_Linux.ProvidesProperFailureMessage(&quot;/Folder1/Folder2&quot;,&quot;\&quot;/Folder1/Folder2\&quot;&quot;)" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                              <test-case name="NUnit.Framework.Constraints.SubPathTest_Linux.ProvidesProperFailureMessage(&quot;/FOLDER1/./junk/../Folder2&quot;,&quot;\&quot;/FOLDER1/./junk/../Folder2\&quot;&quot;)" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                              <test-case name="NUnit.Framework.Constraints.SubPathTest_Linux.ProvidesProperFailureMessage(&quot;/FOLDER1/./junk/../Folder2/temp/../Folder3&quot;,&quot;\&quot;/FOLDER1/./junk/../Folder2/temp/../Folder3\&quot;&quot;)" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                              <test-case name="NUnit.Framework.Constraints.SubPathTest_Linux.ProvidesProperFailureMessage(&quot;/folder1/folder3&quot;,&quot;\&quot;/folder1/folder3\&quot;&quot;)" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                              <test-case name="NUnit.Framework.Constraints.SubPathTest_Linux.ProvidesProperFailureMessage(&quot;/folder1/./folder2/../folder3&quot;,&quot;\&quot;/folder1/./folder2/../folder3\&quot;&quot;)" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                              <test-case name="NUnit.Framework.Constraints.SubPathTest_Linux.ProvidesProperFailureMessage(&quot;/folder1&quot;,&quot;\&quot;/folder1\&quot;&quot;)" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                              <test-case name="NUnit.Framework.Constraints.SubPathTest_Linux.ProvidesProperFailureMessage(&quot;/folder1/folder2&quot;,&quot;\&quot;/folder1/folder2\&quot;&quot;)" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                              <test-case name="NUnit.Framework.Constraints.SubPathTest_Linux.ProvidesProperFailureMessage(&quot;/folder1/./folder2&quot;,&quot;\&quot;/folder1/./folder2\&quot;&quot;)" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                              <test-case name="NUnit.Framework.Constraints.SubPathTest_Linux.ProvidesProperFailureMessage(&quot;/folder1/junk/../folder2&quot;,&quot;\&quot;/folder1/junk/../folder2\&quot;&quot;)" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                              <test-case name="NUnit.Framework.Constraints.SubPathTest_Linux.ProvidesProperFailureMessage(&quot;\\folder1\\folder2&quot;,&quot;\&quot;\\folder1\\folder2\&quot;&quot;)" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                            </results>
+                          </test-suite>
+                          <test-case name="NUnit.Framework.Constraints.SubPathTest_Linux.SubPathOfRoot" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                          <test-suite type="ParameterizedTest" name="SucceedsWithGoodValues" executed="True" result="Success" success="True" time="0.005" asserts="0">
+                            <results>
+                              <test-case name="NUnit.Framework.Constraints.SubPathTest_Linux.SucceedsWithGoodValues(&quot;/folder1/folder2/folder3&quot;)" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                              <test-case name="NUnit.Framework.Constraints.SubPathTest_Linux.SucceedsWithGoodValues(&quot;/folder1/./folder2/folder3&quot;)" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                              <test-case name="NUnit.Framework.Constraints.SubPathTest_Linux.SucceedsWithGoodValues(&quot;/folder1/junk/../folder2/folder3&quot;)" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                              <test-case name="NUnit.Framework.Constraints.SubPathTest_Linux.SucceedsWithGoodValues(&quot;\\folder1\\folder2\\folder3&quot;)" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                            </results>
+                          </test-suite>
+                        </results>
+                      </test-suite>
+                      <test-suite type="TestFixture" name="SubPathTest_Windows" executed="True" result="Success" success="True" time="0.041" asserts="0">
+                        <results>
+                          <test-case name="NUnit.Framework.Constraints.SubPathTest_Windows.ConstraintTestBaseNoData.ProvidesProperDescription" executed="True" result="Success" success="True" time="0.001" asserts="1" />
+                          <test-case name="NUnit.Framework.Constraints.SubPathTest_Windows.ConstraintTestBaseNoData.ProvidesProperStringRepresentation" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                          <test-suite type="ParameterizedTest" name="FailsWithBadValues" executed="True" result="Success" success="True" time="0.012" asserts="0">
+                            <results>
+                              <test-case name="NUnit.Framework.Constraints.SubPathTest_Windows.FailsWithBadValues(123)" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                              <test-case name="NUnit.Framework.Constraints.SubPathTest_Windows.FailsWithBadValues(&quot;C:\\folder1\\folder3&quot;)" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                              <test-case name="NUnit.Framework.Constraints.SubPathTest_Windows.FailsWithBadValues(&quot;C:\\folder1\\.\\folder2\\..\\file.temp&quot;)" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                              <test-case name="NUnit.Framework.Constraints.SubPathTest_Windows.FailsWithBadValues(&quot;C:\\folder1\\folder2&quot;)" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                              <test-case name="NUnit.Framework.Constraints.SubPathTest_Windows.FailsWithBadValues(&quot;C:\\Folder1\\Folder2&quot;)" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                              <test-case name="NUnit.Framework.Constraints.SubPathTest_Windows.FailsWithBadValues(&quot;C:\\folder1\\.\\folder2&quot;)" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                              <test-case name="NUnit.Framework.Constraints.SubPathTest_Windows.FailsWithBadValues(&quot;C:\\folder1\\junk\\..\\folder2&quot;)" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                              <test-case name="NUnit.Framework.Constraints.SubPathTest_Windows.FailsWithBadValues(&quot;C:\\FOLDER1\\.\\junk\\..\\Folder2&quot;)" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                              <test-case name="NUnit.Framework.Constraints.SubPathTest_Windows.FailsWithBadValues(&quot;C:/folder1/folder2&quot;)" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                            </results>
+                          </test-suite>
+                          <test-suite type="ParameterizedTest" name="ProvidesProperFailureMessage" executed="True" result="Success" success="True" time="0.012" asserts="0">
+                            <results>
+                              <test-case name="NUnit.Framework.Constraints.SubPathTest_Windows.ProvidesProperFailureMessage(123,&quot;123&quot;)" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                              <test-case name="NUnit.Framework.Constraints.SubPathTest_Windows.ProvidesProperFailureMessage(&quot;C:\\folder1\\folder3&quot;,&quot;\&quot;C:\\folder1\\folder3\&quot;&quot;)" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                              <test-case name="NUnit.Framework.Constraints.SubPathTest_Windows.ProvidesProperFailureMessage(&quot;C:\\folder1\\.\\folder2\\..\\file.temp&quot;,&quot;\&quot;C:\\folder1\\.\\folder2\\..\\file.temp\&quot;&quot;)" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                              <test-case name="NUnit.Framework.Constraints.SubPathTest_Windows.ProvidesProperFailureMessage(&quot;C:\\folder1\\folder2&quot;,&quot;\&quot;C:\\folder1\\folder2\&quot;&quot;)" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                              <test-case name="NUnit.Framework.Constraints.SubPathTest_Windows.ProvidesProperFailureMessage(&quot;C:\\Folder1\\Folder2&quot;,&quot;\&quot;C:\\Folder1\\Folder2\&quot;&quot;)" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                              <test-case name="NUnit.Framework.Constraints.SubPathTest_Windows.ProvidesProperFailureMessage(&quot;C:\\folder1\\.\\folder2&quot;,&quot;\&quot;C:\\folder1\\.\\folder2\&quot;&quot;)" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                              <test-case name="NUnit.Framework.Constraints.SubPathTest_Windows.ProvidesProperFailureMessage(&quot;C:\\folder1\\junk\\..\\folder2&quot;,&quot;\&quot;C:\\folder1\\junk\\..\\folder2\&quot;&quot;)" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                              <test-case name="NUnit.Framework.Constraints.SubPathTest_Windows.ProvidesProperFailureMessage(&quot;C:\\FOLDER1\\.\\junk\\..\\Folder2&quot;,&quot;\&quot;C:\\FOLDER1\\.\\junk\\..\\Folder2\&quot;&quot;)" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                              <test-case name="NUnit.Framework.Constraints.SubPathTest_Windows.ProvidesProperFailureMessage(&quot;C:/folder1/folder2&quot;,&quot;\&quot;C:/folder1/folder2\&quot;&quot;)" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                            </results>
+                          </test-suite>
+                          <test-case name="NUnit.Framework.Constraints.SubPathTest_Windows.SubPathOfRoot" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                          <test-suite type="ParameterizedTest" name="SucceedsWithGoodValues" executed="True" result="Success" success="True" time="0.007" asserts="0">
+                            <results>
+                              <test-case name="NUnit.Framework.Constraints.SubPathTest_Windows.SucceedsWithGoodValues(&quot;C:\\folder1\\folder2\\folder3&quot;)" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                              <test-case name="NUnit.Framework.Constraints.SubPathTest_Windows.SucceedsWithGoodValues(&quot;C:\\folder1\\.\\folder2\\folder3&quot;)" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                              <test-case name="NUnit.Framework.Constraints.SubPathTest_Windows.SucceedsWithGoodValues(&quot;C:\\folder1\\junk\\..\\folder2\\folder3&quot;)" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                              <test-case name="NUnit.Framework.Constraints.SubPathTest_Windows.SucceedsWithGoodValues(&quot;C:\\FOLDER1\\.\\junk\\..\\Folder2\\temp\\..\\Folder3&quot;)" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                              <test-case name="NUnit.Framework.Constraints.SubPathTest_Windows.SucceedsWithGoodValues(&quot;C:/folder1/folder2/folder3&quot;)" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                            </results>
+                          </test-suite>
+                        </results>
+                      </test-suite>
+                      <test-suite type="TestFixture" name="SubstringTest" executed="True" result="Success" success="True" time="0.026" asserts="0">
+                        <results>
+                          <test-case name="NUnit.Framework.Constraints.SubstringTest.ConstraintTestBaseNoData.ProvidesProperDescription" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Framework.Constraints.SubstringTest.ConstraintTestBaseNoData.ProvidesProperStringRepresentation" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                          <test-suite type="ParameterizedTest" name="FailsWithBadValues" executed="True" result="Success" success="True" time="0.007" asserts="0">
+                            <results>
+                              <test-case name="NUnit.Framework.Constraints.SubstringTest.FailsWithBadValues(&quot;goodbye&quot;)" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                              <test-case name="NUnit.Framework.Constraints.SubstringTest.FailsWithBadValues(&quot;HELLO&quot;)" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                              <test-case name="NUnit.Framework.Constraints.SubstringTest.FailsWithBadValues(&quot;What the hell?&quot;)" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                              <test-case name="NUnit.Framework.Constraints.SubstringTest.FailsWithBadValues(&quot;&quot;)" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                              <test-case name="NUnit.Framework.Constraints.SubstringTest.FailsWithBadValues(null)" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                            </results>
+                          </test-suite>
+                          <test-suite type="ParameterizedTest" name="ProvidesProperFailureMessage" executed="True" result="Success" success="True" time="0.006" asserts="0">
+                            <results>
+                              <test-case name="NUnit.Framework.Constraints.SubstringTest.ProvidesProperFailureMessage(&quot;goodbye&quot;,&quot;\&quot;goodbye\&quot;&quot;)" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                              <test-case name="NUnit.Framework.Constraints.SubstringTest.ProvidesProperFailureMessage(&quot;HELLO&quot;,&quot;\&quot;HELLO\&quot;&quot;)" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                              <test-case name="NUnit.Framework.Constraints.SubstringTest.ProvidesProperFailureMessage(&quot;What the hell?&quot;,&quot;\&quot;What the hell?\&quot;&quot;)" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                              <test-case name="NUnit.Framework.Constraints.SubstringTest.ProvidesProperFailureMessage(&quot;&quot;,&quot;&lt;string.Empty&gt;&quot;)" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                              <test-case name="NUnit.Framework.Constraints.SubstringTest.ProvidesProperFailureMessage(null,&quot;null&quot;)" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                            </results>
+                          </test-suite>
+                          <test-suite type="ParameterizedTest" name="SucceedsWithGoodValues" executed="True" result="Success" success="True" time="0.006" asserts="0">
+                            <results>
+                              <test-case name="NUnit.Framework.Constraints.SubstringTest.SucceedsWithGoodValues(&quot;hello&quot;)" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                              <test-case name="NUnit.Framework.Constraints.SubstringTest.SucceedsWithGoodValues(&quot;hello there&quot;)" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                              <test-case name="NUnit.Framework.Constraints.SubstringTest.SucceedsWithGoodValues(&quot;I said hello&quot;)" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                              <test-case name="NUnit.Framework.Constraints.SubstringTest.SucceedsWithGoodValues(&quot;say hello to fred&quot;)" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                            </results>
+                          </test-suite>
+                        </results>
+                      </test-suite>
+                      <test-suite type="TestFixture" name="SubstringTestIgnoringCase" executed="True" result="Success" success="True" time="0.021" asserts="0">
+                        <results>
+                          <test-case name="NUnit.Framework.Constraints.SubstringTestIgnoringCase.ConstraintTestBaseNoData.ProvidesProperDescription" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Framework.Constraints.SubstringTestIgnoringCase.ConstraintTestBaseNoData.ProvidesProperStringRepresentation" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                          <test-suite type="ParameterizedTest" name="FailsWithBadValues" executed="True" result="Success" success="True" time="0.004" asserts="0">
+                            <results>
+                              <test-case name="NUnit.Framework.Constraints.SubstringTestIgnoringCase.FailsWithBadValues(&quot;goodbye&quot;)" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                              <test-case name="NUnit.Framework.Constraints.SubstringTestIgnoringCase.FailsWithBadValues(&quot;What the hell?&quot;)" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                              <test-case name="NUnit.Framework.Constraints.SubstringTestIgnoringCase.FailsWithBadValues(&quot;&quot;)" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                              <test-case name="NUnit.Framework.Constraints.SubstringTestIgnoringCase.FailsWithBadValues(null)" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                            </results>
+                          </test-suite>
+                          <test-suite type="ParameterizedTest" name="ProvidesProperFailureMessage" executed="True" result="Success" success="True" time="0.005" asserts="0">
+                            <results>
+                              <test-case name="NUnit.Framework.Constraints.SubstringTestIgnoringCase.ProvidesProperFailureMessage(&quot;goodbye&quot;,&quot;\&quot;goodbye\&quot;&quot;)" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                              <test-case name="NUnit.Framework.Constraints.SubstringTestIgnoringCase.ProvidesProperFailureMessage(&quot;What the hell?&quot;,&quot;\&quot;What the hell?\&quot;&quot;)" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                              <test-case name="NUnit.Framework.Constraints.SubstringTestIgnoringCase.ProvidesProperFailureMessage(&quot;&quot;,&quot;&lt;string.Empty&gt;&quot;)" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                              <test-case name="NUnit.Framework.Constraints.SubstringTestIgnoringCase.ProvidesProperFailureMessage(null,&quot;null&quot;)" executed="True" result="Success" success="True" time="0.001" asserts="1" />
+                            </results>
+                          </test-suite>
+                          <test-suite type="ParameterizedTest" name="SucceedsWithGoodValues" executed="True" result="Success" success="True" time="0.004" asserts="0">
+                            <results>
+                              <test-case name="NUnit.Framework.Constraints.SubstringTestIgnoringCase.SucceedsWithGoodValues(&quot;Hello&quot;)" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                              <test-case name="NUnit.Framework.Constraints.SubstringTestIgnoringCase.SucceedsWithGoodValues(&quot;HellO there&quot;)" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                              <test-case name="NUnit.Framework.Constraints.SubstringTestIgnoringCase.SucceedsWithGoodValues(&quot;I said HELLO&quot;)" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                              <test-case name="NUnit.Framework.Constraints.SubstringTestIgnoringCase.SucceedsWithGoodValues(&quot;say hello to fred&quot;)" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                            </results>
+                          </test-suite>
+                        </results>
+                      </test-suite>
+                      <test-suite type="TestFixture" name="ThrowsConstraintTest_ExactType" executed="True" result="Success" success="True" time="0.017" asserts="0">
+                        <results>
+                          <test-case name="NUnit.Framework.Constraints.ThrowsConstraintTest_ExactType.ConstraintTestBaseNoData.ProvidesProperDescription" executed="True" result="Success" success="True" time="0.001" asserts="1" />
+                          <test-case name="NUnit.Framework.Constraints.ThrowsConstraintTest_ExactType.ConstraintTestBaseNoData.ProvidesProperStringRepresentation" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                          <test-suite type="ParameterizedTest" name="FailsWithBadValues" executed="True" result="Success" success="True" time="0.005" asserts="0">
+                            <results>
+                              <test-case name="NUnit.Framework.Constraints.ThrowsConstraintTest_ExactType.FailsWithBadValues(NUnit.Framework.TestDelegate)" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                              <test-case name="NUnit.Framework.Constraints.ThrowsConstraintTest_ExactType.FailsWithBadValues(NUnit.Framework.TestDelegate)" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                              <test-case name="NUnit.Framework.Constraints.ThrowsConstraintTest_ExactType.FailsWithBadValues(NUnit.Framework.TestDelegate)" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                            </results>
+                          </test-suite>
+                          <test-suite type="ParameterizedTest" name="ProvidesProperFailureMessage" executed="True" result="Success" success="True" time="0.004" asserts="0">
+                            <results>
+                              <test-case name="NUnit.Framework.Constraints.ThrowsConstraintTest_ExactType.ProvidesProperFailureMessage(NUnit.Framework.TestDelegate,&quot;&lt;System.ApplicationException&gt;&quot;)" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                              <test-case name="NUnit.Framework.Constraints.ThrowsConstraintTest_ExactType.ProvidesProperFailureMessage(NUnit.Framework.TestDelegate,&quot;no exception thrown&quot;)" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                              <test-case name="NUnit.Framework.Constraints.ThrowsConstraintTest_ExactType.ProvidesProperFailureMessage(NUnit.Framework.TestDelegate,&quot;&lt;System.Exception&gt;&quot;)" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                            </results>
+                          </test-suite>
+                          <test-suite type="ParameterizedTest" name="SucceedsWithGoodValues" executed="True" result="Success" success="True" time="0.001" asserts="0">
+                            <results>
+                              <test-case name="NUnit.Framework.Constraints.ThrowsConstraintTest_ExactType.SucceedsWithGoodValues(NUnit.Framework.TestDelegate)" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                            </results>
+                          </test-suite>
+                        </results>
+                      </test-suite>
+                      <test-suite type="TestFixture" name="ThrowsConstraintTest_InstanceOfType" executed="True" result="Success" success="True" time="0.015" asserts="0">
+                        <results>
+                          <test-case name="NUnit.Framework.Constraints.ThrowsConstraintTest_InstanceOfType.ConstraintTestBaseNoData.ProvidesProperDescription" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Framework.Constraints.ThrowsConstraintTest_InstanceOfType.ConstraintTestBaseNoData.ProvidesProperStringRepresentation" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                          <test-suite type="ParameterizedTest" name="FailsWithBadValues" executed="True" result="Success" success="True" time="0.003" asserts="0">
+                            <results>
+                              <test-case name="NUnit.Framework.Constraints.ThrowsConstraintTest_InstanceOfType.FailsWithBadValues(NUnit.Framework.TestDelegate)" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                              <test-case name="NUnit.Framework.Constraints.ThrowsConstraintTest_InstanceOfType.FailsWithBadValues(NUnit.Framework.TestDelegate)" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                              <test-case name="NUnit.Framework.Constraints.ThrowsConstraintTest_InstanceOfType.FailsWithBadValues(NUnit.Framework.TestDelegate)" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                            </results>
+                          </test-suite>
+                          <test-suite type="ParameterizedTest" name="ProvidesProperFailureMessage" executed="True" result="Success" success="True" time="0.003" asserts="0">
+                            <results>
+                              <test-case name="NUnit.Framework.Constraints.ThrowsConstraintTest_InstanceOfType.ProvidesProperFailureMessage(NUnit.Framework.TestDelegate,&quot;&lt;System.ArgumentException&gt;&quot;)" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                              <test-case name="NUnit.Framework.Constraints.ThrowsConstraintTest_InstanceOfType.ProvidesProperFailureMessage(NUnit.Framework.TestDelegate,&quot;no exception thrown&quot;)" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                              <test-case name="NUnit.Framework.Constraints.ThrowsConstraintTest_InstanceOfType.ProvidesProperFailureMessage(NUnit.Framework.TestDelegate,&quot;&lt;System.Exception&gt;&quot;)" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                            </results>
+                          </test-suite>
+                          <test-suite type="ParameterizedTest" name="SucceedsWithGoodValues" executed="True" result="Success" success="True" time="0.002" asserts="0">
+                            <results>
+                              <test-case name="NUnit.Framework.Constraints.ThrowsConstraintTest_InstanceOfType.SucceedsWithGoodValues(NUnit.Framework.TestDelegate)" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                              <test-case name="NUnit.Framework.Constraints.ThrowsConstraintTest_InstanceOfType.SucceedsWithGoodValues(NUnit.Framework.TestDelegate)" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                            </results>
+                          </test-suite>
+                        </results>
+                      </test-suite>
+                      <test-suite type="TestFixture" name="ThrowsConstraintTest_WithConstraint" executed="True" result="Success" success="True" time="0.014" asserts="0">
+                        <results>
+                          <test-case name="NUnit.Framework.Constraints.ThrowsConstraintTest_WithConstraint.ConstraintTestBaseNoData.ProvidesProperDescription" executed="True" result="Success" success="True" time="0.001" asserts="1" />
+                          <test-case name="NUnit.Framework.Constraints.ThrowsConstraintTest_WithConstraint.ConstraintTestBaseNoData.ProvidesProperStringRepresentation" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                          <test-suite type="ParameterizedTest" name="FailsWithBadValues" executed="True" result="Success" success="True" time="0.003" asserts="0">
+                            <results>
+                              <test-case name="NUnit.Framework.Constraints.ThrowsConstraintTest_WithConstraint.FailsWithBadValues(NUnit.Framework.TestDelegate)" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                              <test-case name="NUnit.Framework.Constraints.ThrowsConstraintTest_WithConstraint.FailsWithBadValues(NUnit.Framework.TestDelegate)" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                              <test-case name="NUnit.Framework.Constraints.ThrowsConstraintTest_WithConstraint.FailsWithBadValues(NUnit.Framework.TestDelegate)" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                            </results>
+                          </test-suite>
+                          <test-suite type="ParameterizedTest" name="ProvidesProperFailureMessage" executed="True" result="Success" success="True" time="0.003" asserts="0">
+                            <results>
+                              <test-case name="NUnit.Framework.Constraints.ThrowsConstraintTest_WithConstraint.ProvidesProperFailureMessage(NUnit.Framework.TestDelegate,&quot;&lt;System.ApplicationException&gt;&quot;)" executed="True" result="Success" success="True" time="0.001" asserts="1" />
+                              <test-case name="NUnit.Framework.Constraints.ThrowsConstraintTest_WithConstraint.ProvidesProperFailureMessage(NUnit.Framework.TestDelegate,&quot;no exception thrown&quot;)" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                              <test-case name="NUnit.Framework.Constraints.ThrowsConstraintTest_WithConstraint.ProvidesProperFailureMessage(NUnit.Framework.TestDelegate,&quot;&lt;System.Exception&gt;&quot;)" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                            </results>
+                          </test-suite>
+                          <test-suite type="ParameterizedTest" name="SucceedsWithGoodValues" executed="True" result="Success" success="True" time="0.001" asserts="0">
+                            <results>
+                              <test-case name="NUnit.Framework.Constraints.ThrowsConstraintTest_WithConstraint.SucceedsWithGoodValues(NUnit.Framework.TestDelegate)" executed="True" result="Success" success="True" time="0.001" asserts="1" />
+                            </results>
+                          </test-suite>
+                        </results>
+                      </test-suite>
+                      <test-suite type="TestFixture" name="ToStringTests" executed="True" result="Success" success="True" time="0.011" asserts="0">
+                        <results>
+                          <test-case name="NUnit.Framework.Constraints.ToStringTests.CanDisplayPrefixConstraints_Resolved" executed="True" result="Success" success="True" time="0.001" asserts="3" />
+                          <test-case name="NUnit.Framework.Constraints.ToStringTests.CanDisplaySimpleConstraints_Resolved" executed="True" result="Success" success="True" time="0.000" asserts="3" />
+                          <test-case name="NUnit.Framework.Constraints.ToStringTests.CanDisplaySimpleConstraints_Unresolved" executed="True" result="Success" success="True" time="0.000" asserts="3" />
+                          <test-case name="NUnit.Framework.Constraints.ToStringTests.DisplayBinaryConstraints_Resolved" executed="True" result="Success" success="True" time="0.001" asserts="1" />
+                          <test-case name="NUnit.Framework.Constraints.ToStringTests.DisplayBinaryConstraints_UnResolved" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Framework.Constraints.ToStringTests.DisplayPrefixConstraints_Unresolved" executed="True" result="Success" success="True" time="0.000" asserts="4" />
+                        </results>
+                      </test-suite>
+                      <test-suite type="TestFixture" name="TrueConstraintTest" executed="True" result="Success" success="True" time="0.019" asserts="0">
+                        <results>
+                          <test-case name="NUnit.Framework.Constraints.TrueConstraintTest.ConstraintTestBaseNoData.ProvidesProperDescription" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Framework.Constraints.TrueConstraintTest.ConstraintTestBaseNoData.ProvidesProperStringRepresentation" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                          <test-suite type="ParameterizedTest" name="FailsWithBadValues" executed="True" result="Success" success="True" time="0.006" asserts="0">
+                            <results>
+                              <test-case name="NUnit.Framework.Constraints.TrueConstraintTest.FailsWithBadValues(null)" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                              <test-case name="NUnit.Framework.Constraints.TrueConstraintTest.FailsWithBadValues(&quot;hello&quot;)" executed="True" result="Success" success="True" time="0.002" asserts="1" />
+                              <test-case name="NUnit.Framework.Constraints.TrueConstraintTest.FailsWithBadValues(False)" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                              <test-case name="NUnit.Framework.Constraints.TrueConstraintTest.FailsWithBadValues(False)" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                            </results>
+                          </test-suite>
+                          <test-suite type="ParameterizedTest" name="ProvidesProperFailureMessage" executed="True" result="Success" success="True" time="0.004" asserts="0">
+                            <results>
+                              <test-case name="NUnit.Framework.Constraints.TrueConstraintTest.ProvidesProperFailureMessage(null,&quot;null&quot;)" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                              <test-case name="NUnit.Framework.Constraints.TrueConstraintTest.ProvidesProperFailureMessage(&quot;hello&quot;,&quot;\&quot;hello\&quot;&quot;)" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                              <test-case name="NUnit.Framework.Constraints.TrueConstraintTest.ProvidesProperFailureMessage(False,&quot;False&quot;)" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                              <test-case name="NUnit.Framework.Constraints.TrueConstraintTest.ProvidesProperFailureMessage(False,&quot;False&quot;)" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                            </results>
+                          </test-suite>
+                          <test-suite type="ParameterizedTest" name="SucceedsWithGoodValues" executed="True" result="Success" success="True" time="0.002" asserts="0">
+                            <results>
+                              <test-case name="NUnit.Framework.Constraints.TrueConstraintTest.SucceedsWithGoodValues(True)" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                              <test-case name="NUnit.Framework.Constraints.TrueConstraintTest.SucceedsWithGoodValues(True)" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                            </results>
+                          </test-suite>
+                        </results>
+                      </test-suite>
+                      <test-suite type="TestFixture" name="XmlSerializableTest" executed="True" result="Success" success="True" time="1.333" asserts="0">
+                        <results>
+                          <test-case name="NUnit.Framework.Constraints.XmlSerializableTest.ConstraintTestBaseNoData.ProvidesProperDescription" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Framework.Constraints.XmlSerializableTest.ConstraintTestBaseNoData.ProvidesProperStringRepresentation" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                          <test-suite type="ParameterizedTest" name="FailsWithBadValues" executed="True" result="Success" success="True" time="0.574" asserts="0">
+                            <results>
+                              <test-case name="NUnit.Framework.Constraints.XmlSerializableTest.FailsWithBadValues(System.Collections.Generic.Dictionary`2[System.String,System.String])" executed="True" result="Success" success="True" time="0.291" asserts="1" />
+                              <test-case name="NUnit.Framework.Constraints.XmlSerializableTest.FailsWithBadValues(NUnit.Framework.Constraints.InternalClass)" executed="True" result="Success" success="True" time="0.158" asserts="1" />
+                              <test-case name="NUnit.Framework.Constraints.XmlSerializableTest.FailsWithBadValues(NUnit.Framework.Constraints.InternalWithSerializableAttributeClass)" executed="True" result="Success" success="True" time="0.121" asserts="1" />
+                            </results>
+                          </test-suite>
+                          <test-suite type="ParameterizedTest" name="InvalidDataThrowsArgumentException" executed="True" result="Success" success="True" time="0.003" asserts="0">
+                            <results>
+                              <test-case name="NUnit.Framework.Constraints.XmlSerializableTest.InvalidDataThrowsArgumentException(null)" executed="True" result="Success" success="True" time="0.002" asserts="0" />
+                            </results>
+                          </test-suite>
+                          <test-suite type="ParameterizedTest" name="ProvidesProperFailureMessage" executed="True" result="Success" success="True" time="0.335" asserts="0">
+                            <results>
+                              <test-case name="NUnit.Framework.Constraints.XmlSerializableTest.ProvidesProperFailureMessage(System.Collections.Generic.Dictionary`2[System.String,System.String],&quot;&lt;Dictionary`2&gt;&quot;)" executed="True" result="Success" success="True" time="0.110" asserts="1" />
+                              <test-case name="NUnit.Framework.Constraints.XmlSerializableTest.ProvidesProperFailureMessage(NUnit.Framework.Constraints.InternalClass,&quot;&lt;InternalClass&gt;&quot;)" executed="True" result="Success" success="True" time="0.110" asserts="1" />
+                              <test-case name="NUnit.Framework.Constraints.XmlSerializableTest.ProvidesProperFailureMessage(NUnit.Framework.Constraints.InternalWithSerializableAttributeClass,&quot;&lt;InternalWithSerializableAttributeClass&gt;&quot;)" executed="True" result="Success" success="True" time="0.111" asserts="1" />
+                            </results>
+                          </test-suite>
+                          <test-suite type="ParameterizedTest" name="SucceedsWithGoodValues" executed="True" result="Success" success="True" time="0.408" asserts="0">
+                            <results>
+                              <test-case name="NUnit.Framework.Constraints.XmlSerializableTest.SucceedsWithGoodValues(1)" executed="True" result="Success" success="True" time="0.019" asserts="1" />
+                              <test-case name="NUnit.Framework.Constraints.XmlSerializableTest.SucceedsWithGoodValues(&quot;a&quot;)" executed="True" result="Success" success="True" time="0.003" asserts="1" />
+                              <test-case name="NUnit.Framework.Constraints.XmlSerializableTest.SucceedsWithGoodValues(System.Collections.ArrayList)" executed="True" result="Success" success="True" time="0.382" asserts="1" />
+                            </results>
+                          </test-suite>
+                        </results>
+                      </test-suite>
+                    </results>
+                  </test-suite>
+                  <test-suite type="Namespace" name="Syntax" executed="True" result="Success" success="True" time="4.224" asserts="0">
+                    <results>
+                      <test-suite type="TestFixture" name="AfterSyntaxUsingActualPassedByRef" executed="True" result="Success" success="True" time="1.435" asserts="0">
+                        <results>
+                          <test-case name="NUnit.Framework.Syntax.AfterSyntaxUsingActualPassedByRef.EqualToTest" executed="True" result="Success" success="True" time="0.202" asserts="1" />
+                          <test-case name="NUnit.Framework.Syntax.AfterSyntaxUsingActualPassedByRef.GreaterTest" executed="True" result="Success" success="True" time="0.201" asserts="1" />
+                          <test-case name="NUnit.Framework.Syntax.AfterSyntaxUsingActualPassedByRef.HasMemberTest" executed="True" result="Success" success="True" time="0.203" asserts="1" />
+                          <test-case name="NUnit.Framework.Syntax.AfterSyntaxUsingActualPassedByRef.NullTest" executed="True" result="Success" success="True" time="0.201" asserts="1" />
+                          <test-case name="NUnit.Framework.Syntax.AfterSyntaxUsingActualPassedByRef.SameAsTest" executed="True" result="Success" success="True" time="0.201" asserts="1" />
+                          <test-case name="NUnit.Framework.Syntax.AfterSyntaxUsingActualPassedByRef.TextTest" executed="True" result="Success" success="True" time="0.201" asserts="1" />
+                          <test-case name="NUnit.Framework.Syntax.AfterSyntaxUsingActualPassedByRef.TrueTest" executed="True" result="Success" success="True" time="0.201" asserts="1" />
+                        </results>
+                      </test-suite>
+                      <test-suite type="TestFixture" name="AfterSyntaxUsingAnonymousDelegates" executed="True" result="Success" success="True" time="1.432" asserts="0">
+                        <results>
+                          <test-case name="NUnit.Framework.Syntax.AfterSyntaxUsingAnonymousDelegates.EqualToTest" executed="True" result="Success" success="True" time="0.201" asserts="1" />
+                          <test-case name="NUnit.Framework.Syntax.AfterSyntaxUsingAnonymousDelegates.GreaterTest" executed="True" result="Success" success="True" time="0.201" asserts="1" />
+                          <test-case name="NUnit.Framework.Syntax.AfterSyntaxUsingAnonymousDelegates.HasMemberTest" executed="True" result="Success" success="True" time="0.201" asserts="1" />
+                          <test-case name="NUnit.Framework.Syntax.AfterSyntaxUsingAnonymousDelegates.NullTest" executed="True" result="Success" success="True" time="0.201" asserts="1" />
+                          <test-case name="NUnit.Framework.Syntax.AfterSyntaxUsingAnonymousDelegates.SameAsTest" executed="True" result="Success" success="True" time="0.201" asserts="1" />
+                          <test-case name="NUnit.Framework.Syntax.AfterSyntaxUsingAnonymousDelegates.TextTest" executed="True" result="Success" success="True" time="0.201" asserts="1" />
+                          <test-case name="NUnit.Framework.Syntax.AfterSyntaxUsingAnonymousDelegates.TrueTest" executed="True" result="Success" success="True" time="0.201" asserts="1" />
+                        </results>
+                      </test-suite>
+                      <test-suite type="TestFixture" name="AfterTest_AndOperator" executed="True" result="Success" success="True" time="0.013" asserts="0">
+                        <results>
+                          <test-case name="NUnit.Framework.Syntax.AfterTest_AndOperator.SyntaxTest.SupportedByConstraintBuilder" executed="True" result="Success" success="True" time="0.002" asserts="1" />
+                          <test-case name="NUnit.Framework.Syntax.AfterTest_AndOperator.SyntaxTest.SupportedByInheritedSyntax" executed="True" result="Success" success="True" time="0.001" asserts="1" />
+                          <test-case name="NUnit.Framework.Syntax.AfterTest_AndOperator.SyntaxTest.SupportedByStaticSyntax" executed="True" result="Success" success="True" time="0.001" asserts="1" />
+                        </results>
+                      </test-suite>
+                      <test-suite type="TestFixture" name="AfterTest_ProperyTest" executed="True" result="Success" success="True" time="0.009" asserts="0">
+                        <results>
+                          <test-case name="NUnit.Framework.Syntax.AfterTest_ProperyTest.SyntaxTest.SupportedByConstraintBuilder" executed="True" result="Success" success="True" time="0.001" asserts="1" />
+                          <test-case name="NUnit.Framework.Syntax.AfterTest_ProperyTest.SyntaxTest.SupportedByInheritedSyntax" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Framework.Syntax.AfterTest_ProperyTest.SyntaxTest.SupportedByStaticSyntax" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                        </results>
+                      </test-suite>
+                      <test-suite type="TestFixture" name="AfterTest_SimpleConstraint" executed="True" result="Success" success="True" time="0.009" asserts="0">
+                        <results>
+                          <test-case name="NUnit.Framework.Syntax.AfterTest_SimpleConstraint.SyntaxTest.SupportedByConstraintBuilder" executed="True" result="Success" success="True" time="0.001" asserts="1" />
+                          <test-case name="NUnit.Framework.Syntax.AfterTest_SimpleConstraint.SyntaxTest.SupportedByInheritedSyntax" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Framework.Syntax.AfterTest_SimpleConstraint.SyntaxTest.SupportedByStaticSyntax" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                        </results>
+                      </test-suite>
+                      <test-suite type="TestFixture" name="AllTest" executed="True" result="Success" success="True" time="0.008" asserts="0">
+                        <results>
+                          <test-case name="NUnit.Framework.Syntax.AllTest.SyntaxTest.SupportedByConstraintBuilder" executed="True" result="Success" success="True" time="0.001" asserts="1" />
+                          <test-case name="NUnit.Framework.Syntax.AllTest.SyntaxTest.SupportedByInheritedSyntax" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Framework.Syntax.AllTest.SyntaxTest.SupportedByStaticSyntax" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                        </results>
+                      </test-suite>
+                      <test-suite type="TestFixture" name="AndIsEvaluatedBeforeFollowingOr" executed="True" result="Success" success="True" time="0.008" asserts="0">
+                        <results>
+                          <test-case name="NUnit.Framework.Syntax.AndIsEvaluatedBeforeFollowingOr.SyntaxTest.SupportedByConstraintBuilder" executed="True" result="Success" success="True" time="0.001" asserts="1" />
+                          <test-case name="NUnit.Framework.Syntax.AndIsEvaluatedBeforeFollowingOr.SyntaxTest.SupportedByInheritedSyntax" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Framework.Syntax.AndIsEvaluatedBeforeFollowingOr.SyntaxTest.SupportedByStaticSyntax" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                        </results>
+                      </test-suite>
+                      <test-suite type="TestFixture" name="AndIsEvaluatedBeforePrecedingOr" executed="True" result="Success" success="True" time="0.007" asserts="0">
+                        <results>
+                          <test-case name="NUnit.Framework.Syntax.AndIsEvaluatedBeforePrecedingOr.SyntaxTest.SupportedByConstraintBuilder" executed="True" result="Success" success="True" time="0.001" asserts="1" />
+                          <test-case name="NUnit.Framework.Syntax.AndIsEvaluatedBeforePrecedingOr.SyntaxTest.SupportedByInheritedSyntax" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Framework.Syntax.AndIsEvaluatedBeforePrecedingOr.SyntaxTest.SupportedByStaticSyntax" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                        </results>
+                      </test-suite>
+                      <test-suite type="TestFixture" name="AndOperatorOverride" executed="True" result="Success" success="True" time="0.007" asserts="0">
+                        <results>
+                          <test-case name="NUnit.Framework.Syntax.AndOperatorOverride.SyntaxTest.SupportedByConstraintBuilder" executed="True" result="Success" success="True" time="0.001" asserts="1" />
+                          <test-case name="NUnit.Framework.Syntax.AndOperatorOverride.SyntaxTest.SupportedByInheritedSyntax" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Framework.Syntax.AndOperatorOverride.SyntaxTest.SupportedByStaticSyntax" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                        </results>
+                      </test-suite>
+                      <test-suite type="TestFixture" name="AndTest" executed="True" result="Success" success="True" time="0.007" asserts="0">
+                        <results>
+                          <test-case name="NUnit.Framework.Syntax.AndTest.SyntaxTest.SupportedByConstraintBuilder" executed="True" result="Success" success="True" time="0.001" asserts="1" />
+                          <test-case name="NUnit.Framework.Syntax.AndTest.SyntaxTest.SupportedByInheritedSyntax" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Framework.Syntax.AndTest.SyntaxTest.SupportedByStaticSyntax" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                        </results>
+                      </test-suite>
+                      <test-suite type="TestFixture" name="AndTest_ThreeAndsWithNot" executed="True" result="Success" success="True" time="0.009" asserts="0">
+                        <results>
+                          <test-case name="NUnit.Framework.Syntax.AndTest_ThreeAndsWithNot.SyntaxTest.SupportedByConstraintBuilder" executed="True" result="Success" success="True" time="0.001" asserts="1" />
+                          <test-case name="NUnit.Framework.Syntax.AndTest_ThreeAndsWithNot.SyntaxTest.SupportedByInheritedSyntax" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Framework.Syntax.AndTest_ThreeAndsWithNot.SyntaxTest.SupportedByStaticSyntax" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                        </results>
+                      </test-suite>
+                      <test-suite type="TestFixture" name="ArbitraryConstraintMatching" executed="True" result="Success" success="True" time="0.012" asserts="0">
+                        <results>
+                          <test-case name="NUnit.Framework.Syntax.ArbitraryConstraintMatching.CanMatchCustomConstraint" executed="True" result="Success" success="True" time="0.001" asserts="1" />
+                          <test-case name="NUnit.Framework.Syntax.ArbitraryConstraintMatching.CanMatchCustomConstraintAfterPrefix" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Framework.Syntax.ArbitraryConstraintMatching.CanMatchCustomConstraintsUnderAndOperator" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Framework.Syntax.ArbitraryConstraintMatching.CanMatchPredicate" executed="True" result="Success" success="True" time="0.002" asserts="2" />
+                        </results>
+                      </test-suite>
+                      <test-suite type="TestFixture" name="AssignableFromTest" executed="True" result="Success" success="True" time="0.007" asserts="0">
+                        <results>
+                          <test-case name="NUnit.Framework.Syntax.AssignableFromTest.SyntaxTest.SupportedByConstraintBuilder" executed="True" result="Success" success="True" time="0.001" asserts="1" />
+                          <test-case name="NUnit.Framework.Syntax.AssignableFromTest.SyntaxTest.SupportedByInheritedSyntax" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Framework.Syntax.AssignableFromTest.SyntaxTest.SupportedByStaticSyntax" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                        </results>
+                      </test-suite>
+                      <test-suite type="TestFixture" name="AssignableFromTest_Generic" executed="True" result="Success" success="True" time="0.008" asserts="0">
+                        <results>
+                          <test-case name="NUnit.Framework.Syntax.AssignableFromTest_Generic.SyntaxTest.SupportedByConstraintBuilder" executed="True" result="Success" success="True" time="0.001" asserts="1" />
+                          <test-case name="NUnit.Framework.Syntax.AssignableFromTest_Generic.SyntaxTest.SupportedByInheritedSyntax" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Framework.Syntax.AssignableFromTest_Generic.SyntaxTest.SupportedByStaticSyntax" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                        </results>
+                      </test-suite>
+                      <test-suite type="TestFixture" name="AssignableToTest" executed="True" result="Success" success="True" time="0.007" asserts="0">
+                        <results>
+                          <test-case name="NUnit.Framework.Syntax.AssignableToTest.SyntaxTest.SupportedByConstraintBuilder" executed="True" result="Success" success="True" time="0.001" asserts="1" />
+                          <test-case name="NUnit.Framework.Syntax.AssignableToTest.SyntaxTest.SupportedByInheritedSyntax" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Framework.Syntax.AssignableToTest.SyntaxTest.SupportedByStaticSyntax" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                        </results>
+                      </test-suite>
+                      <test-suite type="TestFixture" name="AssignableToTest_Generic" executed="True" result="Success" success="True" time="0.008" asserts="0">
+                        <results>
+                          <test-case name="NUnit.Framework.Syntax.AssignableToTest_Generic.SyntaxTest.SupportedByConstraintBuilder" executed="True" result="Success" success="True" time="0.002" asserts="1" />
+                          <test-case name="NUnit.Framework.Syntax.AssignableToTest_Generic.SyntaxTest.SupportedByInheritedSyntax" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Framework.Syntax.AssignableToTest_Generic.SyntaxTest.SupportedByStaticSyntax" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                        </results>
+                      </test-suite>
+                      <test-suite type="TestFixture" name="AtLeastTest" executed="True" result="Success" success="True" time="0.005" asserts="0">
+                        <results>
+                          <test-case name="NUnit.Framework.Syntax.AtLeastTest.SyntaxTest.SupportedByConstraintBuilder" executed="True" result="Success" success="True" time="0.001" asserts="1" />
+                          <test-case name="NUnit.Framework.Syntax.AtLeastTest.SyntaxTest.SupportedByInheritedSyntax" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Framework.Syntax.AtLeastTest.SyntaxTest.SupportedByStaticSyntax" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                        </results>
+                      </test-suite>
+                      <test-suite type="TestFixture" name="AtMostTest" executed="True" result="Success" success="True" time="0.013" asserts="0">
+                        <results>
+                          <test-case name="NUnit.Framework.Syntax.AtMostTest.SyntaxTest.SupportedByConstraintBuilder" executed="True" result="Success" success="True" time="0.001" asserts="1" />
+                          <test-case name="NUnit.Framework.Syntax.AtMostTest.SyntaxTest.SupportedByInheritedSyntax" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Framework.Syntax.AtMostTest.SyntaxTest.SupportedByStaticSyntax" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                        </results>
+                      </test-suite>
+                      <test-suite type="TestFixture" name="AttributeTest" executed="True" result="Success" success="True" time="0.005" asserts="0">
+                        <results>
+                          <test-case name="NUnit.Framework.Syntax.AttributeTest.SyntaxTest.SupportedByConstraintBuilder" executed="True" result="Success" success="True" time="0.001" asserts="1" />
+                          <test-case name="NUnit.Framework.Syntax.AttributeTest.SyntaxTest.SupportedByInheritedSyntax" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Framework.Syntax.AttributeTest.SyntaxTest.SupportedByStaticSyntax" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                        </results>
+                      </test-suite>
+                      <test-suite type="TestFixture" name="AttributeTest_Generic" executed="True" result="Success" success="True" time="0.005" asserts="0">
+                        <results>
+                          <test-case name="NUnit.Framework.Syntax.AttributeTest_Generic.SyntaxTest.SupportedByConstraintBuilder" executed="True" result="Success" success="True" time="0.001" asserts="1" />
+                          <test-case name="NUnit.Framework.Syntax.AttributeTest_Generic.SyntaxTest.SupportedByInheritedSyntax" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Framework.Syntax.AttributeTest_Generic.SyntaxTest.SupportedByStaticSyntax" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                        </results>
+                      </test-suite>
+                      <test-suite type="TestFixture" name="AttributeTestWithFollowingConstraint" executed="True" result="Success" success="True" time="0.005" asserts="0">
+                        <results>
+                          <test-case name="NUnit.Framework.Syntax.AttributeTestWithFollowingConstraint.SyntaxTest.SupportedByConstraintBuilder" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Framework.Syntax.AttributeTestWithFollowingConstraint.SyntaxTest.SupportedByInheritedSyntax" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Framework.Syntax.AttributeTestWithFollowingConstraint.SyntaxTest.SupportedByStaticSyntax" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                        </results>
+                      </test-suite>
+                      <test-suite type="TestFixture" name="BinarySerializableTest" executed="True" result="Success" success="True" time="0.005" asserts="0">
+                        <results>
+                          <test-case name="NUnit.Framework.Syntax.BinarySerializableTest.SyntaxTest.SupportedByConstraintBuilder" executed="True" result="Success" success="True" time="0.001" asserts="1" />
+                          <test-case name="NUnit.Framework.Syntax.BinarySerializableTest.SyntaxTest.SupportedByInheritedSyntax" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Framework.Syntax.BinarySerializableTest.SyntaxTest.SupportedByStaticSyntax" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                        </results>
+                      </test-suite>
+                      <test-suite type="TestFixture" name="CollectionContainsTest" executed="True" result="Success" success="True" time="0.006" asserts="0">
+                        <results>
+                          <test-case name="NUnit.Framework.Syntax.CollectionContainsTest.SyntaxTest.SupportedByConstraintBuilder" executed="True" result="Success" success="True" time="0.001" asserts="1" />
+                          <test-case name="NUnit.Framework.Syntax.CollectionContainsTest.SyntaxTest.SupportedByInheritedSyntax" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Framework.Syntax.CollectionContainsTest.SyntaxTest.SupportedByStaticSyntax" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                        </results>
+                      </test-suite>
+                      <test-suite type="TestFixture" name="CollectionContainsTest_Comparer" executed="True" result="Success" success="True" time="0.010" asserts="0">
+                        <results>
+                          <test-case name="NUnit.Framework.Syntax.CollectionContainsTest_Comparer.ComparerIsCalled" executed="True" result="Success" success="True" time="0.000" asserts="2" />
+                          <test-case name="NUnit.Framework.Syntax.CollectionContainsTest_Comparer.ComparerIsCalledInExpression" executed="True" result="Success" success="True" time="0.000" asserts="2" />
+                          <test-case name="NUnit.Framework.Syntax.CollectionContainsTest_Comparer.SyntaxTest.SupportedByConstraintBuilder" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Framework.Syntax.CollectionContainsTest_Comparer.SyntaxTest.SupportedByInheritedSyntax" executed="True" result="Success" success="True" time="0.001" asserts="1" />
+                          <test-case name="NUnit.Framework.Syntax.CollectionContainsTest_Comparer.SyntaxTest.SupportedByStaticSyntax" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                        </results>
+                      </test-suite>
+                      <test-suite type="TestFixture" name="CollectionContainsTest_Comparer_String" executed="True" result="Success" success="True" time="0.009" asserts="0">
+                        <results>
+                          <test-case name="NUnit.Framework.Syntax.CollectionContainsTest_Comparer_String.ComparerIsCalled" executed="True" result="Success" success="True" time="0.002" asserts="2" />
+                          <test-case name="NUnit.Framework.Syntax.CollectionContainsTest_Comparer_String.ComparerIsCalledInExpression" executed="True" result="Success" success="True" time="0.001" asserts="2" />
+                          <test-case name="NUnit.Framework.Syntax.CollectionContainsTest_Comparer_String.SyntaxTest.SupportedByConstraintBuilder" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Framework.Syntax.CollectionContainsTest_Comparer_String.SyntaxTest.SupportedByInheritedSyntax" executed="True" result="Success" success="True" time="0.001" asserts="1" />
+                          <test-case name="NUnit.Framework.Syntax.CollectionContainsTest_Comparer_String.SyntaxTest.SupportedByStaticSyntax" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                        </results>
+                      </test-suite>
+                      <test-suite type="TestFixture" name="CollectionContainsTest_String" executed="True" result="Success" success="True" time="0.005" asserts="0">
+                        <results>
+                          <test-case name="NUnit.Framework.Syntax.CollectionContainsTest_String.SyntaxTest.SupportedByConstraintBuilder" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Framework.Syntax.CollectionContainsTest_String.SyntaxTest.SupportedByInheritedSyntax" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Framework.Syntax.CollectionContainsTest_String.SyntaxTest.SupportedByStaticSyntax" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                        </results>
+                      </test-suite>
+                      <test-suite type="TestFixture" name="CollectionEquivalentTest" executed="True" result="Success" success="True" time="0.006" asserts="0">
+                        <results>
+                          <test-case name="NUnit.Framework.Syntax.CollectionEquivalentTest.SyntaxTest.SupportedByConstraintBuilder" executed="True" result="Success" success="True" time="0.001" asserts="1" />
+                          <test-case name="NUnit.Framework.Syntax.CollectionEquivalentTest.SyntaxTest.SupportedByInheritedSyntax" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Framework.Syntax.CollectionEquivalentTest.SyntaxTest.SupportedByStaticSyntax" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                        </results>
+                      </test-suite>
+                      <test-suite type="TestFixture" name="CollectionMemberTest" executed="True" result="Success" success="True" time="0.005" asserts="0">
+                        <results>
+                          <test-case name="NUnit.Framework.Syntax.CollectionMemberTest.SyntaxTest.SupportedByConstraintBuilder" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Framework.Syntax.CollectionMemberTest.SyntaxTest.SupportedByInheritedSyntax" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Framework.Syntax.CollectionMemberTest.SyntaxTest.SupportedByStaticSyntax" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                        </results>
+                      </test-suite>
+                      <test-suite type="TestFixture" name="CollectionMemberTest_Comparer" executed="True" result="Success" success="True" time="0.005" asserts="0">
+                        <results>
+                          <test-case name="NUnit.Framework.Syntax.CollectionMemberTest_Comparer.SyntaxTest.SupportedByConstraintBuilder" executed="True" result="Success" success="True" time="0.001" asserts="1" />
+                          <test-case name="NUnit.Framework.Syntax.CollectionMemberTest_Comparer.SyntaxTest.SupportedByInheritedSyntax" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Framework.Syntax.CollectionMemberTest_Comparer.SyntaxTest.SupportedByStaticSyntax" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                        </results>
+                      </test-suite>
+                      <test-suite type="TestFixture" name="CollectionOrderedByTest" executed="True" result="Success" success="True" time="0.007" asserts="0">
+                        <results>
+                          <test-case name="NUnit.Framework.Syntax.CollectionOrderedByTest.SyntaxTest.SupportedByConstraintBuilder" executed="True" result="Success" success="True" time="0.001" asserts="1" />
+                          <test-case name="NUnit.Framework.Syntax.CollectionOrderedByTest.SyntaxTest.SupportedByInheritedSyntax" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Framework.Syntax.CollectionOrderedByTest.SyntaxTest.SupportedByStaticSyntax" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                        </results>
+                      </test-suite>
+                      <test-suite type="TestFixture" name="CollectionOrderedByTest_Comparer" executed="True" result="Success" success="True" time="0.005" asserts="0">
+                        <results>
+                          <test-case name="NUnit.Framework.Syntax.CollectionOrderedByTest_Comparer.SyntaxTest.SupportedByConstraintBuilder" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Framework.Syntax.CollectionOrderedByTest_Comparer.SyntaxTest.SupportedByInheritedSyntax" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Framework.Syntax.CollectionOrderedByTest_Comparer.SyntaxTest.SupportedByStaticSyntax" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                        </results>
+                      </test-suite>
+                      <test-suite type="TestFixture" name="CollectionOrderedByTest_Comparer_Descending" executed="True" result="Success" success="True" time="0.004" asserts="0">
+                        <results>
+                          <test-case name="NUnit.Framework.Syntax.CollectionOrderedByTest_Comparer_Descending.SyntaxTest.SupportedByConstraintBuilder" executed="True" result="Success" success="True" time="0.001" asserts="1" />
+                          <test-case name="NUnit.Framework.Syntax.CollectionOrderedByTest_Comparer_Descending.SyntaxTest.SupportedByInheritedSyntax" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Framework.Syntax.CollectionOrderedByTest_Comparer_Descending.SyntaxTest.SupportedByStaticSyntax" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                        </results>
+                      </test-suite>
+                      <test-suite type="TestFixture" name="CollectionOrderedByTest_Descending" executed="True" result="Success" success="True" time="0.004" asserts="0">
+                        <results>
+                          <test-case name="NUnit.Framework.Syntax.CollectionOrderedByTest_Descending.SyntaxTest.SupportedByConstraintBuilder" executed="True" result="Success" success="True" time="0.001" asserts="1" />
+                          <test-case name="NUnit.Framework.Syntax.CollectionOrderedByTest_Descending.SyntaxTest.SupportedByInheritedSyntax" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Framework.Syntax.CollectionOrderedByTest_Descending.SyntaxTest.SupportedByStaticSyntax" executed="True" result="Success" success="True" time="0.001" asserts="1" />
+                        </results>
+                      </test-suite>
+                      <test-suite type="TestFixture" name="CollectionOrderedTest" executed="True" result="Success" success="True" time="0.004" asserts="0">
+                        <results>
+                          <test-case name="NUnit.Framework.Syntax.CollectionOrderedTest.SyntaxTest.SupportedByConstraintBuilder" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Framework.Syntax.CollectionOrderedTest.SyntaxTest.SupportedByInheritedSyntax" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Framework.Syntax.CollectionOrderedTest.SyntaxTest.SupportedByStaticSyntax" executed="True" result="Success" success="True" time="0.001" asserts="1" />
+                        </results>
+                      </test-suite>
+                      <test-suite type="TestFixture" name="CollectionOrderedTest_Comparer" executed="True" result="Success" success="True" time="0.004" asserts="0">
+                        <results>
+                          <test-case name="NUnit.Framework.Syntax.CollectionOrderedTest_Comparer.SyntaxTest.SupportedByConstraintBuilder" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Framework.Syntax.CollectionOrderedTest_Comparer.SyntaxTest.SupportedByInheritedSyntax" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Framework.Syntax.CollectionOrderedTest_Comparer.SyntaxTest.SupportedByStaticSyntax" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                        </results>
+                      </test-suite>
+                      <test-suite type="TestFixture" name="CollectionOrderedTest_Comparer_Descending" executed="True" result="Success" success="True" time="0.004" asserts="0">
+                        <results>
+                          <test-case name="NUnit.Framework.Syntax.CollectionOrderedTest_Comparer_Descending.SyntaxTest.SupportedByConstraintBuilder" executed="True" result="Success" success="True" time="0.001" asserts="1" />
+                          <test-case name="NUnit.Framework.Syntax.CollectionOrderedTest_Comparer_Descending.SyntaxTest.SupportedByInheritedSyntax" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Framework.Syntax.CollectionOrderedTest_Comparer_Descending.SyntaxTest.SupportedByStaticSyntax" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                        </results>
+                      </test-suite>
+                      <test-suite type="TestFixture" name="CollectionOrderedTest_Descending" executed="True" result="Success" success="True" time="0.005" asserts="0">
+                        <results>
+                          <test-case name="NUnit.Framework.Syntax.CollectionOrderedTest_Descending.SyntaxTest.SupportedByConstraintBuilder" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Framework.Syntax.CollectionOrderedTest_Descending.SyntaxTest.SupportedByInheritedSyntax" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Framework.Syntax.CollectionOrderedTest_Descending.SyntaxTest.SupportedByStaticSyntax" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                        </results>
+                      </test-suite>
+                      <test-suite type="TestFixture" name="CollectionSubsetTest" executed="True" result="Success" success="True" time="0.005" asserts="0">
+                        <results>
+                          <test-case name="NUnit.Framework.Syntax.CollectionSubsetTest.SyntaxTest.SupportedByConstraintBuilder" executed="True" result="Success" success="True" time="0.001" asserts="1" />
+                          <test-case name="NUnit.Framework.Syntax.CollectionSubsetTest.SyntaxTest.SupportedByInheritedSyntax" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Framework.Syntax.CollectionSubsetTest.SyntaxTest.SupportedByStaticSyntax" executed="True" result="Success" success="True" time="0.001" asserts="1" />
+                        </results>
+                      </test-suite>
+                      <test-suite type="TestFixture" name="CountTest" executed="True" result="Success" success="True" time="0.004" asserts="0">
+                        <results>
+                          <test-case name="NUnit.Framework.Syntax.CountTest.SyntaxTest.SupportedByConstraintBuilder" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Framework.Syntax.CountTest.SyntaxTest.SupportedByInheritedSyntax" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Framework.Syntax.CountTest.SyntaxTest.SupportedByStaticSyntax" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                        </results>
+                      </test-suite>
+                      <test-suite type="TestFixture" name="EmptyTest" executed="True" result="Success" success="True" time="0.005" asserts="0">
+                        <results>
+                          <test-case name="NUnit.Framework.Syntax.EmptyTest.SyntaxTest.SupportedByConstraintBuilder" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Framework.Syntax.EmptyTest.SyntaxTest.SupportedByInheritedSyntax" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Framework.Syntax.EmptyTest.SyntaxTest.SupportedByStaticSyntax" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                        </results>
+                      </test-suite>
+                      <test-suite type="TestFixture" name="EndsWithTest" executed="True" result="Success" success="True" time="0.005" asserts="0">
+                        <results>
+                          <test-case name="NUnit.Framework.Syntax.EndsWithTest.SyntaxTest.SupportedByConstraintBuilder" executed="True" result="Success" success="True" time="0.001" asserts="1" />
+                          <test-case name="NUnit.Framework.Syntax.EndsWithTest.SyntaxTest.SupportedByInheritedSyntax" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Framework.Syntax.EndsWithTest.SyntaxTest.SupportedByStaticSyntax" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                        </results>
+                      </test-suite>
+                      <test-suite type="TestFixture" name="EndsWithTest_IgnoreCase" executed="True" result="Success" success="True" time="0.004" asserts="0">
+                        <results>
+                          <test-case name="NUnit.Framework.Syntax.EndsWithTest_IgnoreCase.SyntaxTest.SupportedByConstraintBuilder" executed="True" result="Success" success="True" time="0.001" asserts="1" />
+                          <test-case name="NUnit.Framework.Syntax.EndsWithTest_IgnoreCase.SyntaxTest.SupportedByInheritedSyntax" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Framework.Syntax.EndsWithTest_IgnoreCase.SyntaxTest.SupportedByStaticSyntax" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                        </results>
+                      </test-suite>
+                      <test-suite type="TestFixture" name="EqualityTests" executed="True" result="Success" success="True" time="0.013" asserts="0">
+                        <results>
+                          <test-case name="NUnit.Framework.Syntax.EqualityTests.EqualityTestsUsingDefaultFloatingPointTolerance" executed="True" result="Success" success="True" time="0.001" asserts="3" />
+                          <test-case name="NUnit.Framework.Syntax.EqualityTests.EqualityTestsWithTolerance" executed="True" result="Success" success="True" time="0.002" asserts="8" />
+                          <test-case name="NUnit.Framework.Syntax.EqualityTests.EqualityTestsWithTolerance_MixedFloatAndDouble" executed="True" result="Success" success="True" time="0.001" asserts="6" />
+                          <test-case name="NUnit.Framework.Syntax.EqualityTests.EqualityTestsWithTolerance_MixingTypesGenerally" executed="True" result="Success" success="True" time="0.002" asserts="7" />
+                          <test-case name="NUnit.Framework.Syntax.EqualityTests.SimpleEqualityTests" executed="True" result="Success" success="True" time="0.001" asserts="6" />
+                        </results>
+                      </test-suite>
+                      <test-suite type="TestFixture" name="EqualToTest" executed="True" result="Success" success="True" time="0.004" asserts="0">
+                        <results>
+                          <test-case name="NUnit.Framework.Syntax.EqualToTest.SyntaxTest.SupportedByConstraintBuilder" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Framework.Syntax.EqualToTest.SyntaxTest.SupportedByInheritedSyntax" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Framework.Syntax.EqualToTest.SyntaxTest.SupportedByStaticSyntax" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                        </results>
+                      </test-suite>
+                      <test-suite type="TestFixture" name="EqualToTest_IgnoreCase" executed="True" result="Success" success="True" time="0.004" asserts="0">
+                        <results>
+                          <test-case name="NUnit.Framework.Syntax.EqualToTest_IgnoreCase.SyntaxTest.SupportedByConstraintBuilder" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Framework.Syntax.EqualToTest_IgnoreCase.SyntaxTest.SupportedByInheritedSyntax" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Framework.Syntax.EqualToTest_IgnoreCase.SyntaxTest.SupportedByStaticSyntax" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                        </results>
+                      </test-suite>
+                      <test-suite type="TestFixture" name="EqualToTest_WithinTolerance" executed="True" result="Success" success="True" time="0.004" asserts="0">
+                        <results>
+                          <test-case name="NUnit.Framework.Syntax.EqualToTest_WithinTolerance.SyntaxTest.SupportedByConstraintBuilder" executed="True" result="Success" success="True" time="0.001" asserts="1" />
+                          <test-case name="NUnit.Framework.Syntax.EqualToTest_WithinTolerance.SyntaxTest.SupportedByInheritedSyntax" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Framework.Syntax.EqualToTest_WithinTolerance.SyntaxTest.SupportedByStaticSyntax" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                        </results>
+                      </test-suite>
+                      <test-suite type="TestFixture" name="ExactTypeTest" executed="True" result="Success" success="True" time="0.004" asserts="0">
+                        <results>
+                          <test-case name="NUnit.Framework.Syntax.ExactTypeTest.SyntaxTest.SupportedByConstraintBuilder" executed="True" result="Success" success="True" time="0.001" asserts="1" />
+                          <test-case name="NUnit.Framework.Syntax.ExactTypeTest.SyntaxTest.SupportedByInheritedSyntax" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Framework.Syntax.ExactTypeTest.SyntaxTest.SupportedByStaticSyntax" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                        </results>
+                      </test-suite>
+                      <test-suite type="TestFixture" name="ExactTypeTest_Generic" executed="True" result="Success" success="True" time="0.005" asserts="0">
+                        <results>
+                          <test-case name="NUnit.Framework.Syntax.ExactTypeTest_Generic.SyntaxTest.SupportedByConstraintBuilder" executed="True" result="Success" success="True" time="0.001" asserts="1" />
+                          <test-case name="NUnit.Framework.Syntax.ExactTypeTest_Generic.SyntaxTest.SupportedByInheritedSyntax" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Framework.Syntax.ExactTypeTest_Generic.SyntaxTest.SupportedByStaticSyntax" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                        </results>
+                      </test-suite>
+                      <test-suite type="TestFixture" name="FalseTest" executed="True" result="Success" success="True" time="0.004" asserts="0">
+                        <results>
+                          <test-case name="NUnit.Framework.Syntax.FalseTest.SyntaxTest.SupportedByConstraintBuilder" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Framework.Syntax.FalseTest.SyntaxTest.SupportedByInheritedSyntax" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Framework.Syntax.FalseTest.SyntaxTest.SupportedByStaticSyntax" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                        </results>
+                      </test-suite>
+                      <test-suite type="TestFixture" name="GreaterThanOrEqualTest" executed="True" result="Success" success="True" time="0.005" asserts="0">
+                        <results>
+                          <test-case name="NUnit.Framework.Syntax.GreaterThanOrEqualTest.SyntaxTest.SupportedByConstraintBuilder" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Framework.Syntax.GreaterThanOrEqualTest.SyntaxTest.SupportedByInheritedSyntax" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Framework.Syntax.GreaterThanOrEqualTest.SyntaxTest.SupportedByStaticSyntax" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                        </results>
+                      </test-suite>
+                      <test-suite type="TestFixture" name="GreaterThanTest" executed="True" result="Success" success="True" time="0.004" asserts="0">
+                        <results>
+                          <test-case name="NUnit.Framework.Syntax.GreaterThanTest.SyntaxTest.SupportedByConstraintBuilder" executed="True" result="Success" success="True" time="0.001" asserts="1" />
+                          <test-case name="NUnit.Framework.Syntax.GreaterThanTest.SyntaxTest.SupportedByInheritedSyntax" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Framework.Syntax.GreaterThanTest.SyntaxTest.SupportedByStaticSyntax" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                        </results>
+                      </test-suite>
+                      <test-suite type="TestFixture" name="InstanceOfTest" executed="True" result="Success" success="True" time="0.004" asserts="0">
+                        <results>
+                          <test-case name="NUnit.Framework.Syntax.InstanceOfTest.SyntaxTest.SupportedByConstraintBuilder" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Framework.Syntax.InstanceOfTest.SyntaxTest.SupportedByInheritedSyntax" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Framework.Syntax.InstanceOfTest.SyntaxTest.SupportedByStaticSyntax" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                        </results>
+                      </test-suite>
+                      <test-suite type="TestFixture" name="InstanceOfTest_Generic" executed="True" result="Success" success="True" time="0.005" asserts="0">
+                        <results>
+                          <test-case name="NUnit.Framework.Syntax.InstanceOfTest_Generic.SyntaxTest.SupportedByConstraintBuilder" executed="True" result="Success" success="True" time="0.001" asserts="1" />
+                          <test-case name="NUnit.Framework.Syntax.InstanceOfTest_Generic.SyntaxTest.SupportedByInheritedSyntax" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Framework.Syntax.InstanceOfTest_Generic.SyntaxTest.SupportedByStaticSyntax" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                        </results>
+                      </test-suite>
+                      <test-suite type="TestFixture" name="InstanceOfTypeTest" executed="True" result="Success" success="True" time="0.005" asserts="0">
+                        <results>
+                          <test-case name="NUnit.Framework.Syntax.InstanceOfTypeTest.SyntaxTest.SupportedByConstraintBuilder" executed="True" result="Success" success="True" time="0.001" asserts="1" />
+                          <test-case name="NUnit.Framework.Syntax.InstanceOfTypeTest.SyntaxTest.SupportedByInheritedSyntax" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Framework.Syntax.InstanceOfTypeTest.SyntaxTest.SupportedByStaticSyntax" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                        </results>
+                      </test-suite>
+                      <test-suite type="TestFixture" name="InstanceOfTypeTest_Generic" executed="True" result="Success" success="True" time="0.005" asserts="0">
+                        <results>
+                          <test-case name="NUnit.Framework.Syntax.InstanceOfTypeTest_Generic.SyntaxTest.SupportedByConstraintBuilder" executed="True" result="Success" success="True" time="0.001" asserts="1" />
+                          <test-case name="NUnit.Framework.Syntax.InstanceOfTypeTest_Generic.SyntaxTest.SupportedByInheritedSyntax" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Framework.Syntax.InstanceOfTypeTest_Generic.SyntaxTest.SupportedByStaticSyntax" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                        </results>
+                      </test-suite>
+                      <test-suite type="TestFixture" name="InvalidCodeTests" executed="True" result="Success" success="True" time="0.600" asserts="0">
+                        <results>
+                          <test-suite type="ParameterizedTest" name="CodeShouldNotCompile" executed="True" result="Success" success="True" time="0.408" asserts="0">
+                            <results>
+                              <test-case name="NUnit.Framework.Syntax.InvalidCodeTests.CodeShouldNotCompile(&quot;Is.Null.Not&quot;)" executed="True" result="Success" success="True" time="0.171" asserts="1" />
+                              <test-case name="NUnit.Framework.Syntax.InvalidCodeTests.CodeShouldNotCompile(&quot;Is.Null.And.Throws&quot;)" executed="True" result="Success" success="True" time="0.048" asserts="1" />
+                              <test-case name="NUnit.Framework.Syntax.InvalidCodeTests.CodeShouldNotCompile(&quot;Is.All.And.And&quot;)" executed="True" result="Success" success="True" time="0.044" asserts="1" />
+                              <test-case name="NUnit.Framework.Syntax.InvalidCodeTests.CodeShouldNotCompile(&quot;Is.Not.Null.GreaterThan(10))&quot;)" executed="True" result="Success" success="True" time="0.043" asserts="1" />
+                              <test-case name="NUnit.Framework.Syntax.InvalidCodeTests.CodeShouldNotCompile(&quot;Is.Null.All&quot;)" executed="True" result="Success" success="True" time="0.042" asserts="1" />
+                              <test-case name="NUnit.Framework.Syntax.InvalidCodeTests.CodeShouldNotCompile(&quot;Is.And&quot;)" executed="True" result="Success" success="True" time="0.048" asserts="1" />
+                            </results>
+                          </test-suite>
+                          <test-suite type="ParameterizedTest" name="CodeShouldNotCompileAsFinishedConstraint" executed="True" result="Success" success="True" time="0.189" asserts="0">
+                            <results>
+                              <test-case name="NUnit.Framework.Syntax.InvalidCodeTests.CodeShouldNotCompileAsFinishedConstraint(&quot;Is.All&quot;)" executed="True" result="Success" success="True" time="0.046" asserts="1" />
+                              <test-case name="NUnit.Framework.Syntax.InvalidCodeTests.CodeShouldNotCompileAsFinishedConstraint(&quot;Is.All.Not&quot;)" executed="True" result="Success" success="True" time="0.044" asserts="1" />
+                              <test-case name="NUnit.Framework.Syntax.InvalidCodeTests.CodeShouldNotCompileAsFinishedConstraint(&quot;Is.Not&quot;)" executed="True" result="Success" success="True" time="0.047" asserts="1" />
+                              <test-case name="NUnit.Framework.Syntax.InvalidCodeTests.CodeShouldNotCompileAsFinishedConstraint(&quot;Is.Not.All&quot;)" executed="True" result="Success" success="True" time="0.046" asserts="1" />
+                            </results>
+                          </test-suite>
+                        </results>
+                      </test-suite>
+                      <test-suite type="TestFixture" name="LengthTest" executed="True" result="Success" success="True" time="0.005" asserts="0">
+                        <results>
+                          <test-case name="NUnit.Framework.Syntax.LengthTest.SyntaxTest.SupportedByConstraintBuilder" executed="True" result="Success" success="True" time="0.001" asserts="1" />
+                          <test-case name="NUnit.Framework.Syntax.LengthTest.SyntaxTest.SupportedByInheritedSyntax" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Framework.Syntax.LengthTest.SyntaxTest.SupportedByStaticSyntax" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                        </results>
+                      </test-suite>
+                      <test-suite type="TestFixture" name="LessThanOrEqualTest" executed="True" result="Success" success="True" time="0.005" asserts="0">
+                        <results>
+                          <test-case name="NUnit.Framework.Syntax.LessThanOrEqualTest.SyntaxTest.SupportedByConstraintBuilder" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Framework.Syntax.LessThanOrEqualTest.SyntaxTest.SupportedByInheritedSyntax" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Framework.Syntax.LessThanOrEqualTest.SyntaxTest.SupportedByStaticSyntax" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                        </results>
+                      </test-suite>
+                      <test-suite type="TestFixture" name="LessThanTest" executed="True" result="Success" success="True" time="0.004" asserts="0">
+                        <results>
+                          <test-case name="NUnit.Framework.Syntax.LessThanTest.SyntaxTest.SupportedByConstraintBuilder" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Framework.Syntax.LessThanTest.SyntaxTest.SupportedByInheritedSyntax" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Framework.Syntax.LessThanTest.SyntaxTest.SupportedByStaticSyntax" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                        </results>
+                      </test-suite>
+                      <test-suite type="TestFixture" name="MessageTest" executed="True" result="Success" success="True" time="0.005" asserts="0">
+                        <results>
+                          <test-case name="NUnit.Framework.Syntax.MessageTest.SyntaxTest.SupportedByConstraintBuilder" executed="True" result="Success" success="True" time="0.001" asserts="1" />
+                          <test-case name="NUnit.Framework.Syntax.MessageTest.SyntaxTest.SupportedByInheritedSyntax" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Framework.Syntax.MessageTest.SyntaxTest.SupportedByStaticSyntax" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                        </results>
+                      </test-suite>
+                      <test-suite type="TestFixture" name="MixedOperatorOverrides" executed="True" result="Success" success="True" time="0.002" asserts="0">
+                        <results>
+                          <test-case name="NUnit.Framework.Syntax.MixedOperatorOverrides.ComplexTests" executed="True" result="Success" success="True" time="0.001" asserts="3" />
+                        </results>
+                      </test-suite>
+                      <test-suite type="TestFixture" name="NaNTest" executed="True" result="Success" success="True" time="0.004" asserts="0">
+                        <results>
+                          <test-case name="NUnit.Framework.Syntax.NaNTest.SyntaxTest.SupportedByConstraintBuilder" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Framework.Syntax.NaNTest.SyntaxTest.SupportedByInheritedSyntax" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Framework.Syntax.NaNTest.SyntaxTest.SupportedByStaticSyntax" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                        </results>
+                      </test-suite>
+                      <test-suite type="TestFixture" name="NoneTest" executed="True" result="Success" success="True" time="0.006" asserts="0">
+                        <results>
+                          <test-case name="NUnit.Framework.Syntax.NoneTest.SyntaxTest.SupportedByConstraintBuilder" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Framework.Syntax.NoneTest.SyntaxTest.SupportedByInheritedSyntax" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Framework.Syntax.NoneTest.SyntaxTest.SupportedByStaticSyntax" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                        </results>
+                      </test-suite>
+                      <test-suite type="TestFixture" name="NotOperatorOverride" executed="True" result="Success" success="True" time="0.004" asserts="0">
+                        <results>
+                          <test-case name="NUnit.Framework.Syntax.NotOperatorOverride.SyntaxTest.SupportedByConstraintBuilder" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Framework.Syntax.NotOperatorOverride.SyntaxTest.SupportedByInheritedSyntax" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Framework.Syntax.NotOperatorOverride.SyntaxTest.SupportedByStaticSyntax" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                        </results>
+                      </test-suite>
+                      <test-suite type="TestFixture" name="NotSamePathOrUnderTest_IgnoreCase" executed="True" result="Success" success="True" time="0.004" asserts="0">
+                        <results>
+                          <test-case name="NUnit.Framework.Syntax.NotSamePathOrUnderTest_IgnoreCase.SyntaxTest.SupportedByConstraintBuilder" executed="True" result="Success" success="True" time="0.001" asserts="1" />
+                          <test-case name="NUnit.Framework.Syntax.NotSamePathOrUnderTest_IgnoreCase.SyntaxTest.SupportedByInheritedSyntax" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Framework.Syntax.NotSamePathOrUnderTest_IgnoreCase.SyntaxTest.SupportedByStaticSyntax" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                        </results>
+                      </test-suite>
+                      <test-suite type="TestFixture" name="NotSamePathOrUnderTest_RespectCase" executed="True" result="Success" success="True" time="0.004" asserts="0">
+                        <results>
+                          <test-case name="NUnit.Framework.Syntax.NotSamePathOrUnderTest_RespectCase.SyntaxTest.SupportedByConstraintBuilder" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Framework.Syntax.NotSamePathOrUnderTest_RespectCase.SyntaxTest.SupportedByInheritedSyntax" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Framework.Syntax.NotSamePathOrUnderTest_RespectCase.SyntaxTest.SupportedByStaticSyntax" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                        </results>
+                      </test-suite>
+                      <test-suite type="TestFixture" name="NotSamePathTest_IgnoreCase" executed="True" result="Success" success="True" time="0.004" asserts="0">
+                        <results>
+                          <test-case name="NUnit.Framework.Syntax.NotSamePathTest_IgnoreCase.SyntaxTest.SupportedByConstraintBuilder" executed="True" result="Success" success="True" time="0.001" asserts="1" />
+                          <test-case name="NUnit.Framework.Syntax.NotSamePathTest_IgnoreCase.SyntaxTest.SupportedByInheritedSyntax" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Framework.Syntax.NotSamePathTest_IgnoreCase.SyntaxTest.SupportedByStaticSyntax" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                        </results>
+                      </test-suite>
+                      <test-suite type="TestFixture" name="NotSamePathTest_RespectCase" executed="True" result="Success" success="True" time="0.003" asserts="0">
+                        <results>
+                          <test-case name="NUnit.Framework.Syntax.NotSamePathTest_RespectCase.SyntaxTest.SupportedByConstraintBuilder" executed="True" result="Success" success="True" time="0.001" asserts="1" />
+                          <test-case name="NUnit.Framework.Syntax.NotSamePathTest_RespectCase.SyntaxTest.SupportedByInheritedSyntax" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Framework.Syntax.NotSamePathTest_RespectCase.SyntaxTest.SupportedByStaticSyntax" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                        </results>
+                      </test-suite>
+                      <test-suite type="TestFixture" name="NotTest" executed="True" result="Success" success="True" time="0.004" asserts="0">
+                        <results>
+                          <test-case name="NUnit.Framework.Syntax.NotTest.SyntaxTest.SupportedByConstraintBuilder" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Framework.Syntax.NotTest.SyntaxTest.SupportedByInheritedSyntax" executed="True" result="Success" success="True" time="0.001" asserts="1" />
+                          <test-case name="NUnit.Framework.Syntax.NotTest.SyntaxTest.SupportedByStaticSyntax" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                        </results>
+                      </test-suite>
+                      <test-suite type="TestFixture" name="NotTest_Cascaded" executed="True" result="Success" success="True" time="0.005" asserts="0">
+                        <results>
+                          <test-case name="NUnit.Framework.Syntax.NotTest_Cascaded.SyntaxTest.SupportedByConstraintBuilder" executed="True" result="Success" success="True" time="0.001" asserts="1" />
+                          <test-case name="NUnit.Framework.Syntax.NotTest_Cascaded.SyntaxTest.SupportedByInheritedSyntax" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Framework.Syntax.NotTest_Cascaded.SyntaxTest.SupportedByStaticSyntax" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                        </results>
+                      </test-suite>
+                      <test-suite type="TestFixture" name="NullTest" executed="True" result="Success" success="True" time="0.004" asserts="0">
+                        <results>
+                          <test-case name="NUnit.Framework.Syntax.NullTest.SyntaxTest.SupportedByConstraintBuilder" executed="True" result="Success" success="True" time="0.001" asserts="1" />
+                          <test-case name="NUnit.Framework.Syntax.NullTest.SyntaxTest.SupportedByInheritedSyntax" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Framework.Syntax.NullTest.SyntaxTest.SupportedByStaticSyntax" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                        </results>
+                      </test-suite>
+                      <test-suite type="TestFixture" name="OperatorPrecedenceTests" executed="True" result="Success" success="True" time="0.005" asserts="0">
+                        <results>
+                          <test-case name="NUnit.Framework.Syntax.OperatorPrecedenceTests.SomeTests" executed="True" result="Success" success="True" time="0.001" asserts="2" />
+                          <test-case name="NUnit.Framework.Syntax.OperatorPrecedenceTests.WithTests" executed="True" result="Success" success="True" time="0.001" asserts="6" />
+                        </results>
+                      </test-suite>
+                      <test-suite type="TestFixture" name="OrOperatorOverride" executed="True" result="Success" success="True" time="0.005" asserts="0">
+                        <results>
+                          <test-case name="NUnit.Framework.Syntax.OrOperatorOverride.SyntaxTest.SupportedByConstraintBuilder" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Framework.Syntax.OrOperatorOverride.SyntaxTest.SupportedByInheritedSyntax" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Framework.Syntax.OrOperatorOverride.SyntaxTest.SupportedByStaticSyntax" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                        </results>
+                      </test-suite>
+                      <test-suite type="TestFixture" name="OrTest" executed="True" result="Success" success="True" time="0.005" asserts="0">
+                        <results>
+                          <test-case name="NUnit.Framework.Syntax.OrTest.SyntaxTest.SupportedByConstraintBuilder" executed="True" result="Success" success="True" time="0.001" asserts="1" />
+                          <test-case name="NUnit.Framework.Syntax.OrTest.SyntaxTest.SupportedByInheritedSyntax" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Framework.Syntax.OrTest.SyntaxTest.SupportedByStaticSyntax" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                        </results>
+                      </test-suite>
+                      <test-suite type="TestFixture" name="OrTest_ThreeOrs" executed="True" result="Success" success="True" time="0.005" asserts="0">
+                        <results>
+                          <test-case name="NUnit.Framework.Syntax.OrTest_ThreeOrs.SyntaxTest.SupportedByConstraintBuilder" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Framework.Syntax.OrTest_ThreeOrs.SyntaxTest.SupportedByInheritedSyntax" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Framework.Syntax.OrTest_ThreeOrs.SyntaxTest.SupportedByStaticSyntax" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                        </results>
+                      </test-suite>
+                      <test-suite type="TestFixture" name="PropertyExistsTest" executed="True" result="Success" success="True" time="0.005" asserts="0">
+                        <results>
+                          <test-case name="NUnit.Framework.Syntax.PropertyExistsTest.SyntaxTest.SupportedByConstraintBuilder" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Framework.Syntax.PropertyExistsTest.SyntaxTest.SupportedByInheritedSyntax" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Framework.Syntax.PropertyExistsTest.SyntaxTest.SupportedByStaticSyntax" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                        </results>
+                      </test-suite>
+                      <test-suite type="TestFixture" name="PropertyExistsTest_AndFollows" executed="True" result="Success" success="True" time="0.006" asserts="0">
+                        <results>
+                          <test-case name="NUnit.Framework.Syntax.PropertyExistsTest_AndFollows.SyntaxTest.SupportedByConstraintBuilder" executed="True" result="Success" success="True" time="0.001" asserts="1" />
+                          <test-case name="NUnit.Framework.Syntax.PropertyExistsTest_AndFollows.SyntaxTest.SupportedByInheritedSyntax" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Framework.Syntax.PropertyExistsTest_AndFollows.SyntaxTest.SupportedByStaticSyntax" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                        </results>
+                      </test-suite>
+                      <test-suite type="TestFixture" name="PropertySyntaxVariations" executed="True" result="Success" success="True" time="0.003" asserts="0">
+                        <results>
+                          <test-case name="NUnit.Framework.Syntax.PropertySyntaxVariations.ExistenceTest" executed="True" result="Success" success="True" time="0.000" asserts="2" />
+                          <test-case name="NUnit.Framework.Syntax.PropertySyntaxVariations.SeparateConstraintTest" executed="True" result="Success" success="True" time="0.000" asserts="2" />
+                        </results>
+                      </test-suite>
+                      <test-suite type="TestFixture" name="PropertyTest_ConstraintFollows" executed="True" result="Success" success="True" time="0.005" asserts="0">
+                        <results>
+                          <test-case name="NUnit.Framework.Syntax.PropertyTest_ConstraintFollows.SyntaxTest.SupportedByConstraintBuilder" executed="True" result="Success" success="True" time="0.001" asserts="1" />
+                          <test-case name="NUnit.Framework.Syntax.PropertyTest_ConstraintFollows.SyntaxTest.SupportedByInheritedSyntax" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Framework.Syntax.PropertyTest_ConstraintFollows.SyntaxTest.SupportedByStaticSyntax" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                        </results>
+                      </test-suite>
+                      <test-suite type="TestFixture" name="PropertyTest_NotFollows" executed="True" result="Success" success="True" time="0.005" asserts="0">
+                        <results>
+                          <test-case name="NUnit.Framework.Syntax.PropertyTest_NotFollows.SyntaxTest.SupportedByConstraintBuilder" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Framework.Syntax.PropertyTest_NotFollows.SyntaxTest.SupportedByInheritedSyntax" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Framework.Syntax.PropertyTest_NotFollows.SyntaxTest.SupportedByStaticSyntax" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                        </results>
+                      </test-suite>
+                      <test-suite type="TestFixture" name="RegexTest" executed="True" result="Success" success="True" time="0.005" asserts="0">
+                        <results>
+                          <test-case name="NUnit.Framework.Syntax.RegexTest.SyntaxTest.SupportedByConstraintBuilder" executed="True" result="Success" success="True" time="0.001" asserts="1" />
+                          <test-case name="NUnit.Framework.Syntax.RegexTest.SyntaxTest.SupportedByInheritedSyntax" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Framework.Syntax.RegexTest.SyntaxTest.SupportedByStaticSyntax" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                        </results>
+                      </test-suite>
+                      <test-suite type="TestFixture" name="RegexTest_IgnoreCase" executed="True" result="Success" success="True" time="0.004" asserts="0">
+                        <results>
+                          <test-case name="NUnit.Framework.Syntax.RegexTest_IgnoreCase.SyntaxTest.SupportedByConstraintBuilder" executed="True" result="Success" success="True" time="0.001" asserts="1" />
+                          <test-case name="NUnit.Framework.Syntax.RegexTest_IgnoreCase.SyntaxTest.SupportedByInheritedSyntax" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Framework.Syntax.RegexTest_IgnoreCase.SyntaxTest.SupportedByStaticSyntax" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                        </results>
+                      </test-suite>
+                      <test-suite type="TestFixture" name="SamePathOrUnderTest" executed="True" result="Success" success="True" time="0.005" asserts="0">
+                        <results>
+                          <test-case name="NUnit.Framework.Syntax.SamePathOrUnderTest.SyntaxTest.SupportedByConstraintBuilder" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Framework.Syntax.SamePathOrUnderTest.SyntaxTest.SupportedByInheritedSyntax" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Framework.Syntax.SamePathOrUnderTest.SyntaxTest.SupportedByStaticSyntax" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                        </results>
+                      </test-suite>
+                      <test-suite type="TestFixture" name="SamePathOrUnderTest_IgnoreCase" executed="True" result="Success" success="True" time="0.008" asserts="0">
+                        <results>
+                          <test-case name="NUnit.Framework.Syntax.SamePathOrUnderTest_IgnoreCase.SyntaxTest.SupportedByConstraintBuilder" executed="True" result="Success" success="True" time="0.001" asserts="1" />
+                          <test-case name="NUnit.Framework.Syntax.SamePathOrUnderTest_IgnoreCase.SyntaxTest.SupportedByInheritedSyntax" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Framework.Syntax.SamePathOrUnderTest_IgnoreCase.SyntaxTest.SupportedByStaticSyntax" executed="True" result="Success" success="True" time="0.001" asserts="1" />
+                        </results>
+                      </test-suite>
+                      <test-suite type="TestFixture" name="SamePathOrUnderTest_RespectCase" executed="True" result="Success" success="True" time="0.004" asserts="0">
+                        <results>
+                          <test-case name="NUnit.Framework.Syntax.SamePathOrUnderTest_RespectCase.SyntaxTest.SupportedByConstraintBuilder" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Framework.Syntax.SamePathOrUnderTest_RespectCase.SyntaxTest.SupportedByInheritedSyntax" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Framework.Syntax.SamePathOrUnderTest_RespectCase.SyntaxTest.SupportedByStaticSyntax" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                        </results>
+                      </test-suite>
+                      <test-suite type="TestFixture" name="SamePathTest" executed="True" result="Success" success="True" time="0.005" asserts="0">
+                        <results>
+                          <test-case name="NUnit.Framework.Syntax.SamePathTest.SyntaxTest.SupportedByConstraintBuilder" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Framework.Syntax.SamePathTest.SyntaxTest.SupportedByInheritedSyntax" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Framework.Syntax.SamePathTest.SyntaxTest.SupportedByStaticSyntax" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                        </results>
+                      </test-suite>
+                      <test-suite type="TestFixture" name="SamePathTest_IgnoreCase" executed="True" result="Success" success="True" time="0.005" asserts="0">
+                        <results>
+                          <test-case name="NUnit.Framework.Syntax.SamePathTest_IgnoreCase.SyntaxTest.SupportedByConstraintBuilder" executed="True" result="Success" success="True" time="0.001" asserts="1" />
+                          <test-case name="NUnit.Framework.Syntax.SamePathTest_IgnoreCase.SyntaxTest.SupportedByInheritedSyntax" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Framework.Syntax.SamePathTest_IgnoreCase.SyntaxTest.SupportedByStaticSyntax" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                        </results>
+                      </test-suite>
+                      <test-suite type="TestFixture" name="SamePathTest_RespectCase" executed="True" result="Success" success="True" time="0.004" asserts="0">
+                        <results>
+                          <test-case name="NUnit.Framework.Syntax.SamePathTest_RespectCase.SyntaxTest.SupportedByConstraintBuilder" executed="True" result="Success" success="True" time="0.001" asserts="1" />
+                          <test-case name="NUnit.Framework.Syntax.SamePathTest_RespectCase.SyntaxTest.SupportedByInheritedSyntax" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Framework.Syntax.SamePathTest_RespectCase.SyntaxTest.SupportedByStaticSyntax" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                        </results>
+                      </test-suite>
+                      <test-suite type="TestFixture" name="SomeTest" executed="True" result="Success" success="True" time="0.004" asserts="0">
+                        <results>
+                          <test-case name="NUnit.Framework.Syntax.SomeTest.SyntaxTest.SupportedByConstraintBuilder" executed="True" result="Success" success="True" time="0.001" asserts="1" />
+                          <test-case name="NUnit.Framework.Syntax.SomeTest.SyntaxTest.SupportedByInheritedSyntax" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Framework.Syntax.SomeTest.SyntaxTest.SupportedByStaticSyntax" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                        </results>
+                      </test-suite>
+                      <test-suite type="TestFixture" name="SomeTest_BeforeBinaryOperators" executed="True" result="Success" success="True" time="0.004" asserts="0">
+                        <results>
+                          <test-case name="NUnit.Framework.Syntax.SomeTest_BeforeBinaryOperators.SyntaxTest.SupportedByConstraintBuilder" executed="True" result="Success" success="True" time="0.001" asserts="1" />
+                          <test-case name="NUnit.Framework.Syntax.SomeTest_BeforeBinaryOperators.SyntaxTest.SupportedByInheritedSyntax" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Framework.Syntax.SomeTest_BeforeBinaryOperators.SyntaxTest.SupportedByStaticSyntax" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                        </results>
+                      </test-suite>
+                      <test-suite type="TestFixture" name="SomeTest_NestedSome" executed="True" result="Success" success="True" time="0.006" asserts="0">
+                        <results>
+                          <test-case name="NUnit.Framework.Syntax.SomeTest_NestedSome.SyntaxTest.SupportedByConstraintBuilder" executed="True" result="Success" success="True" time="0.002" asserts="1" />
+                          <test-case name="NUnit.Framework.Syntax.SomeTest_NestedSome.SyntaxTest.SupportedByInheritedSyntax" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Framework.Syntax.SomeTest_NestedSome.SyntaxTest.SupportedByStaticSyntax" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                        </results>
+                      </test-suite>
+                      <test-suite type="TestFixture" name="SomeTest_UseOfAndSome" executed="True" result="Success" success="True" time="0.005" asserts="0">
+                        <results>
+                          <test-case name="NUnit.Framework.Syntax.SomeTest_UseOfAndSome.SyntaxTest.SupportedByConstraintBuilder" executed="True" result="Success" success="True" time="0.001" asserts="1" />
+                          <test-case name="NUnit.Framework.Syntax.SomeTest_UseOfAndSome.SyntaxTest.SupportedByInheritedSyntax" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Framework.Syntax.SomeTest_UseOfAndSome.SyntaxTest.SupportedByStaticSyntax" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                        </results>
+                      </test-suite>
+                      <test-suite type="TestFixture" name="StartsWithTest" executed="True" result="Success" success="True" time="0.004" asserts="0">
+                        <results>
+                          <test-case name="NUnit.Framework.Syntax.StartsWithTest.SyntaxTest.SupportedByConstraintBuilder" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Framework.Syntax.StartsWithTest.SyntaxTest.SupportedByInheritedSyntax" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Framework.Syntax.StartsWithTest.SyntaxTest.SupportedByStaticSyntax" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                        </results>
+                      </test-suite>
+                      <test-suite type="TestFixture" name="StartsWithTest_IgnoreCase" executed="True" result="Success" success="True" time="0.003" asserts="0">
+                        <results>
+                          <test-case name="NUnit.Framework.Syntax.StartsWithTest_IgnoreCase.SyntaxTest.SupportedByConstraintBuilder" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Framework.Syntax.StartsWithTest_IgnoreCase.SyntaxTest.SupportedByInheritedSyntax" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Framework.Syntax.StartsWithTest_IgnoreCase.SyntaxTest.SupportedByStaticSyntax" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                        </results>
+                      </test-suite>
+                      <test-suite type="TestFixture" name="SubstringTest" executed="True" result="Success" success="True" time="0.005" asserts="0">
+                        <results>
+                          <test-case name="NUnit.Framework.Syntax.SubstringTest.SyntaxTest.SupportedByConstraintBuilder" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Framework.Syntax.SubstringTest.SyntaxTest.SupportedByInheritedSyntax" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Framework.Syntax.SubstringTest.SyntaxTest.SupportedByStaticSyntax" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                        </results>
+                      </test-suite>
+                      <test-suite type="TestFixture" name="SubstringTest_IgnoreCase" executed="True" result="Success" success="True" time="0.004" asserts="0">
+                        <results>
+                          <test-case name="NUnit.Framework.Syntax.SubstringTest_IgnoreCase.SyntaxTest.SupportedByConstraintBuilder" executed="True" result="Success" success="True" time="0.001" asserts="1" />
+                          <test-case name="NUnit.Framework.Syntax.SubstringTest_IgnoreCase.SyntaxTest.SupportedByInheritedSyntax" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Framework.Syntax.SubstringTest_IgnoreCase.SyntaxTest.SupportedByStaticSyntax" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                        </results>
+                      </test-suite>
+                      <test-suite type="TestFixture" name="TextContains" executed="True" result="Success" success="True" time="0.004" asserts="0">
+                        <results>
+                          <test-case name="NUnit.Framework.Syntax.TextContains.SyntaxTest.SupportedByConstraintBuilder" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Framework.Syntax.TextContains.SyntaxTest.SupportedByInheritedSyntax" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Framework.Syntax.TextContains.SyntaxTest.SupportedByStaticSyntax" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                        </results>
+                      </test-suite>
+                      <test-suite type="TestFixture" name="TextEndsWithTest" executed="True" result="Success" success="True" time="0.004" asserts="0">
+                        <results>
+                          <test-case name="NUnit.Framework.Syntax.TextEndsWithTest.SyntaxTest.SupportedByConstraintBuilder" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Framework.Syntax.TextEndsWithTest.SyntaxTest.SupportedByInheritedSyntax" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Framework.Syntax.TextEndsWithTest.SyntaxTest.SupportedByStaticSyntax" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                        </results>
+                      </test-suite>
+                      <test-suite type="TestFixture" name="TextMatchesTest" executed="True" result="Success" success="True" time="0.004" asserts="0">
+                        <results>
+                          <test-case name="NUnit.Framework.Syntax.TextMatchesTest.SyntaxTest.SupportedByConstraintBuilder" executed="True" result="Success" success="True" time="0.001" asserts="1" />
+                          <test-case name="NUnit.Framework.Syntax.TextMatchesTest.SyntaxTest.SupportedByInheritedSyntax" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Framework.Syntax.TextMatchesTest.SyntaxTest.SupportedByStaticSyntax" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                        </results>
+                      </test-suite>
+                      <test-suite type="TestFixture" name="TextStartsWithTest" executed="True" result="Success" success="True" time="0.005" asserts="0">
+                        <results>
+                          <test-case name="NUnit.Framework.Syntax.TextStartsWithTest.SyntaxTest.SupportedByConstraintBuilder" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Framework.Syntax.TextStartsWithTest.SyntaxTest.SupportedByInheritedSyntax" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Framework.Syntax.TextStartsWithTest.SyntaxTest.SupportedByStaticSyntax" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                        </results>
+                      </test-suite>
+                      <test-suite type="TestFixture" name="ThrowsTests" executed="True" result="Success" success="True" time="0.029" asserts="0">
+                        <results>
+                          <test-case name="NUnit.Framework.Syntax.ThrowsTests.DelegateThrowsException" executed="True" result="Success" success="True" time="0.001" asserts="1" />
+                          <test-case name="NUnit.Framework.Syntax.ThrowsTests.ThrowsArgumentException" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Framework.Syntax.ThrowsTests.ThrowsException" executed="True" result="Success" success="True" time="0.001" asserts="1" />
+                          <test-case name="NUnit.Framework.Syntax.ThrowsTests.ThrowsExceptionInstanceOf" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Framework.Syntax.ThrowsTests.ThrowsExceptionTypeOf" executed="True" result="Success" success="True" time="0.001" asserts="1" />
+                          <test-case name="NUnit.Framework.Syntax.ThrowsTests.ThrowsExceptionTypeOfAndConstraint" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Framework.Syntax.ThrowsTests.ThrowsExceptionWithConstraint" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Framework.Syntax.ThrowsTests.ThrowsExceptionWithInnerException" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Framework.Syntax.ThrowsTests.ThrowsInnerException" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Framework.Syntax.ThrowsTests.ThrowsInstanceOf" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Framework.Syntax.ThrowsTests.ThrowsInvalidOperationException" executed="True" result="Success" success="True" time="0.001" asserts="1" />
+                          <test-case name="NUnit.Framework.Syntax.ThrowsTests.ThrowsTargetInvocationExceptionWithInnerException" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Framework.Syntax.ThrowsTests.ThrowsTypeOf" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Framework.Syntax.ThrowsTests.ThrowsTypeOfAndConstraint" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Framework.Syntax.ThrowsTests.ThrowsTypeOfWithConstraint" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Framework.Syntax.ThrowsTests.ThrowsTypeOfWithInnerException" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Framework.Syntax.ThrowsTests.ThrowsTypeofWithMessage" executed="True" result="Success" success="True" time="0.001" asserts="1" />
+                        </results>
+                      </test-suite>
+                      <test-suite type="TestFixture" name="TrueTest" executed="True" result="Success" success="True" time="0.005" asserts="0">
+                        <results>
+                          <test-case name="NUnit.Framework.Syntax.TrueTest.SyntaxTest.SupportedByConstraintBuilder" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Framework.Syntax.TrueTest.SyntaxTest.SupportedByInheritedSyntax" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Framework.Syntax.TrueTest.SyntaxTest.SupportedByStaticSyntax" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                        </results>
+                      </test-suite>
+                      <test-suite type="TestFixture" name="UniqueTest" executed="True" result="Success" success="True" time="0.004" asserts="0">
+                        <results>
+                          <test-case name="NUnit.Framework.Syntax.UniqueTest.SyntaxTest.SupportedByConstraintBuilder" executed="True" result="Success" success="True" time="0.001" asserts="1" />
+                          <test-case name="NUnit.Framework.Syntax.UniqueTest.SyntaxTest.SupportedByInheritedSyntax" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Framework.Syntax.UniqueTest.SyntaxTest.SupportedByStaticSyntax" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                        </results>
+                      </test-suite>
+                      <test-suite type="TestFixture" name="XmlSerializableTest" executed="True" result="Success" success="True" time="0.004" asserts="0">
+                        <results>
+                          <test-case name="NUnit.Framework.Syntax.XmlSerializableTest.SyntaxTest.SupportedByConstraintBuilder" executed="True" result="Success" success="True" time="0.001" asserts="1" />
+                          <test-case name="NUnit.Framework.Syntax.XmlSerializableTest.SyntaxTest.SupportedByInheritedSyntax" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Framework.Syntax.XmlSerializableTest.SyntaxTest.SupportedByStaticSyntax" executed="True" result="Success" success="True" time="0.001" asserts="1" />
+                        </results>
+                      </test-suite>
+                    </results>
+                  </test-suite>
+                  <test-suite type="Namespace" name="Tests" executed="True" result="Success" success="True" time="1.297" asserts="0">
+                    <results>
+                      <test-suite type="TestFixture" name="ArrayEqualsFailureMessageFixture" executed="True" result="Success" success="True" time="0.040" asserts="0">
+                        <results>
+                          <test-case name="NUnit.Framework.Tests.ArrayEqualsFailureMessageFixture.ActualArrayIsLonger" executed="True" result="Success" success="True" time="0.003" asserts="2" />
+                          <test-case name="NUnit.Framework.Tests.ArrayEqualsFailureMessageFixture.ArrayAndCollection_Failure" executed="True" result="Success" success="True" time="0.001" asserts="1" />
+                          <test-case name="NUnit.Framework.Tests.ArrayEqualsFailureMessageFixture.ArraysDeclaredAsDifferentTypes" executed="True" result="Success" success="True" time="0.000" asserts="2" />
+                          <test-case name="NUnit.Framework.Tests.ArrayEqualsFailureMessageFixture.ArraysHaveDifferentRanks" executed="True" result="Success" success="True" time="0.001" asserts="2" />
+                          <test-case name="NUnit.Framework.Tests.ArrayEqualsFailureMessageFixture.ArraysWithDifferentDimensionsAsCollection" executed="True" result="Success" success="True" time="0.001" asserts="2" />
+                          <test-case name="NUnit.Framework.Tests.ArrayEqualsFailureMessageFixture.ArraysWithDifferentRanksAsCollection" executed="True" result="Success" success="True" time="0.001" asserts="2" />
+                          <test-case name="NUnit.Framework.Tests.ArrayEqualsFailureMessageFixture.DifferentArrayTypesEqualFails" executed="True" result="Success" success="True" time="0.001" asserts="2" />
+                          <test-case name="NUnit.Framework.Tests.ArrayEqualsFailureMessageFixture.DoubleDimensionedArrays" executed="True" result="Success" success="True" time="0.001" asserts="2" />
+                          <test-case name="NUnit.Framework.Tests.ArrayEqualsFailureMessageFixture.ExpectedArrayIsLonger" executed="True" result="Success" success="True" time="0.001" asserts="2" />
+                          <test-case name="NUnit.Framework.Tests.ArrayEqualsFailureMessageFixture.FailureOnSingleDimensionedArrays" executed="True" result="Success" success="True" time="0.001" asserts="2" />
+                          <test-case name="NUnit.Framework.Tests.ArrayEqualsFailureMessageFixture.FiveDimensionedArrays" executed="True" result="Success" success="True" time="0.001" asserts="2" />
+                          <test-case name="NUnit.Framework.Tests.ArrayEqualsFailureMessageFixture.JaggedArrayComparedToSimpleArray" executed="True" result="Success" success="True" time="0.001" asserts="2" />
+                          <test-case name="NUnit.Framework.Tests.ArrayEqualsFailureMessageFixture.JaggedArrays" executed="True" result="Success" success="True" time="0.001" asserts="2" />
+                          <test-case name="NUnit.Framework.Tests.ArrayEqualsFailureMessageFixture.SameLengthDifferentContent" executed="True" result="Success" success="True" time="0.001" asserts="2" />
+                          <test-case name="NUnit.Framework.Tests.ArrayEqualsFailureMessageFixture.TripleDimensionedArrays" executed="True" result="Success" success="True" time="0.001" asserts="2" />
+                        </results>
+                      </test-suite>
+                      <test-suite type="TestFixture" name="ArrayEqualsFixture" executed="True" result="Success" success="True" time="0.029" asserts="0">
+                        <results>
+                          <test-case name="NUnit.Framework.Tests.ArrayEqualsFixture.ArrayAndCollection" executed="True" result="Success" success="True" time="0.001" asserts="4" />
+                          <test-case name="NUnit.Framework.Tests.ArrayEqualsFixture.ArrayIsEqualToItself" executed="True" result="Success" success="True" time="0.000" asserts="3" />
+                          <test-case name="NUnit.Framework.Tests.ArrayEqualsFixture.ArrayOfIntAndArrayOfDouble" executed="True" result="Success" success="True" time="0.000" asserts="4" />
+                          <test-case name="NUnit.Framework.Tests.ArrayEqualsFixture.ArraysDeclaredAsDifferentTypes" executed="True" result="Success" success="True" time="0.001" asserts="4" />
+                          <test-case name="NUnit.Framework.Tests.ArrayEqualsFixture.ArraysOfArrays" executed="True" result="Success" success="True" time="0.001" asserts="4" />
+                          <test-case name="NUnit.Framework.Tests.ArrayEqualsFixture.ArraysOfDecimal" executed="True" result="Success" success="True" time="0.001" asserts="4" />
+                          <test-case name="NUnit.Framework.Tests.ArrayEqualsFixture.ArraysOfDouble" executed="True" result="Success" success="True" time="0.000" asserts="4" />
+                          <test-case name="NUnit.Framework.Tests.ArrayEqualsFixture.ArraysOfInt" executed="True" result="Success" success="True" time="0.000" asserts="4" />
+                          <test-case name="NUnit.Framework.Tests.ArrayEqualsFixture.ArraysOfMixedTypes" executed="True" result="Success" success="True" time="0.001" asserts="4" />
+                          <test-case name="NUnit.Framework.Tests.ArrayEqualsFixture.ArraysOfString" executed="True" result="Success" success="True" time="0.001" asserts="5" />
+                          <test-case name="NUnit.Framework.Tests.ArrayEqualsFixture.ArraysPassedAsObjects" executed="True" result="Success" success="True" time="0.000" asserts="4" />
+                          <test-case name="NUnit.Framework.Tests.ArrayEqualsFixture.ArraysWithDifferentDimensionsMatchedAsCollection" executed="True" result="Success" success="True" time="0.000" asserts="3" />
+                          <test-case name="NUnit.Framework.Tests.ArrayEqualsFixture.ArraysWithDifferentRanksComparedAsCollection" executed="True" result="Success" success="True" time="0.000" asserts="3" />
+                          <test-case name="NUnit.Framework.Tests.ArrayEqualsFixture.DoubleDimensionedArrays" executed="True" result="Success" success="True" time="0.001" asserts="4" />
+                          <test-case name="NUnit.Framework.Tests.ArrayEqualsFixture.FiveDimensionedArrays" executed="True" result="Success" success="True" time="0.000" asserts="2" />
+                          <test-case name="NUnit.Framework.Tests.ArrayEqualsFixture.JaggedArrays" executed="True" result="Success" success="True" time="0.001" asserts="2" />
+                          <test-case name="NUnit.Framework.Tests.ArrayEqualsFixture.TripleDimensionedArrays" executed="True" result="Success" success="True" time="0.000" asserts="2" />
+                        </results>
+                      </test-suite>
+                      <test-suite type="TestFixture" name="ArrayNotEqualFixture" executed="True" result="Success" success="True" time="0.005" asserts="0">
+                        <results>
+                          <test-case name="NUnit.Framework.Tests.ArrayNotEqualFixture.ArraysDeclaredAsDifferentTypes" executed="True" result="Success" success="True" time="0.000" asserts="3" />
+                          <test-case name="NUnit.Framework.Tests.ArrayNotEqualFixture.DifferentLengthArrays" executed="True" result="Success" success="True" time="0.001" asserts="4" />
+                          <test-case name="NUnit.Framework.Tests.ArrayNotEqualFixture.SameLengthDifferentContent" executed="True" result="Success" success="True" time="0.000" asserts="4" />
+                        </results>
+                      </test-suite>
+                      <test-suite type="TestFixture" name="AssertThrowsTests" executed="True" result="Success" success="True" time="0.029" asserts="0">
+                        <results>
+                          <test-case name="NUnit.Framework.Tests.AssertThrowsTests.BaseExceptionThrown" executed="True" result="Success" success="True" time="0.002" asserts="2" />
+                          <test-case name="NUnit.Framework.Tests.AssertThrowsTests.CanCatchExceptionOfDerivedType" executed="True" result="Success" success="True" time="0.001" asserts="4" />
+                          <test-case name="NUnit.Framework.Tests.AssertThrowsTests.CanCatchExceptionOfExactType" executed="True" result="Success" success="True" time="0.001" asserts="4" />
+                          <test-case name="NUnit.Framework.Tests.AssertThrowsTests.CanCatchUnspecifiedException" executed="True" result="Success" success="True" time="0.000" asserts="4" />
+                          <test-case name="NUnit.Framework.Tests.AssertThrowsTests.CorrectExceptionIsReturnedToMethod" executed="True" result="Success" success="True" time="0.001" asserts="16" />
+                          <test-case name="NUnit.Framework.Tests.AssertThrowsTests.CorrectExceptionThrown" executed="True" result="Success" success="True" time="0.001" asserts="5" />
+                          <test-case name="NUnit.Framework.Tests.AssertThrowsTests.DerivedExceptionThrown" executed="True" result="Success" success="True" time="0.001" asserts="2" />
+                          <test-case name="NUnit.Framework.Tests.AssertThrowsTests.DoesNotThrowFails" executed="True" result="Success" success="True" time="0.001" asserts="0" />
+                          <test-case name="NUnit.Framework.Tests.AssertThrowsTests.DoesNotThrowSuceeds" executed="True" result="Success" success="True" time="0.000" asserts="0" />
+                          <test-case name="NUnit.Framework.Tests.AssertThrowsTests.NoExceptionThrown" executed="True" result="Success" success="True" time="0.001" asserts="2" />
+                          <test-case name="NUnit.Framework.Tests.AssertThrowsTests.UnrelatedExceptionThrown" executed="True" result="Success" success="True" time="0.001" asserts="2" />
+                        </results>
+                      </test-suite>
+                      <test-suite type="TestFixture" name="AssumeThatTests" executed="True" result="Success" success="True" time="0.048" asserts="0">
+                        <results>
+                          <test-case name="NUnit.Framework.Tests.AssumeThatTests.AssumptionPasses_ActualAndConstraint" executed="True" result="Success" success="True" time="0.000" asserts="0" />
+                          <test-case name="NUnit.Framework.Tests.AssumeThatTests.AssumptionPasses_ActualAndConstraintWithMessage" executed="True" result="Success" success="True" time="0.000" asserts="0" />
+                          <test-case name="NUnit.Framework.Tests.AssumeThatTests.AssumptionPasses_ActualAndConstraintWithMessageAndArgs" executed="True" result="Success" success="True" time="0.001" asserts="0" />
+                          <test-case name="NUnit.Framework.Tests.AssumeThatTests.AssumptionPasses_Boolean" executed="True" result="Success" success="True" time="0.000" asserts="0" />
+                          <test-case name="NUnit.Framework.Tests.AssumeThatTests.AssumptionPasses_BooleanWithMessage" executed="True" result="Success" success="True" time="0.000" asserts="0" />
+                          <test-case name="NUnit.Framework.Tests.AssumeThatTests.AssumptionPasses_BooleanWithMessageAndArgs" executed="True" result="Success" success="True" time="0.000" asserts="0" />
+                          <test-case name="NUnit.Framework.Tests.AssumeThatTests.AssumptionPasses_DelegateAndConstraint" executed="True" result="Success" success="True" time="0.000" asserts="0" />
+                          <test-case name="NUnit.Framework.Tests.AssumeThatTests.AssumptionPasses_DelegateAndConstraintWithMessage" executed="True" result="Success" success="True" time="0.000" asserts="0" />
+                          <test-case name="NUnit.Framework.Tests.AssumeThatTests.AssumptionPasses_DelegateAndConstraintWithMessageAndArgs" executed="True" result="Success" success="True" time="0.001" asserts="0" />
+                          <test-case name="NUnit.Framework.Tests.AssumeThatTests.AssumptionPasses_ReferenceAndConstraint" executed="True" result="Success" success="True" time="0.001" asserts="0" />
+                          <test-case name="NUnit.Framework.Tests.AssumeThatTests.AssumptionPasses_ReferenceAndConstraintWithMessage" executed="True" result="Success" success="True" time="0.001" asserts="0" />
+                          <test-case name="NUnit.Framework.Tests.AssumeThatTests.AssumptionPasses_ReferenceAndConstraintWithMessageAndArgs" executed="True" result="Success" success="True" time="0.000" asserts="0" />
+                          <test-case name="NUnit.Framework.Tests.AssumeThatTests.FailureThrowsInconclusiveException_ActualAndConstraint" executed="True" result="Success" success="True" time="0.001" asserts="0" />
+                          <test-case name="NUnit.Framework.Tests.AssumeThatTests.FailureThrowsInconclusiveException_ActualAndConstraintWithMessage" executed="True" result="Success" success="True" time="0.001" asserts="0" />
+                          <test-case name="NUnit.Framework.Tests.AssumeThatTests.FailureThrowsInconclusiveException_ActualAndConstraintWithMessageAndArgs" executed="True" result="Success" success="True" time="0.001" asserts="0" />
+                          <test-case name="NUnit.Framework.Tests.AssumeThatTests.FailureThrowsInconclusiveException_Boolean" executed="True" result="Success" success="True" time="0.001" asserts="0" />
+                          <test-case name="NUnit.Framework.Tests.AssumeThatTests.FailureThrowsInconclusiveException_BooleanWithMessage" executed="True" result="Success" success="True" time="0.001" asserts="0" />
+                          <test-case name="NUnit.Framework.Tests.AssumeThatTests.FailureThrowsInconclusiveException_BooleanWithMessageAndArgs" executed="True" result="Success" success="True" time="0.001" asserts="0" />
+                          <test-case name="NUnit.Framework.Tests.AssumeThatTests.FailureThrowsInconclusiveException_DelegateAndConstraint" executed="True" result="Success" success="True" time="0.000" asserts="0" />
+                          <test-case name="NUnit.Framework.Tests.AssumeThatTests.FailureThrowsInconclusiveException_DelegateAndConstraintWithMessage" executed="True" result="Success" success="True" time="0.000" asserts="0" />
+                          <test-case name="NUnit.Framework.Tests.AssumeThatTests.FailureThrowsInconclusiveException_DelegateAndConstraintWithMessageAndArgs" executed="True" result="Success" success="True" time="0.001" asserts="0" />
+                          <test-case name="NUnit.Framework.Tests.AssumeThatTests.FailureThrowsInconclusiveException_ReferenceAndConstraint" executed="True" result="Success" success="True" time="0.001" asserts="0" />
+                          <test-case name="NUnit.Framework.Tests.AssumeThatTests.FailureThrowsInconclusiveException_ReferenceAndConstraintWithMessage" executed="True" result="Success" success="True" time="0.001" asserts="0" />
+                          <test-case name="NUnit.Framework.Tests.AssumeThatTests.FailureThrowsInconclusiveException_ReferenceAndConstraintWithMessageAndArgs" executed="True" result="Success" success="True" time="0.001" asserts="0" />
+                        </results>
+                      </test-suite>
+                      <test-suite type="TestFixture" name="CollectionAssertTest" executed="True" result="Success" success="True" time="0.098" asserts="0">
+                        <results>
+                          <test-case name="NUnit.Framework.Tests.CollectionAssertTest.AreEqual" executed="True" result="Success" success="True" time="0.001" asserts="3" />
+                          <test-case name="NUnit.Framework.Tests.CollectionAssertTest.AreEqual_HandlesNull" executed="True" result="Success" success="True" time="0.000" asserts="2" />
+                          <test-case name="NUnit.Framework.Tests.CollectionAssertTest.AreEqual_UsingIterator" executed="True" result="Success" success="True" time="0.001" asserts="1" />
+                          <test-case name="NUnit.Framework.Tests.CollectionAssertTest.AreEqualFail" executed="True" result="Success" success="True" time="0.001" asserts="2" />
+                          <test-case name="NUnit.Framework.Tests.CollectionAssertTest.AreEqualFailCount" executed="True" result="Success" success="True" time="0.001" asserts="2" />
+                          <test-case name="NUnit.Framework.Tests.CollectionAssertTest.AreEquivalentHandlesNull" executed="True" result="Success" success="True" time="0.001" asserts="1" />
+                          <test-case name="NUnit.Framework.Tests.CollectionAssertTest.AreNotEqual" executed="True" result="Success" success="True" time="0.001" asserts="6" />
+                          <test-case name="NUnit.Framework.Tests.CollectionAssertTest.AreNotEqual_Fails" executed="True" result="Success" success="True" time="0.001" asserts="2" />
+                          <test-case name="NUnit.Framework.Tests.CollectionAssertTest.AreNotEqual_HandlesNull" executed="True" result="Success" success="True" time="0.000" asserts="2" />
+                          <test-case name="NUnit.Framework.Tests.CollectionAssertTest.Contains_ICollection" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Framework.Tests.CollectionAssertTest.Contains_IList" executed="True" result="Success" success="True" time="0.001" asserts="1" />
+                          <test-case name="NUnit.Framework.Tests.CollectionAssertTest.ContainsFails_EmptyICollection" executed="True" result="Success" success="True" time="0.001" asserts="2" />
+                          <test-case name="NUnit.Framework.Tests.CollectionAssertTest.ContainsFails_EmptyIList" executed="True" result="Success" success="True" time="0.001" asserts="2" />
+                          <test-case name="NUnit.Framework.Tests.CollectionAssertTest.ContainsFails_ICollection" executed="True" result="Success" success="True" time="0.001" asserts="2" />
+                          <test-case name="NUnit.Framework.Tests.CollectionAssertTest.ContainsFails_ILIst" executed="True" result="Success" success="True" time="0.001" asserts="2" />
+                          <test-case name="NUnit.Framework.Tests.CollectionAssertTest.ContainsNull_ICollection" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Framework.Tests.CollectionAssertTest.ContainsNull_IList" executed="True" result="Success" success="True" time="0.001" asserts="1" />
+                          <test-case name="NUnit.Framework.Tests.CollectionAssertTest.DoesNotContain" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Framework.Tests.CollectionAssertTest.DoesNotContain_Empty" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Framework.Tests.CollectionAssertTest.DoesNotContain_Fails" executed="True" result="Success" success="True" time="0.001" asserts="2" />
+                          <test-case name="NUnit.Framework.Tests.CollectionAssertTest.EnsureComparerIsUsed" executed="True" result="Success" success="True" time="0.001" asserts="1" />
+                          <test-case name="NUnit.Framework.Tests.CollectionAssertTest.Equivalent" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Framework.Tests.CollectionAssertTest.EquivalentFailOne" executed="True" result="Success" success="True" time="0.001" asserts="2" />
+                          <test-case name="NUnit.Framework.Tests.CollectionAssertTest.EquivalentFailTwo" executed="True" result="Success" success="True" time="0.001" asserts="2" />
+                          <test-case name="NUnit.Framework.Tests.CollectionAssertTest.IsNotSubsetOf" executed="True" result="Success" success="True" time="0.001" asserts="2" />
+                          <test-case name="NUnit.Framework.Tests.CollectionAssertTest.IsNotSubsetOf_Fails" executed="True" result="Success" success="True" time="0.001" asserts="2" />
+                          <test-case name="NUnit.Framework.Tests.CollectionAssertTest.IsNotSubsetOfHandlesNull" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Framework.Tests.CollectionAssertTest.IsOrdered" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Framework.Tests.CollectionAssertTest.IsOrdered_Allows_adjacent_equal_values" executed="True" result="Success" success="True" time="0.001" asserts="1" />
+                          <test-case name="NUnit.Framework.Tests.CollectionAssertTest.IsOrdered_ContainedTypesMustBeCompatible" executed="True" result="Success" success="True" time="0.001" asserts="1" />
+                          <test-case name="NUnit.Framework.Tests.CollectionAssertTest.IsOrdered_Fails" executed="True" result="Success" success="True" time="0.001" asserts="2" />
+                          <test-case name="NUnit.Framework.Tests.CollectionAssertTest.IsOrdered_Handles_custom_comparison" executed="True" result="Success" success="True" time="0.001" asserts="1" />
+                          <test-case name="NUnit.Framework.Tests.CollectionAssertTest.IsOrdered_Handles_custom_comparison2" executed="True" result="Success" success="True" time="0.001" asserts="1" />
+                          <test-case name="NUnit.Framework.Tests.CollectionAssertTest.IsOrdered_Handles_null" executed="True" result="Success" success="True" time="0.001" asserts="1" />
+                          <test-case name="NUnit.Framework.Tests.CollectionAssertTest.IsOrdered_TypesMustImplementIComparable" executed="True" result="Success" success="True" time="0.001" asserts="1" />
+                          <test-case name="NUnit.Framework.Tests.CollectionAssertTest.IsSubsetOf" executed="True" result="Success" success="True" time="0.001" asserts="2" />
+                          <test-case name="NUnit.Framework.Tests.CollectionAssertTest.IsSubsetOf_Fails" executed="True" result="Success" success="True" time="0.001" asserts="2" />
+                          <test-case name="NUnit.Framework.Tests.CollectionAssertTest.IsSubsetOfHandlesNull" executed="True" result="Success" success="True" time="0.000" asserts="2" />
+                          <test-case name="NUnit.Framework.Tests.CollectionAssertTest.ItemsNotNull" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Framework.Tests.CollectionAssertTest.ItemsNotNullFailure" executed="True" result="Success" success="True" time="0.001" asserts="2" />
+                          <test-case name="NUnit.Framework.Tests.CollectionAssertTest.ItemsOfType" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Framework.Tests.CollectionAssertTest.ItemsOfTypeFailure" executed="True" result="Success" success="True" time="0.000" asserts="2" />
+                          <test-case name="NUnit.Framework.Tests.CollectionAssertTest.NotEquivalent" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Framework.Tests.CollectionAssertTest.NotEquivalent_Fails" executed="True" result="Success" success="True" time="0.001" asserts="2" />
+                          <test-case name="NUnit.Framework.Tests.CollectionAssertTest.NotEquivalentHandlesNull" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Framework.Tests.CollectionAssertTest.Unique_WithNull" executed="True" result="Success" success="True" time="0.001" asserts="1" />
+                          <test-case name="NUnit.Framework.Tests.CollectionAssertTest.Unique_WithObjects" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Framework.Tests.CollectionAssertTest.Unique_WithStrings" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Framework.Tests.CollectionAssertTest.UniqueFailure" executed="True" result="Success" success="True" time="0.001" asserts="2" />
+                          <test-case name="NUnit.Framework.Tests.CollectionAssertTest.UniqueFailure_WithTwoNulls" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                        </results>
+                      </test-suite>
+                      <test-suite type="TestFixture" name="ConditionAssertTests" executed="True" result="Success" success="True" time="0.038" asserts="0">
+                        <results>
+                          <test-case name="NUnit.Framework.Tests.ConditionAssertTests.IsEmpty" executed="True" result="Success" success="True" time="0.001" asserts="4" />
+                          <test-case name="NUnit.Framework.Tests.ConditionAssertTests.IsEmptyFailsOnNonEmptyArray" executed="True" result="Success" success="True" time="0.001" asserts="2" />
+                          <test-case name="NUnit.Framework.Tests.ConditionAssertTests.IsEmptyFailsOnNullString" executed="True" result="Success" success="True" time="0.001" asserts="2" />
+                          <test-case name="NUnit.Framework.Tests.ConditionAssertTests.IsEmptyFailsOnString" executed="True" result="Success" success="True" time="0.001" asserts="2" />
+                          <test-case name="NUnit.Framework.Tests.ConditionAssertTests.IsFalse" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Framework.Tests.ConditionAssertTests.IsFalseFails" executed="True" result="Success" success="True" time="0.001" asserts="2" />
+                          <test-case name="NUnit.Framework.Tests.ConditionAssertTests.IsNaN" executed="True" result="Success" success="True" time="0.001" asserts="1" />
+                          <test-case name="NUnit.Framework.Tests.ConditionAssertTests.IsNaNFails" executed="True" result="Success" success="True" time="0.001" asserts="2" />
+                          <test-case name="NUnit.Framework.Tests.ConditionAssertTests.IsNotEmpty" executed="True" result="Success" success="True" time="0.001" asserts="4" />
+                          <test-case name="NUnit.Framework.Tests.ConditionAssertTests.IsNotEmptyFailsOnEmptyArray" executed="True" result="Success" success="True" time="0.001" asserts="2" />
+                          <test-case name="NUnit.Framework.Tests.ConditionAssertTests.IsNotEmptyFailsOnEmptyArrayList" executed="True" result="Success" success="True" time="0.001" asserts="2" />
+                          <test-case name="NUnit.Framework.Tests.ConditionAssertTests.IsNotEmptyFailsOnEmptyHashTable" executed="True" result="Success" success="True" time="0.001" asserts="2" />
+                          <test-case name="NUnit.Framework.Tests.ConditionAssertTests.IsNotEmptyFailsOnEmptyString" executed="True" result="Success" success="True" time="0.000" asserts="2" />
+                          <test-case name="NUnit.Framework.Tests.ConditionAssertTests.IsNotNull" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Framework.Tests.ConditionAssertTests.IsNotNullFails" executed="True" result="Success" success="True" time="0.001" asserts="2" />
+                          <test-case name="NUnit.Framework.Tests.ConditionAssertTests.IsNull" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Framework.Tests.ConditionAssertTests.IsNullFails" executed="True" result="Success" success="True" time="0.001" asserts="2" />
+                          <test-case name="NUnit.Framework.Tests.ConditionAssertTests.IsTrue" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Framework.Tests.ConditionAssertTests.IsTrueFails" executed="True" result="Success" success="True" time="0.000" asserts="2" />
+                        </results>
+                      </test-suite>
+                      <test-suite type="TestFixture" name="DirectoryAssertTests" executed="True" result="Success" success="True" time="0.316" asserts="0">
+                        <results>
+                          <test-case name="NUnit.Framework.Tests.DirectoryAssertTests.AreEqualFailsWhenOneDoesNotExist" executed="True" result="Success" success="True" time="0.010" asserts="1" />
+                          <test-case name="NUnit.Framework.Tests.DirectoryAssertTests.AreEqualFailsWhenOneIsNull" executed="True" result="Success" success="True" time="0.008" asserts="1" />
+                          <test-case name="NUnit.Framework.Tests.DirectoryAssertTests.AreEqualFailsWithDirectoryInfos" executed="True" result="Success" success="True" time="0.014" asserts="1" />
+                          <test-case name="NUnit.Framework.Tests.DirectoryAssertTests.AreEqualFailsWithStringPath" executed="True" result="Success" success="True" time="0.015" asserts="1" />
+                          <test-case name="NUnit.Framework.Tests.DirectoryAssertTests.AreEqualPassesWhenBothAreNull" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Framework.Tests.DirectoryAssertTests.AreEqualPassesWithDirectoryInfos" executed="True" result="Success" success="True" time="0.006" asserts="1" />
+                          <test-case name="NUnit.Framework.Tests.DirectoryAssertTests.AreEqualPassesWithStringPath" executed="True" result="Success" success="True" time="0.007" asserts="1" />
+                          <test-case name="NUnit.Framework.Tests.DirectoryAssertTests.AreNotEqualFailsWhenBothAreNull" executed="True" result="Success" success="True" time="0.001" asserts="2" />
+                          <test-case name="NUnit.Framework.Tests.DirectoryAssertTests.AreNotEqualFailsWithDirectoryInfos" executed="True" result="Success" success="True" time="0.007" asserts="1" />
+                          <test-case name="NUnit.Framework.Tests.DirectoryAssertTests.AreNotEqualFailsWithStringPath" executed="True" result="Success" success="True" time="0.008" asserts="1" />
+                          <test-case name="NUnit.Framework.Tests.DirectoryAssertTests.AreNotEqualPassesIfOneIsNull" executed="True" result="Success" success="True" time="0.007" asserts="1" />
+                          <test-case name="NUnit.Framework.Tests.DirectoryAssertTests.AreNotEqualPassesWhenOneDoesNotExist" executed="True" result="Success" success="True" time="0.006" asserts="1" />
+                          <test-case name="NUnit.Framework.Tests.DirectoryAssertTests.AreNotEqualPassesWithStringPath" executed="True" result="Success" success="True" time="0.013" asserts="1" />
+                          <test-case name="NUnit.Framework.Tests.DirectoryAssertTests.IsEmptyFailsWithInvalidDirectory" executed="True" result="Success" success="True" time="0.028" asserts="1" />
+                          <test-case name="NUnit.Framework.Tests.DirectoryAssertTests.IsEmptyFailsWithNonEmptyDirectoryUsingDirectoryInfo" executed="True" result="Success" success="True" time="0.008" asserts="1" />
+                          <test-case name="NUnit.Framework.Tests.DirectoryAssertTests.IsEmptyFailsWithNonEmptyDirectoryUsingStringPath" executed="True" result="Success" success="True" time="0.008" asserts="1" />
+                          <test-case name="NUnit.Framework.Tests.DirectoryAssertTests.IsEmptyPassesWithEmptyDirectoryUsingDirectoryInfo" executed="True" result="Success" success="True" time="0.004" asserts="2" />
+                          <test-case name="NUnit.Framework.Tests.DirectoryAssertTests.IsEmptyPassesWithEmptyDirectoryUsingStringPath" executed="True" result="Success" success="True" time="0.004" asserts="1" />
+                          <test-case name="NUnit.Framework.Tests.DirectoryAssertTests.IsEmptyThrowsUsingNull" executed="True" result="Success" success="True" time="0.001" asserts="1" />
+                          <test-case name="NUnit.Framework.Tests.DirectoryAssertTests.IsNotEmptyFailsWithEmptyDirectoryUsingDirectoryInfo" executed="True" result="Success" success="True" time="0.004" asserts="1" />
+                          <test-case name="NUnit.Framework.Tests.DirectoryAssertTests.IsNotEmptyFailsWithEmptyDirectoryUsingStringPath" executed="True" result="Success" success="True" time="0.005" asserts="1" />
+                          <test-case name="NUnit.Framework.Tests.DirectoryAssertTests.IsNotEmptyFailsWithInvalidDirectory" executed="True" result="Success" success="True" time="0.004" asserts="1" />
+                          <test-case name="NUnit.Framework.Tests.DirectoryAssertTests.IsNotEmptyPassesWithNonEmptyDirectoryUsingDirectoryInfo" executed="True" result="Success" success="True" time="0.008" asserts="2" />
+                          <test-case name="NUnit.Framework.Tests.DirectoryAssertTests.IsNotEmptyPassesWithNonEmptyDirectoryUsingStringPath" executed="True" result="Success" success="True" time="0.007" asserts="1" />
+                          <test-case name="NUnit.Framework.Tests.DirectoryAssertTests.IsNotEmptyThrowsUsingNull" executed="True" result="Success" success="True" time="0.001" asserts="1" />
+                          <test-case name="NUnit.Framework.Tests.DirectoryAssertTests.IsNotWithinFailsWithDirectoryInfo" executed="True" result="Success" success="True" time="0.008" asserts="1" />
+                          <test-case name="NUnit.Framework.Tests.DirectoryAssertTests.IsNotWithinFailsWithStringPath" executed="True" result="Success" success="True" time="0.008" asserts="1" />
+                          <test-case name="NUnit.Framework.Tests.DirectoryAssertTests.IsNotWithinPassesWhenOutsidePathUsingDirectoryInfo" executed="True" result="Success" success="True" time="0.007" asserts="1" />
+                          <test-case name="NUnit.Framework.Tests.DirectoryAssertTests.IsNotWithinPassesWhenOutsidePathUsingStringPath" executed="True" result="Success" success="True" time="0.006" asserts="1" />
+                          <test-case name="NUnit.Framework.Tests.DirectoryAssertTests.IsNotWithinThrowsWhenBothAreNull" executed="True" result="Success" success="True" time="0.001" asserts="0" />
+                          <test-case name="NUnit.Framework.Tests.DirectoryAssertTests.IsWithinFailsWhenOutsidePathUsingDirectoryInfo" executed="True" result="Success" success="True" time="0.008" asserts="1" />
+                          <test-case name="NUnit.Framework.Tests.DirectoryAssertTests.IsWithinFailsWhenOutsidePathUsingStringPath" executed="True" result="Success" success="True" time="0.008" asserts="1" />
+                          <test-case name="NUnit.Framework.Tests.DirectoryAssertTests.IsWithinPassesWithDirectoryInfo" executed="True" result="Success" success="True" time="0.007" asserts="1" />
+                          <test-case name="NUnit.Framework.Tests.DirectoryAssertTests.IsWithinPassesWithStringPath" executed="True" result="Success" success="True" time="0.007" asserts="1" />
+                          <test-case name="NUnit.Framework.Tests.DirectoryAssertTests.IsWithinPassesWithTempPath" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Framework.Tests.DirectoryAssertTests.IsWithinThrowsWhenBothAreNull" executed="True" result="Success" success="True" time="0.001" asserts="0" />
+                        </results>
+                      </test-suite>
+                      <test-suite type="TestFixture" name="EqualsFixture" executed="True" result="Success" success="True" time="0.079" asserts="0">
+                        <results>
+                          <test-case name="NUnit.Framework.Tests.EqualsFixture.Bug575936Int32Int64Comparison" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Framework.Tests.EqualsFixture.Byte" executed="True" result="Success" success="True" time="0.000" asserts="2" />
+                          <test-case name="NUnit.Framework.Tests.EqualsFixture.DateTimeEqual" executed="True" result="Success" success="True" time="0.001" asserts="1" />
+                          <test-case name="NUnit.Framework.Tests.EqualsFixture.DateTimeNotEqual" executed="True" result="Success" success="True" time="0.002" asserts="2" />
+                          <test-case name="NUnit.Framework.Tests.EqualsFixture.Decimal" executed="True" result="Success" success="True" time="0.002" asserts="6" />
+                          <test-case name="NUnit.Framework.Tests.EqualsFixture.DirectoryInfoEquality" executed="True" result="Success" success="True" time="0.001" asserts="1" />
+                          <test-case name="NUnit.Framework.Tests.EqualsFixture.DirectoryInfoEqualityIgnoresTrailingDirectorySeparator" executed="True" result="Success" success="True" time="0.001" asserts="1" />
+                          <test-case name="NUnit.Framework.Tests.EqualsFixture.DoubleNotEqualMessageDisplaysAllDigits" executed="True" result="Success" success="True" time="0.000" asserts="2" />
+                          <test-case name="NUnit.Framework.Tests.EqualsFixture.DoubleNotEqualMessageDisplaysDefaultTolerance" executed="True" result="Success" success="True" time="0.001" asserts="2" />
+                          <test-case name="NUnit.Framework.Tests.EqualsFixture.DoubleNotEqualMessageDisplaysTolerance" executed="True" result="Success" success="True" time="0.001" asserts="2" />
+                          <test-case name="NUnit.Framework.Tests.EqualsFixture.DoubleNotEqualWithNanDoesNotDisplayDefaultTolerance" executed="True" result="Success" success="True" time="0.001" asserts="2" />
+                          <test-case name="NUnit.Framework.Tests.EqualsFixture.EnumsEqual" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Framework.Tests.EqualsFixture.EnumsNotEqual" executed="True" result="Success" success="True" time="0.001" asserts="2" />
+                          <test-case name="NUnit.Framework.Tests.EqualsFixture.Equals" executed="True" result="Success" success="True" time="0.000" asserts="2" />
+                          <test-case name="NUnit.Framework.Tests.EqualsFixture.EqualsFail" executed="True" result="Success" success="True" time="0.001" asserts="2" />
+                          <test-case name="NUnit.Framework.Tests.EqualsFixture.EqualsNaNFails" executed="True" result="Success" success="True" time="0.000" asserts="2" />
+                          <test-case name="NUnit.Framework.Tests.EqualsFixture.EqualsNull" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Framework.Tests.EqualsFixture.EqualsSameTypes" executed="True" result="Success" success="True" time="0.002" asserts="31" />
+                          <test-case name="NUnit.Framework.Tests.EqualsFixture.EqualsThrowsException" executed="True" result="Success" success="True" time="0.001" asserts="0" />
+                          <test-case name="NUnit.Framework.Tests.EqualsFixture.Float" executed="True" result="Success" success="True" time="0.000" asserts="2" />
+                          <test-case name="NUnit.Framework.Tests.EqualsFixture.FloatNotEqualMessageDisplaysAllDigits" executed="True" result="Success" success="True" time="0.001" asserts="2" />
+                          <test-case name="NUnit.Framework.Tests.EqualsFixture.FloatNotEqualMessageDisplaysTolerance" executed="True" result="Success" success="True" time="0.000" asserts="2" />
+                          <test-case name="NUnit.Framework.Tests.EqualsFixture.Int" executed="True" result="Success" success="True" time="0.000" asserts="2" />
+                          <test-case name="NUnit.Framework.Tests.EqualsFixture.IntegerEquals" executed="True" result="Success" success="True" time="0.001" asserts="1" />
+                          <test-case name="NUnit.Framework.Tests.EqualsFixture.IntegerLongComparison" executed="True" result="Success" success="True" time="0.000" asserts="2" />
+                          <test-case name="NUnit.Framework.Tests.EqualsFixture.NanEqualsFails" executed="True" result="Success" success="True" time="0.001" asserts="2" />
+                          <test-case name="NUnit.Framework.Tests.EqualsFixture.NanEqualsNaNSucceeds" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Framework.Tests.EqualsFixture.NegInfinityEqualsInfinity" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Framework.Tests.EqualsFixture.PosInfinityEqualsInfinity" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Framework.Tests.EqualsFixture.PosInfinityNotEquals" executed="True" result="Success" success="True" time="0.001" asserts="2" />
+                          <test-case name="NUnit.Framework.Tests.EqualsFixture.PosInfinityNotEqualsNegInfinity" executed="True" result="Success" success="True" time="0.001" asserts="2" />
+                          <test-case name="NUnit.Framework.Tests.EqualsFixture.ReferenceEqualsThrowsException" executed="True" result="Success" success="True" time="0.001" asserts="0" />
+                          <test-case name="NUnit.Framework.Tests.EqualsFixture.Short" executed="True" result="Success" success="True" time="0.001" asserts="2" />
+                          <test-case name="NUnit.Framework.Tests.EqualsFixture.SinglePosInfinityNotEqualsNegInfinity" executed="True" result="Success" success="True" time="0.001" asserts="2" />
+                          <test-case name="NUnit.Framework.Tests.EqualsFixture.String" executed="True" result="Success" success="True" time="0.000" asserts="2" />
+                          <test-case name="NUnit.Framework.Tests.EqualsFixture.UInt" executed="True" result="Success" success="True" time="0.000" asserts="2" />
+                        </results>
+                      </test-suite>
+                      <test-suite type="TestFixture" name="FileAssertTests" executed="True" result="Success" success="True" time="0.146" asserts="0">
+                        <results>
+                          <test-case name="NUnit.Framework.Tests.FileAssertTests.AreEqualFailsWhenOneIsNull" executed="True" result="Success" success="True" time="0.005" asserts="2" />
+                          <test-case name="NUnit.Framework.Tests.FileAssertTests.AreEqualFailsWithFileInfos" executed="True" result="Success" success="True" time="0.007" asserts="2" />
+                          <test-case name="NUnit.Framework.Tests.FileAssertTests.AreEqualFailsWithFiles" executed="True" result="Success" success="True" time="0.006" asserts="2" />
+                          <test-case name="NUnit.Framework.Tests.FileAssertTests.AreEqualFailsWithStreams" executed="True" result="Success" success="True" time="0.005" asserts="2" />
+                          <test-case name="NUnit.Framework.Tests.FileAssertTests.AreEqualFailsWithTextFilesAfterReadingBothFiles" executed="True" result="Success" success="True" time="0.006" asserts="1" />
+                          <test-case name="NUnit.Framework.Tests.FileAssertTests.AreEqualPassesUsingSameFileTwice" executed="True" result="Success" success="True" time="0.003" asserts="1" />
+                          <test-case name="NUnit.Framework.Tests.FileAssertTests.AreEqualPassesWhenBothAreNull" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Framework.Tests.FileAssertTests.AreEqualPassesWithEqualStreams" executed="True" result="Success" success="True" time="0.004" asserts="1" />
+                          <test-case name="NUnit.Framework.Tests.FileAssertTests.AreEqualPassesWithFileInfos" executed="True" result="Success" success="True" time="0.006" asserts="2" />
+                          <test-case name="NUnit.Framework.Tests.FileAssertTests.AreEqualPassesWithFiles" executed="True" result="Success" success="True" time="0.004" asserts="1" />
+                          <test-case name="NUnit.Framework.Tests.FileAssertTests.AreEqualPassesWithSameStream" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Framework.Tests.FileAssertTests.AreEqualPassesWithTextFiles" executed="True" result="Success" success="True" time="0.005" asserts="1" />
+                          <test-case name="NUnit.Framework.Tests.FileAssertTests.AreNotEqualFailsWhenBothAreNull" executed="True" result="Success" success="True" time="0.001" asserts="2" />
+                          <test-case name="NUnit.Framework.Tests.FileAssertTests.AreNotEqualFailsWithFileInfos" executed="True" result="Success" success="True" time="0.005" asserts="2" />
+                          <test-case name="NUnit.Framework.Tests.FileAssertTests.AreNotEqualFailsWithFiles" executed="True" result="Success" success="True" time="0.004" asserts="2" />
+                          <test-case name="NUnit.Framework.Tests.FileAssertTests.AreNotEqualFailsWithStreams" executed="True" result="Success" success="True" time="0.005" asserts="2" />
+                          <test-case name="NUnit.Framework.Tests.FileAssertTests.AreNotEqualIteratesOverTheEntireFile" executed="True" result="Success" success="True" time="0.005" asserts="1" />
+                          <test-case name="NUnit.Framework.Tests.FileAssertTests.AreNotEqualIteratesOverTheEntireFileAndFails" executed="True" result="Success" success="True" time="0.006" asserts="2" />
+                          <test-case name="NUnit.Framework.Tests.FileAssertTests.AreNotEqualPassesIfOneIsNull" executed="True" result="Success" success="True" time="0.003" asserts="1" />
+                          <test-case name="NUnit.Framework.Tests.FileAssertTests.AreNotEqualPassesWithFileInfos" executed="True" result="Success" success="True" time="0.004" asserts="1" />
+                          <test-case name="NUnit.Framework.Tests.FileAssertTests.AreNotEqualPassesWithFiles" executed="True" result="Success" success="True" time="0.005" asserts="1" />
+                          <test-case name="NUnit.Framework.Tests.FileAssertTests.AreNotEqualPassesWithStreams" executed="True" result="Success" success="True" time="0.005" asserts="1" />
+                          <test-case name="NUnit.Framework.Tests.FileAssertTests.NonReadableStreamGivesException" executed="True" result="Success" success="True" time="0.006" asserts="1" />
+                          <test-case name="NUnit.Framework.Tests.FileAssertTests.NonSeekableStreamGivesException" executed="True" result="Success" success="True" time="0.003" asserts="1" />
+                        </results>
+                      </test-suite>
+                      <test-suite type="TestFixture" name="GreaterEqualFixture" executed="True" result="Success" success="True" time="0.047" asserts="0">
+                        <results>
+                          <test-case name="NUnit.Framework.Tests.GreaterEqualFixture.FailureMessage" executed="True" result="Success" success="True" time="0.000" asserts="3" />
+                          <test-case name="NUnit.Framework.Tests.GreaterEqualFixture.GreaterOrEqual_Decimal" executed="True" result="Success" success="True" time="0.000" asserts="2" />
+                          <test-case name="NUnit.Framework.Tests.GreaterEqualFixture.GreaterOrEqual_Double" executed="True" result="Success" success="True" time="0.000" asserts="2" />
+                          <test-case name="NUnit.Framework.Tests.GreaterEqualFixture.GreaterOrEqual_Float" executed="True" result="Success" success="True" time="0.000" asserts="2" />
+                          <test-case name="NUnit.Framework.Tests.GreaterEqualFixture.GreaterOrEqual_Int32" executed="True" result="Success" success="True" time="0.000" asserts="2" />
+                          <test-case name="NUnit.Framework.Tests.GreaterEqualFixture.GreaterOrEqual_Long" executed="True" result="Success" success="True" time="0.001" asserts="2" />
+                          <test-case name="NUnit.Framework.Tests.GreaterEqualFixture.GreaterOrEqual_UInt32" executed="True" result="Success" success="True" time="0.001" asserts="2" />
+                          <test-case name="NUnit.Framework.Tests.GreaterEqualFixture.GreaterOrEqual_ULong" executed="True" result="Success" success="True" time="0.001" asserts="2" />
+                          <test-case name="NUnit.Framework.Tests.GreaterEqualFixture.MixedTypes" executed="True" result="Success" success="True" time="0.003" asserts="42" />
+                          <test-case name="NUnit.Framework.Tests.GreaterEqualFixture.NotGreaterEqualIComparable" executed="True" result="Success" success="True" time="0.001" asserts="2" />
+                          <test-case name="NUnit.Framework.Tests.GreaterEqualFixture.NotGreaterOrEqual" executed="True" result="Success" success="True" time="0.001" asserts="2" />
+                        </results>
+                      </test-suite>
+                      <test-suite type="TestFixture" name="GreaterFixture" executed="True" result="Success" success="True" time="0.017" asserts="0">
+                        <results>
+                          <test-case name="NUnit.Framework.Tests.GreaterFixture.FailureMessage" executed="True" result="Success" success="True" time="0.001" asserts="2" />
+                          <test-case name="NUnit.Framework.Tests.GreaterFixture.Greater" executed="True" result="Success" success="True" time="0.001" asserts="7" />
+                          <test-case name="NUnit.Framework.Tests.GreaterFixture.MixedTypes" executed="True" result="Success" success="True" time="0.002" asserts="42" />
+                          <test-case name="NUnit.Framework.Tests.GreaterFixture.NotGreater" executed="True" result="Success" success="True" time="0.001" asserts="2" />
+                          <test-case name="NUnit.Framework.Tests.GreaterFixture.NotGreaterIComparable" executed="True" result="Success" success="True" time="0.001" asserts="2" />
+                          <test-case name="NUnit.Framework.Tests.GreaterFixture.NotGreaterWhenEqual" executed="True" result="Success" success="True" time="0.001" asserts="2" />
+                        </results>
+                      </test-suite>
+                      <test-suite type="TestFixture" name="LessEqualFixture" executed="True" result="Success" success="True" time="0.017" asserts="0">
+                        <results>
+                          <test-case name="NUnit.Framework.Tests.LessEqualFixture.FailureMessage" executed="True" result="Success" success="True" time="0.001" asserts="2" />
+                          <test-case name="NUnit.Framework.Tests.LessEqualFixture.LessOrEqual" executed="True" result="Success" success="True" time="0.005" asserts="42" />
+                          <test-case name="NUnit.Framework.Tests.LessEqualFixture.MixedTypes" executed="True" result="Success" success="True" time="0.002" asserts="42" />
+                          <test-case name="NUnit.Framework.Tests.LessEqualFixture.NotLessEqualIComparable" executed="True" result="Success" success="True" time="0.001" asserts="2" />
+                          <test-case name="NUnit.Framework.Tests.LessEqualFixture.NotLessOrEqual" executed="True" result="Success" success="True" time="0.001" asserts="2" />
+                        </results>
+                      </test-suite>
+                      <test-suite type="TestFixture" name="LessFixture" executed="True" result="Success" success="True" time="0.018" asserts="0">
+                        <results>
+                          <test-case name="NUnit.Framework.Tests.LessFixture.FailureMessage" executed="True" result="Success" success="True" time="0.001" asserts="3" />
+                          <test-case name="NUnit.Framework.Tests.LessFixture.Less" executed="True" result="Success" success="True" time="0.004" asserts="18" />
+                          <test-case name="NUnit.Framework.Tests.LessFixture.MixedTypes" executed="True" result="Success" success="True" time="0.003" asserts="42" />
+                          <test-case name="NUnit.Framework.Tests.LessFixture.NotLess" executed="True" result="Success" success="True" time="0.001" asserts="2" />
+                          <test-case name="NUnit.Framework.Tests.LessFixture.NotLessIComparable" executed="True" result="Success" success="True" time="0.001" asserts="2" />
+                          <test-case name="NUnit.Framework.Tests.LessFixture.NotLessWhenEqual" executed="True" result="Success" success="True" time="0.001" asserts="2" />
+                        </results>
+                      </test-suite>
+                      <test-suite type="TestFixture" name="ListContentsTests" executed="True" result="Success" success="True" time="0.020" asserts="0">
+                        <results>
+                          <test-case name="NUnit.Framework.Tests.ListContentsTests.ArrayFails" executed="True" result="Success" success="True" time="0.001" asserts="2" />
+                          <test-case name="NUnit.Framework.Tests.ListContentsTests.ArrayListFails" executed="True" result="Success" success="True" time="0.000" asserts="2" />
+                          <test-case name="NUnit.Framework.Tests.ListContentsTests.ArrayListSucceeds" executed="True" result="Success" success="True" time="0.000" asserts="3" />
+                          <test-case name="NUnit.Framework.Tests.ListContentsTests.ArraySucceeds" executed="True" result="Success" success="True" time="0.000" asserts="3" />
+                          <test-case name="NUnit.Framework.Tests.ListContentsTests.DifferentTypesMayBeEqual" executed="True" result="Success" success="True" time="0.001" asserts="1" />
+                          <test-case name="NUnit.Framework.Tests.ListContentsTests.EmptyArrayFails" executed="True" result="Success" success="True" time="0.001" asserts="2" />
+                          <test-case name="NUnit.Framework.Tests.ListContentsTests.NullArrayIsError" executed="True" result="Success" success="True" time="0.001" asserts="1" />
+                        </results>
+                      </test-suite>
+                      <test-suite type="TestFixture" name="NotEqualFixture" executed="True" result="Success" success="True" time="0.026" asserts="0">
+                        <results>
+                          <test-case name="NUnit.Framework.Tests.NotEqualFixture.ArraysNotEqual" executed="True" result="Success" success="True" time="0.001" asserts="1" />
+                          <test-case name="NUnit.Framework.Tests.NotEqualFixture.ArraysNotEqualFails" executed="True" result="Success" success="True" time="0.001" asserts="2" />
+                          <test-case name="NUnit.Framework.Tests.NotEqualFixture.NotEqual" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Framework.Tests.NotEqualFixture.NotEqualFails" executed="True" result="Success" success="True" time="0.000" asserts="2" />
+                          <test-case name="NUnit.Framework.Tests.NotEqualFixture.NotEqualSameTypes" executed="True" result="Success" success="True" time="0.003" asserts="21" />
+                          <test-case name="NUnit.Framework.Tests.NotEqualFixture.NullEqualsNull" executed="True" result="Success" success="True" time="0.001" asserts="2" />
+                          <test-case name="NUnit.Framework.Tests.NotEqualFixture.NullNotEqualToNonNull" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Framework.Tests.NotEqualFixture.UInt" executed="True" result="Success" success="True" time="0.001" asserts="1" />
+                        </results>
+                      </test-suite>
+                      <test-suite type="TestFixture" name="NotSameFixture" executed="True" result="Success" success="True" time="0.005" asserts="0">
+                        <results>
+                          <test-case name="NUnit.Framework.Tests.NotSameFixture.NotSame" executed="True" result="Success" success="True" time="0.001" asserts="1" />
+                          <test-case name="NUnit.Framework.Tests.NotSameFixture.NotSameFails" executed="True" result="Success" success="True" time="0.001" asserts="2" />
+                        </results>
+                      </test-suite>
+                      <test-suite type="TestFixture" name="NullableTypesTests" executed="True" result="Success" success="True" time="0.035" asserts="0">
+                        <categories>
+                          <category name="Generics" />
+                        </categories>
+                        <results>
+                          <test-case name="NUnit.Framework.Tests.NullableTypesTests.CanCompareNullableDecimals" executed="True" result="Success" success="True" time="0.002" asserts="12" />
+                          <test-case name="NUnit.Framework.Tests.NullableTypesTests.CanCompareNullableDoubles" executed="True" result="Success" success="True" time="0.001" asserts="12" />
+                          <test-case name="NUnit.Framework.Tests.NullableTypesTests.CanCompareNullableEnums" executed="True" result="Success" success="True" time="0.001" asserts="3" />
+                          <test-case name="NUnit.Framework.Tests.NullableTypesTests.CanCompareNullableInts" executed="True" result="Success" success="True" time="0.001" asserts="12" />
+                          <test-case name="NUnit.Framework.Tests.NullableTypesTests.CanCompareNullableMixedNumerics" executed="True" result="Success" success="True" time="0.004" asserts="54" />
+                          <test-case name="NUnit.Framework.Tests.NullableTypesTests.CanCompareNullableStructs" executed="True" result="Success" success="True" time="0.001" asserts="4" />
+                          <test-case name="NUnit.Framework.Tests.NullableTypesTests.CanCompareWithTolerance" executed="True" result="Success" success="True" time="0.001" asserts="4" />
+                          <test-case name="NUnit.Framework.Tests.NullableTypesTests.CanTestForNaN" executed="True" result="Success" success="True" time="0.000" asserts="2" />
+                          <test-case name="NUnit.Framework.Tests.NullableTypesTests.CanTestForNull" executed="True" result="Success" success="True" time="0.000" asserts="4" />
+                        </results>
+                      </test-suite>
+                      <test-suite type="TestFixture" name="RandomizerTests" executed="True" result="Success" success="True" time="0.017" asserts="0">
+                        <results>
+                          <test-case name="NUnit.Framework.Tests.RandomizerTests.RandomDoublesAreUnique" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Framework.Tests.RandomizerTests.RandomIntsAreUnique" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Framework.Tests.RandomizerTests.RandomizersWithDifferentSeedsReturnDifferentValues" executed="True" result="Success" success="True" time="0.000" asserts="10" />
+                          <test-case name="NUnit.Framework.Tests.RandomizerTests.RandomizersWithSameSeedsReturnSameValues" executed="True" result="Success" success="True" time="0.000" asserts="10" />
+                          <test-case name="NUnit.Framework.Tests.RandomizerTests.RandomSeedsAreUnique" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Framework.Tests.RandomizerTests.ReturnsDifferentRandomizersForDifferentMethods" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Framework.Tests.RandomizerTests.ReturnsSameRandomizerForDifferentParametersOfSameMethod" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Framework.Tests.RandomizerTests.ReturnsSameRandomizerForSameMethod" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Framework.Tests.RandomizerTests.ReturnsSameRandomizerForSameParameter" executed="True" result="Success" success="True" time="0.001" asserts="1" />
+                        </results>
+                      </test-suite>
+                      <test-suite type="TestFixture" name="RangeTests" executed="True" result="Success" success="True" time="0.008" asserts="0">
+                        <results>
+                          <test-case name="NUnit.Framework.Tests.RangeTests.InRangeFails" executed="True" result="Success" success="True" time="0.001" asserts="2" />
+                          <test-case name="NUnit.Framework.Tests.RangeTests.InRangeSucceeds" executed="True" result="Success" success="True" time="0.000" asserts="3" />
+                          <test-case name="NUnit.Framework.Tests.RangeTests.NotInRangeFails" executed="True" result="Success" success="True" time="0.001" asserts="2" />
+                          <test-case name="NUnit.Framework.Tests.RangeTests.NotInRangeSucceeds" executed="True" result="Success" success="True" time="0.000" asserts="2" />
+                        </results>
+                      </test-suite>
+                      <test-suite type="TestFixture" name="SameFixture" executed="True" result="Success" success="True" time="0.006" asserts="0">
+                        <results>
+                          <test-case name="NUnit.Framework.Tests.SameFixture.Same" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Framework.Tests.SameFixture.SameFails" executed="True" result="Success" success="True" time="0.001" asserts="2" />
+                          <test-case name="NUnit.Framework.Tests.SameFixture.SameValueTypes" executed="True" result="Success" success="True" time="0.001" asserts="2" />
+                        </results>
+                      </test-suite>
+                      <test-suite type="TestFixture" name="StringAssertTests" executed="True" result="Success" success="True" time="0.040" asserts="0">
+                        <results>
+                          <test-case name="NUnit.Framework.Tests.StringAssertTests.CaseInsensitiveCompare" executed="True" result="Success" success="True" time="0.001" asserts="1" />
+                          <test-case name="NUnit.Framework.Tests.StringAssertTests.CaseInsensitiveCompareFails" executed="True" result="Success" success="True" time="0.001" asserts="2" />
+                          <test-case name="NUnit.Framework.Tests.StringAssertTests.Contains" executed="True" result="Success" success="True" time="0.000" asserts="3" />
+                          <test-case name="NUnit.Framework.Tests.StringAssertTests.ContainsFails" executed="True" result="Success" success="True" time="0.001" asserts="2" />
+                          <test-case name="NUnit.Framework.Tests.StringAssertTests.DifferentEncodingsOfSameStringAreNotEqual" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Framework.Tests.StringAssertTests.DoesNotContain" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Framework.Tests.StringAssertTests.DoesNotContainFails" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Framework.Tests.StringAssertTests.DoesNotEndWith" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Framework.Tests.StringAssertTests.DoesNotEndWithFails" executed="True" result="Success" success="True" time="0.001" asserts="1" />
+                          <test-case name="NUnit.Framework.Tests.StringAssertTests.DoesNotStartWith" executed="True" result="Success" success="True" time="0.001" asserts="1" />
+                          <test-case name="NUnit.Framework.Tests.StringAssertTests.DoesNotStartWithFails" executed="True" result="Success" success="True" time="0.001" asserts="1" />
+                          <test-case name="NUnit.Framework.Tests.StringAssertTests.EndsWith" executed="True" result="Success" success="True" time="0.000" asserts="2" />
+                          <test-case name="NUnit.Framework.Tests.StringAssertTests.EndsWithFails" executed="True" result="Success" success="True" time="0.001" asserts="2" />
+                          <test-case name="NUnit.Framework.Tests.StringAssertTests.IsMatch" executed="True" result="Success" success="True" time="0.002" asserts="1" />
+                          <test-case name="NUnit.Framework.Tests.StringAssertTests.IsMatchFails" executed="True" result="Success" success="True" time="0.001" asserts="2" />
+                          <test-case name="NUnit.Framework.Tests.StringAssertTests.StartsWith" executed="True" result="Success" success="True" time="0.000" asserts="2" />
+                          <test-case name="NUnit.Framework.Tests.StringAssertTests.StartsWithFails" executed="True" result="Success" success="True" time="0.000" asserts="2" />
+                        </results>
+                      </test-suite>
+                      <test-suite type="TestFixture" name="TestFixtureAttributeTests" executed="True" result="Success" success="True" time="0.011" asserts="0">
+                        <results>
+                          <test-case name="NUnit.Framework.Tests.TestFixtureAttributeTests.ConstructWithCombinedArgs" executed="True" result="Success" success="True" time="0.001" asserts="2">
+                            <categories>
+                              <category name="Generics" />
+                            </categories>
+                          </test-case>
+                          <test-case name="NUnit.Framework.Tests.TestFixtureAttributeTests.ConstructWithFixtureArgs" executed="True" result="Success" success="True" time="0.001" asserts="2" />
+                          <test-case name="NUnit.Framework.Tests.TestFixtureAttributeTests.ConstructWithFixtureArgsAndSetTypeArgs" executed="True" result="Success" success="True" time="0.001" asserts="2">
+                            <categories>
+                              <category name="Generics" />
+                            </categories>
+                          </test-case>
+                          <test-case name="NUnit.Framework.Tests.TestFixtureAttributeTests.ConstructWithJustTypeArgs" executed="True" result="Success" success="True" time="0.000" asserts="2">
+                            <categories>
+                              <category name="Generics" />
+                            </categories>
+                          </test-case>
+                          <test-case name="NUnit.Framework.Tests.TestFixtureAttributeTests.ConstructWithNoArgumentsAndSetTypeArgs" executed="True" result="Success" success="True" time="0.000" asserts="2">
+                            <categories>
+                              <category name="Generics" />
+                            </categories>
+                          </test-case>
+                          <test-case name="NUnit.Framework.Tests.TestFixtureAttributeTests.ConstructWithoutArguments" executed="True" result="Success" success="True" time="0.000" asserts="2" />
+                        </results>
+                      </test-suite>
+                      <test-suite type="TestFixture" name="TextMessageWriterTests" executed="True" result="Success" success="True" time="0.028" asserts="0">
+                        <results>
+                          <test-case name="NUnit.Framework.Tests.TextMessageWriterTests.ConnectorIsWrittenWithSurroundingSpaces" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Framework.Tests.TextMessageWriterTests.DateTimeTest" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Framework.Tests.TextMessageWriterTests.DecimalIsWrittenToTwentyNineDigits" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Framework.Tests.TextMessageWriterTests.DecimalIsWrittenWithTrailingM" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Framework.Tests.TextMessageWriterTests.DisplayStringDifferences" executed="True" result="Success" success="True" time="0.004" asserts="1" />
+                          <test-case name="NUnit.Framework.Tests.TextMessageWriterTests.DisplayStringDifferences_NoClipping" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Framework.Tests.TextMessageWriterTests.DoubleIsWrittenToSeventeenDigits" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Framework.Tests.TextMessageWriterTests.DoubleIsWrittenWithTrailingD" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Framework.Tests.TextMessageWriterTests.FloatIsWrittenToNineDigits" executed="True" result="Success" success="True" time="0.001" asserts="2" />
+                          <test-case name="NUnit.Framework.Tests.TextMessageWriterTests.FloatIsWrittenWithTrailingF" executed="True" result="Success" success="True" time="0.001" asserts="1" />
+                          <test-case name="NUnit.Framework.Tests.TextMessageWriterTests.IntegerIsWrittenAsIs" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Framework.Tests.TextMessageWriterTests.PredicateIsWrittenWithTrailingSpace" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Framework.Tests.TextMessageWriterTests.StringIsWrittenWithQuotes" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                        </results>
+                      </test-suite>
+                      <test-suite type="TestFixture" name="TypeAssertTests" executed="True" result="Success" success="True" time="0.022" asserts="0">
+                        <results>
+                          <test-case name="NUnit.Framework.Tests.TypeAssertTests.ExactType" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Framework.Tests.TypeAssertTests.ExactTypeFails" executed="True" result="Success" success="True" time="0.000" asserts="2" />
+                          <test-case name="NUnit.Framework.Tests.TypeAssertTests.IsAssignableFrom" executed="True" result="Success" success="True" time="0.001" asserts="3" />
+                          <test-case name="NUnit.Framework.Tests.TypeAssertTests.IsAssignableFromFails" executed="True" result="Success" success="True" time="0.001" asserts="2" />
+                          <test-case name="NUnit.Framework.Tests.TypeAssertTests.IsInstanceOf" executed="True" result="Success" success="True" time="0.000" asserts="3" />
+                          <test-case name="NUnit.Framework.Tests.TypeAssertTests.IsInstanceOfFails" executed="True" result="Success" success="True" time="0.000" asserts="2" />
+                          <test-case name="NUnit.Framework.Tests.TypeAssertTests.IsNotAssignableFrom" executed="True" result="Success" success="True" time="0.001" asserts="3" />
+                          <test-case name="NUnit.Framework.Tests.TypeAssertTests.IsNotAssignableFromFails" executed="True" result="Success" success="True" time="0.001" asserts="2" />
+                          <test-case name="NUnit.Framework.Tests.TypeAssertTests.IsNotInstanceOf" executed="True" result="Success" success="True" time="0.001" asserts="3" />
+                          <test-case name="NUnit.Framework.Tests.TypeAssertTests.IsNotInstanceOfFails" executed="True" result="Success" success="True" time="0.000" asserts="2" />
+                        </results>
+                      </test-suite>
+                      <test-suite type="TestFixture" name="ValuesAttributeTests" executed="True" result="Success" success="True" time="0.079" asserts="0">
+                        <results>
+                          <test-suite type="ParameterizedTest" name="CanConverDoubleToDecimal" executed="True" result="Success" success="True" time="0.001" asserts="0">
+                            <results>
+                              <test-case name="NUnit.Framework.Tests.ValuesAttributeTests.CanConverDoubleToDecimal(12.5m)" executed="True" result="Success" success="True" time="0.001" asserts="0" />
+                            </results>
+                          </test-suite>
+                          <test-suite type="ParameterizedTest" name="CanConvertDoubleRangeToDecimal" executed="True" result="Success" success="True" time="0.005" asserts="0">
+                            <results>
+                              <test-case name="NUnit.Framework.Tests.ValuesAttributeTests.CanConvertDoubleRangeToDecimal(1m)" executed="True" result="Success" success="True" time="0.000" asserts="0" />
+                              <test-case name="NUnit.Framework.Tests.ValuesAttributeTests.CanConvertDoubleRangeToDecimal(1.1m)" executed="True" result="Success" success="True" time="0.000" asserts="0" />
+                              <test-case name="NUnit.Framework.Tests.ValuesAttributeTests.CanConvertDoubleRangeToDecimal(1.2m)" executed="True" result="Success" success="True" time="0.000" asserts="0" />
+                              <test-case name="NUnit.Framework.Tests.ValuesAttributeTests.CanConvertDoubleRangeToDecimal(1.3m)" executed="True" result="Success" success="True" time="0.000" asserts="0" />
+                            </results>
+                          </test-suite>
+                          <test-suite type="ParameterizedTest" name="CanConvertIntRangeToByte" executed="True" result="Success" success="True" time="0.004" asserts="0">
+                            <results>
+                              <test-case name="NUnit.Framework.Tests.ValuesAttributeTests.CanConvertIntRangeToByte(1)" executed="True" result="Success" success="True" time="0.000" asserts="0" />
+                              <test-case name="NUnit.Framework.Tests.ValuesAttributeTests.CanConvertIntRangeToByte(2)" executed="True" result="Success" success="True" time="0.000" asserts="0" />
+                              <test-case name="NUnit.Framework.Tests.ValuesAttributeTests.CanConvertIntRangeToByte(3)" executed="True" result="Success" success="True" time="0.000" asserts="0" />
+                            </results>
+                          </test-suite>
+                          <test-suite type="ParameterizedTest" name="CanConvertIntRangeToDecimal" executed="True" result="Success" success="True" time="0.004" asserts="0">
+                            <results>
+                              <test-case name="NUnit.Framework.Tests.ValuesAttributeTests.CanConvertIntRangeToDecimal(1m)" executed="True" result="Success" success="True" time="0.000" asserts="0" />
+                              <test-case name="NUnit.Framework.Tests.ValuesAttributeTests.CanConvertIntRangeToDecimal(2m)" executed="True" result="Success" success="True" time="0.000" asserts="0" />
+                              <test-case name="NUnit.Framework.Tests.ValuesAttributeTests.CanConvertIntRangeToDecimal(3m)" executed="True" result="Success" success="True" time="0.000" asserts="0" />
+                            </results>
+                          </test-suite>
+                          <test-suite type="ParameterizedTest" name="CanConvertIntRangeToSByte" executed="True" result="Success" success="True" time="0.004" asserts="0">
+                            <results>
+                              <test-case name="NUnit.Framework.Tests.ValuesAttributeTests.CanConvertIntRangeToSByte(1)" executed="True" result="Success" success="True" time="0.000" asserts="0" />
+                              <test-case name="NUnit.Framework.Tests.ValuesAttributeTests.CanConvertIntRangeToSByte(2)" executed="True" result="Success" success="True" time="0.000" asserts="0" />
+                              <test-case name="NUnit.Framework.Tests.ValuesAttributeTests.CanConvertIntRangeToSByte(3)" executed="True" result="Success" success="True" time="0.000" asserts="0" />
+                            </results>
+                          </test-suite>
+                          <test-suite type="ParameterizedTest" name="CanConvertIntRangeToShort" executed="True" result="Success" success="True" time="0.004" asserts="0">
+                            <results>
+                              <test-case name="NUnit.Framework.Tests.ValuesAttributeTests.CanConvertIntRangeToShort(1)" executed="True" result="Success" success="True" time="0.000" asserts="0" />
+                              <test-case name="NUnit.Framework.Tests.ValuesAttributeTests.CanConvertIntRangeToShort(2)" executed="True" result="Success" success="True" time="0.001" asserts="0" />
+                              <test-case name="NUnit.Framework.Tests.ValuesAttributeTests.CanConvertIntRangeToShort(3)" executed="True" result="Success" success="True" time="0.000" asserts="0" />
+                            </results>
+                          </test-suite>
+                          <test-suite type="ParameterizedTest" name="CanConvertIntToDecimal" executed="True" result="Success" success="True" time="0.000" asserts="0">
+                            <results>
+                              <test-case name="NUnit.Framework.Tests.ValuesAttributeTests.CanConvertIntToDecimal(12m)" executed="True" result="Success" success="True" time="0.000" asserts="0" />
+                            </results>
+                          </test-suite>
+                          <test-suite type="ParameterizedTest" name="CanConvertRandomDoubleToDecimal" executed="True" result="Success" success="True" time="0.003" asserts="0">
+                            <results>
+                              <test-case name="NUnit.Framework.Tests.ValuesAttributeTests.CanConvertRandomDoubleToDecimal(1.46836388505453m)" executed="True" result="Success" success="True" time="0.000" asserts="0" />
+                              <test-case name="NUnit.Framework.Tests.ValuesAttributeTests.CanConvertRandomDoubleToDecimal(5.0845184536113m)" executed="True" result="Success" success="True" time="0.000" asserts="0" />
+                              <test-case name="NUnit.Framework.Tests.ValuesAttributeTests.CanConvertRandomDoubleToDecimal(3.02339543729247m)" executed="True" result="Success" success="True" time="0.000" asserts="0" />
+                            </results>
+                          </test-suite>
+                          <test-suite type="ParameterizedTest" name="CanConvertRandomIntToByte" executed="True" result="Success" success="True" time="0.003" asserts="0">
+                            <results>
+                              <test-case name="NUnit.Framework.Tests.ValuesAttributeTests.CanConvertRandomIntToByte(5)" executed="True" result="Success" success="True" time="0.000" asserts="0" />
+                              <test-case name="NUnit.Framework.Tests.ValuesAttributeTests.CanConvertRandomIntToByte(1)" executed="True" result="Success" success="True" time="0.000" asserts="0" />
+                              <test-case name="NUnit.Framework.Tests.ValuesAttributeTests.CanConvertRandomIntToByte(8)" executed="True" result="Success" success="True" time="0.000" asserts="0" />
+                            </results>
+                          </test-suite>
+                          <test-suite type="ParameterizedTest" name="CanConvertRandomIntToDecimal" executed="True" result="Success" success="True" time="0.005" asserts="0">
+                            <results>
+                              <test-case name="NUnit.Framework.Tests.ValuesAttributeTests.CanConvertRandomIntToDecimal(3m)" executed="True" result="Success" success="True" time="0.000" asserts="0" />
+                              <test-case name="NUnit.Framework.Tests.ValuesAttributeTests.CanConvertRandomIntToDecimal(9m)" executed="True" result="Success" success="True" time="0.000" asserts="0" />
+                              <test-case name="NUnit.Framework.Tests.ValuesAttributeTests.CanConvertRandomIntToDecimal(6m)" executed="True" result="Success" success="True" time="0.000" asserts="0" />
+                            </results>
+                          </test-suite>
+                          <test-suite type="ParameterizedTest" name="CanConvertRandomIntToSByte" executed="True" result="Success" success="True" time="0.003" asserts="0">
+                            <results>
+                              <test-case name="NUnit.Framework.Tests.ValuesAttributeTests.CanConvertRandomIntToSByte(2)" executed="True" result="Success" success="True" time="0.000" asserts="0" />
+                              <test-case name="NUnit.Framework.Tests.ValuesAttributeTests.CanConvertRandomIntToSByte(4)" executed="True" result="Success" success="True" time="0.000" asserts="0" />
+                              <test-case name="NUnit.Framework.Tests.ValuesAttributeTests.CanConvertRandomIntToSByte(6)" executed="True" result="Success" success="True" time="0.000" asserts="0" />
+                            </results>
+                          </test-suite>
+                          <test-suite type="ParameterizedTest" name="CanConvertRandomIntToShort" executed="True" result="Success" success="True" time="0.004" asserts="0">
+                            <results>
+                              <test-case name="NUnit.Framework.Tests.ValuesAttributeTests.CanConvertRandomIntToShort(1)" executed="True" result="Success" success="True" time="0.000" asserts="0" />
+                              <test-case name="NUnit.Framework.Tests.ValuesAttributeTests.CanConvertRandomIntToShort(7)" executed="True" result="Success" success="True" time="0.000" asserts="0" />
+                              <test-case name="NUnit.Framework.Tests.ValuesAttributeTests.CanConvertRandomIntToShort(6)" executed="True" result="Success" success="True" time="0.000" asserts="0" />
+                            </results>
+                          </test-suite>
+                          <test-suite type="ParameterizedTest" name="CanConvertSmallIntsToByte" executed="True" result="Success" success="True" time="0.001" asserts="0">
+                            <results>
+                              <test-case name="NUnit.Framework.Tests.ValuesAttributeTests.CanConvertSmallIntsToByte(5)" executed="True" result="Success" success="True" time="0.000" asserts="0" />
+                            </results>
+                          </test-suite>
+                          <test-suite type="ParameterizedTest" name="CanConvertSmallIntsToSByte" executed="True" result="Success" success="True" time="0.000" asserts="0">
+                            <results>
+                              <test-case name="NUnit.Framework.Tests.ValuesAttributeTests.CanConvertSmallIntsToSByte(5)" executed="True" result="Success" success="True" time="0.000" asserts="0" />
+                            </results>
+                          </test-suite>
+                          <test-suite type="ParameterizedTest" name="CanConvertSmallIntsToShort" executed="True" result="Success" success="True" time="0.000" asserts="0">
+                            <results>
+                              <test-case name="NUnit.Framework.Tests.ValuesAttributeTests.CanConvertSmallIntsToShort(5)" executed="True" result="Success" success="True" time="0.000" asserts="0" />
+                            </results>
+                          </test-suite>
+                          <test-suite type="ParameterizedTest" name="CanConvertStringToDecimal" executed="True" result="Success" success="True" time="0.001" asserts="0">
+                            <results>
+                              <test-case name="NUnit.Framework.Tests.ValuesAttributeTests.CanConvertStringToDecimal(12.5m)" executed="True" result="Success" success="True" time="0.001" asserts="0" />
+                            </results>
+                          </test-suite>
+                          <test-case name="NUnit.Framework.Tests.ValuesAttributeTests.RangeAttributeWithDoubleRangeAndStep" executed="True" result="Success" success="True" time="0.001" asserts="1" />
+                          <test-case name="NUnit.Framework.Tests.ValuesAttributeTests.RangeAttributeWithFloatRangeAndStep" executed="True" result="Success" success="True" time="0.001" asserts="1" />
+                          <test-case name="NUnit.Framework.Tests.ValuesAttributeTests.RangeAttributeWithIntRange" executed="True" result="Success" success="True" time="0.001" asserts="1" />
+                          <test-case name="NUnit.Framework.Tests.ValuesAttributeTests.RangeAttributeWithIntRangeAndStep" executed="True" result="Success" success="True" time="0.001" asserts="1" />
+                          <test-case name="NUnit.Framework.Tests.ValuesAttributeTests.RangeAttributeWithLongRangeAndStep" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Framework.Tests.ValuesAttributeTests.ValuesAttributeProvidesSpecifiedValues" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                        </results>
+                      </test-suite>
+                    </results>
+                  </test-suite>
+                </results>
+              </test-suite>
+            </results>
+          </test-suite>
+        </results>
+      </test-suite>
+      <test-suite type="Assembly" name="C:\Program Files\NUnit 2.5.10\bin\net-2.0\tests/nunit.core.tests.dll" executed="True" result="Success" success="True" time="7.941" asserts="0">
+        <results>
+          <test-suite type="Namespace" name="NUnit" executed="True" result="Success" success="True" time="7.937" asserts="0">
+            <results>
+              <test-suite type="Namespace" name="Core" executed="True" result="Success" success="True" time="7.937" asserts="0">
+                <results>
+                  <test-suite type="Namespace" name="Tests" executed="True" result="Success" success="True" time="7.936" asserts="0">
+                    <results>
+                      <test-suite type="TestFixture" name="AssemblyHelperTests" executed="True" result="Success" success="True" time="0.021" asserts="0">
+                        <results>
+                          <test-case name="NUnit.Core.Tests.AssemblyHelperTests.GetPathForAssembly" executed="True" result="Success" success="True" time="0.011" asserts="2" />
+                          <test-case name="NUnit.Core.Tests.AssemblyHelperTests.GetPathForType" executed="True" result="Success" success="True" time="0.000" asserts="2" />
+                        </results>
+                      </test-suite>
+                      <test-suite type="TestFixture" name="AssemblyReaderTests" executed="True" result="Success" success="True" time="0.018" asserts="0">
+                        <results>
+                          <test-case name="NUnit.Core.Tests.AssemblyReaderTests.CreateFromAssembly" executed="True" result="Success" success="True" time="0.002" asserts="1" />
+                          <test-case name="NUnit.Core.Tests.AssemblyReaderTests.CreateFromPath" executed="True" result="Success" success="True" time="0.001" asserts="1" />
+                          <test-case name="NUnit.Core.Tests.AssemblyReaderTests.ImageRuntimeVersion" executed="True" result="Success" success="True" time="0.002" asserts="1" />
+                          <test-case name="NUnit.Core.Tests.AssemblyReaderTests.IsDotNetFile" executed="True" result="Success" success="True" time="0.001" asserts="1" />
+                          <test-case name="NUnit.Core.Tests.AssemblyReaderTests.IsValidPeFile" executed="True" result="Success" success="True" time="0.001" asserts="1" />
+                          <test-case name="NUnit.Core.Tests.AssemblyReaderTests.IsValidPeFile_Fails" executed="True" result="Success" success="True" time="0.001" asserts="1" />
+                        </results>
+                      </test-suite>
+                      <test-suite type="TestFixture" name="AssemblyResolverTests" executed="True" result="Success" success="True" time="0.042" asserts="0">
+                        <results>
+                          <test-case name="NUnit.Core.Tests.AssemblyResolverTests.AddFile" executed="True" result="Success" success="True" time="0.037" asserts="0" />
+                        </results>
+                      </test-suite>
+                      <test-suite type="TestFixture" name="AssemblyTests" executed="True" result="Success" success="True" time="0.567" asserts="0">
+                        <results>
+                          <test-case name="NUnit.Core.Tests.AssemblyTests.AppSettingsLoaded" executed="True" result="Success" success="True" time="0.043" asserts="3" />
+                          <test-case name="NUnit.Core.Tests.AssemblyTests.LoadAssembly" executed="True" result="Success" success="True" time="0.295" asserts="2" />
+                          <test-case name="NUnit.Core.Tests.AssemblyTests.LoadAssemblyNotFound" executed="True" result="Success" success="True" time="0.131" asserts="0" />
+                          <test-case name="NUnit.Core.Tests.AssemblyTests.LoadAssemblyWithoutTestFixtures" executed="True" result="Success" success="True" time="0.068" asserts="3" />
+                          <test-case name="NUnit.Core.Tests.AssemblyTests.LoadTestFixtureFromAssembly" executed="True" result="Success" success="True" time="0.015" asserts="1" />
+                          <test-case name="NUnit.Core.Tests.AssemblyTests.NUnitTraceIsEnabled" executed="True" result="Success" success="True" time="0.001" asserts="1" />
+                          <test-case name="NUnit.Core.Tests.AssemblyTests.RunSetsCurrentDirectory" executed="True" result="Success" success="True" time="0.001" asserts="1" />
+                        </results>
+                      </test-suite>
+                      <test-suite type="TestFixture" name="AssemblyVersionFixture" executed="True" result="Success" success="True" time="0.002" asserts="0">
+                        <results>
+                          <test-case name="NUnit.Core.Tests.AssemblyVersionFixture.Version" executed="True" result="Success" success="True" time="0.002" asserts="1" />
+                        </results>
+                      </test-suite>
+                      <test-suite type="TestFixture" name="AssertInconclusiveFixture" executed="True" result="Success" success="True" time="0.002" asserts="0">
+                        <results>
+                          <test-case name="NUnit.Core.Tests.AssertInconclusiveFixture.AssertInconclusiveThrowsException" executed="True" result="Success" success="True" time="0.001" asserts="2" />
+                        </results>
+                      </test-suite>
+                      <test-suite type="TestFixture" name="AssertPassFixture" executed="True" result="Success" success="True" time="0.010" asserts="0">
+                        <results>
+                          <test-case name="NUnit.Core.Tests.AssertPassFixture.AssertPassReturnsSuccess" executed="True" result="Success" success="True" time="0.007" asserts="0">
+                            <reason>
+                              <message><![CDATA[This test is OK!]]></message>
+                            </reason>
+                          </test-case>
+                          <test-case name="NUnit.Core.Tests.AssertPassFixture.SubsequentFailureIsIrrelevant" executed="True" result="Success" success="True" time="0.001" asserts="0">
+                            <reason>
+                              <message><![CDATA[This test is OK!]]></message>
+                            </reason>
+                          </test-case>
+                        </results>
+                      </test-suite>
+                      <test-suite type="TestFixture" name="AttributeInheritance" executed="True" result="Success" success="True" time="0.012" asserts="0">
+                        <results>
+                          <test-case name="NUnit.Core.Tests.AttributeInheritance.InheritedExplicitAttributeIsRecognized" executed="True" result="Success" success="True" time="0.003" asserts="2" />
+                          <test-case name="NUnit.Core.Tests.AttributeInheritance.InheritedFixtureAttributeIsRecognized" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Core.Tests.AttributeInheritance.InheritedIgnoreAttributeIsRecognized" executed="True" result="Success" success="True" time="0.001" asserts="2" />
+                          <test-case name="NUnit.Core.Tests.AttributeInheritance.InheritedTestAttributeIsRecognized" executed="True" result="Success" success="True" time="0.001" asserts="1" />
+                        </results>
+                      </test-suite>
+                      <test-suite type="TestFixture" name="CallContextTests" executed="True" result="Success" success="True" time="0.013" asserts="0">
+                        <results>
+                          <test-case name="NUnit.Core.Tests.CallContextTests.GenericPrincipalTest" executed="True" result="Success" success="True" time="0.001" asserts="0" />
+                          <test-case name="NUnit.Core.Tests.CallContextTests.ILogicalThreadAffinativeTest" executed="True" result="Success" success="True" time="0.000" asserts="0" />
+                          <test-case name="NUnit.Core.Tests.CallContextTests.ILogicalThreadAffinativeTestConsole" executed="True" result="Success" success="True" time="0.000" asserts="0" />
+                          <test-case name="NUnit.Core.Tests.CallContextTests.SetCustomPrincipalOnThread" executed="True" result="Success" success="True" time="0.000" asserts="0" />
+                          <test-case name="NUnit.Core.Tests.CallContextTests.SetGenericPrincipalOnThread" executed="True" result="Success" success="True" time="0.000" asserts="0" />
+                          <test-case name="NUnit.Core.Tests.CallContextTests.UseCustomIdentity" executed="True" result="Success" success="True" time="0.000" asserts="0" />
+                        </results>
+                      </test-suite>
+                      <test-suite type="TestFixture" name="CategoryAttributeTests" executed="True" result="Success" success="True" time="0.029" asserts="0">
+                        <results>
+                          <test-case name="NUnit.Core.Tests.CategoryAttributeTests.CanDeriveFromCategoryAttribute" executed="True" result="Success" success="True" time="0.004" asserts="1" />
+                          <test-case name="NUnit.Core.Tests.CategoryAttributeTests.CategoryOnFixture" executed="True" result="Success" success="True" time="0.002" asserts="1" />
+                          <test-case name="NUnit.Core.Tests.CategoryAttributeTests.CategoryOnTestCase" executed="True" result="Success" success="True" time="0.002" asserts="1" />
+                          <test-suite type="ParameterizedTest" name="CountTestsUsingCategoryFilter" executed="True" result="Success" success="True" time="0.009" asserts="0">
+                            <results>
+                              <test-case name="NUnit.Core.Tests.CategoryAttributeTests.CountTestsUsingCategoryFilter(&quot;Database&quot;)" executed="True" result="Success" success="True" time="0.004" asserts="1" />
+                              <test-case name="NUnit.Core.Tests.CategoryAttributeTests.CountTestsUsingCategoryFilter(&quot;Critical&quot;)" executed="True" result="Success" success="True" time="0.002" asserts="1" />
+                              <test-case name="NUnit.Core.Tests.CategoryAttributeTests.CountTestsUsingCategoryFilter(&quot;Long&quot;)" executed="True" result="Success" success="True" time="0.001" asserts="1" />
+                            </results>
+                          </test-suite>
+                          <test-case name="NUnit.Core.Tests.CategoryAttributeTests.CountTestsWithoutCategoryFilter" executed="True" result="Success" success="True" time="0.002" asserts="1" />
+                          <test-case name="NUnit.Core.Tests.CategoryAttributeTests.DerivedCategoryMayBeInherited" executed="True" result="Success" success="True" time="0.002" asserts="1" />
+                        </results>
+                      </test-suite>
+                      <test-suite type="TestFixture" name="CombinatorialTests" executed="True" result="Success" success="True" time="0.082" asserts="0">
+                        <results>
+                          <test-suite type="ParameterizedTest" name="RandomArgsAreIndependent" executed="True" result="Success" success="True" time="0.002" asserts="0">
+                            <results>
+                              <test-case name="NUnit.Core.Tests.CombinatorialTests.RandomArgsAreIndependent(0.651908174926372d,0.51187893911818d)" executed="True" result="Success" success="True" time="0.001" asserts="1" />
+                            </results>
+                          </test-suite>
+                          <test-suite type="ParameterizedTest" name="RandomTest" executed="True" result="Success" success="True" time="0.009" asserts="0">
+                            <results>
+                              <test-case name="NUnit.Core.Tests.CombinatorialTests.RandomTest(158,0.264626883559221d)" executed="True" result="Success" success="True" time="0.002" asserts="2" />
+                              <test-case name="NUnit.Core.Tests.CombinatorialTests.RandomTest(186,0.673774998948805d)" executed="True" result="Success" success="True" time="0.000" asserts="2" />
+                              <test-case name="NUnit.Core.Tests.CombinatorialTests.RandomTest(144,0.498290064045363d)" executed="True" result="Success" success="True" time="0.000" asserts="2" />
+                              <test-case name="NUnit.Core.Tests.CombinatorialTests.RandomTest(114,0.308914143270307d)" executed="True" result="Success" success="True" time="0.001" asserts="2" />
+                              <test-case name="NUnit.Core.Tests.CombinatorialTests.RandomTest(107,0.132779451148947d)" executed="True" result="Success" success="True" time="0.000" asserts="2" />
+                            </results>
+                          </test-suite>
+                          <test-suite type="ParameterizedTest" name="RangeTest" executed="True" result="Success" success="True" time="0.012" asserts="0">
+                            <results>
+                              <test-case name="NUnit.Core.Tests.CombinatorialTests.RangeTest(0.2d,10)" executed="True" result="Success" success="True" time="0.000" asserts="0" />
+                              <test-case name="NUnit.Core.Tests.CombinatorialTests.RangeTest(0.2d,15)" executed="True" result="Success" success="True" time="0.000" asserts="0" />
+                              <test-case name="NUnit.Core.Tests.CombinatorialTests.RangeTest(0.2d,20)" executed="True" result="Success" success="True" time="0.000" asserts="0" />
+                              <test-case name="NUnit.Core.Tests.CombinatorialTests.RangeTest(0.4d,10)" executed="True" result="Success" success="True" time="0.000" asserts="0" />
+                              <test-case name="NUnit.Core.Tests.CombinatorialTests.RangeTest(0.4d,15)" executed="True" result="Success" success="True" time="0.000" asserts="0" />
+                              <test-case name="NUnit.Core.Tests.CombinatorialTests.RangeTest(0.4d,20)" executed="True" result="Success" success="True" time="0.000" asserts="0" />
+                              <test-case name="NUnit.Core.Tests.CombinatorialTests.RangeTest(0.6d,10)" executed="True" result="Success" success="True" time="0.000" asserts="0" />
+                              <test-case name="NUnit.Core.Tests.CombinatorialTests.RangeTest(0.6d,15)" executed="True" result="Success" success="True" time="0.000" asserts="0" />
+                              <test-case name="NUnit.Core.Tests.CombinatorialTests.RangeTest(0.6d,20)" executed="True" result="Success" success="True" time="0.001" asserts="0" />
+                            </results>
+                          </test-suite>
+                          <test-suite type="ParameterizedTest" name="SingleArgument" executed="True" result="Success" success="True" time="0.003" asserts="0">
+                            <results>
+                              <test-case name="NUnit.Core.Tests.CombinatorialTests.SingleArgument(1.3d)" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                              <test-case name="NUnit.Core.Tests.CombinatorialTests.SingleArgument(1.7d)" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                              <test-case name="NUnit.Core.Tests.CombinatorialTests.SingleArgument(1.5d)" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                            </results>
+                          </test-suite>
+                          <test-suite type="ParameterizedTest" name="ThreeArguments_Combinatorial" executed="True" result="Success" success="True" time="0.025" asserts="0">
+                            <results>
+                              <test-case name="NUnit.Core.Tests.CombinatorialTests.ThreeArguments_Combinatorial(1,10,&quot;Charlie&quot;)" executed="True" result="Success" success="True" time="0.001" asserts="2" />
+                              <test-case name="NUnit.Core.Tests.CombinatorialTests.ThreeArguments_Combinatorial(1,10,&quot;Joe&quot;)" executed="True" result="Success" success="True" time="0.000" asserts="2" />
+                              <test-case name="NUnit.Core.Tests.CombinatorialTests.ThreeArguments_Combinatorial(1,10,&quot;Frank&quot;)" executed="True" result="Success" success="True" time="0.000" asserts="2" />
+                              <test-case name="NUnit.Core.Tests.CombinatorialTests.ThreeArguments_Combinatorial(1,20,&quot;Charlie&quot;)" executed="True" result="Success" success="True" time="0.000" asserts="2" />
+                              <test-case name="NUnit.Core.Tests.CombinatorialTests.ThreeArguments_Combinatorial(1,20,&quot;Joe&quot;)" executed="True" result="Success" success="True" time="0.000" asserts="2" />
+                              <test-case name="NUnit.Core.Tests.CombinatorialTests.ThreeArguments_Combinatorial(1,20,&quot;Frank&quot;)" executed="True" result="Success" success="True" time="0.000" asserts="2" />
+                              <test-case name="NUnit.Core.Tests.CombinatorialTests.ThreeArguments_Combinatorial(2,10,&quot;Charlie&quot;)" executed="True" result="Success" success="True" time="0.000" asserts="2" />
+                              <test-case name="NUnit.Core.Tests.CombinatorialTests.ThreeArguments_Combinatorial(2,10,&quot;Joe&quot;)" executed="True" result="Success" success="True" time="0.000" asserts="2" />
+                              <test-case name="NUnit.Core.Tests.CombinatorialTests.ThreeArguments_Combinatorial(2,10,&quot;Frank&quot;)" executed="True" result="Success" success="True" time="0.001" asserts="2" />
+                              <test-case name="NUnit.Core.Tests.CombinatorialTests.ThreeArguments_Combinatorial(2,20,&quot;Charlie&quot;)" executed="True" result="Success" success="True" time="0.000" asserts="2" />
+                              <test-case name="NUnit.Core.Tests.CombinatorialTests.ThreeArguments_Combinatorial(2,20,&quot;Joe&quot;)" executed="True" result="Success" success="True" time="0.000" asserts="2" />
+                              <test-case name="NUnit.Core.Tests.CombinatorialTests.ThreeArguments_Combinatorial(2,20,&quot;Frank&quot;)" executed="True" result="Success" success="True" time="0.000" asserts="2" />
+                              <test-case name="NUnit.Core.Tests.CombinatorialTests.ThreeArguments_Combinatorial(3,10,&quot;Charlie&quot;)" executed="True" result="Success" success="True" time="0.000" asserts="2" />
+                              <test-case name="NUnit.Core.Tests.CombinatorialTests.ThreeArguments_Combinatorial(3,10,&quot;Joe&quot;)" executed="True" result="Success" success="True" time="0.000" asserts="2" />
+                              <test-case name="NUnit.Core.Tests.CombinatorialTests.ThreeArguments_Combinatorial(3,10,&quot;Frank&quot;)" executed="True" result="Success" success="True" time="0.000" asserts="2" />
+                              <test-case name="NUnit.Core.Tests.CombinatorialTests.ThreeArguments_Combinatorial(3,20,&quot;Charlie&quot;)" executed="True" result="Success" success="True" time="0.000" asserts="2" />
+                              <test-case name="NUnit.Core.Tests.CombinatorialTests.ThreeArguments_Combinatorial(3,20,&quot;Joe&quot;)" executed="True" result="Success" success="True" time="0.000" asserts="2" />
+                              <test-case name="NUnit.Core.Tests.CombinatorialTests.ThreeArguments_Combinatorial(3,20,&quot;Frank&quot;)" executed="True" result="Success" success="True" time="0.000" asserts="2" />
+                            </results>
+                          </test-suite>
+                          <test-suite type="ParameterizedTest" name="ThreeArguments_Sequential" executed="True" result="Success" success="True" time="0.004" asserts="0">
+                            <results>
+                              <test-case name="NUnit.Core.Tests.CombinatorialTests.ThreeArguments_Sequential(1,10,&quot;Charlie&quot;)" executed="True" result="Success" success="True" time="0.000" asserts="2" />
+                              <test-case name="NUnit.Core.Tests.CombinatorialTests.ThreeArguments_Sequential(2,20,&quot;Joe&quot;)" executed="True" result="Success" success="True" time="0.001" asserts="2" />
+                              <test-case name="NUnit.Core.Tests.CombinatorialTests.ThreeArguments_Sequential(3,null,&quot;Frank&quot;)" executed="True" result="Success" success="True" time="0.000" asserts="2" />
+                            </results>
+                          </test-suite>
+                          <test-suite type="ParameterizedTest" name="TwoArguments_Combinatorial" executed="True" result="Success" success="True" time="0.007" asserts="0">
+                            <results>
+                              <test-case name="NUnit.Core.Tests.CombinatorialTests.TwoArguments_Combinatorial(1,10)" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                              <test-case name="NUnit.Core.Tests.CombinatorialTests.TwoArguments_Combinatorial(1,20)" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                              <test-case name="NUnit.Core.Tests.CombinatorialTests.TwoArguments_Combinatorial(2,10)" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                              <test-case name="NUnit.Core.Tests.CombinatorialTests.TwoArguments_Combinatorial(2,20)" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                              <test-case name="NUnit.Core.Tests.CombinatorialTests.TwoArguments_Combinatorial(3,10)" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                              <test-case name="NUnit.Core.Tests.CombinatorialTests.TwoArguments_Combinatorial(3,20)" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                            </results>
+                          </test-suite>
+                          <test-suite type="ParameterizedTest" name="TwoArguments_Sequential" executed="True" result="Success" success="True" time="0.003" asserts="0">
+                            <results>
+                              <test-case name="NUnit.Core.Tests.CombinatorialTests.TwoArguments_Sequential(1,10)" executed="True" result="Success" success="True" time="0.001" asserts="1" />
+                              <test-case name="NUnit.Core.Tests.CombinatorialTests.TwoArguments_Sequential(2,20)" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                              <test-case name="NUnit.Core.Tests.CombinatorialTests.TwoArguments_Sequential(3,null)" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                            </results>
+                          </test-suite>
+                        </results>
+                      </test-suite>
+                      <test-suite type="TestFixture" name="CoreExtensionsTests" executed="True" result="Success" success="True" time="0.025" asserts="0">
+                        <results>
+                          <test-case name="NUnit.Core.Tests.CoreExtensionsTests.CanAddDecorator" executed="True" result="Success" success="True" time="0.005" asserts="2" />
+                          <test-case name="NUnit.Core.Tests.CoreExtensionsTests.CanAddEventListener" executed="True" result="Success" success="True" time="0.001" asserts="4" />
+                          <test-case name="NUnit.Core.Tests.CoreExtensionsTests.CanAddSuiteBuilder" executed="True" result="Success" success="True" time="0.001" asserts="4" />
+                          <test-case name="NUnit.Core.Tests.CoreExtensionsTests.CanAddTestCaseBuilder" executed="True" result="Success" success="True" time="0.001" asserts="4" />
+                          <test-case name="NUnit.Core.Tests.CoreExtensionsTests.CanAddTestCaseBuilder2" executed="True" result="Success" success="True" time="0.001" asserts="4" />
+                          <test-case name="NUnit.Core.Tests.CoreExtensionsTests.DecoratorsRunInOrderOfPriorities" executed="True" result="Success" success="True" time="0.002" asserts="2" />
+                          <test-case name="NUnit.Core.Tests.CoreExtensionsTests.HasEventListenerExtensionPoint" executed="True" result="Success" success="True" time="0.000" asserts="3" />
+                          <test-case name="NUnit.Core.Tests.CoreExtensionsTests.HasSuiteBuildersExtensionPoint" executed="True" result="Success" success="True" time="0.000" asserts="3" />
+                          <test-case name="NUnit.Core.Tests.CoreExtensionsTests.HasTestCaseBuildersExtensionPoint" executed="True" result="Success" success="True" time="0.000" asserts="3" />
+                          <test-case name="NUnit.Core.Tests.CoreExtensionsTests.HasTestDecoratorsExtensionPoint" executed="True" result="Success" success="True" time="0.000" asserts="3" />
+                          <test-case name="NUnit.Core.Tests.CoreExtensionsTests.HasTestFrameworkRegistry" executed="True" result="Success" success="True" time="0.001" asserts="3" />
+                        </results>
+                      </test-suite>
+                      <test-suite type="TestFixture" name="CultureSettingAndDetectionTests" executed="True" result="Success" success="True" time="0.045" asserts="0">
+                        <results>
+                          <test-case name="NUnit.Core.Tests.CultureSettingAndDetectionTests.CanMatchAttributeWithExclude" executed="True" result="Success" success="True" time="0.002" asserts="2" />
+                          <test-case name="NUnit.Core.Tests.CultureSettingAndDetectionTests.CanMatchAttributeWithInclude" executed="True" result="Success" success="True" time="0.001" asserts="2" />
+                          <test-case name="NUnit.Core.Tests.CultureSettingAndDetectionTests.CanMatchAttributeWithIncludeAndExclude" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Core.Tests.CultureSettingAndDetectionTests.CanMatchStrings" executed="True" result="Success" success="True" time="0.000" asserts="5" />
+                          <test-case name="NUnit.Core.Tests.CultureSettingAndDetectionTests.LoadWithFrenchCanadianCulture" executed="True" result="Success" success="True" time="0.004" asserts="5" />
+                          <test-case name="NUnit.Core.Tests.CultureSettingAndDetectionTests.LoadWithFrenchCulture" executed="True" result="Success" success="True" time="0.003" asserts="5" />
+                          <test-case name="NUnit.Core.Tests.CultureSettingAndDetectionTests.LoadWithRussianCulture" executed="True" result="Success" success="True" time="0.002" asserts="5" />
+                          <test-case name="NUnit.Core.Tests.CultureSettingAndDetectionTests.SettingInvalidCultureGivesError" executed="True" result="Success" success="True" time="0.019" asserts="3" />
+                          <test-suite type="ParameterizedTest" name="UseWithParameterizedTest" executed="True" result="Success" success="True" time="0.001" asserts="0">
+                            <results>
+                              <test-case name="NUnit.Core.Tests.CultureSettingAndDetectionTests.UseWithParameterizedTest()" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                            </results>
+                          </test-suite>
+                        </results>
+                      </test-suite>
+                      <test-suite type="TestFixture" name="CultureSettingAndDetectionTests+NestedFixture" executed="True" result="Success" success="True" time="0.001" asserts="0">
+                        <results>
+                          <test-case name="NUnit.Core.Tests.CultureSettingAndDetectionTests+NestedFixture.CanSetCultureOnFixture" executed="True" result="Success" success="True" time="0.001" asserts="1" />
+                        </results>
+                      </test-suite>
+                      <test-suite type="TestFixture" name="DatapointTests" executed="True" result="Success" success="True" time="0.029" asserts="0">
+                        <results>
+                          <test-case name="NUnit.Core.Tests.DatapointTests.WorksOnArray" executed="True" result="Success" success="True" time="0.011" asserts="3" />
+                          <test-case name="NUnit.Core.Tests.DatapointTests.WorksOnField" executed="True" result="Success" success="True" time="0.004" asserts="3" />
+                          <test-case name="NUnit.Core.Tests.DatapointTests.WorksOnMethodReturningArray" executed="True" result="Success" success="True" time="0.003" asserts="3" />
+                          <test-case name="NUnit.Core.Tests.DatapointTests.WorksOnPropertyReturningArray" executed="True" result="Success" success="True" time="0.004" asserts="3" />
+                        </results>
+                      </test-suite>
+                      <test-suite type="TestFixture" name="DirectoryChangeTests" executed="True" result="Success" success="True" time="0.002" asserts="0">
+                        <results>
+                          <test-case name="NUnit.Core.Tests.DirectoryChangeTests.ChangingCurrentDirectoryGivesWarning" executed="True" result="Success" success="True" time="0.001" asserts="2" />
+                        </results>
+                      </test-suite>
+                      <test-suite type="TestFixture" name="DirectorySwapperTests" executed="True" result="Success" success="True" time="0.006" asserts="0">
+                        <results>
+                          <test-case name="NUnit.Core.Tests.DirectorySwapperTests.ChangeAndRestore" executed="True" result="Success" success="True" time="0.000" asserts="3" />
+                          <test-case name="NUnit.Core.Tests.DirectorySwapperTests.SwapAndRestore" executed="True" result="Success" success="True" time="0.000" asserts="2" />
+                        </results>
+                      </test-suite>
+                      <test-suite type="TestFixture" name="EventQueueTests" executed="True" result="Success" success="True" time="0.382" asserts="0">
+                        <results>
+                          <test-case name="NUnit.Core.Tests.EventQueueTests.DequeueEmpty" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Core.Tests.EventQueueTests.PumpAutoStopsOnRunFinished" executed="True" result="Success" success="True" time="0.101" asserts="3" />
+                          <test-case name="NUnit.Core.Tests.EventQueueTests.PumpEvents" executed="True" result="Success" success="True" time="0.009" asserts="12">
+                            <properties>
+                              <property name="Timeout" value="3000" />
+                            </properties>
+                          </test-case>
+                          <test-case name="NUnit.Core.Tests.EventQueueTests.PumpEventsWithAutoStop" executed="True" result="Success" success="True" time="0.003" asserts="1">
+                            <properties>
+                              <property name="Timeout" value="2000" />
+                            </properties>
+                          </test-case>
+                          <test-case name="NUnit.Core.Tests.EventQueueTests.PumpPendingEventsAfterAutoStop" executed="True" result="Success" success="True" time="0.103" asserts="2">
+                            <properties>
+                              <property name="Timeout" value="2000" />
+                            </properties>
+                          </test-case>
+                          <test-case name="NUnit.Core.Tests.EventQueueTests.PumpSynchronousAndAsynchronousEvents" executed="True" result="Success" success="True" time="0.005" asserts="6">
+                            <properties>
+                              <property name="Timeout" value="1000" />
+                            </properties>
+                          </test-case>
+                          <test-case name="NUnit.Core.Tests.EventQueueTests.QueueEvents" executed="True" result="Success" success="True" time="0.001" asserts="9" />
+                          <test-case name="NUnit.Core.Tests.EventQueueTests.SendEvents" executed="True" result="Success" success="True" time="0.001" asserts="9" />
+                          <test-case name="NUnit.Core.Tests.EventQueueTests.StartAndStopPumpOnEmptyQueue" executed="True" result="Success" success="True" time="0.002" asserts="2" />
+                          <test-case name="NUnit.Core.Tests.EventQueueTests.TracingEventListenerDoesNotDeadlock" executed="True" result="Success" success="True" time="0.048" asserts="0">
+                            <properties>
+                              <property name="Timeout" value="1000" />
+                            </properties>
+                          </test-case>
+                        </results>
+                      </test-suite>
+                      <test-suite type="TestFixture" name="EventQueueTests+DequeueBlocking_StopTest" executed="True" result="Success" success="True" time="0.034" asserts="0">
+                        <results>
+                          <test-case name="NUnit.Core.Tests.EventQueueTests+DequeueBlocking_StopTest.DequeueBlocking_Stop" executed="True" result="Success" success="True" time="0.032" asserts="3">
+                            <properties>
+                              <property name="Timeout" value="1000" />
+                            </properties>
+                          </test-case>
+                        </results>
+                      </test-suite>
+                      <test-suite type="TestFixture" name="EventQueueTests+SetWaitHandle_Enqueue_AsynchronousTest" executed="True" result="Success" success="True" time="0.033" asserts="0">
+                        <results>
+                          <test-case name="NUnit.Core.Tests.EventQueueTests+SetWaitHandle_Enqueue_AsynchronousTest.SetWaitHandle_Enqueue_Asynchronous" executed="True" result="Success" success="True" time="0.031" asserts="4">
+                            <properties>
+                              <property name="Timeout" value="1000" />
+                            </properties>
+                          </test-case>
+                        </results>
+                      </test-suite>
+                      <test-suite type="TestFixture" name="EventQueueTests+SetWaitHandle_Enqueue_SynchronousTest" executed="True" result="Success" success="True" time="0.064" asserts="0">
+                        <results>
+                          <test-case name="NUnit.Core.Tests.EventQueueTests+SetWaitHandle_Enqueue_SynchronousTest.SetWaitHandle_Enqueue_Synchronous" executed="True" result="Success" success="True" time="0.062" asserts="5">
+                            <properties>
+                              <property name="Timeout" value="1000" />
+                            </properties>
+                          </test-case>
+                        </results>
+                      </test-suite>
+                      <test-suite type="TestFixture" name="EventTestFixture" description="Tests that proper events are generated when running  test" executed="True" result="Success" success="True" time="0.100" asserts="0">
+                        <results>
+                          <test-case name="NUnit.Core.Tests.EventTestFixture.CheckEventListening" executed="True" result="Success" success="True" time="0.037" asserts="4" />
+                        </results>
+                      </test-suite>
+                      <test-suite type="TestFixture" name="ExpectExceptionTest" executed="True" result="Success" success="True" time="0.188" asserts="0">
+                        <results>
+                          <test-case name="NUnit.Core.Tests.ExpectExceptionTest.AssertFailBeforeException" executed="True" result="Success" success="True" time="0.003" asserts="2" />
+                          <test-case name="NUnit.Core.Tests.ExpectExceptionTest.CanExpectUnspecifiedException" executed="True" result="Success" success="True" time="0.001" asserts="0" />
+                          <test-case name="NUnit.Core.Tests.ExpectExceptionTest.ExceptionHandlerIsCalledWhenExceptionMatches" executed="True" result="Success" success="True" time="0.002" asserts="2" />
+                          <test-case name="NUnit.Core.Tests.ExpectExceptionTest.ExceptionHandlerIsCalledWhenExceptionMatches_AlternateHandler" executed="True" result="Success" success="True" time="0.001" asserts="2" />
+                          <test-case name="NUnit.Core.Tests.ExpectExceptionTest.ExceptionHandlerIsNotCalledWhenExceptionDoesNotMatch" executed="True" result="Success" success="True" time="0.001" asserts="2" />
+                          <test-case name="NUnit.Core.Tests.ExpectExceptionTest.ExceptionHandlerIsNotCalledWhenExceptionDoesNotMatch_AlternateHandler" executed="True" result="Success" success="True" time="0.001" asserts="2" />
+                          <test-case name="NUnit.Core.Tests.ExpectExceptionTest.MethodThrowsArgumentOutOfRange" executed="True" result="Success" success="True" time="0.003" asserts="1" />
+                          <test-case name="NUnit.Core.Tests.ExpectExceptionTest.MethodThrowsException" executed="True" result="Success" success="True" time="0.002" asserts="1" />
+                          <test-case name="NUnit.Core.Tests.ExpectExceptionTest.MethodThrowsRightExceptionMessage" executed="True" result="Success" success="True" time="0.003" asserts="1" />
+                          <test-case name="NUnit.Core.Tests.ExpectExceptionTest.MethodThrowsWrongExceptionMessage" executed="True" result="Success" success="True" time="0.006" asserts="1" />
+                          <test-case name="NUnit.Core.Tests.ExpectExceptionTest.SetUpThrowsSameException" executed="True" result="Success" success="True" time="0.003" asserts="1" />
+                          <test-case name="NUnit.Core.Tests.ExpectExceptionTest.TearDownThrowsSameException" executed="True" result="Success" success="True" time="0.002" asserts="1" />
+                          <test-case name="NUnit.Core.Tests.ExpectExceptionTest.TestExceptionNameNotThrown" executed="True" result="Success" success="True" time="0.001" asserts="2" />
+                          <test-case name="NUnit.Core.Tests.ExpectExceptionTest.TestExceptionNameNotThrownWithUserMessage" executed="True" result="Success" success="True" time="0.001" asserts="2" />
+                          <test-case name="NUnit.Core.Tests.ExpectExceptionTest.TestExceptionTypeNotThrown" executed="True" result="Success" success="True" time="0.001" asserts="2" />
+                          <test-case name="NUnit.Core.Tests.ExpectExceptionTest.TestExceptionTypeNotThrownWithUserMessage" executed="True" result="Success" success="True" time="0.001" asserts="2" />
+                          <test-case name="NUnit.Core.Tests.ExpectExceptionTest.TestFailsWhenBaseExceptionIsThrown" executed="True" result="Success" success="True" time="0.002" asserts="2" />
+                          <test-case name="NUnit.Core.Tests.ExpectExceptionTest.TestFailsWhenDerivedExceptionIsThrown" executed="True" result="Success" success="True" time="0.002" asserts="2" />
+                          <test-case name="NUnit.Core.Tests.ExpectExceptionTest.TestIsNotRunnableWhenAlternateHandlerIsNotFound" executed="True" result="Success" success="True" time="0.001" asserts="2" />
+                          <test-case name="NUnit.Core.Tests.ExpectExceptionTest.TestMismatchedExceptionMessage" executed="True" result="Success" success="True" time="0.001" asserts="2" />
+                          <test-case name="NUnit.Core.Tests.ExpectExceptionTest.TestMismatchedExceptionMessageWithUserMessage" executed="True" result="Success" success="True" time="0.002" asserts="2" />
+                          <test-case name="NUnit.Core.Tests.ExpectExceptionTest.TestMismatchedExceptionName" executed="True" result="Success" success="True" time="0.002" asserts="2" />
+                          <test-case name="NUnit.Core.Tests.ExpectExceptionTest.TestMismatchedExceptionNameWithUserMessage" executed="True" result="Success" success="True" time="0.002" asserts="2" />
+                          <test-case name="NUnit.Core.Tests.ExpectExceptionTest.TestMismatchedExceptionType" executed="True" result="Success" success="True" time="0.001" asserts="2" />
+                          <test-case name="NUnit.Core.Tests.ExpectExceptionTest.TestMismatchedExceptionTypeAsNamedParameter" executed="True" result="Success" success="True" time="0.001" asserts="2" />
+                          <test-case name="NUnit.Core.Tests.ExpectExceptionTest.TestMismatchedExceptionTypeWithUserMessage" executed="True" result="Success" success="True" time="0.001" asserts="2" />
+                          <test-case name="NUnit.Core.Tests.ExpectExceptionTest.TestSucceedsWhenSpecifiedExceptionNameAndContainsMatch" executed="True" result="Success" success="True" time="0.001" asserts="0" />
+                          <test-case name="NUnit.Core.Tests.ExpectExceptionTest.TestSucceedsWhenSpecifiedExceptionNameAndRegexMatch" executed="True" result="Success" success="True" time="0.057" asserts="0" />
+                          <test-case name="NUnit.Core.Tests.ExpectExceptionTest.TestSucceedsWithSpecifiedExceptionName" executed="True" result="Success" success="True" time="0.000" asserts="0" />
+                          <test-case name="NUnit.Core.Tests.ExpectExceptionTest.TestSucceedsWithSpecifiedExceptionNameAndExactMatch" executed="True" result="Success" success="True" time="0.001" asserts="0" />
+                          <test-case name="NUnit.Core.Tests.ExpectExceptionTest.TestSucceedsWithSpecifiedExceptionNameAndMessage_NewFormat" executed="True" result="Success" success="True" time="0.001" asserts="0" />
+                          <test-case name="NUnit.Core.Tests.ExpectExceptionTest.TestSucceedsWithSpecifiedExceptionNameAsNamedParameter" executed="True" result="Success" success="True" time="0.000" asserts="0" />
+                          <test-case name="NUnit.Core.Tests.ExpectExceptionTest.TestSucceedsWithSpecifiedExceptionType" executed="True" result="Success" success="True" time="0.000" asserts="0" />
+                          <test-case name="NUnit.Core.Tests.ExpectExceptionTest.TestSucceedsWithSpecifiedExceptionTypeAndContainsMatch" executed="True" result="Success" success="True" time="0.000" asserts="0" />
+                          <test-case name="NUnit.Core.Tests.ExpectExceptionTest.TestSucceedsWithSpecifiedExceptionTypeAndExactMatch" executed="True" result="Success" success="True" time="0.000" asserts="0" />
+                          <test-case name="NUnit.Core.Tests.ExpectExceptionTest.TestSucceedsWithSpecifiedExceptionTypeAndMessage" executed="True" result="Success" success="True" time="0.001" asserts="0" />
+                          <test-case name="NUnit.Core.Tests.ExpectExceptionTest.TestSucceedsWithSpecifiedExceptionTypeAndRegexMatch" executed="True" result="Success" success="True" time="0.003" asserts="0" />
+                          <test-case name="NUnit.Core.Tests.ExpectExceptionTest.TestSucceedsWithSpecifiedExceptionTypeAndStartsWithMatch" executed="True" result="Success" success="True" time="0.001" asserts="0" />
+                          <test-case name="NUnit.Core.Tests.ExpectExceptionTest.TestSucceedsWithSpecifiedExceptionTypeAsNamedParameter" executed="True" result="Success" success="True" time="0.001" asserts="0" />
+                          <test-case name="NUnit.Core.Tests.ExpectExceptionTest.TestUnspecifiedExceptionNotThrown" executed="True" result="Success" success="True" time="0.001" asserts="2" />
+                          <test-case name="NUnit.Core.Tests.ExpectExceptionTest.TestUnspecifiedExceptionNotThrownWithUserMessage" executed="True" result="Success" success="True" time="0.000" asserts="2" />
+                          <test-case name="NUnit.Core.Tests.ExpectExceptionTest.ThrowingMyAppException" executed="True" result="Success" success="True" time="0.001" asserts="0" />
+                          <test-case name="NUnit.Core.Tests.ExpectExceptionTest.ThrowingMyAppExceptionWithMessage" executed="True" result="Success" success="True" time="0.001" asserts="0" />
+                          <test-case name="NUnit.Core.Tests.ExpectExceptionTest.ThrowNUnitException" executed="True" result="Success" success="True" time="0.000" asserts="0" />
+                        </results>
+                      </test-suite>
+                      <test-suite type="TestFixture" name="FailFixture" executed="True" result="Success" success="True" time="0.016" asserts="0">
+                        <results>
+                          <test-case name="NUnit.Core.Tests.FailFixture.BadStackTraceIsHandled" executed="True" result="Success" success="True" time="0.001" asserts="3" />
+                          <test-case name="NUnit.Core.Tests.FailFixture.CustomExceptionIsHandled" executed="True" result="Success" success="True" time="0.001" asserts="2" />
+                          <test-case name="NUnit.Core.Tests.FailFixture.FailInheritsFromSystemException" executed="True" result="Success" success="True" time="0.000" asserts="0" />
+                          <test-case name="NUnit.Core.Tests.FailFixture.FailRecordsInnerException" executed="True" result="Success" success="True" time="0.001" asserts="2" />
+                          <test-case name="NUnit.Core.Tests.FailFixture.FailThrowsAssertionException" executed="True" result="Success" success="True" time="0.001" asserts="0" />
+                          <test-case name="NUnit.Core.Tests.FailFixture.VerifyFailWorks" executed="True" result="Success" success="True" time="0.002" asserts="2" />
+                        </results>
+                      </test-suite>
+                      <test-suite type="TestFixture" name="FixtureSetupTearDownTest" executed="True" result="Success" success="True" time="0.084" asserts="0">
+                        <results>
+                          <test-case name="NUnit.Core.Tests.FixtureSetupTearDownTest.BaseSetUpCalledFirstAndTearDownCalledLast" executed="True" result="Success" success="True" time="0.003" asserts="6" />
+                          <test-case name="NUnit.Core.Tests.FixtureSetupTearDownTest.CheckInheritedSetUpAndTearDownAreCalled" executed="True" result="Success" success="True" time="0.002" asserts="2" />
+                          <test-case name="NUnit.Core.Tests.FixtureSetupTearDownTest.DisposeCalledWhenFixtureImplementsIDisposable" executed="True" result="Success" success="True" time="0.002" asserts="1" />
+                          <test-case name="NUnit.Core.Tests.FixtureSetupTearDownTest.FixtureWithNoTestsCallsFixtureSetUpAndTearDown" executed="True" result="Success" success="True" time="0.002" asserts="2" />
+                          <test-case name="NUnit.Core.Tests.FixtureSetupTearDownTest.HandleErrorInFixtureSetup" executed="True" result="Success" success="True" time="0.004" asserts="11" />
+                          <test-case name="NUnit.Core.Tests.FixtureSetupTearDownTest.HandleErrorInFixtureTearDown" executed="True" result="Success" success="True" time="0.002" asserts="9" />
+                          <test-case name="NUnit.Core.Tests.FixtureSetupTearDownTest.HandleExceptionInFixtureConstructor" executed="True" result="Success" success="True" time="0.002" asserts="9" />
+                          <test-case name="NUnit.Core.Tests.FixtureSetupTearDownTest.HandleIgnoreInFixtureSetup" executed="True" result="Success" success="True" time="0.003" asserts="7" />
+                          <test-case name="NUnit.Core.Tests.FixtureSetupTearDownTest.HandleSetUpAndTearDownWithTestInName" executed="True" result="Success" success="True" time="0.002" asserts="2" />
+                          <test-case name="NUnit.Core.Tests.FixtureSetupTearDownTest.IgnoredFixtureShouldNotCallFixtureSetUpOrTearDown" executed="True" result="Success" success="True" time="0.002" asserts="2" />
+                          <test-case name="NUnit.Core.Tests.FixtureSetupTearDownTest.MakeSureSetUpAndTearDownAreCalled" executed="True" result="Success" success="True" time="0.002" asserts="2" />
+                          <test-case name="NUnit.Core.Tests.FixtureSetupTearDownTest.MakeSureSetUpAndTearDownAreCalledOnExplicitFixture" executed="True" result="Success" success="True" time="0.002" asserts="2" />
+                          <test-case name="NUnit.Core.Tests.FixtureSetupTearDownTest.OverriddenSetUpAndTearDownAreNotCalled" executed="True" result="Success" success="True" time="0.002" asserts="4" />
+                          <test-case name="NUnit.Core.Tests.FixtureSetupTearDownTest.RerunFixtureAfterSetUpFixed" executed="True" result="Success" success="True" time="0.004" asserts="4" />
+                          <test-case name="NUnit.Core.Tests.FixtureSetupTearDownTest.RerunFixtureAfterTearDownFixed" executed="True" result="Success" success="True" time="0.004" asserts="4" />
+                          <test-case name="NUnit.Core.Tests.FixtureSetupTearDownTest.RunningSingleMethodCallsSetUpAndTearDown" executed="True" result="Success" success="True" time="0.002" asserts="2" />
+                          <test-case name="NUnit.Core.Tests.FixtureSetupTearDownTest.StaticBaseSetUpCalledFirstAndTearDownCalledLast" executed="True" result="Success" success="True" time="0.002" asserts="6" />
+                          <test-case name="NUnit.Core.Tests.FixtureSetupTearDownTest.StaticClassSetUpAndTearDownAreCalled" executed="True" result="Success" success="True" time="0.003" asserts="2" />
+                          <test-case name="NUnit.Core.Tests.FixtureSetupTearDownTest.StaticSetUpAndTearDownAreCalled" executed="True" result="Success" success="True" time="0.001" asserts="2" />
+                        </results>
+                      </test-suite>
+                      <test-suite type="TestFixture" name="FixtureSetupTearDownTest+ChangesMadeInFixtureSetUp" executed="True" result="Success" success="True" time="0.004" asserts="0">
+                        <results>
+                          <test-case name="NUnit.Core.Tests.FixtureSetupTearDownTest+ChangesMadeInFixtureSetUp.TestThatChangesPersistUsingSameThread" executed="True" result="Success" success="True" time="0.000" asserts="3" />
+                          <test-case name="NUnit.Core.Tests.FixtureSetupTearDownTest+ChangesMadeInFixtureSetUp.TestThatChangesPersistUsingSeparateThread" executed="True" result="Success" success="True" time="0.000" asserts="3">
+                            <properties>
+                              <property name="RequiresThread" value="True" />
+                            </properties>
+                          </test-case>
+                        </results>
+                      </test-suite>
+                      <test-suite type="Namespace" name="Generic" executed="True" result="Success" success="True" time="0.054" asserts="0">
+                        <results>
+                          <test-suite type="GenericFixture" name="DeduceTypeArgsFromArgs&lt;T1,T2&gt;" executed="True" result="Success" success="True" time="0.007" asserts="0">
+                            <results>
+                              <test-suite type="TestFixture" name="DeduceTypeArgsFromArgs&lt;Double,Int32&gt;(100.0d,42)" executed="True" result="Success" success="True" time="0.002" asserts="0">
+                                <categories>
+                                  <category name="Generics" />
+                                </categories>
+                                <results>
+                                  <test-suite type="ParameterizedTest" name="TestMyArgTypes" executed="True" result="Success" success="True" time="0.002" asserts="0">
+                                    <results>
+                                      <test-case name="NUnit.Core.Tests.Generic.DeduceTypeArgsFromArgs&lt;Double,Int32&gt;(100.0d,42).TestMyArgTypes(5,7)" executed="True" result="Success" success="True" time="0.001" asserts="3" />
+                                    </results>
+                                  </test-suite>
+                                </results>
+                              </test-suite>
+                              <test-suite type="TestFixture" name="DeduceTypeArgsFromArgs&lt;Int32,Double&gt;(42,100.0d)" executed="True" result="Success" success="True" time="0.001" asserts="0">
+                                <categories>
+                                  <category name="Generics" />
+                                </categories>
+                                <results>
+                                  <test-suite type="ParameterizedTest" name="TestMyArgTypes" executed="True" result="Success" success="True" time="0.001" asserts="0">
+                                    <results>
+                                      <test-case name="NUnit.Core.Tests.Generic.DeduceTypeArgsFromArgs&lt;Int32,Double&gt;(42,100.0d).TestMyArgTypes(5,7)" executed="True" result="Success" success="True" time="0.001" asserts="3" />
+                                    </results>
+                                  </test-suite>
+                                </results>
+                              </test-suite>
+                            </results>
+                          </test-suite>
+                          <test-suite type="GenericFixture" name="SimpleGenericFixture&lt;TList&gt;" executed="True" result="Success" success="True" time="0.006" asserts="0">
+                            <results>
+                              <test-suite type="TestFixture" name="SimpleGenericFixture&lt;ArrayList&gt;" executed="True" result="Success" success="True" time="0.002" asserts="0">
+                                <categories>
+                                  <category name="Generics" />
+                                </categories>
+                                <results>
+                                  <test-case name="NUnit.Core.Tests.Generic.SimpleGenericFixture&lt;ArrayList&gt;.TestCollectionCount" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                                </results>
+                              </test-suite>
+                              <test-suite type="TestFixture" name="SimpleGenericFixture&lt;List&lt;Int32&gt;&gt;" executed="True" result="Success" success="True" time="0.001" asserts="0">
+                                <categories>
+                                  <category name="Generics" />
+                                </categories>
+                                <results>
+                                  <test-case name="NUnit.Core.Tests.Generic.SimpleGenericFixture&lt;List&lt;Int32&gt;&gt;.TestCollectionCount" executed="True" result="Success" success="True" time="0.001" asserts="1" />
+                                </results>
+                              </test-suite>
+                            </results>
+                          </test-suite>
+                          <test-suite type="TestFixture" name="SimpleGenericMethods" executed="True" result="Success" success="True" time="0.028" asserts="0">
+                            <categories>
+                              <category name="Generics" />
+                            </categories>
+                            <results>
+                              <test-suite type="ParameterizedTest" name="GenericTestMethodWithOneTypeParameter" executed="True" result="Success" success="True" time="0.008" asserts="0">
+                                <results>
+                                  <test-case name="NUnit.Core.Tests.Generic.SimpleGenericMethods.GenericTestMethodWithOneTypeParameter&lt;Double&gt;(5.0d,2.0d,&quot;ABC&quot;)" executed="True" result="Success" success="True" time="0.001" asserts="4" />
+                                  <test-case name="NUnit.Core.Tests.Generic.SimpleGenericMethods.GenericTestMethodWithOneTypeParameter&lt;Double&gt;(5.0d,2.0d,&quot;ABC&quot;)" executed="True" result="Success" success="True" time="0.000" asserts="4" />
+                                  <test-case name="NUnit.Core.Tests.Generic.SimpleGenericMethods.GenericTestMethodWithOneTypeParameter&lt;Int32&gt;(5,2,&quot;ABC&quot;)" executed="True" result="Success" success="True" time="0.000" asserts="4" />
+                                  <test-case name="NUnit.Core.Tests.Generic.SimpleGenericMethods.GenericTestMethodWithOneTypeParameter&lt;Double&gt;(5.0d,2.0d,&quot;ABC&quot;)" executed="True" result="Success" success="True" time="0.000" asserts="4" />
+                                </results>
+                              </test-suite>
+                              <test-suite type="ParameterizedTest" name="GenericTestMethodWithTwoTypeParameters" executed="True" result="Success" success="True" time="0.008" asserts="0">
+                                <results>
+                                  <test-case name="NUnit.Core.Tests.Generic.SimpleGenericMethods.GenericTestMethodWithTwoTypeParameters&lt;Int32,Double&gt;(5,2.0d,&quot;ABC&quot;)" executed="True" result="Success" success="True" time="0.001" asserts="4" />
+                                  <test-case name="NUnit.Core.Tests.Generic.SimpleGenericMethods.GenericTestMethodWithTwoTypeParameters&lt;Double,Int64&gt;(5.0d,2L,&quot;ABC&quot;)" executed="True" result="Success" success="True" time="0.000" asserts="4" />
+                                  <test-case name="NUnit.Core.Tests.Generic.SimpleGenericMethods.GenericTestMethodWithTwoTypeParameters&lt;Int32,Int32&gt;(5,2,&quot;ABC&quot;)" executed="True" result="Success" success="True" time="0.001" asserts="4" />
+                                  <test-case name="NUnit.Core.Tests.Generic.SimpleGenericMethods.GenericTestMethodWithTwoTypeParameters&lt;Double,Double&gt;(5.0d,2.0d,&quot;ABC&quot;)" executed="True" result="Success" success="True" time="0.001" asserts="4" />
+                                </results>
+                              </test-suite>
+                              <test-suite type="ParameterizedTest" name="GenericTestMethodWithTwoTypeParameters_Reversed" executed="True" result="Success" success="True" time="0.007" asserts="0">
+                                <results>
+                                  <test-case name="NUnit.Core.Tests.Generic.SimpleGenericMethods.GenericTestMethodWithTwoTypeParameters_Reversed&lt;Int32,Int32&gt;(5,2,&quot;ABC&quot;)" executed="True" result="Success" success="True" time="0.001" asserts="4" />
+                                  <test-case name="NUnit.Core.Tests.Generic.SimpleGenericMethods.GenericTestMethodWithTwoTypeParameters_Reversed&lt;Double,Double&gt;(5.0d,2.0d,&quot;ABC&quot;)" executed="True" result="Success" success="True" time="0.001" asserts="4" />
+                                  <test-case name="NUnit.Core.Tests.Generic.SimpleGenericMethods.GenericTestMethodWithTwoTypeParameters_Reversed&lt;Double,Int32&gt;(5,2.0d,&quot;ABC&quot;)" executed="True" result="Success" success="True" time="0.001" asserts="4" />
+                                  <test-case name="NUnit.Core.Tests.Generic.SimpleGenericMethods.GenericTestMethodWithTwoTypeParameters_Reversed&lt;Int64,Double&gt;(5.0d,2L,&quot;ABC&quot;)" executed="True" result="Success" success="True" time="0.001" asserts="4" />
+                                </results>
+                              </test-suite>
+                            </results>
+                          </test-suite>
+                          <test-suite type="GenericFixture" name="TypeParameterUsedWithTestMethod&lt;T&gt;" executed="True" result="Success" success="True" time="0.004" asserts="0">
+                            <results>
+                              <test-suite type="TestFixture" name="TypeParameterUsedWithTestMethod&lt;Double&gt;" executed="True" result="Success" success="True" time="0.003" asserts="0">
+                                <categories>
+                                  <category name="Generics" />
+                                </categories>
+                                <results>
+                                  <test-suite type="ParameterizedTest" name="TestMyArgType" executed="True" result="Success" success="True" time="0.003" asserts="0">
+                                    <results>
+                                      <test-case name="NUnit.Core.Tests.Generic.TypeParameterUsedWithTestMethod&lt;Double&gt;.TestMyArgType(5)" executed="True" result="Success" success="True" time="0.000" asserts="2" />
+                                      <test-case name="NUnit.Core.Tests.Generic.TypeParameterUsedWithTestMethod&lt;Double&gt;.TestMyArgType(1.23d)" executed="True" result="Success" success="True" time="0.000" asserts="2" />
+                                    </results>
+                                  </test-suite>
+                                </results>
+                              </test-suite>
+                            </results>
+                          </test-suite>
+                        </results>
+                      </test-suite>
+                      <test-suite type="TestFixture" name="IgnoreFixture" executed="True" result="Success" success="True" time="0.023" asserts="0">
+                        <results>
+                          <test-case name="NUnit.Core.Tests.IgnoreFixture.IgnoreTakesPrecedenceOverExpectedException" executed="True" result="Success" success="True" time="0.002" asserts="2" />
+                          <test-case name="NUnit.Core.Tests.IgnoreFixture.IgnoreThrowsIgnoreException" executed="True" result="Success" success="True" time="0.001" asserts="1" />
+                          <test-case name="NUnit.Core.Tests.IgnoreFixture.IgnoreWithUserMessage" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Core.Tests.IgnoreFixture.IgnoreWithUserMessage_ArrayOfArgs" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Core.Tests.IgnoreFixture.IgnoreWithUserMessage_OneArg" executed="True" result="Success" success="True" time="0.001" asserts="1" />
+                          <test-case name="NUnit.Core.Tests.IgnoreFixture.IgnoreWithUserMessage_ThreeArgs" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Core.Tests.IgnoreFixture.IgnoreWorksForTestCase" executed="True" result="Success" success="True" time="0.001" asserts="2" />
+                          <test-case name="NUnit.Core.Tests.IgnoreFixture.IgnoreWorksForTestSuite" executed="True" result="Success" success="True" time="0.003" asserts="3" />
+                          <test-case name="NUnit.Core.Tests.IgnoreFixture.IgnoreWorksFromSetUp" executed="True" result="Success" success="True" time="0.003" asserts="3" />
+                        </results>
+                      </test-suite>
+                      <test-suite type="TestFixture" name="LegacySuiteTests" executed="True" result="Success" success="True" time="0.074" asserts="0">
+                        <results>
+                          <test-case name="NUnit.Core.Tests.LegacySuiteTests.SetUpAndTearDownAreCalled" executed="True" result="Success" success="True" time="0.003" asserts="3" />
+                          <test-case name="NUnit.Core.Tests.LegacySuiteTests.SuitePropertyWithInvalidType" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Core.Tests.LegacySuiteTests.SuiteReturningFixtures" executed="True" result="Success" success="True" time="0.047" asserts="3" />
+                          <test-case name="NUnit.Core.Tests.LegacySuiteTests.SuiteReturningFixtureWithArguments" executed="True" result="Success" success="True" time="0.003" asserts="3" />
+                          <test-case name="NUnit.Core.Tests.LegacySuiteTests.SuiteReturningTestSuite" executed="True" result="Success" success="True" time="0.006" asserts="3" />
+                          <test-case name="NUnit.Core.Tests.LegacySuiteTests.SuiteReturningTypes" executed="True" result="Success" success="True" time="0.006" asserts="3" />
+                        </results>
+                      </test-suite>
+                      <test-suite type="TestFixture" name="MaxTimeTests" executed="True" result="Success" success="True" time="0.084" asserts="0">
+                        <results>
+                          <test-case name="NUnit.Core.Tests.MaxTimeTests.ErrorReport" executed="True" result="Success" success="True" time="0.000" asserts="0">
+                            <properties>
+                              <property name="MaxTime" value="1000" />
+                            </properties>
+                          </test-case>
+                          <test-case name="NUnit.Core.Tests.MaxTimeTests.ErrorReportHasPriorityOverMaxTime" executed="True" result="Success" success="True" time="0.023" asserts="3" />
+                          <test-case name="NUnit.Core.Tests.MaxTimeTests.FailureReport" executed="True" result="Success" success="True" time="0.001" asserts="0">
+                            <properties>
+                              <property name="MaxTime" value="1000" />
+                            </properties>
+                          </test-case>
+                          <test-case name="NUnit.Core.Tests.MaxTimeTests.FailureReportHasPriorityOverMaxTime" executed="True" result="Success" success="True" time="0.022" asserts="3" />
+                          <test-case name="NUnit.Core.Tests.MaxTimeTests.MaxTimeExceeded" executed="True" result="Success" success="True" time="0.026" asserts="2" />
+                          <test-case name="NUnit.Core.Tests.MaxTimeTests.MaxTimeNotExceeded" executed="True" result="Success" success="True" time="0.001" asserts="0">
+                            <properties>
+                              <property name="MaxTime" value="1000" />
+                            </properties>
+                          </test-case>
+                        </results>
+                      </test-suite>
+                      <test-suite type="TestFixture" name="NameFilterTest" executed="True" result="Success" success="True" time="0.054" asserts="0">
+                        <results>
+                          <test-case name="NUnit.Core.Tests.NameFilterTest.ExplicitTestCaseDoesNotMatchWhenNotSelectedDirectly" executed="True" result="Success" success="True" time="0.004" asserts="1" />
+                          <test-case name="NUnit.Core.Tests.NameFilterTest.ExplicitTestCaseMatchesWhenSelectedDirectly" executed="True" result="Success" success="True" time="0.004" asserts="2" />
+                          <test-case name="NUnit.Core.Tests.NameFilterTest.ExplicitTestSuiteDoesNotMatchWhenNotSelectedDirectly" executed="True" result="Success" success="True" time="0.004" asserts="2" />
+                          <test-case name="NUnit.Core.Tests.NameFilterTest.ExplicitTestSuiteMatchesWhenSelectedDirectly" executed="True" result="Success" success="True" time="0.003" asserts="3" />
+                          <test-case name="NUnit.Core.Tests.NameFilterTest.HighLevelSuite" executed="True" result="Success" success="True" time="0.003" asserts="3" />
+                          <test-case name="NUnit.Core.Tests.NameFilterTest.MultipleNameMatch" executed="True" result="Success" success="True" time="0.003" asserts="3" />
+                          <test-case name="NUnit.Core.Tests.NameFilterTest.SingleNameMatch" executed="True" result="Success" success="True" time="0.003" asserts="4" />
+                          <test-case name="NUnit.Core.Tests.NameFilterTest.SuiteNameMatch" executed="True" result="Success" success="True" time="0.003" asserts="3" />
+                          <test-case name="NUnit.Core.Tests.NameFilterTest.TestDoesNotMatch" executed="True" result="Success" success="True" time="0.004" asserts="2" />
+                        </results>
+                      </test-suite>
+                      <test-suite type="TestFixture" name="NamespaceAssemblyTests" executed="True" result="Success" success="True" time="0.085" asserts="0">
+                        <results>
+                          <test-case name="NUnit.Core.Tests.NamespaceAssemblyTests.Hierarchy" executed="True" result="Success" success="True" time="0.028" asserts="17" />
+                          <test-case name="NUnit.Core.Tests.NamespaceAssemblyTests.LoadTestFixtureFromAssembly" executed="True" result="Success" success="True" time="0.013" asserts="1" />
+                          <test-case name="NUnit.Core.Tests.NamespaceAssemblyTests.NoNamespaceInAssembly" executed="True" result="Success" success="True" time="0.012" asserts="5" />
+                          <test-case name="NUnit.Core.Tests.NamespaceAssemblyTests.TestRoot" executed="True" result="Success" success="True" time="0.026" asserts="1" />
+                        </results>
+                      </test-suite>
+                      <test-suite type="TestFixture" name="PairwiseTest" executed="True" result="Success" success="True" time="0.020" asserts="0">
+                        <results>
+                          <test-suite type="ParameterizedTest" name="Test" executed="True" result="Success" success="True" time="0.020" asserts="0">
+                            <results>
+                              <test-case name="NUnit.Core.Tests.PairwiseTest.Test 2x4" executed="True" result="Success" success="True" time="0.003" asserts="3" />
+                              <test-case name="NUnit.Core.Tests.PairwiseTest.Test 2x2x2" executed="True" result="Success" success="True" time="0.000" asserts="3" />
+                              <test-case name="NUnit.Core.Tests.PairwiseTest.Test 3x2x2" executed="True" result="Success" success="True" time="0.001" asserts="3" />
+                              <test-case name="NUnit.Core.Tests.PairwiseTest.Test 3x2x2x2" executed="True" result="Success" success="True" time="0.001" asserts="3" />
+                              <test-case name="NUnit.Core.Tests.PairwiseTest.Test 3x2x2x2x2" executed="True" result="Success" success="True" time="0.001" asserts="3" />
+                              <test-case name="NUnit.Core.Tests.PairwiseTest.Test 3x2x2x2x2x2" executed="True" result="Success" success="True" time="0.001" asserts="3" />
+                              <test-case name="NUnit.Core.Tests.PairwiseTest.Test 3x3x3" executed="True" result="Success" success="True" time="0.001" asserts="3" />
+                              <test-case name="NUnit.Core.Tests.PairwiseTest.Test 4x4x4" executed="True" result="Success" success="True" time="0.001" asserts="3" />
+                              <test-case name="NUnit.Core.Tests.PairwiseTest.Test 5x5x5" executed="True" result="Success" success="True" time="0.001" asserts="3" />
+                            </results>
+                          </test-suite>
+                        </results>
+                      </test-suite>
+                      <test-suite type="TestFixture" name="PairwiseTest+LiveTest" executed="True" result="Success" success="True" time="0.013" asserts="1">
+                        <results>
+                          <test-suite type="ParameterizedTest" name="Test" executed="True" result="Success" success="True" time="0.013" asserts="0">
+                            <results>
+                              <test-case name="NUnit.Core.Tests.PairwiseTest+LiveTest.Test(&quot;a&quot;,&quot;-&quot;,&quot;x&quot;)" executed="True" result="Success" success="True" time="0.000" asserts="0" />
+                              <test-case name="NUnit.Core.Tests.PairwiseTest+LiveTest.Test(&quot;b&quot;,&quot;+&quot;,&quot;y&quot;)" executed="True" result="Success" success="True" time="0.000" asserts="0" />
+                              <test-case name="NUnit.Core.Tests.PairwiseTest+LiveTest.Test(&quot;c&quot;,&quot;+&quot;,&quot;x&quot;)" executed="True" result="Success" success="True" time="0.000" asserts="0" />
+                              <test-case name="NUnit.Core.Tests.PairwiseTest+LiveTest.Test(&quot;b&quot;,&quot;-&quot;,&quot;x&quot;)" executed="True" result="Success" success="True" time="0.000" asserts="0" />
+                              <test-case name="NUnit.Core.Tests.PairwiseTest+LiveTest.Test(&quot;a&quot;,&quot;-&quot;,&quot;y&quot;)" executed="True" result="Success" success="True" time="0.000" asserts="0" />
+                              <test-case name="NUnit.Core.Tests.PairwiseTest+LiveTest.Test(&quot;c&quot;,&quot;-&quot;,&quot;y&quot;)" executed="True" result="Success" success="True" time="0.000" asserts="0" />
+                              <test-case name="NUnit.Core.Tests.PairwiseTest+LiveTest.Test(&quot;a&quot;,&quot;+&quot;,&quot;x&quot;)" executed="True" result="Success" success="True" time="0.000" asserts="0" />
+                            </results>
+                          </test-suite>
+                        </results>
+                      </test-suite>
+                      <test-suite type="ParameterizedFixture" name="ParameterizedTestFixture" executed="True" result="Success" success="True" time="0.012" asserts="0">
+                        <results>
+                          <test-suite type="TestFixture" name="ParameterizedTestFixture(&quot;hello&quot;,&quot;hello&quot;,&quot;goodbye&quot;)" executed="True" result="Success" success="True" time="0.003" asserts="0">
+                            <results>
+                              <test-case name="NUnit.Core.Tests.ParameterizedTestFixture(&quot;hello&quot;,&quot;hello&quot;,&quot;goodbye&quot;).TestEquality" executed="True" result="Success" success="True" time="0.000" asserts="2" />
+                              <test-case name="NUnit.Core.Tests.ParameterizedTestFixture(&quot;hello&quot;,&quot;hello&quot;,&quot;goodbye&quot;).TestInequality" executed="True" result="Success" success="True" time="0.001" asserts="2" />
+                            </results>
+                          </test-suite>
+                          <test-suite type="TestFixture" name="ParameterizedTestFixture(&quot;zip&quot;,&quot;zip&quot;)" executed="True" result="Success" success="True" time="0.002" asserts="0">
+                            <results>
+                              <test-case name="NUnit.Core.Tests.ParameterizedTestFixture(&quot;zip&quot;,&quot;zip&quot;).TestEquality" executed="True" result="Success" success="True" time="0.000" asserts="2" />
+                              <test-case name="NUnit.Core.Tests.ParameterizedTestFixture(&quot;zip&quot;,&quot;zip&quot;).TestInequality" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                            </results>
+                          </test-suite>
+                          <test-suite type="TestFixture" name="ParameterizedTestFixture(42,42,99)" executed="True" result="Success" success="True" time="0.003" asserts="0">
+                            <results>
+                              <test-case name="NUnit.Core.Tests.ParameterizedTestFixture(42,42,99).TestEquality" executed="True" result="Success" success="True" time="0.000" asserts="2" />
+                              <test-case name="NUnit.Core.Tests.ParameterizedTestFixture(42,42,99).TestInequality" executed="True" result="Success" success="True" time="0.000" asserts="2" />
+                            </results>
+                          </test-suite>
+                        </results>
+                      </test-suite>
+                      <test-suite type="TestFixture" name="ParameterizedTestFixtureNamingTests" executed="True" result="Success" success="True" time="0.025" asserts="0">
+                        <results>
+                          <test-case name="NUnit.Core.Tests.ParameterizedTestFixtureNamingTests.FixtureInstancesAreNamedCorrectly" executed="True" result="Success" success="True" time="0.005" asserts="2" />
+                          <test-case name="NUnit.Core.Tests.ParameterizedTestFixtureNamingTests.MethodWithoutParamsIsNamedCorrectly" executed="True" result="Success" success="True" time="0.003" asserts="2" />
+                          <test-case name="NUnit.Core.Tests.ParameterizedTestFixtureNamingTests.MethodWithParamsIsNamedCorrectly" executed="True" result="Success" success="True" time="0.003" asserts="3" />
+                          <test-case name="NUnit.Core.Tests.ParameterizedTestFixtureNamingTests.SuiteHasCorrectNumberOfInstances" executed="True" result="Success" success="True" time="0.003" asserts="1" />
+                          <test-case name="NUnit.Core.Tests.ParameterizedTestFixtureNamingTests.TopLevelSuiteIsNamedCorrectly" executed="True" result="Success" success="True" time="0.003" asserts="2" />
+                        </results>
+                      </test-suite>
+                      <test-suite type="TestFixture" name="ParameterizedTestFixtureTests" executed="True" result="Success" success="True" time="0.005" asserts="0">
+                        <results>
+                          <test-case name="NUnit.Core.Tests.ParameterizedTestFixtureTests.CanSpecifyCategory" executed="True" result="Success" success="True" time="0.002" asserts="1" />
+                          <test-case name="NUnit.Core.Tests.ParameterizedTestFixtureTests.CanSpecifyMultipleCategories" executed="True" result="Success" success="True" time="0.002" asserts="1" />
+                        </results>
+                      </test-suite>
+                      <test-suite type="ParameterizedFixture" name="ParameterizedTestFixtureWithDataSources" executed="True" result="Success" success="True" time="0.023" asserts="0">
+                        <results>
+                          <test-suite type="TestFixture" name="ParameterizedTestFixtureWithDataSources(42)" executed="True" result="Success" success="True" time="0.022" asserts="0">
+                            <results>
+                              <test-suite type="ParameterizedTest" name="CanAccessTestCaseSource" executed="True" result="Success" success="True" time="0.002" asserts="0">
+                                <results>
+                                  <test-case name="NUnit.Core.Tests.ParameterizedTestFixtureWithDataSources(42).CanAccessTestCaseSource(6,7)" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                                  <test-case name="NUnit.Core.Tests.ParameterizedTestFixtureWithDataSources(42).CanAccessTestCaseSource(3,14)" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                                </results>
+                              </test-suite>
+                              <test-suite type="ParameterizedTest" name="CanAccessValueSource" executed="True" result="Success" success="True" time="0.005" asserts="0">
+                                <results>
+                                  <test-case name="NUnit.Core.Tests.ParameterizedTestFixtureWithDataSources(42).CanAccessValueSource(1)" executed="True" result="Success" success="True" time="0.001" asserts="1" />
+                                  <test-case name="NUnit.Core.Tests.ParameterizedTestFixtureWithDataSources(42).CanAccessValueSource(2)" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                                  <test-case name="NUnit.Core.Tests.ParameterizedTestFixtureWithDataSources(42).CanAccessValueSource(3)" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                                </results>
+                              </test-suite>
+                              <test-suite type="ParameterizedTest" name="CanGenerateDataFromParameter" executed="True" result="Success" success="True" time="0.010" asserts="0">
+                                <results>
+                                  <test-case name="NUnit.Core.Tests.ParameterizedTestFixtureWithDataSources(42).CanGenerateDataFromParameter(1,42)" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                                  <test-case name="NUnit.Core.Tests.ParameterizedTestFixtureWithDataSources(42).CanGenerateDataFromParameter(2,21)" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                                  <test-case name="NUnit.Core.Tests.ParameterizedTestFixtureWithDataSources(42).CanGenerateDataFromParameter(3,14)" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                                  <test-case name="NUnit.Core.Tests.ParameterizedTestFixtureWithDataSources(42).CanGenerateDataFromParameter(6,7)" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                                  <test-case name="NUnit.Core.Tests.ParameterizedTestFixtureWithDataSources(42).CanGenerateDataFromParameter(7,6)" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                                  <test-case name="NUnit.Core.Tests.ParameterizedTestFixtureWithDataSources(42).CanGenerateDataFromParameter(14,3)" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                                  <test-case name="NUnit.Core.Tests.ParameterizedTestFixtureWithDataSources(42).CanGenerateDataFromParameter(21,2)" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                                  <test-case name="NUnit.Core.Tests.ParameterizedTestFixtureWithDataSources(42).CanGenerateDataFromParameter(42,1)" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                                </results>
+                              </test-suite>
+                            </results>
+                          </test-suite>
+                        </results>
+                      </test-suite>
+                      <test-suite type="ParameterizedFixture" name="ParameterizedTestFixtureWithNullArguments" executed="True" result="Success" success="True" time="0.005" asserts="0">
+                        <results>
+                          <test-suite type="TestFixture" name="ParameterizedTestFixtureWithNullArguments(&quot;A&quot;,null)" executed="True" result="Success" success="True" time="0.001" asserts="0">
+                            <results>
+                              <test-case name="NUnit.Core.Tests.ParameterizedTestFixtureWithNullArguments(&quot;A&quot;,null).TestMethod" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                            </results>
+                          </test-suite>
+                          <test-suite type="TestFixture" name="ParameterizedTestFixtureWithNullArguments(null,&quot;A&quot;)" executed="True" result="Success" success="True" time="0.000" asserts="0">
+                            <results>
+                              <test-case name="NUnit.Core.Tests.ParameterizedTestFixtureWithNullArguments(null,&quot;A&quot;).TestMethod" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                            </results>
+                          </test-suite>
+                          <test-suite type="TestFixture" name="ParameterizedTestFixtureWithNullArguments(null,null)" executed="True" result="Success" success="True" time="0.000" asserts="0">
+                            <results>
+                              <test-case name="NUnit.Core.Tests.ParameterizedTestFixtureWithNullArguments(null,null).TestMethod" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                            </results>
+                          </test-suite>
+                        </results>
+                      </test-suite>
+                      <test-suite type="TestFixture" name="PlatformDetectionTests" executed="True" result="Success" success="True" time="0.055" asserts="0">
+                        <results>
+                          <test-case name="NUnit.Core.Tests.PlatformDetectionTests.ArrayOfPlatforms" executed="True" result="Success" success="True" time="0.001" asserts="2" />
+                          <test-case name="NUnit.Core.Tests.PlatformDetectionTests.DetectExactVersion" executed="True" result="Success" success="True" time="0.000" asserts="4" />
+                          <test-case name="NUnit.Core.Tests.PlatformDetectionTests.DetectMono10" executed="True" result="Success" success="True" time="0.001" asserts="8" />
+                          <test-case name="NUnit.Core.Tests.PlatformDetectionTests.DetectMono20" executed="True" result="Success" success="True" time="0.000" asserts="8" />
+                          <test-case name="NUnit.Core.Tests.PlatformDetectionTests.DetectNet10" executed="True" result="Success" success="True" time="0.000" asserts="8" />
+                          <test-case name="NUnit.Core.Tests.PlatformDetectionTests.DetectNet11" executed="True" result="Success" success="True" time="0.000" asserts="8" />
+                          <test-case name="NUnit.Core.Tests.PlatformDetectionTests.DetectNet20" executed="True" result="Success" success="True" time="0.000" asserts="8" />
+                          <test-case name="NUnit.Core.Tests.PlatformDetectionTests.DetectNet40" executed="True" result="Success" success="True" time="0.000" asserts="9" />
+                          <test-case name="NUnit.Core.Tests.PlatformDetectionTests.DetectNetCF" executed="True" result="Success" success="True" time="0.000" asserts="9" />
+                          <test-case name="NUnit.Core.Tests.PlatformDetectionTests.DetectNT3" executed="True" result="Success" success="True" time="0.002" asserts="18" />
+                          <test-case name="NUnit.Core.Tests.PlatformDetectionTests.DetectNT4" executed="True" result="Success" success="True" time="0.000" asserts="18" />
+                          <test-case name="NUnit.Core.Tests.PlatformDetectionTests.DetectSSCLI" executed="True" result="Success" success="True" time="0.000" asserts="8" />
+                          <test-case name="NUnit.Core.Tests.PlatformDetectionTests.DetectUnixUnderMicrosoftDotNet" executed="True" result="Success" success="True" time="0.000" asserts="20" />
+                          <test-case name="NUnit.Core.Tests.PlatformDetectionTests.DetectUnixUnderMono" executed="False" result="Skipped">
+                            <reason>
+                              <message><![CDATA[Not supported on Net]]></message>
+                            </reason>
+                          </test-case>
+                          <test-case name="NUnit.Core.Tests.PlatformDetectionTests.DetectVista" executed="True" result="Success" success="True" time="0.000" asserts="17" />
+                          <test-case name="NUnit.Core.Tests.PlatformDetectionTests.DetectWin2003Server" executed="True" result="Success" success="True" time="0.000" asserts="17" />
+                          <test-case name="NUnit.Core.Tests.PlatformDetectionTests.DetectWin2008ServerOriginal" executed="True" result="Success" success="True" time="0.000" asserts="17" />
+                          <test-case name="NUnit.Core.Tests.PlatformDetectionTests.DetectWin2008ServerR2" executed="True" result="Success" success="True" time="0.000" asserts="16" />
+                          <test-case name="NUnit.Core.Tests.PlatformDetectionTests.DetectWin2K" executed="True" result="Success" success="True" time="0.001" asserts="17" />
+                          <test-case name="NUnit.Core.Tests.PlatformDetectionTests.DetectWin95" executed="True" result="Success" success="True" time="0.000" asserts="18" />
+                          <test-case name="NUnit.Core.Tests.PlatformDetectionTests.DetectWin98" executed="True" result="Success" success="True" time="0.000" asserts="18" />
+                          <test-case name="NUnit.Core.Tests.PlatformDetectionTests.DetectWinCE" executed="True" result="Success" success="True" time="0.000" asserts="19" />
+                          <test-case name="NUnit.Core.Tests.PlatformDetectionTests.DetectWindows7" executed="True" result="Success" success="True" time="0.001" asserts="17" />
+                          <test-case name="NUnit.Core.Tests.PlatformDetectionTests.DetectWinMe" executed="True" result="Success" success="True" time="0.000" asserts="18" />
+                          <test-case name="NUnit.Core.Tests.PlatformDetectionTests.DetectWinXP" executed="True" result="Success" success="True" time="0.000" asserts="17" />
+                          <test-case name="NUnit.Core.Tests.PlatformDetectionTests.DetectWinXPProfessionalX64" executed="True" result="Success" success="True" time="0.001" asserts="17" />
+                          <test-case name="NUnit.Core.Tests.PlatformDetectionTests.PlatformAttribute_Exclude" executed="True" result="Success" success="True" time="0.000" asserts="3" />
+                          <test-case name="NUnit.Core.Tests.PlatformDetectionTests.PlatformAttribute_Include" executed="True" result="Success" success="True" time="0.000" asserts="3" />
+                          <test-case name="NUnit.Core.Tests.PlatformDetectionTests.PlatformAttribute_IncludeAndExclude" executed="True" result="Success" success="True" time="0.001" asserts="7" />
+                          <test-case name="NUnit.Core.Tests.PlatformDetectionTests.PlatformAttribute_InvalidPlatform" executed="True" result="Success" success="True" time="0.001" asserts="2" />
+                        </results>
+                      </test-suite>
+                      <test-suite type="TestFixture" name="PropertyAttributeTests" executed="True" result="Success" success="True" time="0.017" asserts="0">
+                        <results>
+                          <test-case name="NUnit.Core.Tests.PropertyAttributeTests.CanDeriveFromPropertyAttribute" executed="True" result="Success" success="True" time="0.003" asserts="1" />
+                          <test-case name="NUnit.Core.Tests.PropertyAttributeTests.PropertiesWithNumericValues" executed="True" result="Success" success="True" time="0.002" asserts="2" />
+                          <test-case name="NUnit.Core.Tests.PropertyAttributeTests.PropertyWithStringValue" executed="True" result="Success" success="True" time="0.002" asserts="1" />
+                          <test-case name="NUnit.Core.Tests.PropertyAttributeTests.PropertyWorksOnFixtures" executed="True" result="Success" success="True" time="0.002" asserts="1" />
+                        </results>
+                      </test-suite>
+                      <test-suite type="TestFixture" name="ReflectTests" executed="True" result="Success" success="True" time="0.029" asserts="0">
+                        <results>
+                          <test-case name="NUnit.Core.Tests.ReflectTests.CanDetectAttributes" executed="True" result="Success" success="True" time="0.001" asserts="3" />
+                          <test-case name="NUnit.Core.Tests.ReflectTests.CanDetectInheritedAttributes" executed="True" result="Success" success="True" time="0.000" asserts="3" />
+                          <test-case name="NUnit.Core.Tests.ReflectTests.Construct" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Core.Tests.ReflectTests.GetAttribute" executed="True" result="Success" success="True" time="0.001" asserts="3" />
+                          <test-case name="NUnit.Core.Tests.ReflectTests.GetAttributes" executed="True" result="Success" success="True" time="0.001" asserts="4" />
+                          <test-case name="NUnit.Core.Tests.ReflectTests.GetConstructor" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Core.Tests.ReflectTests.GetInheritedAttribute" executed="True" result="Success" success="True" time="0.000" asserts="3" />
+                          <test-case name="NUnit.Core.Tests.ReflectTests.GetInheritedAttributes" executed="True" result="Success" success="True" time="0.000" asserts="4" />
+                          <test-case name="NUnit.Core.Tests.ReflectTests.GetMethodsWithAttribute" executed="True" result="Success" success="True" time="0.001" asserts="1" />
+                          <test-case name="NUnit.Core.Tests.ReflectTests.GetNamedMethod" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Core.Tests.ReflectTests.GetNamedMethodWithArgs" executed="True" result="Success" success="True" time="0.001" asserts="1" />
+                          <test-case name="NUnit.Core.Tests.ReflectTests.GetNamedProperty" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Core.Tests.ReflectTests.GetPropertyValue" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Core.Tests.ReflectTests.GetPropertyWithAttribute" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Core.Tests.ReflectTests.HasInterface" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Core.Tests.ReflectTests.InheritsFrom" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Core.Tests.ReflectTests.InvokeMethod" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                        </results>
+                      </test-suite>
+                      <test-suite type="TestFixture" name="RemoteRunnerTests" executed="True" result="Success" success="True" time="0.424" asserts="1">
+                        <results>
+                          <test-case name="NUnit.Core.Tests.RemoteRunnerTests.BasicRunnerTests.CheckRunnerID" executed="True" result="Success" success="True" time="0.001" asserts="1" />
+                          <test-case name="NUnit.Core.Tests.RemoteRunnerTests.BasicRunnerTests.CountTestCases" executed="True" result="Success" success="True" time="0.031" asserts="1" />
+                          <test-case name="NUnit.Core.Tests.RemoteRunnerTests.BasicRunnerTests.CountTestCasesAcrossMultipleAssemblies" executed="True" result="Success" success="True" time="0.037" asserts="1" />
+                          <test-case name="NUnit.Core.Tests.RemoteRunnerTests.BasicRunnerTests.LoadAndReloadAssembly" executed="True" result="Success" success="True" time="0.052" asserts="2" />
+                          <test-case name="NUnit.Core.Tests.RemoteRunnerTests.BasicRunnerTests.LoadAssemblyWithFixture" executed="True" result="Success" success="True" time="0.013" asserts="1" />
+                          <test-case name="NUnit.Core.Tests.RemoteRunnerTests.BasicRunnerTests.LoadAssemblyWithoutNamespaces" executed="True" result="Success" success="True" time="0.026" asserts="4" />
+                          <test-case name="NUnit.Core.Tests.RemoteRunnerTests.BasicRunnerTests.LoadAssemblyWithSuite" executed="True" result="Success" success="True" time="0.011" asserts="1" />
+                          <test-case name="NUnit.Core.Tests.RemoteRunnerTests.BasicRunnerTests.LoadMultipleAssemblies" executed="True" result="Success" success="True" time="0.035" asserts="1" />
+                          <test-case name="NUnit.Core.Tests.RemoteRunnerTests.BasicRunnerTests.LoadMultipleAssembliesWithFixture" executed="True" result="Success" success="True" time="0.022" asserts="1" />
+                          <test-case name="NUnit.Core.Tests.RemoteRunnerTests.BasicRunnerTests.LoadMultipleAssembliesWithSuite" executed="True" result="Success" success="True" time="0.018" asserts="1" />
+                          <test-case name="NUnit.Core.Tests.RemoteRunnerTests.BasicRunnerTests.RunAssembly" executed="True" result="Success" success="True" time="0.033" asserts="1" />
+                          <test-case name="NUnit.Core.Tests.RemoteRunnerTests.BasicRunnerTests.RunAssemblyUsingBeginAndEndRun" executed="True" result="Success" success="True" time="0.032" asserts="2" />
+                          <test-case name="NUnit.Core.Tests.RemoteRunnerTests.BasicRunnerTests.RunMultipleAssemblies" executed="True" result="Success" success="True" time="0.043" asserts="1" />
+                          <test-case name="NUnit.Core.Tests.RemoteRunnerTests.BasicRunnerTests.RunMultipleAssembliesUsingBeginAndEndRun" executed="True" result="Success" success="True" time="0.042" asserts="2" />
+                        </results>
+                      </test-suite>
+                      <test-suite type="TestFixture" name="RepeatedTestFixture" executed="True" result="Success" success="True" time="0.022" asserts="0">
+                        <results>
+                          <test-case name="NUnit.Core.Tests.RepeatedTestFixture.CategoryWorksWithRepeatedTest" executed="True" result="Success" success="True" time="0.004" asserts="3" />
+                          <test-case name="NUnit.Core.Tests.RepeatedTestFixture.IgnoreWorksWithRepeatedTest" executed="True" result="Success" success="True" time="0.003" asserts="3" />
+                          <test-case name="NUnit.Core.Tests.RepeatedTestFixture.RepeatFailOnFirst" executed="True" result="Success" success="True" time="0.004" asserts="4" />
+                          <test-case name="NUnit.Core.Tests.RepeatedTestFixture.RepeatFailOnThird" executed="True" result="Success" success="True" time="0.004" asserts="4" />
+                          <test-case name="NUnit.Core.Tests.RepeatedTestFixture.RepeatSuccess" executed="True" result="Success" success="True" time="0.003" asserts="6" />
+                        </results>
+                      </test-suite>
+                      <test-suite type="TestFixture" name="RuntimeFrameworkTests" executed="True" result="Success" success="True" time="0.159" asserts="0">
+                        <results>
+                          <test-suite type="ParameterizedTest" name="CanCreateNewRuntimeFramework" executed="True" result="Success" success="True" time="0.036" asserts="0">
+                            <results>
+                              <test-case name="NUnit.Core.Tests.RuntimeFrameworkTests.CanCreateNewRuntimeFramework(&lt;Net-1.0&gt;)" executed="True" result="Success" success="True" time="0.001" asserts="2" />
+                              <test-case name="NUnit.Core.Tests.RuntimeFrameworkTests.CanCreateNewRuntimeFramework(&lt;Net-1.0.3705&gt;)" executed="True" result="Success" success="True" time="0.000" asserts="2" />
+                              <test-case name="NUnit.Core.Tests.RuntimeFrameworkTests.CanCreateNewRuntimeFramework(&lt;Net-1.1&gt;)" executed="True" result="Success" success="True" time="0.000" asserts="2" />
+                              <test-case name="NUnit.Core.Tests.RuntimeFrameworkTests.CanCreateNewRuntimeFramework(&lt;Net-1.1.4322&gt;)" executed="True" result="Success" success="True" time="0.000" asserts="2" />
+                              <test-case name="NUnit.Core.Tests.RuntimeFrameworkTests.CanCreateNewRuntimeFramework(&lt;Net-2.0&gt;)" executed="True" result="Success" success="True" time="0.000" asserts="2" />
+                              <test-case name="NUnit.Core.Tests.RuntimeFrameworkTests.CanCreateNewRuntimeFramework(&lt;Net-2.0.40607&gt;)" executed="True" result="Success" success="True" time="0.000" asserts="2" />
+                              <test-case name="NUnit.Core.Tests.RuntimeFrameworkTests.CanCreateNewRuntimeFramework(&lt;Net-2.0.50727&gt;)" executed="True" result="Success" success="True" time="0.000" asserts="2" />
+                              <test-case name="NUnit.Core.Tests.RuntimeFrameworkTests.CanCreateNewRuntimeFramework(&lt;Net-3.0&gt;)" executed="True" result="Success" success="True" time="0.000" asserts="2" />
+                              <test-case name="NUnit.Core.Tests.RuntimeFrameworkTests.CanCreateNewRuntimeFramework(&lt;Net-3.5&gt;)" executed="True" result="Success" success="True" time="0.000" asserts="2" />
+                              <test-case name="NUnit.Core.Tests.RuntimeFrameworkTests.CanCreateNewRuntimeFramework(&lt;Net-4.0&gt;)" executed="True" result="Success" success="True" time="0.000" asserts="2" />
+                              <test-case name="NUnit.Core.Tests.RuntimeFrameworkTests.CanCreateNewRuntimeFramework(&lt;Net-0.0&gt;)" executed="True" result="Success" success="True" time="0.000" asserts="2" />
+                              <test-case name="NUnit.Core.Tests.RuntimeFrameworkTests.CanCreateNewRuntimeFramework(&lt;Mono-1.0&gt;)" executed="True" result="Success" success="True" time="0.000" asserts="2" />
+                              <test-case name="NUnit.Core.Tests.RuntimeFrameworkTests.CanCreateNewRuntimeFramework(&lt;Mono-2.0&gt;)" executed="True" result="Success" success="True" time="0.000" asserts="2" />
+                              <test-case name="NUnit.Core.Tests.RuntimeFrameworkTests.CanCreateNewRuntimeFramework(&lt;Mono-2.0.50727&gt;)" executed="True" result="Success" success="True" time="0.000" asserts="2" />
+                              <test-case name="NUnit.Core.Tests.RuntimeFrameworkTests.CanCreateNewRuntimeFramework(&lt;Mono-3.5&gt;)" executed="True" result="Success" success="True" time="0.000" asserts="2" />
+                              <test-case name="NUnit.Core.Tests.RuntimeFrameworkTests.CanCreateNewRuntimeFramework(&lt;Mono-0.0&gt;)" executed="True" result="Success" success="True" time="0.000" asserts="2" />
+                              <test-case name="NUnit.Core.Tests.RuntimeFrameworkTests.CanCreateNewRuntimeFramework(&lt;Any-1.1&gt;)" executed="True" result="Success" success="True" time="0.000" asserts="2" />
+                              <test-case name="NUnit.Core.Tests.RuntimeFrameworkTests.CanCreateNewRuntimeFramework(&lt;Any-2.0&gt;)" executed="True" result="Success" success="True" time="0.000" asserts="2" />
+                              <test-case name="NUnit.Core.Tests.RuntimeFrameworkTests.CanCreateNewRuntimeFramework(&lt;Any-2.0.50727&gt;)" executed="True" result="Success" success="True" time="0.001" asserts="2" />
+                              <test-case name="NUnit.Core.Tests.RuntimeFrameworkTests.CanCreateNewRuntimeFramework(&lt;Any-3.5&gt;)" executed="True" result="Success" success="True" time="0.000" asserts="2" />
+                              <test-case name="NUnit.Core.Tests.RuntimeFrameworkTests.CanCreateNewRuntimeFramework(&lt;Any-4.0&gt;)" executed="True" result="Success" success="True" time="0.000" asserts="2" />
+                              <test-case name="NUnit.Core.Tests.RuntimeFrameworkTests.CanCreateNewRuntimeFramework(&lt;Any-0.0&gt;)" executed="True" result="Success" success="True" time="0.000" asserts="2" />
+                            </results>
+                          </test-suite>
+                          <test-suite type="ParameterizedTest" name="CanDisplayFrameworkAsString" executed="True" result="Success" success="True" time="0.036" asserts="0">
+                            <results>
+                              <test-case name="NUnit.Core.Tests.RuntimeFrameworkTests.CanDisplayFrameworkAsString(&lt;Net-1.0&gt;)" executed="True" result="Success" success="True" time="0.001" asserts="2" />
+                              <test-case name="NUnit.Core.Tests.RuntimeFrameworkTests.CanDisplayFrameworkAsString(&lt;Net-1.0.3705&gt;)" executed="True" result="Success" success="True" time="0.000" asserts="2" />
+                              <test-case name="NUnit.Core.Tests.RuntimeFrameworkTests.CanDisplayFrameworkAsString(&lt;Net-1.1&gt;)" executed="True" result="Success" success="True" time="0.000" asserts="2" />
+                              <test-case name="NUnit.Core.Tests.RuntimeFrameworkTests.CanDisplayFrameworkAsString(&lt;Net-1.1.4322&gt;)" executed="True" result="Success" success="True" time="0.000" asserts="2" />
+                              <test-case name="NUnit.Core.Tests.RuntimeFrameworkTests.CanDisplayFrameworkAsString(&lt;Net-2.0&gt;)" executed="True" result="Success" success="True" time="0.000" asserts="2" />
+                              <test-case name="NUnit.Core.Tests.RuntimeFrameworkTests.CanDisplayFrameworkAsString(&lt;Net-2.0.40607&gt;)" executed="True" result="Success" success="True" time="0.000" asserts="2" />
+                              <test-case name="NUnit.Core.Tests.RuntimeFrameworkTests.CanDisplayFrameworkAsString(&lt;Net-2.0.50727&gt;)" executed="True" result="Success" success="True" time="0.001" asserts="2" />
+                              <test-case name="NUnit.Core.Tests.RuntimeFrameworkTests.CanDisplayFrameworkAsString(&lt;Net-3.0&gt;)" executed="True" result="Success" success="True" time="0.000" asserts="2" />
+                              <test-case name="NUnit.Core.Tests.RuntimeFrameworkTests.CanDisplayFrameworkAsString(&lt;Net-3.5&gt;)" executed="True" result="Success" success="True" time="0.000" asserts="2" />
+                              <test-case name="NUnit.Core.Tests.RuntimeFrameworkTests.CanDisplayFrameworkAsString(&lt;Net-4.0&gt;)" executed="True" result="Success" success="True" time="0.000" asserts="2" />
+                              <test-case name="NUnit.Core.Tests.RuntimeFrameworkTests.CanDisplayFrameworkAsString(&lt;Net-0.0&gt;)" executed="True" result="Success" success="True" time="0.000" asserts="2" />
+                              <test-case name="NUnit.Core.Tests.RuntimeFrameworkTests.CanDisplayFrameworkAsString(&lt;Mono-1.0&gt;)" executed="True" result="Success" success="True" time="0.000" asserts="2" />
+                              <test-case name="NUnit.Core.Tests.RuntimeFrameworkTests.CanDisplayFrameworkAsString(&lt;Mono-2.0&gt;)" executed="True" result="Success" success="True" time="0.000" asserts="2" />
+                              <test-case name="NUnit.Core.Tests.RuntimeFrameworkTests.CanDisplayFrameworkAsString(&lt;Mono-2.0.50727&gt;)" executed="True" result="Success" success="True" time="0.000" asserts="2" />
+                              <test-case name="NUnit.Core.Tests.RuntimeFrameworkTests.CanDisplayFrameworkAsString(&lt;Mono-3.5&gt;)" executed="True" result="Success" success="True" time="0.000" asserts="2" />
+                              <test-case name="NUnit.Core.Tests.RuntimeFrameworkTests.CanDisplayFrameworkAsString(&lt;Mono-0.0&gt;)" executed="True" result="Success" success="True" time="0.000" asserts="2" />
+                              <test-case name="NUnit.Core.Tests.RuntimeFrameworkTests.CanDisplayFrameworkAsString(&lt;Any-1.1&gt;)" executed="True" result="Success" success="True" time="0.000" asserts="2" />
+                              <test-case name="NUnit.Core.Tests.RuntimeFrameworkTests.CanDisplayFrameworkAsString(&lt;Any-2.0&gt;)" executed="True" result="Success" success="True" time="0.000" asserts="2" />
+                              <test-case name="NUnit.Core.Tests.RuntimeFrameworkTests.CanDisplayFrameworkAsString(&lt;Any-2.0.50727&gt;)" executed="True" result="Success" success="True" time="0.000" asserts="2" />
+                              <test-case name="NUnit.Core.Tests.RuntimeFrameworkTests.CanDisplayFrameworkAsString(&lt;Any-3.5&gt;)" executed="True" result="Success" success="True" time="0.000" asserts="2" />
+                              <test-case name="NUnit.Core.Tests.RuntimeFrameworkTests.CanDisplayFrameworkAsString(&lt;Any-4.0&gt;)" executed="True" result="Success" success="True" time="0.001" asserts="2" />
+                              <test-case name="NUnit.Core.Tests.RuntimeFrameworkTests.CanDisplayFrameworkAsString(&lt;Any-0.0&gt;)" executed="True" result="Success" success="True" time="0.000" asserts="2" />
+                            </results>
+                          </test-suite>
+                          <test-case name="NUnit.Core.Tests.RuntimeFrameworkTests.CanGetCurrentFramework" executed="True" result="Success" success="True" time="0.001" asserts="2" />
+                          <test-case name="NUnit.Core.Tests.RuntimeFrameworkTests.CanListAvailableFrameworks" executed="True" result="Success" success="True" time="0.007" asserts="2" />
+                          <test-suite type="ParameterizedTest" name="CanMatchRuntimes" executed="True" result="Success" success="True" time="0.024" asserts="0">
+                            <results>
+                              <test-case name="NUnit.Core.Tests.RuntimeFrameworkTests.CanMatchRuntimes(net-2.0,net-2.0)" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                              <test-case name="NUnit.Core.Tests.RuntimeFrameworkTests.CanMatchRuntimes(net-2.0,net-2.0.50727)" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                              <test-case name="NUnit.Core.Tests.RuntimeFrameworkTests.CanMatchRuntimes(net-2.0.50727,net-2.0)" executed="True" result="Success" success="True" time="0.001" asserts="1" />
+                              <test-case name="NUnit.Core.Tests.RuntimeFrameworkTests.CanMatchRuntimes(net-2.0.50727,net-2.0)" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                              <test-case name="NUnit.Core.Tests.RuntimeFrameworkTests.CanMatchRuntimes(net-3.5,net-2.0)" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                              <test-case name="NUnit.Core.Tests.RuntimeFrameworkTests.CanMatchRuntimes(net-2.0,mono-2.0)" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                              <test-case name="NUnit.Core.Tests.RuntimeFrameworkTests.CanMatchRuntimes(net-2.0,net-1.1)" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                              <test-case name="NUnit.Core.Tests.RuntimeFrameworkTests.CanMatchRuntimes(net-2.0.50727,net-2.0.40607)" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                              <test-case name="NUnit.Core.Tests.RuntimeFrameworkTests.CanMatchRuntimes(mono-1.1,mono-1.0)" executed="True" result="Success" success="True" time="0.001" asserts="1" />
+                              <test-case name="NUnit.Core.Tests.RuntimeFrameworkTests.CanMatchRuntimes(mono-2.0,v2.0)" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                              <test-case name="NUnit.Core.Tests.RuntimeFrameworkTests.CanMatchRuntimes(v2.0,mono-2.0)" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                              <test-case name="NUnit.Core.Tests.RuntimeFrameworkTests.CanMatchRuntimes(v2.0,v2.0)" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                              <test-case name="NUnit.Core.Tests.RuntimeFrameworkTests.CanMatchRuntimes(v2.0,v4.0)" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                              <test-case name="NUnit.Core.Tests.RuntimeFrameworkTests.CanMatchRuntimes(net,net-2.0)" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                              <test-case name="NUnit.Core.Tests.RuntimeFrameworkTests.CanMatchRuntimes(net-2.0,net)" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                              <test-case name="NUnit.Core.Tests.RuntimeFrameworkTests.CanMatchRuntimes(any,net-2.0)" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                              <test-case name="NUnit.Core.Tests.RuntimeFrameworkTests.CanMatchRuntimes(net-2.0,any)" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                            </results>
+                          </test-suite>
+                          <test-suite type="ParameterizedTest" name="CanParseRuntimeFramework" executed="True" result="Success" success="True" time="0.032" asserts="0">
+                            <results>
+                              <test-case name="NUnit.Core.Tests.RuntimeFrameworkTests.CanParseRuntimeFramework(&lt;Net-1.0&gt;)" executed="True" result="Success" success="True" time="0.001" asserts="2" />
+                              <test-case name="NUnit.Core.Tests.RuntimeFrameworkTests.CanParseRuntimeFramework(&lt;Net-1.0.3705&gt;)" executed="True" result="Success" success="True" time="0.000" asserts="2" />
+                              <test-case name="NUnit.Core.Tests.RuntimeFrameworkTests.CanParseRuntimeFramework(&lt;Net-1.1&gt;)" executed="True" result="Success" success="True" time="0.000" asserts="2" />
+                              <test-case name="NUnit.Core.Tests.RuntimeFrameworkTests.CanParseRuntimeFramework(&lt;Net-1.1.4322&gt;)" executed="True" result="Success" success="True" time="0.000" asserts="2" />
+                              <test-case name="NUnit.Core.Tests.RuntimeFrameworkTests.CanParseRuntimeFramework(&lt;Net-2.0&gt;)" executed="True" result="Success" success="True" time="0.000" asserts="2" />
+                              <test-case name="NUnit.Core.Tests.RuntimeFrameworkTests.CanParseRuntimeFramework(&lt;Net-2.0.40607&gt;)" executed="True" result="Success" success="True" time="0.000" asserts="2" />
+                              <test-case name="NUnit.Core.Tests.RuntimeFrameworkTests.CanParseRuntimeFramework(&lt;Net-2.0.50727&gt;)" executed="True" result="Success" success="True" time="0.000" asserts="2" />
+                              <test-case name="NUnit.Core.Tests.RuntimeFrameworkTests.CanParseRuntimeFramework(&lt;Net-3.0&gt;)" executed="True" result="Success" success="True" time="0.000" asserts="2" />
+                              <test-case name="NUnit.Core.Tests.RuntimeFrameworkTests.CanParseRuntimeFramework(&lt;Net-3.5&gt;)" executed="True" result="Success" success="True" time="0.000" asserts="2" />
+                              <test-case name="NUnit.Core.Tests.RuntimeFrameworkTests.CanParseRuntimeFramework(&lt;Net-4.0&gt;)" executed="True" result="Success" success="True" time="0.000" asserts="2" />
+                              <test-case name="NUnit.Core.Tests.RuntimeFrameworkTests.CanParseRuntimeFramework(&lt;Net-0.0&gt;)" executed="True" result="Success" success="True" time="0.000" asserts="2" />
+                              <test-case name="NUnit.Core.Tests.RuntimeFrameworkTests.CanParseRuntimeFramework(&lt;Mono-1.0&gt;)" executed="True" result="Success" success="True" time="0.000" asserts="2" />
+                              <test-case name="NUnit.Core.Tests.RuntimeFrameworkTests.CanParseRuntimeFramework(&lt;Mono-2.0&gt;)" executed="True" result="Success" success="True" time="0.000" asserts="2" />
+                              <test-case name="NUnit.Core.Tests.RuntimeFrameworkTests.CanParseRuntimeFramework(&lt;Mono-2.0.50727&gt;)" executed="True" result="Success" success="True" time="0.000" asserts="2" />
+                              <test-case name="NUnit.Core.Tests.RuntimeFrameworkTests.CanParseRuntimeFramework(&lt;Mono-3.5&gt;)" executed="True" result="Success" success="True" time="0.000" asserts="2" />
+                              <test-case name="NUnit.Core.Tests.RuntimeFrameworkTests.CanParseRuntimeFramework(&lt;Mono-0.0&gt;)" executed="True" result="Success" success="True" time="0.000" asserts="2" />
+                              <test-case name="NUnit.Core.Tests.RuntimeFrameworkTests.CanParseRuntimeFramework(&lt;Any-1.1&gt;)" executed="True" result="Success" success="True" time="0.000" asserts="2" />
+                              <test-case name="NUnit.Core.Tests.RuntimeFrameworkTests.CanParseRuntimeFramework(&lt;Any-2.0&gt;)" executed="True" result="Success" success="True" time="0.000" asserts="2" />
+                              <test-case name="NUnit.Core.Tests.RuntimeFrameworkTests.CanParseRuntimeFramework(&lt;Any-2.0.50727&gt;)" executed="True" result="Success" success="True" time="0.000" asserts="2" />
+                              <test-case name="NUnit.Core.Tests.RuntimeFrameworkTests.CanParseRuntimeFramework(&lt;Any-3.5&gt;)" executed="True" result="Success" success="True" time="0.000" asserts="2" />
+                              <test-case name="NUnit.Core.Tests.RuntimeFrameworkTests.CanParseRuntimeFramework(&lt;Any-4.0&gt;)" executed="True" result="Success" success="True" time="0.000" asserts="2" />
+                              <test-case name="NUnit.Core.Tests.RuntimeFrameworkTests.CanParseRuntimeFramework(&lt;Any-0.0&gt;)" executed="True" result="Success" success="True" time="0.000" asserts="2" />
+                            </results>
+                          </test-suite>
+                          <test-case name="NUnit.Core.Tests.RuntimeFrameworkTests.CurrentFrameworkHasBuildSpecified" executed="True" result="Success" success="True" time="0.001" asserts="1" />
+                          <test-case name="NUnit.Core.Tests.RuntimeFrameworkTests.CurrentFrameworkMustBeAvailable" executed="True" result="Success" success="True" time="0.001" asserts="1" />
+                        </results>
+                      </test-suite>
+                      <test-suite type="TestFixture" name="SerializationBug" executed="True" result="Success" success="True" time="0.007" asserts="0">
+                        <results>
+                          <test-case name="NUnit.Core.Tests.SerializationBug.SaveAndLoad" executed="True" result="Success" success="True" time="0.007" asserts="3" />
+                        </results>
+                      </test-suite>
+                      <test-suite type="TestFixture" name="SetCultureAttributeTests" executed="True" result="Success" success="True" time="0.013" asserts="0">
+                        <results>
+                          <test-case name="NUnit.Core.Tests.SetCultureAttributeTests.SetBothCulturesToFrench" executed="True" result="Success" success="True" time="0.001" asserts="2" />
+                          <test-case name="NUnit.Core.Tests.SetCultureAttributeTests.SetBothCulturesToFrenchCanadian" executed="True" result="Success" success="True" time="0.001" asserts="2" />
+                          <test-case name="NUnit.Core.Tests.SetCultureAttributeTests.SetBothCulturesToRussian" executed="True" result="Success" success="True" time="0.000" asserts="2" />
+                          <test-case name="NUnit.Core.Tests.SetCultureAttributeTests.SetMixedCulturesToFrenchAndUIFrenchCanadian" executed="True" result="Success" success="True" time="0.000" asserts="2" />
+                          <test-case name="NUnit.Core.Tests.SetCultureAttributeTests.SetMixedCulturesToRussianAndUIEnglishUS" executed="True" result="Success" success="True" time="0.001" asserts="2" />
+                          <test-case name="NUnit.Core.Tests.SetCultureAttributeTests.SetUICultureOnlyToFrench" executed="True" result="Success" success="True" time="0.000" asserts="2" />
+                          <test-case name="NUnit.Core.Tests.SetCultureAttributeTests.SetUICultureOnlyToFrenchCanadian" executed="True" result="Success" success="True" time="0.000" asserts="2" />
+                          <test-case name="NUnit.Core.Tests.SetCultureAttributeTests.SetUICultureOnlyToRussian" executed="True" result="Success" success="True" time="0.001" asserts="2" />
+                        </results>
+                      </test-suite>
+                      <test-suite type="TestFixture" name="SetCultureAttributeTests+NestedBehavior" executed="True" result="Success" success="True" time="0.002" asserts="0">
+                        <results>
+                          <test-case name="NUnit.Core.Tests.SetCultureAttributeTests+NestedBehavior.InheritedRussian" executed="True" result="Success" success="True" time="0.000" asserts="2" />
+                          <test-case name="NUnit.Core.Tests.SetCultureAttributeTests+NestedBehavior.InheritedRussianWithUIFrench" executed="True" result="Success" success="True" time="0.000" asserts="2" />
+                        </results>
+                      </test-suite>
+                      <test-suite type="TestFixture" name="SetUpFixtureTests" executed="True" result="Success" success="True" time="0.649" asserts="0">
+                        <results>
+                          <test-case name="NUnit.Core.Tests.SetUpFixtureTests.AssemblySetUpFixtureReplacesAssemblyNodeInTree" executed="True" result="Success" success="True" time="0.278" asserts="4" />
+                          <test-case name="NUnit.Core.Tests.SetUpFixtureTests.AssemblySetupFixtureWrapsExecutionOfTest" executed="True" result="Success" success="True" time="0.255" asserts="5" />
+                          <test-case name="NUnit.Core.Tests.SetUpFixtureTests.NamespaceSetUpFixtureReplacesNamespaceNodeInTree" executed="True" result="Success" success="True" time="0.014" asserts="14" />
+                          <test-case name="NUnit.Core.Tests.SetUpFixtureTests.NamespaceSetUpFixtureWrapsExecutionOfSingleTest" executed="True" result="Success" success="True" time="0.014" asserts="8" />
+                          <test-case name="NUnit.Core.Tests.SetUpFixtureTests.NamespaceSetUpFixtureWrapsExecutionOfTwoTests" executed="True" result="Success" success="True" time="0.016" asserts="13" />
+                          <test-case name="NUnit.Core.Tests.SetUpFixtureTests.NamespaceSetUpFixtureWrapsNestedNamespaceSetUpFixture" executed="True" result="Success" success="True" time="0.018" asserts="15" />
+                          <test-case name="NUnit.Core.Tests.SetUpFixtureTests.NamespaceSetUpMethodsMayBeStatic" executed="True" result="Success" success="True" time="0.016" asserts="8" />
+                          <test-case name="NUnit.Core.Tests.SetUpFixtureTests.WithTwoSetUpFixtuesOnlyOneIsUsed" executed="True" result="Success" success="True" time="0.015" asserts="8" />
+                        </results>
+                      </test-suite>
+                      <test-suite type="TestFixture" name="SetUpTest" executed="True" result="Success" success="True" time="0.030" asserts="0">
+                        <results>
+                          <test-case name="NUnit.Core.Tests.SetUpTest.BaseSetUpIsCalledFirstTearDownLast" executed="True" result="Success" success="True" time="0.002" asserts="6" />
+                          <test-case name="NUnit.Core.Tests.SetUpTest.CheckInheritedSetUpAndTearDownAreCalled" executed="True" result="Success" success="True" time="0.002" asserts="2" />
+                          <test-case name="NUnit.Core.Tests.SetUpTest.CheckOverriddenSetUpAndTearDownAreNotCalled" executed="True" result="Success" success="True" time="0.002" asserts="4" />
+                          <test-case name="NUnit.Core.Tests.SetUpTest.MakeSureSetUpAndTearDownAreCalled" executed="True" result="Success" success="True" time="0.002" asserts="2" />
+                          <test-case name="NUnit.Core.Tests.SetUpTest.MultipleSetUpAndTearDownMethodsAreCalled" executed="True" result="Success" success="True" time="0.002" asserts="5" />
+                          <test-case name="NUnit.Core.Tests.SetUpTest.SetUpAndTearDownCounter" executed="True" result="Success" success="True" time="0.002" asserts="2" />
+                          <test-case name="NUnit.Core.Tests.SetUpTest.SetupRecordsOriginalExceptionThownByTestCase" executed="True" result="Success" success="True" time="0.003" asserts="4" />
+                          <test-case name="NUnit.Core.Tests.SetUpTest.TearDownRecordsOriginalExceptionThownByTestCase" executed="True" result="Success" success="True" time="0.003" asserts="4" />
+                        </results>
+                      </test-suite>
+                      <test-suite type="TestFixture" name="SetUpTest+SetupCallDerived" executed="True" result="Success" success="True" time="0.002" asserts="0">
+                        <results>
+                          <test-case name="NUnit.Core.Tests.SetUpTest+SetupCallDerived.AssertCount" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                        </results>
+                      </test-suite>
+                      <test-suite type="TestFixture" name="SimpleNameFilterTests" executed="True" result="Success" success="True" time="0.050" asserts="0">
+                        <results>
+                          <test-case name="NUnit.Core.Tests.SimpleNameFilterTests.ExplicitTestCaseDoesNotMatchWhenNotSelectedDirectly" executed="True" result="Success" success="True" time="0.004" asserts="1" />
+                          <test-case name="NUnit.Core.Tests.SimpleNameFilterTests.ExplicitTestCaseMatchesWhenSelectedDirectly" executed="True" result="Success" success="True" time="0.003" asserts="2" />
+                          <test-case name="NUnit.Core.Tests.SimpleNameFilterTests.ExplicitTestSuiteDoesNotMatchWhenNotSelectedDirectly" executed="True" result="Success" success="True" time="0.005" asserts="2" />
+                          <test-case name="NUnit.Core.Tests.SimpleNameFilterTests.ExplicitTestSuiteMatchesWhenSelectedDirectly" executed="True" result="Success" success="True" time="0.004" asserts="3" />
+                          <test-case name="NUnit.Core.Tests.SimpleNameFilterTests.HighLevelSuite" executed="True" result="Success" success="True" time="0.004" asserts="3" />
+                          <test-case name="NUnit.Core.Tests.SimpleNameFilterTests.MultipleNameMatch" executed="True" result="Success" success="True" time="0.004" asserts="3" />
+                          <test-case name="NUnit.Core.Tests.SimpleNameFilterTests.SingleNameMatch" executed="True" result="Success" success="True" time="0.003" asserts="4" />
+                          <test-case name="NUnit.Core.Tests.SimpleNameFilterTests.SuiteNameMatch" executed="True" result="Success" success="True" time="0.003" asserts="3" />
+                          <test-case name="NUnit.Core.Tests.SimpleNameFilterTests.TestDoesNotMatch" executed="True" result="Success" success="True" time="0.003" asserts="2" />
+                        </results>
+                      </test-suite>
+                      <test-suite type="TestFixture" name="SimpleTestRunnerTests" executed="True" result="Success" success="True" time="0.404" asserts="1">
+                        <results>
+                          <test-case name="NUnit.Core.Tests.SimpleTestRunnerTests.BasicRunnerTests.CheckRunnerID" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Core.Tests.SimpleTestRunnerTests.BasicRunnerTests.CountTestCases" executed="True" result="Success" success="True" time="0.027" asserts="1" />
+                          <test-case name="NUnit.Core.Tests.SimpleTestRunnerTests.BasicRunnerTests.CountTestCasesAcrossMultipleAssemblies" executed="True" result="Success" success="True" time="0.036" asserts="1" />
+                          <test-case name="NUnit.Core.Tests.SimpleTestRunnerTests.BasicRunnerTests.LoadAndReloadAssembly" executed="True" result="Success" success="True" time="0.049" asserts="2" />
+                          <test-case name="NUnit.Core.Tests.SimpleTestRunnerTests.BasicRunnerTests.LoadAssemblyWithFixture" executed="True" result="Success" success="True" time="0.014" asserts="1" />
+                          <test-case name="NUnit.Core.Tests.SimpleTestRunnerTests.BasicRunnerTests.LoadAssemblyWithoutNamespaces" executed="True" result="Success" success="True" time="0.027" asserts="4" />
+                          <test-case name="NUnit.Core.Tests.SimpleTestRunnerTests.BasicRunnerTests.LoadAssemblyWithSuite" executed="True" result="Success" success="True" time="0.010" asserts="1" />
+                          <test-case name="NUnit.Core.Tests.SimpleTestRunnerTests.BasicRunnerTests.LoadMultipleAssemblies" executed="True" result="Success" success="True" time="0.035" asserts="1" />
+                          <test-case name="NUnit.Core.Tests.SimpleTestRunnerTests.BasicRunnerTests.LoadMultipleAssembliesWithFixture" executed="True" result="Success" success="True" time="0.021" asserts="1" />
+                          <test-case name="NUnit.Core.Tests.SimpleTestRunnerTests.BasicRunnerTests.LoadMultipleAssembliesWithSuite" executed="True" result="Success" success="True" time="0.018" asserts="1" />
+                          <test-case name="NUnit.Core.Tests.SimpleTestRunnerTests.BasicRunnerTests.RunAssembly" executed="True" result="Success" success="True" time="0.031" asserts="1" />
+                          <test-case name="NUnit.Core.Tests.SimpleTestRunnerTests.BasicRunnerTests.RunAssemblyUsingBeginAndEndRun" executed="True" result="Success" success="True" time="0.028" asserts="2" />
+                          <test-case name="NUnit.Core.Tests.SimpleTestRunnerTests.BasicRunnerTests.RunMultipleAssemblies" executed="True" result="Success" success="True" time="0.040" asserts="1" />
+                          <test-case name="NUnit.Core.Tests.SimpleTestRunnerTests.BasicRunnerTests.RunMultipleAssembliesUsingBeginAndEndRun" executed="True" result="Success" success="True" time="0.039" asserts="2" />
+                        </results>
+                      </test-suite>
+                      <test-suite type="TestFixture" name="StackOverflowTestFixture" executed="False" result="Skipped">
+                        <reason>
+                          <message><![CDATA[Cannot handle StackOverflowException in managed code]]></message>
+                        </reason>
+                        <results>
+                          <test-case name="NUnit.Core.Tests.StackOverflowTestFixture.SimpleOverflow" executed="False" result="Skipped">
+                            <reason>
+                              <message><![CDATA[Cannot handle StackOverflowException in managed code]]></message>
+                            </reason>
+                          </test-case>
+                        </results>
+                      </test-suite>
+                      <test-suite type="TestFixture" name="SuiteBuilderTests" executed="True" result="Success" success="True" time="1.108" asserts="0">
+                        <results>
+                          <test-case name="NUnit.Core.Tests.SuiteBuilderTests.DiscoverSuite" executed="True" result="Success" success="True" time="0.012" asserts="1" />
+                          <test-case name="NUnit.Core.Tests.SuiteBuilderTests.FileNotFound" executed="True" result="Success" success="True" time="0.011" asserts="0" />
+                          <test-case name="NUnit.Core.Tests.SuiteBuilderTests.FixtureNotFound" executed="True" result="Success" success="True" time="0.011" asserts="1" />
+                          <test-case name="NUnit.Core.Tests.SuiteBuilderTests.InvalidAssembly" executed="True" result="Success" success="True" time="0.086" asserts="0" />
+                          <test-case name="NUnit.Core.Tests.SuiteBuilderTests.LoadAssembly" executed="True" result="Success" success="True" time="0.324" asserts="3" />
+                          <test-case name="NUnit.Core.Tests.SuiteBuilderTests.LoadAssemblyWithoutNamespaces" executed="True" result="Success" success="True" time="0.303" asserts="3" />
+                          <test-case name="NUnit.Core.Tests.SuiteBuilderTests.LoadFixture" executed="True" result="Success" success="True" time="0.015" asserts="1" />
+                          <test-case name="NUnit.Core.Tests.SuiteBuilderTests.LoadNamespaceAsSuite" executed="True" result="Success" success="True" time="0.297" asserts="3" />
+                          <test-case name="NUnit.Core.Tests.SuiteBuilderTests.LoadSuite" executed="True" result="Success" success="True" time="0.017" asserts="2" />
+                          <test-case name="NUnit.Core.Tests.SuiteBuilderTests.WrongReturnTypeSuite" executed="True" result="Success" success="True" time="0.011" asserts="2" />
+                        </results>
+                      </test-suite>
+                      <test-suite type="TestFixture" name="SuiteBuilderTests_Multiple" executed="True" result="Success" success="True" time="0.163" asserts="0">
+                        <results>
+                          <test-case name="NUnit.Core.Tests.SuiteBuilderTests_Multiple.BuildSuite" executed="True" result="Success" success="True" time="0.033" asserts="1" />
+                          <test-case name="NUnit.Core.Tests.SuiteBuilderTests_Multiple.LoadFixture" executed="True" result="Success" success="True" time="0.055" asserts="2" />
+                          <test-case name="NUnit.Core.Tests.SuiteBuilderTests_Multiple.RootNode" executed="True" result="Success" success="True" time="0.034" asserts="1" />
+                          <test-case name="NUnit.Core.Tests.SuiteBuilderTests_Multiple.TestCaseCount" executed="True" result="Success" success="True" time="0.034" asserts="1" />
+                        </results>
+                      </test-suite>
+                      <test-suite type="TestFixture" name="TestAttributeFixture" executed="True" result="Success" success="True" time="0.022" asserts="0">
+                        <results>
+                          <test-case name="NUnit.Core.Tests.TestAttributeFixture.Description" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Core.Tests.TestAttributeFixture.DescriptionInResult" executed="True" result="Success" success="True" time="0.003" asserts="2" />
+                          <test-case name="NUnit.Core.Tests.TestAttributeFixture.FixtureDescription" executed="True" result="Success" success="True" time="0.002" asserts="1" />
+                          <test-case name="NUnit.Core.Tests.TestAttributeFixture.FixtureDescriptionInResult" executed="True" result="Success" success="True" time="0.002" asserts="1" />
+                          <test-case name="NUnit.Core.Tests.TestAttributeFixture.NoDescription" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Core.Tests.TestAttributeFixture.ReflectionTest" executed="True" result="Success" success="True" time="0.001" asserts="1" />
+                          <test-case name="NUnit.Core.Tests.TestAttributeFixture.SeparateDescriptionAttribute" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Core.Tests.TestAttributeFixture.SeparateDescriptionInResult" executed="True" result="Success" success="True" time="0.002" asserts="1" />
+                        </results>
+                      </test-suite>
+                      <test-suite type="TestFixture" name="TestCaseAttributeTests" executed="True" result="Success" success="True" time="0.109" asserts="0">
+                        <results>
+                          <test-suite type="ParameterizedTest" name="ArgumentsAreCoalescedInObjectArray" executed="True" result="Success" success="True" time="0.001" asserts="0">
+                            <results>
+                              <test-case name="NUnit.Core.Tests.TestCaseAttributeTests.ArgumentsAreCoalescedInObjectArray(&quot;a&quot;,&quot;b&quot;)" executed="True" result="Success" success="True" time="0.001" asserts="3" />
+                            </results>
+                          </test-suite>
+                          <test-suite type="ParameterizedTest" name="ArgumentsOfDifferentTypeAreCoalescedInObjectArray" executed="True" result="Success" success="True" time="0.001" asserts="0">
+                            <results>
+                              <test-case name="NUnit.Core.Tests.TestCaseAttributeTests.ArgumentsOfDifferentTypeAreCoalescedInObjectArray(1,&quot;b&quot;)" executed="True" result="Success" success="True" time="0.000" asserts="3" />
+                            </results>
+                          </test-suite>
+                          <test-suite type="ParameterizedTest" name="CanConvertDoubleToDecimal" executed="True" result="Success" success="True" time="0.001" asserts="0">
+                            <results>
+                              <test-case name="NUnit.Core.Tests.TestCaseAttributeTests.CanConvertDoubleToDecimal(2.2m,3.3m)" executed="True" result="Success" success="True" time="0.001" asserts="1" />
+                            </results>
+                          </test-suite>
+                          <test-suite type="ParameterizedTest" name="CanConvertIntToDecimal" executed="True" result="Success" success="True" time="0.002" asserts="0">
+                            <results>
+                              <test-case name="NUnit.Core.Tests.TestCaseAttributeTests.CanConvertIntToDecimal(5m,2m)" executed="True" result="Success" success="True" time="0.002" asserts="1" />
+                            </results>
+                          </test-suite>
+                          <test-suite type="ParameterizedTest" name="CanConvertIntToDouble" executed="True" result="Success" success="True" time="0.000" asserts="0">
+                            <results>
+                              <test-case name="NUnit.Core.Tests.TestCaseAttributeTests.CanConvertIntToDouble(2,2)" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                            </results>
+                          </test-suite>
+                          <test-suite type="ParameterizedTest" name="CanConvertSmallIntsToByte" executed="True" result="Success" success="True" time="0.001" asserts="0">
+                            <results>
+                              <test-case name="NUnit.Core.Tests.TestCaseAttributeTests.CanConvertSmallIntsToByte(5,2)" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                            </results>
+                          </test-suite>
+                          <test-suite type="ParameterizedTest" name="CanConvertSmallIntsToSByte" executed="True" result="Success" success="True" time="0.001" asserts="0">
+                            <results>
+                              <test-case name="NUnit.Core.Tests.TestCaseAttributeTests.CanConvertSmallIntsToSByte(5,2)" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                            </results>
+                          </test-suite>
+                          <test-suite type="ParameterizedTest" name="CanConvertSmallIntsToShort" executed="True" result="Success" success="True" time="0.001" asserts="0">
+                            <results>
+                              <test-case name="NUnit.Core.Tests.TestCaseAttributeTests.CanConvertSmallIntsToShort(5,2)" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                            </results>
+                          </test-suite>
+                          <test-suite type="ParameterizedTest" name="CanConvertStringToDateTime" executed="True" result="Success" success="True" time="0.001" asserts="0">
+                            <results>
+                              <test-case name="NUnit.Core.Tests.TestCaseAttributeTests.CanConvertStringToDateTime(10/12/1942 00:00:00)" executed="True" result="Success" success="True" time="0.000" asserts="2" />
+                            </results>
+                          </test-suite>
+                          <test-suite type="ParameterizedTest" name="CanConvertStringToDecimal" executed="True" result="Success" success="True" time="0.001" asserts="0">
+                            <results>
+                              <test-case name="NUnit.Core.Tests.TestCaseAttributeTests.CanConvertStringToDecimal(2.2m,3.3m)" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                            </results>
+                          </test-suite>
+                          <test-case name="NUnit.Core.Tests.TestCaseAttributeTests.CanIgnoreIndividualTestCase" executed="True" result="Success" success="True" time="0.003" asserts="3" />
+                          <test-suite type="ParameterizedTest" name="CanPassArrayAsArgument" executed="True" result="Success" success="True" time="0.001" asserts="0">
+                            <results>
+                              <test-case name="NUnit.Core.Tests.TestCaseAttributeTests.CanPassArrayAsArgument(&quot;a&quot;,&quot;b&quot;)" executed="True" result="Success" success="True" time="0.000" asserts="3" />
+                            </results>
+                          </test-suite>
+                          <test-suite type="ParameterizedTest" name="CanPassNullAsArgument" executed="True" result="Success" success="True" time="0.001" asserts="0">
+                            <results>
+                              <test-case name="NUnit.Core.Tests.TestCaseAttributeTests.CanPassNullAsArgument(null,null)" executed="True" result="Success" success="True" time="0.000" asserts="3" />
+                            </results>
+                          </test-suite>
+                          <test-suite type="ParameterizedTest" name="CanPassNullAsSoleArgument" executed="True" result="Success" success="True" time="0.000" asserts="0">
+                            <results>
+                              <test-case name="NUnit.Core.Tests.TestCaseAttributeTests.CanPassNullAsSoleArgument(null)" executed="True" result="Success" success="True" time="0.000" asserts="2" />
+                            </results>
+                          </test-suite>
+                          <test-suite type="ParameterizedTest" name="CanPassObjectArrayAsFirstArgument" executed="True" result="Success" success="True" time="0.003" asserts="0">
+                            <results>
+                              <test-case name="NUnit.Core.Tests.TestCaseAttributeTests.CanPassObjectArrayAsFirstArgument(1,&quot;two&quot;,3.0d)" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                              <test-case name="NUnit.Core.Tests.TestCaseAttributeTests.CanPassObjectArrayAsFirstArgument(&quot;zip&quot;)" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                            </results>
+                          </test-suite>
+                          <test-case name="NUnit.Core.Tests.TestCaseAttributeTests.CanSpecifyCategory" executed="True" result="Success" success="True" time="0.001" asserts="1" />
+                          <test-case name="NUnit.Core.Tests.TestCaseAttributeTests.CanSpecifyDescription" executed="True" result="Success" success="True" time="0.001" asserts="1" />
+                          <test-suite type="ParameterizedTest" name="CanSpecifyExceptionMessage" executed="True" result="Success" success="True" time="0.001" asserts="0">
+                            <results>
+                              <test-case name="NUnit.Core.Tests.TestCaseAttributeTests.CanSpecifyExceptionMessage(42)" executed="True" result="Success" success="True" time="0.001" asserts="0" />
+                            </results>
+                          </test-suite>
+                          <test-suite type="ParameterizedTest" name="CanSpecifyExceptionMessageAndMatchType" executed="True" result="Success" success="True" time="0.001" asserts="0">
+                            <results>
+                              <test-case name="NUnit.Core.Tests.TestCaseAttributeTests.CanSpecifyExceptionMessageAndMatchType(42)" executed="True" result="Success" success="True" time="0.000" asserts="0" />
+                            </results>
+                          </test-suite>
+                          <test-case name="NUnit.Core.Tests.TestCaseAttributeTests.CanSpecifyExpectedException" executed="True" result="Success" success="True" time="0.002" asserts="1" />
+                          <test-case name="NUnit.Core.Tests.TestCaseAttributeTests.CanSpecifyExpectedException_NoneThrown" executed="True" result="Success" success="True" time="0.001" asserts="2" />
+                          <test-case name="NUnit.Core.Tests.TestCaseAttributeTests.CanSpecifyExpectedException_WrongException" executed="True" result="Success" success="True" time="0.002" asserts="2" />
+                          <test-case name="NUnit.Core.Tests.TestCaseAttributeTests.CanSpecifyExpectedException_WrongMessage" executed="True" result="Success" success="True" time="0.002" asserts="2" />
+                          <test-case name="NUnit.Core.Tests.TestCaseAttributeTests.CanSpecifyMultipleCategories" executed="True" result="Success" success="True" time="0.001" asserts="1" />
+                          <test-case name="NUnit.Core.Tests.TestCaseAttributeTests.CanSpecifyTestName" executed="True" result="Success" success="True" time="0.000" asserts="2" />
+                          <test-case name="NUnit.Core.Tests.TestCaseAttributeTests.ConversionOverflowMakesTestNonRunnable" executed="True" result="Success" success="True" time="0.001" asserts="1" />
+                          <test-suite type="ParameterizedTest" name="ExpectedResultCanBeNull" executed="True" result="Success" success="True" time="0.001" asserts="0">
+                            <results>
+                              <test-case name="NUnit.Core.Tests.TestCaseAttributeTests.ExpectedResultCanBeNull()" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                            </results>
+                          </test-suite>
+                          <test-suite type="ParameterizedTest" name="HandlesParamsArrayAsLastArgument" executed="True" result="Success" success="True" time="0.001" asserts="0">
+                            <results>
+                              <test-case name="NUnit.Core.Tests.TestCaseAttributeTests.HandlesParamsArrayAsLastArgument(&quot;a&quot;,&quot;b&quot;,&quot;c&quot;,&quot;d&quot;)" executed="True" result="Success" success="True" time="0.001" asserts="5" />
+                            </results>
+                          </test-suite>
+                          <test-suite type="ParameterizedTest" name="HandlesParamsArrayAsSoleArgument" executed="True" result="Success" success="True" time="0.001" asserts="0">
+                            <results>
+                              <test-case name="NUnit.Core.Tests.TestCaseAttributeTests.HandlesParamsArrayAsSoleArgument(&quot;a&quot;,&quot;b&quot;)" executed="True" result="Success" success="True" time="0.000" asserts="3" />
+                            </results>
+                          </test-suite>
+                          <test-case name="NUnit.Core.Tests.TestCaseAttributeTests.IgnoreTakesPrecedenceOverExpectedException" executed="True" result="Success" success="True" time="0.003" asserts="2" />
+                          <test-suite type="ParameterizedTest" name="IntegerDivisionWithResultCheckedByNUnit" executed="True" result="Success" success="True" time="0.009" asserts="0">
+                            <results>
+                              <test-case name="NUnit.Core.Tests.TestCaseAttributeTests.IntegerDivisionWithResultCheckedByNUnit(12,2)" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                              <test-case name="NUnit.Core.Tests.TestCaseAttributeTests.IntegerDivisionWithResultCheckedByNUnit(12,3)" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                              <test-case name="NUnit.Core.Tests.TestCaseAttributeTests.IntegerDivisionWithResultCheckedByNUnit(12,4)" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                              <test-case name="NUnit.Core.Tests.TestCaseAttributeTests.IntegerDivisionWithResultCheckedByNUnit(12,0)" executed="True" result="Success" success="True" time="0.001" asserts="0" />
+                              <test-case name="NUnit.Core.Tests.TestCaseAttributeTests.DivisionByZeroThrowsException" executed="True" result="Success" success="True" time="0.001" asserts="0" />
+                            </results>
+                          </test-suite>
+                          <test-suite type="ParameterizedTest" name="IntegerDivisionWithResultPassedToTest" executed="True" result="Success" success="True" time="0.009" asserts="0">
+                            <results>
+                              <test-case name="NUnit.Core.Tests.TestCaseAttributeTests.IntegerDivisionWithResultPassedToTest(12,2,6)" executed="True" result="Success" success="True" time="0.001" asserts="2" />
+                              <test-case name="NUnit.Core.Tests.TestCaseAttributeTests.IntegerDivisionWithResultPassedToTest(12,0,0)" executed="True" result="Success" success="True" time="0.001" asserts="0" />
+                              <test-case name="NUnit.Core.Tests.TestCaseAttributeTests.IntegerDivisionWithResultPassedToTest(12,3,4)" executed="True" result="Success" success="True" time="0.000" asserts="2" />
+                              <test-case name="NUnit.Core.Tests.TestCaseAttributeTests.IntegerDivisionWithResultPassedToTest(12,4,3)" executed="True" result="Success" success="True" time="0.000" asserts="2" />
+                              <test-case name="NUnit.Core.Tests.TestCaseAttributeTests.IntegerDivisionWithResultPassedToTest(12,0,0)" executed="True" result="Success" success="True" time="0.001" asserts="0" />
+                            </results>
+                          </test-suite>
+                        </results>
+                      </test-suite>
+                      <test-suite type="TestFixture" name="TestCaseResultFixture" executed="True" result="Success" success="True" time="0.008" asserts="0">
+                        <results>
+                          <test-case name="NUnit.Core.Tests.TestCaseResultFixture.TestCaseDefault" executed="True" result="Success" success="True" time="0.001" asserts="1" />
+                          <test-case name="NUnit.Core.Tests.TestCaseResultFixture.TestCaseFailure" executed="True" result="Success" success="True" time="0.001" asserts="4" />
+                          <test-case name="NUnit.Core.Tests.TestCaseResultFixture.TestCaseNotRun" executed="True" result="Success" success="True" time="0.001" asserts="2" />
+                          <test-case name="NUnit.Core.Tests.TestCaseResultFixture.TestCaseSuccess" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                        </results>
+                      </test-suite>
+                      <test-suite type="TestFixture" name="TestCaseSourceTests" executed="True" result="Success" success="True" time="0.092" asserts="0">
+                        <results>
+                          <test-case name="NUnit.Core.Tests.TestCaseSourceTests.CanIgnoreIndividualTestCases" executed="True" result="Success" success="True" time="0.002" asserts="3" />
+                          <test-case name="NUnit.Core.Tests.TestCaseSourceTests.CanSpecifyExpectedException" executed="True" result="Success" success="True" time="0.002" asserts="1" />
+                          <test-case name="NUnit.Core.Tests.TestCaseSourceTests.CanSpecifyExpectedException_NoneThrown" executed="True" result="Success" success="True" time="0.001" asserts="2" />
+                          <test-case name="NUnit.Core.Tests.TestCaseSourceTests.CanSpecifyExpectedException_WrongException" executed="True" result="Success" success="True" time="0.001" asserts="2" />
+                          <test-suite type="ParameterizedTest" name="ExpectedResultCanBeNull" executed="True" result="Success" success="True" time="0.000" asserts="0">
+                            <results>
+                              <test-case name="NUnit.Core.Tests.TestCaseSourceTests.ExpectedResultCanBeNull()" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                            </results>
+                          </test-suite>
+                          <test-case name="NUnit.Core.Tests.TestCaseSourceTests.HandlesExceptionInTestCaseSource" executed="True" result="Success" success="True" time="0.001" asserts="3" />
+                          <test-case name="NUnit.Core.Tests.TestCaseSourceTests.IgnoreTakesPrecedenceOverExpectedException" executed="True" result="Success" success="True" time="0.002" asserts="2" />
+                          <test-suite type="ParameterizedTest" name="MethodTakingTwoStringArrays" executed="True" result="Success" success="True" time="0.001" asserts="0">
+                            <results>
+                              <test-case name="NUnit.Core.Tests.TestCaseSourceTests.MethodTakingTwoStringArrays(System.String[],System.String[])" executed="True" result="Success" success="True" time="0.001" asserts="3" />
+                            </results>
+                          </test-suite>
+                          <test-suite type="ParameterizedTest" name="SourceCanBeInstanceField" executed="True" result="Success" success="True" time="0.000" asserts="0">
+                            <results>
+                              <test-case name="NUnit.Core.Tests.TestCaseSourceTests.SourceCanBeInstanceField(&quot;InstanceField&quot;)" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                            </results>
+                          </test-suite>
+                          <test-suite type="ParameterizedTest" name="SourceCanBeInstanceMethod" executed="True" result="Success" success="True" time="0.001" asserts="0">
+                            <results>
+                              <test-case name="NUnit.Core.Tests.TestCaseSourceTests.SourceCanBeInstanceMethod(&quot;InstanceMethod&quot;)" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                            </results>
+                          </test-suite>
+                          <test-suite type="ParameterizedTest" name="SourceCanBeInstanceProperty" executed="True" result="Success" success="True" time="0.001" asserts="0">
+                            <results>
+                              <test-case name="NUnit.Core.Tests.TestCaseSourceTests.SourceCanBeInstanceProperty(&quot;InstanceProperty&quot;)" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                            </results>
+                          </test-suite>
+                          <test-suite type="ParameterizedTest" name="SourceCanBeStaticField" executed="True" result="Success" success="True" time="0.000" asserts="0">
+                            <results>
+                              <test-case name="NUnit.Core.Tests.TestCaseSourceTests.SourceCanBeStaticField(&quot;StaticField&quot;)" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                            </results>
+                          </test-suite>
+                          <test-suite type="ParameterizedTest" name="SourceCanBeStaticMethod" executed="True" result="Success" success="True" time="0.000" asserts="0">
+                            <results>
+                              <test-case name="NUnit.Core.Tests.TestCaseSourceTests.SourceCanBeStaticMethod(&quot;StaticMethod&quot;)" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                            </results>
+                          </test-suite>
+                          <test-suite type="ParameterizedTest" name="SourceCanBeStaticProperty" executed="True" result="Success" success="True" time="0.000" asserts="0">
+                            <results>
+                              <test-case name="NUnit.Core.Tests.TestCaseSourceTests.SourceCanBeStaticProperty(&quot;StaticProperty&quot;)" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                            </results>
+                          </test-suite>
+                          <test-suite type="ParameterizedTest" name="SourceIsInvokedWithCorrectCurrentDirectory" executed="True" result="Success" success="True" time="0.001" asserts="0">
+                            <results>
+                              <test-case name="NUnit.Core.Tests.TestCaseSourceTests.SourceIsInvokedWithCorrectCurrentDirectory(True)" executed="True" result="Success" success="True" time="0.001" asserts="1" />
+                            </results>
+                          </test-suite>
+                          <test-suite type="ParameterizedTest" name="SourceMayBeInAnotherClass" executed="True" result="Success" success="True" time="0.004" asserts="0">
+                            <categories>
+                              <category name="Top" />
+                            </categories>
+                            <results>
+                              <test-case name="NUnit.Core.Tests.TestCaseSourceTests.ThisOneShouldThrow" description="Demonstrates use of ExpectedException" executed="True" result="Success" success="True" time="0.000" asserts="0">
+                                <categories>
+                                  <category name="Junk" />
+                                </categories>
+                                <properties>
+                                  <property name="MyProp" value="zip" />
+                                </properties>
+                              </test-case>
+                              <test-case name="NUnit.Core.Tests.TestCaseSourceTests.SourceMayBeInAnotherClass(100,20,5)" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                              <test-case name="NUnit.Core.Tests.TestCaseSourceTests.SourceMayBeInAnotherClass(100,4,25)" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                            </results>
+                          </test-suite>
+                          <test-suite type="ParameterizedTest" name="SourceMayBeInAnotherClassWithReturn" executed="True" result="Success" success="True" time="0.006" asserts="0">
+                            <results>
+                              <test-case name="NUnit.Core.Tests.TestCaseSourceTests.TC1" executed="True" result="Success" success="True" time="0.002" asserts="1" />
+                              <test-case name="NUnit.Core.Tests.TestCaseSourceTests.TC2" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                              <test-case name="NUnit.Core.Tests.TestCaseSourceTests.TC3" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                            </results>
+                          </test-suite>
+                          <test-suite type="ParameterizedTest" name="SourceMayReturnArgumentsAsIntArray" executed="True" result="Success" success="True" time="0.004" asserts="0">
+                            <results>
+                              <test-case name="NUnit.Core.Tests.TestCaseSourceTests.SourceMayReturnArgumentsAsIntArray(12,3,4)" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                              <test-case name="NUnit.Core.Tests.TestCaseSourceTests.SourceMayReturnArgumentsAsIntArray(12,4,3)" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                              <test-case name="NUnit.Core.Tests.TestCaseSourceTests.SourceMayReturnArgumentsAsIntArray(12,6,2)" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                            </results>
+                          </test-suite>
+                          <test-suite type="ParameterizedTest" name="SourceMayReturnArgumentsAsObjectArray" executed="True" result="Success" success="True" time="0.004" asserts="0">
+                            <results>
+                              <test-case name="NUnit.Core.Tests.TestCaseSourceTests.SourceMayReturnArgumentsAsObjectArray(12,3,4)" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                              <test-case name="NUnit.Core.Tests.TestCaseSourceTests.SourceMayReturnArgumentsAsObjectArray(12,4,3)" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                              <test-case name="NUnit.Core.Tests.TestCaseSourceTests.SourceMayReturnArgumentsAsObjectArray(12,6,2)" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                            </results>
+                          </test-suite>
+                          <test-suite type="ParameterizedTest" name="SourceMayReturnArgumentsAsParamSet" executed="True" result="Success" success="True" time="0.002" asserts="0">
+                            <results>
+                              <test-case name="NUnit.Core.Tests.TestCaseSourceTests.SourceMayReturnArgumentsAsParamSet(24,3)" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                              <test-case name="NUnit.Core.Tests.TestCaseSourceTests.SourceMayReturnArgumentsAsParamSet(24,2)" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                            </results>
+                          </test-suite>
+                          <test-suite type="ParameterizedTest" name="SourceMayReturnSinglePrimitiveArgumentAlone" executed="True" result="Success" success="True" time="0.004" asserts="0">
+                            <results>
+                              <test-case name="NUnit.Core.Tests.TestCaseSourceTests.SourceMayReturnSinglePrimitiveArgumentAlone(2)" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                              <test-case name="NUnit.Core.Tests.TestCaseSourceTests.SourceMayReturnSinglePrimitiveArgumentAlone(4)" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                              <test-case name="NUnit.Core.Tests.TestCaseSourceTests.SourceMayReturnSinglePrimitiveArgumentAlone(6)" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                              <test-case name="NUnit.Core.Tests.TestCaseSourceTests.SourceMayReturnSinglePrimitiveArgumentAlone(8)" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                            </results>
+                          </test-suite>
+                          <test-suite type="ParameterizedTest" name="TestAttributeIsOptional" executed="True" result="Success" success="True" time="0.004" asserts="0">
+                            <results>
+                              <test-case name="NUnit.Core.Tests.TestCaseSourceTests.TestAttributeIsOptional(12,3,4)" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                              <test-case name="NUnit.Core.Tests.TestCaseSourceTests.TestAttributeIsOptional(12,4,3)" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                              <test-case name="NUnit.Core.Tests.TestCaseSourceTests.TestAttributeIsOptional(12,6,2)" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                            </results>
+                          </test-suite>
+                          <test-suite type="ParameterizedTest" name="TestMayUseMultipleSourceAttributes" executed="True" result="Success" success="True" time="0.008" asserts="0">
+                            <results>
+                              <test-case name="NUnit.Core.Tests.TestCaseSourceTests.TestMayUseMultipleSourceAttributes(12,3,4)" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                              <test-case name="NUnit.Core.Tests.TestCaseSourceTests.TestMayUseMultipleSourceAttributes(12,4,3)" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                              <test-case name="NUnit.Core.Tests.TestCaseSourceTests.TestMayUseMultipleSourceAttributes(12,6,2)" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                              <test-case name="NUnit.Core.Tests.TestCaseSourceTests.TestMayUseMultipleSourceAttributes(12,1,12)" executed="True" result="Success" success="True" time="0.001" asserts="1" />
+                              <test-case name="NUnit.Core.Tests.TestCaseSourceTests.TestMayUseMultipleSourceAttributes(12,2,6)" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                              <test-case name="NUnit.Core.Tests.TestCaseSourceTests.TestMayUseMultipleSourceAttributes(12,0,0)" executed="True" result="Success" success="True" time="0.001" asserts="0" />
+                            </results>
+                          </test-suite>
+                          <test-suite type="ParameterizedTest" name="TestWithFourArguments" executed="True" result="Success" success="True" time="0.003" asserts="0">
+                            <results>
+                              <test-case name="NUnit.Core.Tests.TestCaseSourceTests.TestWithFourArguments(12,3,4,0)" executed="True" result="Success" success="True" time="0.001" asserts="3" />
+                              <test-case name="NUnit.Core.Tests.TestCaseSourceTests.TestWithFourArguments(12,4,3,0)" executed="True" result="Success" success="True" time="0.000" asserts="3" />
+                              <test-case name="NUnit.Core.Tests.TestCaseSourceTests.TestWithFourArguments(12,5,2,2)" executed="True" result="Success" success="True" time="0.000" asserts="3" />
+                            </results>
+                          </test-suite>
+                        </results>
+                      </test-suite>
+                      <test-suite type="TestFixture" name="TestCaseTest" executed="True" result="Success" success="True" time="0.005" asserts="0">
+                        <results>
+                          <test-case name="NUnit.Core.Tests.TestCaseTest.CreateIgnoredTestCase" executed="True" result="Success" success="True" time="0.001" asserts="3" />
+                          <test-case name="NUnit.Core.Tests.TestCaseTest.LoadMethodCategories" executed="True" result="Success" success="True" time="0.000" asserts="3" />
+                          <test-case name="NUnit.Core.Tests.TestCaseTest.RunIgnoredTestCase" executed="True" result="Success" success="True" time="0.000" asserts="3" />
+                        </results>
+                      </test-suite>
+                      <test-suite type="TestFixture" name="TestConsole" executed="True" result="Success" success="True" time="0.008" asserts="0">
+                        <results>
+                          <test-case name="NUnit.Core.Tests.TestConsole.ConsoleWrite" executed="True" result="Success" success="True" time="0.001" asserts="0" />
+                          <test-case name="NUnit.Core.Tests.TestConsole.ConsoleWriteLine" executed="True" result="Success" success="True" time="0.000" asserts="0" />
+                        </results>
+                      </test-suite>
+                      <test-suite type="TestFixture" name="TestContextTests" executed="True" result="Success" success="True" time="0.027" asserts="0">
+                        <results>
+                          <test-case name="NUnit.Core.Tests.TestContextTests.CanAccessTestContextOnSeparateThread" executed="True" result="Success" success="True" time="0.002" asserts="1">
+                            <properties>
+                              <property name="RequiresThread" value="True" />
+                            </properties>
+                          </test-case>
+                          <test-case name="NUnit.Core.Tests.TestContextTests.TestCanAccessItsOwnFullName" executed="True" result="Success" success="True" time="0.001" asserts="1" />
+                          <test-case name="NUnit.Core.Tests.TestContextTests.TestCanAccessItsOwnName" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Core.Tests.TestContextTests.TestCanAccessItsOwnProperties" executed="True" result="Success" success="True" time="0.000" asserts="1">
+                            <properties>
+                              <property name="Answer" value="42" />
+                            </properties>
+                          </test-case>
+                          <test-case name="NUnit.Core.Tests.TestContextTests.TestCanAccessTestDirectory" executed="True" result="Success" success="True" time="0.001" asserts="3" />
+                          <test-case name="NUnit.Core.Tests.TestContextTests.TestCanAccessTestState_FailingTest" executed="True" result="Success" success="True" time="0.004" asserts="2" />
+                          <test-case name="NUnit.Core.Tests.TestContextTests.TestCanAccessTestState_FailureInSetUp" executed="True" result="Success" success="True" time="0.002" asserts="2" />
+                          <test-case name="NUnit.Core.Tests.TestContextTests.TestCanAccessTestState_IgnoredInSetUp" executed="True" result="Success" success="True" time="0.002" asserts="2" />
+                          <test-case name="NUnit.Core.Tests.TestContextTests.TestCanAccessTestState_PassingTest" executed="True" result="Success" success="True" time="0.002" asserts="2" />
+                        </results>
+                      </test-suite>
+                      <test-suite type="TestFixture" name="TestDelegateFixture" executed="True" result="Success" success="True" time="0.027" asserts="0">
+                        <results>
+                          <test-case name="NUnit.Core.Tests.TestDelegateFixture.DelegateTest" executed="True" result="Success" success="True" time="0.026" asserts="1" />
+                        </results>
+                      </test-suite>
+                      <test-suite type="TestFixture" name="TestExecutionContextTests" executed="True" result="Success" success="True" time="0.010" asserts="0">
+                        <results>
+                          <test-case name="NUnit.Core.Tests.TestExecutionContextTests.SetAndRestoreCurrentCulture" executed="True" result="Success" success="True" time="0.001" asserts="5" />
+                          <test-case name="NUnit.Core.Tests.TestExecutionContextTests.SetAndRestoreCurrentDirectory" executed="True" result="Success" success="True" time="0.001" asserts="5" />
+                          <test-case name="NUnit.Core.Tests.TestExecutionContextTests.SetAndRestoreCurrentPrincipal" executed="True" result="Success" success="True" time="0.000" asserts="5" />
+                          <test-case name="NUnit.Core.Tests.TestExecutionContextTests.SetAndRestoreCurrentUICulture" executed="True" result="Success" success="True" time="0.000" asserts="5" />
+                        </results>
+                      </test-suite>
+                      <test-suite type="TestFixture" name="TestFixtureBuilderTests" executed="True" result="Success" success="True" time="0.006" asserts="0">
+                        <results>
+                          <test-case name="NUnit.Core.Tests.TestFixtureBuilderTests.GoodSignature" executed="True" result="Success" success="True" time="0.002" asserts="2" />
+                          <test-case name="NUnit.Core.Tests.TestFixtureBuilderTests.LoadCategories" executed="True" result="Success" success="True" time="0.002" asserts="2" />
+                        </results>
+                      </test-suite>
+                      <test-suite type="TestFixture" name="TestFixtureExtension" executed="True" result="Success" success="True" time="0.056" asserts="0">
+                        <results>
+                          <test-case name="NUnit.Core.Tests.TestFixtureExtension.CheckMultipleSetUp" executed="True" result="Success" success="True" time="0.013" asserts="1" />
+                          <test-case name="NUnit.Core.Tests.TestFixtureExtension.DerivedTest" executed="True" result="Success" success="True" time="0.011" asserts="1" />
+                          <test-case name="NUnit.Core.Tests.TestFixtureExtension.InheritSetup" executed="True" result="Success" success="True" time="0.013" asserts="1" />
+                          <test-case name="NUnit.Core.Tests.TestFixtureExtension.InheritTearDown" executed="True" result="Success" success="True" time="0.013" asserts="1" />
+                        </results>
+                      </test-suite>
+                      <test-suite type="TestFixture" name="TestFixtureTests" executed="True" result="Success" success="True" time="0.139" asserts="0">
+                        <results>
+                          <test-case name="NUnit.Core.Tests.TestFixtureTests.CannotRunBadConstructor" executed="True" result="Success" success="True" time="0.002" asserts="2" />
+                          <test-case name="NUnit.Core.Tests.TestFixtureTests.CannotRunConstructorWithArgsNotSupplied" executed="True" result="Success" success="True" time="0.001" asserts="2" />
+                          <test-case name="NUnit.Core.Tests.TestFixtureTests.CannotRunFixtureSetupWithParameters" executed="True" result="Success" success="True" time="0.002" asserts="2" />
+                          <test-case name="NUnit.Core.Tests.TestFixtureTests.CannotRunFixtureSetupWithReturnValue" executed="True" result="Success" success="True" time="0.001" asserts="2" />
+                          <test-case name="NUnit.Core.Tests.TestFixtureTests.CannotRunFixtureTearDownWithParameters" executed="True" result="Success" success="True" time="0.003" asserts="2" />
+                          <test-case name="NUnit.Core.Tests.TestFixtureTests.CannotRunFixtureTearDownWithReturnValue" executed="True" result="Success" success="True" time="0.001" asserts="2" />
+                          <test-case name="NUnit.Core.Tests.TestFixtureTests.CannotRunGenericFixtureDerivedFromAbstractFixtureWithNoArgsProvided" executed="True" result="Success" success="True" time="0.004" asserts="2" />
+                          <test-case name="NUnit.Core.Tests.TestFixtureTests.CannotRunGenericFixtureWithNoArgsProvided" executed="True" result="Success" success="True" time="0.001" asserts="2" />
+                          <test-case name="NUnit.Core.Tests.TestFixtureTests.CannotRunGenericFixtureWithNoTestFixtureAttribute" executed="True" result="Success" success="True" time="0.000" asserts="2" />
+                          <test-case name="NUnit.Core.Tests.TestFixtureTests.CannotRunIgnoredFixture" executed="True" result="Success" success="True" time="0.002" asserts="2" />
+                          <test-case name="NUnit.Core.Tests.TestFixtureTests.CannotRunPrivateFixtureSetUp" executed="True" result="Success" success="True" time="0.002" asserts="2" />
+                          <test-case name="NUnit.Core.Tests.TestFixtureTests.CannotRunPrivateFixtureTearDown" executed="True" result="Success" success="True" time="0.001" asserts="2" />
+                          <test-case name="NUnit.Core.Tests.TestFixtureTests.CannotRunPrivateSetUp" executed="True" result="Success" success="True" time="0.001" asserts="2" />
+                          <test-case name="NUnit.Core.Tests.TestFixtureTests.CannotRunPrivateTearDown" executed="True" result="Success" success="True" time="0.002" asserts="2" />
+                          <test-case name="NUnit.Core.Tests.TestFixtureTests.CannotRunSetupWithParameters" executed="True" result="Success" success="True" time="0.001" asserts="2" />
+                          <test-case name="NUnit.Core.Tests.TestFixtureTests.CannotRunSetupWithReturnValue" executed="True" result="Success" success="True" time="0.001" asserts="2" />
+                          <test-case name="NUnit.Core.Tests.TestFixtureTests.CannotRunTearDownWithParameters" executed="True" result="Success" success="True" time="0.001" asserts="2" />
+                          <test-case name="NUnit.Core.Tests.TestFixtureTests.CannotRunTearDownWithReturnValue" executed="True" result="Success" success="True" time="0.002" asserts="2" />
+                          <test-case name="NUnit.Core.Tests.TestFixtureTests.CanRunConstructorWithArgsSupplied" executed="True" result="Success" success="True" time="0.002" asserts="1" />
+                          <test-case name="NUnit.Core.Tests.TestFixtureTests.CanRunFixtureDerivedFromAbstractDerivedTestFixture" executed="True" result="Success" success="True" time="0.002" asserts="1" />
+                          <test-case name="NUnit.Core.Tests.TestFixtureTests.CanRunFixtureDerivedFromAbstractFixture" executed="True" result="Success" success="True" time="0.001" asserts="1" />
+                          <test-case name="NUnit.Core.Tests.TestFixtureTests.CanRunGenericFixtureDerivedFromAbstractFixtureWithArgsProvided" executed="True" result="Success" success="True" time="0.003" asserts="3" />
+                          <test-case name="NUnit.Core.Tests.TestFixtureTests.CanRunGenericFixtureWithProperArgsProvided" executed="True" result="Success" success="True" time="0.003" asserts="3" />
+                          <test-case name="NUnit.Core.Tests.TestFixtureTests.CanRunMultipleSetUp" executed="True" result="Success" success="True" time="0.002" asserts="1" />
+                          <test-case name="NUnit.Core.Tests.TestFixtureTests.CanRunMultipleTearDown" executed="True" result="Success" success="True" time="0.002" asserts="1" />
+                          <test-case name="NUnit.Core.Tests.TestFixtureTests.CanRunMultipleTestFixtureSetUp" executed="True" result="Success" success="True" time="0.002" asserts="1" />
+                          <test-case name="NUnit.Core.Tests.TestFixtureTests.CanRunMultipleTestFixtureTearDown" executed="True" result="Success" success="True" time="0.002" asserts="1" />
+                          <test-case name="NUnit.Core.Tests.TestFixtureTests.CanRunProtectedFixtureSetUp" executed="True" result="Success" success="True" time="0.002" asserts="1" />
+                          <test-case name="NUnit.Core.Tests.TestFixtureTests.CanRunProtectedFixtureTearDown" executed="True" result="Success" success="True" time="0.002" asserts="1" />
+                          <test-case name="NUnit.Core.Tests.TestFixtureTests.CanRunProtectedSetUp" executed="True" result="Success" success="True" time="0.002" asserts="1" />
+                          <test-case name="NUnit.Core.Tests.TestFixtureTests.CanRunProtectedTearDown" executed="True" result="Success" success="True" time="0.002" asserts="1" />
+                          <test-case name="NUnit.Core.Tests.TestFixtureTests.CanRunStaticFixture" executed="True" result="Success" success="True" time="0.002" asserts="1" />
+                          <test-case name="NUnit.Core.Tests.TestFixtureTests.CanRunStaticFixtureSetUp" executed="True" result="Success" success="True" time="0.002" asserts="1" />
+                          <test-case name="NUnit.Core.Tests.TestFixtureTests.CanRunStaticFixtureTearDown" executed="True" result="Success" success="True" time="0.001" asserts="1" />
+                          <test-case name="NUnit.Core.Tests.TestFixtureTests.CanRunStaticSetUp" executed="True" result="Success" success="True" time="0.002" asserts="1" />
+                          <test-case name="NUnit.Core.Tests.TestFixtureTests.CanRunStaticTearDown" executed="True" result="Success" success="True" time="0.002" asserts="1" />
+                          <test-case name="NUnit.Core.Tests.TestFixtureTests.ConstructFromDoublyNestedType" executed="True" result="Success" success="True" time="0.002" asserts="2" />
+                          <test-case name="NUnit.Core.Tests.TestFixtureTests.ConstructFromNestedType" executed="True" result="Success" success="True" time="0.001" asserts="2" />
+                          <test-case name="NUnit.Core.Tests.TestFixtureTests.ConstructFromStaticTypeWithoutTestFixtureAttribute" executed="True" result="Success" success="True" time="0.001" asserts="2" />
+                          <test-case name="NUnit.Core.Tests.TestFixtureTests.ConstructFromType" executed="True" result="Success" success="True" time="0.004" asserts="2" />
+                          <test-case name="NUnit.Core.Tests.TestFixtureTests.ConstructFromTypeWithoutNamespace" executed="True" result="Success" success="True" time="0.005" asserts="2" />
+                          <test-case name="NUnit.Core.Tests.TestFixtureTests.ConstructFromTypeWithoutTestFixtureAttribute" executed="True" result="Success" success="True" time="0.001" asserts="2" />
+                          <test-case name="NUnit.Core.Tests.TestFixtureTests.FixtureInheritingTwoTestFixtureAttributesIsLoadedOnlyOnce" executed="True" result="Success" success="True" time="0.001" asserts="2" />
+                        </results>
+                      </test-suite>
+                      <test-suite type="TestFixture" name="TestFixtureTests+InternalTestFixture" executed="True" result="Success" success="True" time="0.001" asserts="0">
+                        <results>
+                          <test-case name="NUnit.Core.Tests.TestFixtureTests+InternalTestFixture.CanRunTestInInternalTestFixture" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                        </results>
+                      </test-suite>
+                      <test-suite type="TestFixture" name="TestFixtureTests+PrivateTestFixture" executed="True" result="Success" success="True" time="0.001" asserts="0">
+                        <results>
+                          <test-case name="NUnit.Core.Tests.TestFixtureTests+PrivateTestFixture.CanRunTestInPrivateTestFixture" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                        </results>
+                      </test-suite>
+                      <test-suite type="TestFixture" name="TestFixtureTests+ProtectedTestFixture" executed="True" result="Success" success="True" time="0.001" asserts="0">
+                        <results>
+                          <test-case name="NUnit.Core.Tests.TestFixtureTests+ProtectedTestFixture.CanRunTestInProtectedTestFixture" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                        </results>
+                      </test-suite>
+                      <test-suite type="TestFixture" name="TestFrameworkTests" executed="True" result="Success" success="True" time="0.002" asserts="0">
+                        <results>
+                          <test-case name="NUnit.Core.Tests.TestFrameworkTests.NUnitFrameworkIsKnownAndReferenced" executed="True" result="Success" success="True" time="0.002" asserts="0" />
+                        </results>
+                      </test-suite>
+                      <test-suite type="TestFixture" name="TestIDTests" executed="True" result="Success" success="True" time="0.006" asserts="0">
+                        <results>
+                          <test-case name="NUnit.Core.Tests.TestIDTests.ClonedTestIDsAreEqual" executed="True" result="Success" success="True" time="0.001" asserts="3" />
+                          <test-case name="NUnit.Core.Tests.TestIDTests.DifferentTestIDsAreNotEqual" executed="True" result="Success" success="True" time="0.001" asserts="3" />
+                          <test-case name="NUnit.Core.Tests.TestIDTests.DifferentTestIDsDisplayDifferentStrings" executed="True" result="Success" success="True" time="0.001" asserts="1" />
+                        </results>
+                      </test-suite>
+                      <test-suite type="TestFixture" name="TestInfoTests" executed="True" result="Success" success="True" time="0.018" asserts="0">
+                        <results>
+                          <test-case name="NUnit.Core.Tests.TestInfoTests.ConstructFromFixture" executed="True" result="Success" success="True" time="0.005" asserts="8" />
+                          <test-case name="NUnit.Core.Tests.TestInfoTests.ConstructFromSuite" executed="True" result="Success" success="True" time="0.004" asserts="7" />
+                          <test-case name="NUnit.Core.Tests.TestInfoTests.ConstructFromTestCase" executed="True" result="Success" success="True" time="0.006" asserts="7" />
+                        </results>
+                      </test-suite>
+                      <test-suite type="TestFixture" name="TestMethodSignatureTests" executed="True" result="Success" success="True" time="0.159" asserts="0">
+                        <results>
+                          <test-case name="NUnit.Core.Tests.TestMethodSignatureTests.InstanceTestMethodIsRunnable" executed="True" result="Success" success="True" time="0.008" asserts="1" />
+                          <test-case name="NUnit.Core.Tests.TestMethodSignatureTests.PrivateTestMethodIsNotRunnable" executed="True" result="Success" success="True" time="0.006" asserts="2" />
+                          <test-case name="NUnit.Core.Tests.TestMethodSignatureTests.ProtectedTestMethodIsNotRunnable" executed="True" result="Success" success="True" time="0.005" asserts="2" />
+                          <test-case name="NUnit.Core.Tests.TestMethodSignatureTests.RunningTestsThroughFixtureGivesCorrectResults" executed="True" result="Success" success="True" time="0.009" asserts="6" />
+                          <test-case name="NUnit.Core.Tests.TestMethodSignatureTests.StaticTestMethodIsRunnable" executed="True" result="Success" success="True" time="0.005" asserts="1" />
+                          <test-case name="NUnit.Core.Tests.TestMethodSignatureTests.StaticTestMethodWithArgumentsNotProvidedIsNotRunnable" executed="True" result="Success" success="True" time="0.007" asserts="2" />
+                          <test-case name="NUnit.Core.Tests.TestMethodSignatureTests.StaticTestMethodWithArgumentsProvidedIsRunnable" executed="True" result="Success" success="True" time="0.006" asserts="1" />
+                          <test-case name="NUnit.Core.Tests.TestMethodSignatureTests.StaticTestMethodWithWrongArgumentTypesProvidedGivesError" executed="True" result="Success" success="True" time="0.006" asserts="1" />
+                          <test-case name="NUnit.Core.Tests.TestMethodSignatureTests.StaticTestMethodWithWrongNumberOfArgumentsProvidedIsNotRunnable" executed="True" result="Success" success="True" time="0.006" asserts="2" />
+                          <test-case name="NUnit.Core.Tests.TestMethodSignatureTests.TestMethodWithArgumentsNotProvidedIsNotRunnable" executed="True" result="Success" success="True" time="0.005" asserts="2" />
+                          <test-case name="NUnit.Core.Tests.TestMethodSignatureTests.TestMethodWithArgumentsProvidedIsRunnable" executed="True" result="Success" success="True" time="0.006" asserts="1" />
+                          <test-case name="NUnit.Core.Tests.TestMethodSignatureTests.TestMethodWithConvertibleArgumentsIsRunnable" executed="True" result="Success" success="True" time="0.006" asserts="1" />
+                          <test-case name="NUnit.Core.Tests.TestMethodSignatureTests.TestMethodWithMultipleTestCasesExecutesMultipleTimes" executed="True" result="Success" success="True" time="0.007" asserts="2" />
+                          <test-case name="NUnit.Core.Tests.TestMethodSignatureTests.TestMethodWithMultipleTestCasesUsesCorrectNames" executed="True" result="Success" success="True" time="0.006" asserts="7" />
+                          <test-case name="NUnit.Core.Tests.TestMethodSignatureTests.TestMethodWithNonConvertibleArgumentsGivesError" executed="True" result="Success" success="True" time="0.006" asserts="1" />
+                          <test-case name="NUnit.Core.Tests.TestMethodSignatureTests.TestMethodWithoutParametersWithArgumentsProvidedIsNotRunnable" executed="True" result="Success" success="True" time="0.006" asserts="2" />
+                          <test-case name="NUnit.Core.Tests.TestMethodSignatureTests.TestMethodWithParamsArgumentIsRunnable" executed="True" result="Success" success="True" time="0.005" asserts="1" />
+                          <test-case name="NUnit.Core.Tests.TestMethodSignatureTests.TestMethodWithReturnTypeIsNotRunnable" executed="True" result="Success" success="True" time="0.006" asserts="2" />
+                          <test-case name="NUnit.Core.Tests.TestMethodSignatureTests.TestMethodWithWrongArgumentTypesProvidedGivesError" executed="True" result="Success" success="True" time="0.006" asserts="1" />
+                          <test-case name="NUnit.Core.Tests.TestMethodSignatureTests.TestMethodWithWrongNumberOfArgumentsProvidedIsNotRunnable" executed="True" result="Success" success="True" time="0.006" asserts="2" />
+                        </results>
+                      </test-suite>
+                      <test-suite type="TestFixture" name="TestNameTests" executed="True" result="Success" success="True" time="0.019" asserts="0">
+                        <results>
+                          <test-case name="NUnit.Core.Tests.TestNameTests.CanCompareStrongTestNames" executed="True" result="Success" success="True" time="0.001" asserts="9" />
+                          <test-case name="NUnit.Core.Tests.TestNameTests.CanCompareWeakAndStrongTestNames" executed="True" result="Success" success="True" time="0.001" asserts="3" />
+                          <test-case name="NUnit.Core.Tests.TestNameTests.CanCompareWeakTestNames" executed="True" result="Success" success="True" time="0.001" asserts="6" />
+                          <test-case name="NUnit.Core.Tests.TestNameTests.CanDisplayUniqueNames" executed="True" result="Success" success="True" time="0.001" asserts="2" />
+                          <test-case name="NUnit.Core.Tests.TestNameTests.CanParseSimpleTestNames" executed="True" result="Success" success="True" time="0.001" asserts="1" />
+                          <test-case name="NUnit.Core.Tests.TestNameTests.CanParseStrongTestNames" executed="True" result="Success" success="True" time="0.000" asserts="2" />
+                          <test-case name="NUnit.Core.Tests.TestNameTests.CanParseWeakTestNames" executed="True" result="Success" success="True" time="0.000" asserts="2" />
+                          <test-case name="NUnit.Core.Tests.TestNameTests.ClonedTestNamesAreEqual" executed="True" result="Success" success="True" time="0.001" asserts="6" />
+                          <test-case name="NUnit.Core.Tests.TestNameTests.TestNamesWithDifferentRunnerIDsAreNotEqual" executed="True" result="Success" success="True" time="0.001" asserts="7" />
+                        </results>
+                      </test-suite>
+                      <test-suite type="TestFixture" name="TestNodeTests" executed="True" result="Success" success="True" time="0.017" asserts="0">
+                        <results>
+                          <test-case name="NUnit.Core.Tests.TestNodeTests.ConstructFromMultipleTests" executed="True" result="Success" success="True" time="0.006" asserts="8" />
+                          <test-case name="NUnit.Core.Tests.TestNodeTests.ConstructFromSuite" executed="True" result="Success" success="True" time="0.004" asserts="3" />
+                          <test-case name="NUnit.Core.Tests.TestNodeTests.ConstructFromTestCase" executed="True" result="Success" success="True" time="0.003" asserts="1" />
+                        </results>
+                      </test-suite>
+                      <test-suite type="TestFixture" name="TestRunnerThreadTests" executed="True" result="Success" success="True" time="0.009" asserts="0">
+                        <results>
+                          <test-case name="NUnit.Core.Tests.TestRunnerThreadTests.RunMultipleTests" executed="True" result="Success" success="True" time="0.001" asserts="2" />
+                          <test-case name="NUnit.Core.Tests.TestRunnerThreadTests.RunNamedTest" executed="True" result="Success" success="True" time="0.001" asserts="2" />
+                          <test-case name="NUnit.Core.Tests.TestRunnerThreadTests.RunTestSuite" executed="True" result="Success" success="True" time="0.001" asserts="2" />
+                        </results>
+                      </test-suite>
+                      <test-suite type="TestFixture" name="TestSuiteTest" executed="True" result="Success" success="True" time="0.167" asserts="0">
+                        <results>
+                          <test-case name="NUnit.Core.Tests.TestSuiteTest.CanSortUsingExternalComparer" executed="True" result="Success" success="True" time="0.005" asserts="1" />
+                          <test-case name="NUnit.Core.Tests.TestSuiteTest.CountTestCasesFilteredByName" executed="True" result="Success" success="True" time="0.004" asserts="4" />
+                          <test-case name="NUnit.Core.Tests.TestSuiteTest.DefaultSortIsByName" executed="True" result="Success" success="True" time="0.005" asserts="1" />
+                          <test-case name="NUnit.Core.Tests.TestSuiteTest.ExcludingCategoryDoesNotRunExplicitTestCases" executed="True" result="Success" success="True" time="0.006" asserts="1" />
+                          <test-case name="NUnit.Core.Tests.TestSuiteTest.ExcludingCategoryDoesNotRunExplicitTestFixtures" executed="True" result="Success" success="True" time="0.035" asserts="1" />
+                          <test-case name="NUnit.Core.Tests.TestSuiteTest.InheritedTestCount" executed="True" result="Success" success="True" time="0.007" asserts="1" />
+                          <test-case name="NUnit.Core.Tests.TestSuiteTest.RunExplicitTestByCategory" executed="True" result="Success" success="True" time="0.005" asserts="1" />
+                          <test-case name="NUnit.Core.Tests.TestSuiteTest.RunExplicitTestByName" executed="True" result="Success" success="True" time="0.005" asserts="1" />
+                          <test-case name="NUnit.Core.Tests.TestSuiteTest.RunExplicitTestDirectly" executed="True" result="Success" success="True" time="0.005" asserts="1" />
+                          <test-case name="NUnit.Core.Tests.TestSuiteTest.RunNoTestSuite" executed="True" result="Success" success="True" time="0.005" asserts="2" />
+                          <test-case name="NUnit.Core.Tests.TestSuiteTest.RunSingleTest" executed="True" result="Success" success="True" time="0.009" asserts="1" />
+                          <test-case name="NUnit.Core.Tests.TestSuiteTest.RunSuiteByCategory" executed="True" result="Success" success="True" time="0.007" asserts="1" />
+                          <test-case name="NUnit.Core.Tests.TestSuiteTest.RunSuiteByName" executed="True" result="Success" success="True" time="0.007" asserts="2" />
+                          <test-case name="NUnit.Core.Tests.TestSuiteTest.RunTestByCategory" executed="True" result="Success" success="True" time="0.006" asserts="1" />
+                          <test-case name="NUnit.Core.Tests.TestSuiteTest.RunTestByName" executed="True" result="Success" success="True" time="0.006" asserts="2" />
+                          <test-case name="NUnit.Core.Tests.TestSuiteTest.RunTestExcludingCategory" executed="True" result="Success" success="True" time="0.008" asserts="1" />
+                          <test-case name="NUnit.Core.Tests.TestSuiteTest.RunTestsInFixture" executed="True" result="Success" success="True" time="0.007" asserts="6" />
+                          <test-case name="NUnit.Core.Tests.TestSuiteTest.SuiteRunInitialized" executed="True" result="Success" success="True" time="0.005" asserts="1" />
+                          <test-case name="NUnit.Core.Tests.TestSuiteTest.SuiteWithNoTests" executed="True" result="Success" success="True" time="0.005" asserts="2" />
+                        </results>
+                      </test-suite>
+                      <test-suite type="TestFixture" name="TheoryTests" executed="True" result="Success" success="True" time="0.042" asserts="0">
+                        <results>
+                          <test-suite type="Theory" name="ArrayWithDatapointsAttributeIsUsed" executed="True" result="Success" success="True" time="0.003" asserts="0">
+                            <results>
+                              <test-case name="NUnit.Core.Tests.TheoryTests.ArrayWithDatapointsAttributeIsUsed(&quot;xyz1&quot;)" executed="True" result="Success" success="True" time="0.001" asserts="1" />
+                              <test-case name="NUnit.Core.Tests.TheoryTests.ArrayWithDatapointsAttributeIsUsed(&quot;xyz2&quot;)" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                              <test-case name="NUnit.Core.Tests.TheoryTests.ArrayWithDatapointsAttributeIsUsed(&quot;xyz3&quot;)" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                            </results>
+                          </test-suite>
+                          <test-case name="NUnit.Core.Tests.TheoryTests.BooleanArgumentsAreSuppliedAutomatically" executed="True" result="Success" success="True" time="0.002" asserts="2" />
+                          <test-case name="NUnit.Core.Tests.TheoryTests.EnumArgumentsAreSuppliedAutomatically" executed="True" result="Success" success="True" time="0.001" asserts="2" />
+                          <test-suite type="Theory" name="NullDatapointIsOK" executed="True" result="Success" success="True" time="0.001" asserts="0">
+                            <results>
+                              <test-case name="NUnit.Core.Tests.TheoryTests.NullDatapointIsOK(null)" executed="True" result="Success" success="True" time="0.000" asserts="0" />
+                            </results>
+                          </test-suite>
+                          <test-case name="NUnit.Core.Tests.TheoryTests.SimpleTestIgnoresDataPoints" executed="True" result="Success" success="True" time="0.001" asserts="1" />
+                          <test-suite type="Theory" name="SquareRootWithAllGoodValues" executed="True" result="Success" success="True" time="0.004" asserts="0">
+                            <results>
+                              <test-case name="NUnit.Core.Tests.TheoryTests.SquareRootWithAllGoodValues(12.0d)" executed="True" result="Success" success="True" time="0.001" asserts="2" />
+                              <test-case name="NUnit.Core.Tests.TheoryTests.SquareRootWithAllGoodValues(4.0d)" executed="True" result="Success" success="True" time="0.000" asserts="2" />
+                              <test-case name="NUnit.Core.Tests.TheoryTests.SquareRootWithAllGoodValues(9.0d)" executed="True" result="Success" success="True" time="0.000" asserts="2" />
+                            </results>
+                          </test-suite>
+                          <test-suite type="Theory" name="SquareRootWithOneBadValue" executed="True" result="Success" success="True" time="0.005" asserts="0">
+                            <results>
+                              <test-case name="NUnit.Core.Tests.TheoryTests.SquareRootWithOneBadValue(12.0d)" executed="True" result="Success" success="True" time="0.001" asserts="2" />
+                              <test-case name="NUnit.Core.Tests.TheoryTests.SquareRootWithOneBadValue(-4.0d)" executed="True" result="Inconclusive" success="False" time="0.001" asserts="0">
+                                <reason>
+                                  <message><![CDATA[  Expected: True
+  But was:  False
+]]></message>
+                                </reason>
+                              </test-case>
+                              <test-case name="NUnit.Core.Tests.TheoryTests.SquareRootWithOneBadValue(9.0d)" executed="True" result="Success" success="True" time="0.000" asserts="2" />
+                            </results>
+                          </test-suite>
+                          <test-case name="NUnit.Core.Tests.TheoryTests.TheoryFailsIfAllTestsAreInconclusive" executed="True" result="Success" success="True" time="0.004" asserts="2" />
+                          <test-case name="NUnit.Core.Tests.TheoryTests.TheoryWithDatapointsIsRunnable" executed="True" result="Success" success="True" time="0.002" asserts="2" />
+                          <test-case name="NUnit.Core.Tests.TheoryTests.TheoryWithNoArgumentsIsTreatedAsTest" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Core.Tests.TheoryTests.TheoryWithNoDatapointsIsNotRunnable" executed="True" result="Success" success="True" time="0.000" asserts="2" />
+                        </results>
+                      </test-suite>
+                      <test-suite type="TestFixture" name="TheoryTests+SqrtTests_DisplayResults" executed="True" result="Success" success="True" time="0.010" asserts="0">
+                        <results>
+                          <test-suite type="Theory" name="SqrtTimesItselfGivesOriginal" executed="True" result="Success" success="True" time="0.009" asserts="0">
+                            <results>
+                              <test-case name="NUnit.Core.Tests.TheoryTests+SqrtTests_DisplayResults.SqrtTimesItselfGivesOriginal(0.0d)" executed="True" result="Success" success="True" time="0.001" asserts="2" />
+                              <test-case name="NUnit.Core.Tests.TheoryTests+SqrtTests_DisplayResults.SqrtTimesItselfGivesOriginal(1.0d)" executed="True" result="Success" success="True" time="0.000" asserts="2" />
+                              <test-case name="NUnit.Core.Tests.TheoryTests+SqrtTests_DisplayResults.SqrtTimesItselfGivesOriginal(-1.0d)" executed="True" result="Inconclusive" success="False" time="0.001" asserts="0">
+                                <reason>
+                                  <message><![CDATA[  Expected: True
+  But was:  False
+]]></message>
+                                </reason>
+                              </test-case>
+                              <test-case name="NUnit.Core.Tests.TheoryTests+SqrtTests_DisplayResults.SqrtTimesItselfGivesOriginal(double.MaxValue)" executed="True" result="Inconclusive" success="False" time="0.001" asserts="0">
+                                <reason>
+                                  <message><![CDATA[  Expected: True
+  But was:  False
+]]></message>
+                                </reason>
+                              </test-case>
+                              <test-case name="NUnit.Core.Tests.TheoryTests+SqrtTests_DisplayResults.SqrtTimesItselfGivesOriginal(double.PositiveInfinity)" executed="True" result="Inconclusive" success="False" time="0.001" asserts="0">
+                                <reason>
+                                  <message><![CDATA[  Expected: True
+  But was:  False
+]]></message>
+                                </reason>
+                              </test-case>
+                            </results>
+                          </test-suite>
+                        </results>
+                      </test-suite>
+                      <test-suite type="TestFixture" name="ThreadedTestRunnerTests" executed="True" result="Success" success="True" time="0.417" asserts="1">
+                        <results>
+                          <test-case name="NUnit.Core.Tests.ThreadedTestRunnerTests.BasicRunnerTests.CheckRunnerID" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Core.Tests.ThreadedTestRunnerTests.BasicRunnerTests.CountTestCases" executed="True" result="Success" success="True" time="0.027" asserts="1" />
+                          <test-case name="NUnit.Core.Tests.ThreadedTestRunnerTests.BasicRunnerTests.CountTestCasesAcrossMultipleAssemblies" executed="True" result="Success" success="True" time="0.033" asserts="1" />
+                          <test-case name="NUnit.Core.Tests.ThreadedTestRunnerTests.BasicRunnerTests.LoadAndReloadAssembly" executed="True" result="Success" success="True" time="0.049" asserts="2" />
+                          <test-case name="NUnit.Core.Tests.ThreadedTestRunnerTests.BasicRunnerTests.LoadAssemblyWithFixture" executed="True" result="Success" success="True" time="0.012" asserts="1" />
+                          <test-case name="NUnit.Core.Tests.ThreadedTestRunnerTests.BasicRunnerTests.LoadAssemblyWithoutNamespaces" executed="True" result="Success" success="True" time="0.024" asserts="4" />
+                          <test-case name="NUnit.Core.Tests.ThreadedTestRunnerTests.BasicRunnerTests.LoadAssemblyWithSuite" executed="True" result="Success" success="True" time="0.008" asserts="1" />
+                          <test-case name="NUnit.Core.Tests.ThreadedTestRunnerTests.BasicRunnerTests.LoadMultipleAssemblies" executed="True" result="Success" success="True" time="0.034" asserts="1" />
+                          <test-case name="NUnit.Core.Tests.ThreadedTestRunnerTests.BasicRunnerTests.LoadMultipleAssembliesWithFixture" executed="True" result="Success" success="True" time="0.020" asserts="1" />
+                          <test-case name="NUnit.Core.Tests.ThreadedTestRunnerTests.BasicRunnerTests.LoadMultipleAssembliesWithSuite" executed="True" result="Success" success="True" time="0.016" asserts="1" />
+                          <test-case name="NUnit.Core.Tests.ThreadedTestRunnerTests.BasicRunnerTests.RunAssembly" executed="True" result="Success" success="True" time="0.030" asserts="1" />
+                          <test-case name="NUnit.Core.Tests.ThreadedTestRunnerTests.BasicRunnerTests.RunAssemblyUsingBeginAndEndRun" executed="True" result="Success" success="True" time="0.059" asserts="2" />
+                          <test-case name="NUnit.Core.Tests.ThreadedTestRunnerTests.BasicRunnerTests.RunMultipleAssemblies" executed="True" result="Success" success="True" time="0.038" asserts="1" />
+                          <test-case name="NUnit.Core.Tests.ThreadedTestRunnerTests.BasicRunnerTests.RunMultipleAssembliesUsingBeginAndEndRun" executed="True" result="Success" success="True" time="0.039" asserts="2" />
+                        </results>
+                      </test-suite>
+                      <test-suite type="TestFixture" name="ThreadingTests" executed="True" result="Success" success="True" time="0.152" asserts="0">
+                        <results>
+                          <test-case name="NUnit.Core.Tests.ThreadingTests.TestOnSeparateThreadReportsAssertCountCorrectly" executed="True" result="Success" success="True" time="0.001" asserts="1" />
+                          <test-case name="NUnit.Core.Tests.ThreadingTests.TestWithInfiniteLoopTimesOut" executed="True" result="Success" success="True" time="0.060" asserts="2" />
+                          <test-case name="NUnit.Core.Tests.ThreadingTests.TestWithMTAThreadRunsInMTA" executed="True" result="Success" success="True" time="0.000" asserts="2">
+                            <properties>
+                              <property name="APARTMENT_STATE" value="MTA" />
+                            </properties>
+                          </test-case>
+                          <test-case name="NUnit.Core.Tests.ThreadingTests.TestWithRequiresMTARunsInMTA" executed="True" result="Success" success="True" time="0.000" asserts="2">
+                            <properties>
+                              <property name="APARTMENT_STATE" value="MTA" />
+                            </properties>
+                          </test-case>
+                          <test-case name="NUnit.Core.Tests.ThreadingTests.TestWithRequiresSTARunsInSTA" executed="True" result="Success" success="True" time="0.000" asserts="1">
+                            <properties>
+                              <property name="APARTMENT_STATE" value="STA" />
+                            </properties>
+                          </test-case>
+                          <test-case name="NUnit.Core.Tests.ThreadingTests.TestWithRequiresThreadRunsInSeparateThread" executed="True" result="Success" success="True" time="0.001" asserts="1">
+                            <properties>
+                              <property name="RequiresThread" value="True" />
+                            </properties>
+                          </test-case>
+                          <test-case name="NUnit.Core.Tests.ThreadingTests.TestWithRequiresThreadRunsSetUpAndTestOnSameThread" executed="True" result="Success" success="True" time="0.000" asserts="1">
+                            <properties>
+                              <property name="RequiresThread" value="True" />
+                            </properties>
+                          </test-case>
+                          <test-case name="NUnit.Core.Tests.ThreadingTests.TestWithRequiresThreadWithMTAArgRunsOnSeparateThreadInMTA" executed="True" result="Success" success="True" time="0.001" asserts="2">
+                            <properties>
+                              <property name="RequiresThread" value="True" />
+                              <property name="APARTMENT_STATE" value="MTA" />
+                            </properties>
+                          </test-case>
+                          <test-case name="NUnit.Core.Tests.ThreadingTests.TestWithRequiresThreadWithSTAArgRunsOnSeparateThreadInSTA" executed="True" result="Success" success="True" time="0.000" asserts="2">
+                            <properties>
+                              <property name="RequiresThread" value="True" />
+                              <property name="APARTMENT_STATE" value="STA" />
+                            </properties>
+                          </test-case>
+                          <test-case name="NUnit.Core.Tests.ThreadingTests.TestWithSTAThreadRunsInSTA" executed="True" result="Success" success="True" time="0.001" asserts="1">
+                            <properties>
+                              <property name="APARTMENT_STATE" value="STA" />
+                            </properties>
+                          </test-case>
+                          <test-case name="NUnit.Core.Tests.ThreadingTests.TestWithTimeoutRunsOnSeparateThread" executed="True" result="Success" success="True" time="0.000" asserts="1">
+                            <properties>
+                              <property name="Timeout" value="50" />
+                            </properties>
+                          </test-case>
+                          <test-case name="NUnit.Core.Tests.ThreadingTests.TestWithTimeoutRunsSetUpAndTestOnSameThread" executed="True" result="Success" success="True" time="0.001" asserts="1">
+                            <properties>
+                              <property name="Timeout" value="50" />
+                            </properties>
+                          </test-case>
+                          <test-case name="NUnit.Core.Tests.ThreadingTests.TimeoutCanBeSetOnTestFixture" executed="True" result="Success" success="True" time="0.063" asserts="3" />
+                        </results>
+                      </test-suite>
+                      <test-suite type="TestFixture" name="ThreadingTests+FixtureRequiresMTA" executed="True" result="Success" success="True" time="0.002" asserts="0">
+                        <properties>
+                          <property name="APARTMENT_STATE" value="MTA" />
+                        </properties>
+                        <results>
+                          <test-case name="NUnit.Core.Tests.ThreadingTests+FixtureRequiresMTA.RequiresMTACanBeSetOnTestFixture" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                        </results>
+                      </test-suite>
+                      <test-suite type="TestFixture" name="ThreadingTests+FixtureRequiresSTA" executed="True" result="Success" success="True" time="0.003" asserts="0">
+                        <properties>
+                          <property name="APARTMENT_STATE" value="STA" />
+                        </properties>
+                        <results>
+                          <test-case name="NUnit.Core.Tests.ThreadingTests+FixtureRequiresSTA.RequiresSTACanBeSetOnTestFixture" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                        </results>
+                      </test-suite>
+                      <test-suite type="TestFixture" name="ThreadingTests+FixtureRequiresThread" executed="True" result="Success" success="True" time="0.005" asserts="0">
+                        <properties>
+                          <property name="RequiresThread" value="True" />
+                        </properties>
+                        <results>
+                          <test-case name="NUnit.Core.Tests.ThreadingTests+FixtureRequiresThread.RequiresThreadCanBeSetOnTestFixture" executed="True" result="Success" success="True" time="0.003" asserts="1" />
+                        </results>
+                      </test-suite>
+                      <test-suite type="TestFixture" name="TypeHelperTests" executed="True" result="Success" success="True" time="0.034" asserts="0">
+                        <results>
+                          <test-suite type="ParameterizedTest" name="GetDisplayName" executed="True" result="Success" success="True" time="0.033" asserts="0">
+                            <results>
+                              <test-case name="NUnit.Core.Tests.TypeHelperTests.GetDisplayName(NUnit.TestData.TypeHelperFixture.GenericContainerClass`1+NestedClass[System.String],&quot;GenericContainerClass+NestedClass&lt;String&gt;&quot;)" executed="True" result="Success" success="True" time="0.000" asserts="2" />
+                              <test-case name="NUnit.Core.Tests.TypeHelperTests.GetDisplayName(NUnit.TestData.TypeHelperFixture.GenericContainerClass`1+NestedClass+DoublyNestedClass[System.String],&quot;GenericContainerClass+NestedClass+DoublyNestedClass&lt;String&gt;&quot;)" executed="True" result="Success" success="True" time="0.000" asserts="2" />
+                              <test-case name="NUnit.Core.Tests.TypeHelperTests.GetDisplayName(NUnit.TestData.TypeHelperFixture.ContainerClass+NestedGeneric`1+DoublyNestedGeneric`1[System.String,System.Int32],&quot;ContainerClass+NestedGeneric+DoublyNestedGeneric&lt;String,Int32&gt;&quot;)" executed="True" result="Success" success="True" time="0.000" asserts="2" />
+                              <test-case name="NUnit.Core.Tests.TypeHelperTests.GetDisplayName(NUnit.TestData.TypeHelperFixture.GenericContainerClass`1+NestedGeneric`1+DoublyNestedGeneric`1[System.String,System.Int32,System.Boolean],&quot;GenericContainerClass+NestedGeneric+DoublyNestedGeneric&lt;String,Int32,Boolean&gt;&quot;)" executed="True" result="Success" success="True" time="0.000" asserts="2" />
+                              <test-case name="NUnit.Core.Tests.TypeHelperTests.GetDisplayName(NUnit.TestData.TypeHelperFixture.ListTester`1[System.Collections.Generic.List`1[System.Int32]],&quot;ListTester&lt;List&lt;Int32&gt;&gt;&quot;)" executed="True" result="Success" success="True" time="0.000" asserts="2" />
+                              <test-case name="NUnit.Core.Tests.TypeHelperTests.GetDisplayName(NUnit.TestData.TypeHelperFixture.ListTester`1[System.Collections.Generic.List`1[System.Collections.Generic.List`1[System.Int32]]],&quot;ListTester&lt;List&lt;List&lt;Int32&gt;&gt;&gt;&quot;)" executed="True" result="Success" success="True" time="0.000" asserts="2" />
+                              <test-case name="NUnit.Core.Tests.TypeHelperTests.GetDisplayName(NUnit.TestData.TypeHelperFixture.GenericContainerClass`1+NestedClass+DoublyNestedGeneric`1[System.String,System.Boolean],&quot;GenericContainerClass+NestedClass+DoublyNestedGeneric&lt;String,Boolean&gt;&quot;)" executed="True" result="Success" success="True" time="0.000" asserts="2" />
+                              <test-case name="NUnit.Core.Tests.TypeHelperTests.GetDisplayName(NUnit.TestData.TypeHelperFixture.GenericContainerClass`1+NestedGeneric`1[System.String,System.Int32],&quot;GenericContainerClass+NestedGeneric&lt;String,Int32&gt;&quot;)" executed="True" result="Success" success="True" time="0.000" asserts="2" />
+                              <test-case name="NUnit.Core.Tests.TypeHelperTests.GetDisplayName(System.Int32,&quot;Int32&quot;)" executed="True" result="Success" success="True" time="0.000" asserts="2" />
+                              <test-case name="NUnit.Core.Tests.TypeHelperTests.GetDisplayName(NUnit.TestData.TypeHelperFixture.GenericContainerClass`1+NestedGeneric`1+DoublyNestedClass[System.String,System.Int32],&quot;GenericContainerClass+NestedGeneric+DoublyNestedClass&lt;String,Int32&gt;&quot;)" executed="True" result="Success" success="True" time="0.000" asserts="2" />
+                              <test-case name="NUnit.Core.Tests.TypeHelperTests.GetDisplayName(NUnit.TestData.TypeHelperFixture.SimpleClass,&quot;SimpleClass&quot;)" executed="True" result="Success" success="True" time="0.000" asserts="2" />
+                              <test-case name="NUnit.Core.Tests.TypeHelperTests.GetDisplayName(MyNoNamespaceClass,&quot;MyNoNamespaceClass&quot;)" executed="True" result="Success" success="True" time="0.000" asserts="2" />
+                              <test-case name="NUnit.Core.Tests.TypeHelperTests.GetDisplayName(NUnit.TestData.TypeHelperFixture.GenericClass`3[System.Int32,System.Decimal,System.String],&quot;GenericClass&lt;Int32,Decimal,String&gt;&quot;)" executed="True" result="Success" success="True" time="0.000" asserts="2" />
+                              <test-case name="NUnit.Core.Tests.TypeHelperTests.GetDisplayName(NUnit.TestData.TypeHelperFixture.GenericClass`3[System.Int32[],System.Decimal[],System.String[]],&quot;GenericClass&lt;Int32[],Decimal[],String[]&gt;&quot;)" executed="True" result="Success" success="True" time="0.000" asserts="2" />
+                              <test-case name="NUnit.Core.Tests.TypeHelperTests.GetDisplayName(NUnit.TestData.TypeHelperFixture.ContainerClass+NestedClass,&quot;ContainerClass+NestedClass&quot;)" executed="True" result="Success" success="True" time="0.000" asserts="2" />
+                              <test-case name="NUnit.Core.Tests.TypeHelperTests.GetDisplayName(NUnit.TestData.TypeHelperFixture.ContainerClass+NestedClass+DoublyNestedClass,&quot;ContainerClass+NestedClass+DoublyNestedClass&quot;)" executed="True" result="Success" success="True" time="0.000" asserts="2" />
+                              <test-case name="NUnit.Core.Tests.TypeHelperTests.GetDisplayName(NUnit.TestData.TypeHelperFixture.ContainerClass+NestedClass+DoublyNestedGeneric`1[System.Int32],&quot;ContainerClass+NestedClass+DoublyNestedGeneric&lt;Int32&gt;&quot;)" executed="True" result="Success" success="True" time="0.000" asserts="2" />
+                              <test-case name="NUnit.Core.Tests.TypeHelperTests.GetDisplayName(NUnit.TestData.TypeHelperFixture.ContainerClass+NestedGeneric`1[System.Int32],&quot;ContainerClass+NestedGeneric&lt;Int32&gt;&quot;)" executed="True" result="Success" success="True" time="0.000" asserts="2" />
+                              <test-case name="NUnit.Core.Tests.TypeHelperTests.GetDisplayName(NUnit.TestData.TypeHelperFixture.ContainerClass+NestedGeneric`1+DoublyNestedClass[System.Int32],&quot;ContainerClass+NestedGeneric+DoublyNestedClass&lt;Int32&gt;&quot;)" executed="True" result="Success" success="True" time="0.000" asserts="2" />
+                            </results>
+                          </test-suite>
+                        </results>
+                      </test-suite>
+                      <test-suite type="TestFixture" name="ValueSourceTests" executed="True" result="Success" success="True" time="0.033" asserts="0">
+                        <results>
+                          <test-suite type="ParameterizedTest" name="MultipleArguments" executed="True" result="Success" success="True" time="0.004" asserts="0">
+                            <results>
+                              <test-case name="NUnit.Core.Tests.ValueSourceTests.MultipleArguments(12,3,4)" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                              <test-case name="NUnit.Core.Tests.ValueSourceTests.MultipleArguments(12,4,3)" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                              <test-case name="NUnit.Core.Tests.ValueSourceTests.MultipleArguments(12,6,2)" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                            </results>
+                          </test-suite>
+                          <test-suite type="ParameterizedTest" name="ValueSourceCanBeInstanceField" executed="True" result="Success" success="True" time="0.001" asserts="0">
+                            <results>
+                              <test-case name="NUnit.Core.Tests.ValueSourceTests.ValueSourceCanBeInstanceField(&quot;InstanceField&quot;)" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                            </results>
+                          </test-suite>
+                          <test-suite type="ParameterizedTest" name="ValueSourceCanBeInstanceMethod" executed="True" result="Success" success="True" time="0.001" asserts="0">
+                            <results>
+                              <test-case name="NUnit.Core.Tests.ValueSourceTests.ValueSourceCanBeInstanceMethod(&quot;InstanceMethod&quot;)" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                            </results>
+                          </test-suite>
+                          <test-suite type="ParameterizedTest" name="ValueSourceCanBeInstanceProperty" executed="True" result="Success" success="True" time="0.000" asserts="0">
+                            <results>
+                              <test-case name="NUnit.Core.Tests.ValueSourceTests.ValueSourceCanBeInstanceProperty(&quot;InstanceProperty&quot;)" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                            </results>
+                          </test-suite>
+                          <test-suite type="ParameterizedTest" name="ValueSourceCanBeStaticField" executed="True" result="Success" success="True" time="0.001" asserts="0">
+                            <results>
+                              <test-case name="NUnit.Core.Tests.ValueSourceTests.ValueSourceCanBeStaticField(&quot;StaticField&quot;)" executed="True" result="Success" success="True" time="0.001" asserts="1" />
+                            </results>
+                          </test-suite>
+                          <test-suite type="ParameterizedTest" name="ValueSourceCanBeStaticMethod" executed="True" result="Success" success="True" time="0.001" asserts="0">
+                            <results>
+                              <test-case name="NUnit.Core.Tests.ValueSourceTests.ValueSourceCanBeStaticMethod(&quot;StaticMethod&quot;)" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                            </results>
+                          </test-suite>
+                          <test-suite type="ParameterizedTest" name="ValueSourceCanBeStaticProperty" executed="True" result="Success" success="True" time="0.001" asserts="0">
+                            <results>
+                              <test-case name="NUnit.Core.Tests.ValueSourceTests.ValueSourceCanBeStaticProperty(&quot;StaticProperty&quot;)" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                            </results>
+                          </test-suite>
+                          <test-suite type="ParameterizedTest" name="ValueSourceIsInvokedWithCorrectCurrentDirectory" executed="True" result="Success" success="True" time="0.000" asserts="0">
+                            <results>
+                              <test-case name="NUnit.Core.Tests.ValueSourceTests.ValueSourceIsInvokedWithCorrectCurrentDirectory(True)" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                            </results>
+                          </test-suite>
+                          <test-suite type="ParameterizedTest" name="ValueSourceMayBeGeneric" executed="True" result="Success" success="True" time="0.005" asserts="0">
+                            <results>
+                              <test-case name="NUnit.Core.Tests.ValueSourceTests.ValueSourceMayBeGeneric(1)" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                              <test-case name="NUnit.Core.Tests.ValueSourceTests.ValueSourceMayBeGeneric(2)" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                              <test-case name="NUnit.Core.Tests.ValueSourceTests.ValueSourceMayBeGeneric(4)" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                              <test-case name="NUnit.Core.Tests.ValueSourceTests.ValueSourceMayBeGeneric(8)" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                            </results>
+                          </test-suite>
+                          <test-suite type="ParameterizedTest" name="ValueSourceMayBeInAnotherClass" executed="True" result="Success" success="True" time="0.004" asserts="0">
+                            <results>
+                              <test-case name="NUnit.Core.Tests.ValueSourceTests.ValueSourceMayBeInAnotherClass(12,3,4)" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                              <test-case name="NUnit.Core.Tests.ValueSourceTests.ValueSourceMayBeInAnotherClass(12,4,3)" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                              <test-case name="NUnit.Core.Tests.ValueSourceTests.ValueSourceMayBeInAnotherClass(12,6,2)" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                            </results>
+                          </test-suite>
+                        </results>
+                      </test-suite>
+                      <test-suite type="TestFixture" name="XmlTest" executed="True" result="Success" success="True" time="0.491" asserts="0">
+                        <results>
+                          <test-case name="NUnit.Core.Tests.XmlTest.removeTime" executed="True" result="Success" success="True" time="0.006" asserts="1" />
+                          <test-case name="NUnit.Core.Tests.XmlTest.TestSchemaValidatorFrenchCulture" executed="True" result="Success" success="True" time="0.321" asserts="1" />
+                          <test-case name="NUnit.Core.Tests.XmlTest.TestSchemaValidatorInvariantCulture" executed="True" result="Success" success="True" time="0.037" asserts="1" />
+                          <test-case name="NUnit.Core.Tests.XmlTest.TestSchemaValidatorUnitedStatesCulture" executed="True" result="Success" success="True" time="0.038" asserts="1" />
+                          <test-case name="NUnit.Core.Tests.XmlTest.TestStream" executed="True" result="Success" success="True" time="0.078" asserts="1" />
+                        </results>
+                      </test-suite>
+                    </results>
+                  </test-suite>
+                </results>
+              </test-suite>
+            </results>
+          </test-suite>
+        </results>
+      </test-suite>
+      <test-suite type="Assembly" name="C:\Program Files\NUnit 2.5.10\bin\net-2.0\tests/nunit.util.tests.dll" executed="True" result="Success" success="True" time="29.892" asserts="0">
+        <results>
+          <test-suite type="Namespace" name="NUnit" executed="True" result="Success" success="True" time="29.888" asserts="0">
+            <results>
+              <test-suite type="Namespace" name="Util" executed="True" result="Success" success="True" time="29.888" asserts="0">
+                <results>
+                  <test-suite type="SetUpFixture" name="Tests" executed="True" result="Success" success="True" time="29.887" asserts="0">
+                    <results>
+                      <test-suite type="TestFixture" name="AssemblyListTests" executed="True" result="Success" success="True" time="0.040" asserts="0">
+                        <results>
+                          <test-case name="NUnit.Util.Tests.AssemblyListTests.AddFiresChangedEvent" executed="True" result="Success" success="True" time="0.017" asserts="1" />
+                          <test-case name="NUnit.Util.Tests.AssemblyListTests.CanAddAssemblies" executed="True" result="Success" success="True" time="0.001" asserts="3" />
+                          <test-case name="NUnit.Util.Tests.AssemblyListTests.CanRemoveAssemblies" executed="True" result="Success" success="True" time="0.001" asserts="3" />
+                          <test-case name="NUnit.Util.Tests.AssemblyListTests.EmptyList" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Util.Tests.AssemblyListTests.MustAddAbsolutePath" executed="True" result="Success" success="True" time="0.002" asserts="0" />
+                          <test-case name="NUnit.Util.Tests.AssemblyListTests.RemoveAtFiresChangedEvent" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Util.Tests.AssemblyListTests.RemoveFiresChangedEvent" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Util.Tests.AssemblyListTests.SettingFullPathFiresChangedEvent" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                        </results>
+                      </test-suite>
+                      <test-suite type="TestFixture" name="CategoryManagerTest" executed="True" result="Success" success="True" time="0.134" asserts="0">
+                        <results>
+                          <test-case name="NUnit.Util.Tests.CategoryManagerTest.CanAddAllAvailableCategoriesInTestTree" executed="True" result="Success" success="True" time="0.038" asserts="1" />
+                          <test-case name="NUnit.Util.Tests.CategoryManagerTest.CanAddStrings" executed="True" result="Success" success="True" time="0.001" asserts="1" />
+                          <test-case name="NUnit.Util.Tests.CategoryManagerTest.CanAddStringsWithoutDuplicating" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Util.Tests.CategoryManagerTest.CanAddTestCategories" executed="True" result="Success" success="True" time="0.056" asserts="1" />
+                          <test-case name="NUnit.Util.Tests.CategoryManagerTest.CanClearEntries" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                        </results>
+                      </test-suite>
+                      <test-suite type="TestFixture" name="CategoryParseTests" executed="True" result="Success" success="True" time="0.025" asserts="0">
+                        <results>
+                          <test-case name="NUnit.Util.Tests.CategoryParseTests.CanParseCompoundCategory" executed="True" result="Success" success="True" time="0.004" asserts="1" />
+                          <test-case name="NUnit.Util.Tests.CategoryParseTests.CanParseExcludedCategories" executed="True" result="Success" success="True" time="0.001" asserts="1" />
+                          <test-case name="NUnit.Util.Tests.CategoryParseTests.CanParseMultipleAlternatives" executed="True" result="Success" success="True" time="0.001" asserts="4" />
+                          <test-case name="NUnit.Util.Tests.CategoryParseTests.CanParseMultipleCategoriesWithAnd" executed="True" result="Success" success="True" time="0.000" asserts="4" />
+                          <test-case name="NUnit.Util.Tests.CategoryParseTests.CanParseSimpleCategory" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Util.Tests.CategoryParseTests.EmptyStringReturnsEmptyFilter" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Util.Tests.CategoryParseTests.OrAndMinusCombined" executed="True" result="Success" success="True" time="0.001" asserts="5" />
+                          <test-case name="NUnit.Util.Tests.CategoryParseTests.PlusAndMinusCombined" executed="True" result="Success" success="True" time="0.001" asserts="6" />
+                          <test-case name="NUnit.Util.Tests.CategoryParseTests.PrecedenceTest" executed="True" result="Success" success="True" time="0.001" asserts="4" />
+                          <test-case name="NUnit.Util.Tests.CategoryParseTests.PrecedenceTestWithParentheses" executed="True" result="Success" success="True" time="0.000" asserts="5" />
+                        </results>
+                      </test-suite>
+                      <test-suite type="TestFixture" name="DomainManagerTests" executed="True" result="Success" success="True" time="0.018" asserts="0">
+                        <results>
+                          <test-case name="NUnit.Util.Tests.DomainManagerTests.GetCommonAppBase_OneElement" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Util.Tests.DomainManagerTests.GetCommonAppBase_ThreeElements_DiferentDirectories" executed="True" result="Success" success="True" time="0.001" asserts="1" />
+                          <test-case name="NUnit.Util.Tests.DomainManagerTests.GetCommonAppBase_TwoElements_DifferentDirectories" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Util.Tests.DomainManagerTests.GetCommonAppBase_TwoElements_SameDirectory" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Util.Tests.DomainManagerTests.GetPrivateBinPath" executed="True" result="Success" success="True" time="0.002" asserts="1" />
+                          <test-case name="NUnit.Util.Tests.DomainManagerTests.UnloadUnloadedDomain" executed="True" result="Success" success="True" time="0.004" asserts="0" />
+                        </results>
+                      </test-suite>
+                      <test-suite type="TestFixture" name="EventDispatcherTests" executed="True" result="Success" success="True" time="0.053" asserts="0">
+                        <results>
+                          <test-case name="NUnit.Util.Tests.EventDispatcherTests.ProjectLoaded" executed="True" result="Success" success="True" time="0.006" asserts="3" />
+                          <test-case name="NUnit.Util.Tests.EventDispatcherTests.ProjectLoadFailed" executed="True" result="Success" success="True" time="0.001" asserts="4" />
+                          <test-case name="NUnit.Util.Tests.EventDispatcherTests.ProjectLoading" executed="True" result="Success" success="True" time="0.000" asserts="3" />
+                          <test-case name="NUnit.Util.Tests.EventDispatcherTests.ProjectUnloaded" executed="True" result="Success" success="True" time="0.000" asserts="3" />
+                          <test-case name="NUnit.Util.Tests.EventDispatcherTests.ProjectUnloadFailed" executed="True" result="Success" success="True" time="0.001" asserts="4" />
+                          <test-case name="NUnit.Util.Tests.EventDispatcherTests.ProjectUnloading" executed="True" result="Success" success="True" time="0.001" asserts="3" />
+                          <test-case name="NUnit.Util.Tests.EventDispatcherTests.RunFailed" executed="True" result="Success" success="True" time="0.001" asserts="3" />
+                          <test-case name="NUnit.Util.Tests.EventDispatcherTests.RunFinished" executed="True" result="Success" success="True" time="0.000" asserts="3" />
+                          <test-case name="NUnit.Util.Tests.EventDispatcherTests.RunStarting" executed="True" result="Success" success="True" time="0.001" asserts="4" />
+                          <test-case name="NUnit.Util.Tests.EventDispatcherTests.SuiteFinished" executed="True" result="Success" success="True" time="0.000" asserts="3" />
+                          <test-case name="NUnit.Util.Tests.EventDispatcherTests.SuiteStarting" executed="True" result="Success" success="True" time="0.001" asserts="3" />
+                          <test-case name="NUnit.Util.Tests.EventDispatcherTests.TestFinished" executed="True" result="Success" success="True" time="0.001" asserts="3" />
+                          <test-case name="NUnit.Util.Tests.EventDispatcherTests.TestLoaded" executed="True" result="Success" success="True" time="0.001" asserts="4" />
+                          <test-case name="NUnit.Util.Tests.EventDispatcherTests.TestLoadFailed" executed="True" result="Success" success="True" time="0.000" asserts="4" />
+                          <test-case name="NUnit.Util.Tests.EventDispatcherTests.TestLoading" executed="True" result="Success" success="True" time="0.000" asserts="3" />
+                          <test-case name="NUnit.Util.Tests.EventDispatcherTests.TestReloaded" executed="True" result="Success" success="True" time="0.000" asserts="4" />
+                          <test-case name="NUnit.Util.Tests.EventDispatcherTests.TestReloadFailed" executed="True" result="Success" success="True" time="0.000" asserts="4" />
+                          <test-case name="NUnit.Util.Tests.EventDispatcherTests.TestReloading" executed="True" result="Success" success="True" time="0.000" asserts="3" />
+                          <test-case name="NUnit.Util.Tests.EventDispatcherTests.TestStarting" executed="True" result="Success" success="True" time="0.000" asserts="3" />
+                          <test-case name="NUnit.Util.Tests.EventDispatcherTests.TestUnloaded" executed="True" result="Success" success="True" time="0.000" asserts="3" />
+                          <test-case name="NUnit.Util.Tests.EventDispatcherTests.TestUnloadFailed" executed="True" result="Success" success="True" time="0.000" asserts="4" />
+                          <test-case name="NUnit.Util.Tests.EventDispatcherTests.TestUnloading" executed="True" result="Success" success="True" time="0.000" asserts="3" />
+                        </results>
+                      </test-suite>
+                      <test-suite type="TestFixture" name="FileWatcherTest" executed="True" result="Success" success="True" time="0.915" asserts="0">
+                        <results>
+                          <test-case name="NUnit.Util.Tests.FileWatcherTest.ChangingAttributesDoesNotTriggerWatcher" executed="True" result="Success" success="True" time="0.226" asserts="1" />
+                          <test-case name="NUnit.Util.Tests.FileWatcherTest.ChangingFileTriggersWatcher" executed="True" result="Success" success="True" time="0.205" asserts="2" />
+                          <test-case name="NUnit.Util.Tests.FileWatcherTest.CopyingFileDoesNotTriggerWatcher" executed="True" result="Success" success="True" time="0.207" asserts="1" />
+                          <test-case name="NUnit.Util.Tests.FileWatcherTest.MultipleCloselySpacedChangesTriggerWatcherOnlyOnce" executed="True" result="Success" success="True" time="0.265" asserts="2" />
+                        </results>
+                      </test-suite>
+                      <test-suite type="TestFixture" name="MemorySettingsStorageTests" executed="True" result="Success" success="True" time="0.031" asserts="0">
+                        <results>
+                          <test-case name="NUnit.Util.Tests.MemorySettingsStorageTests.MakeStorage" executed="True" result="Success" success="True" time="0.011" asserts="1" />
+                          <test-case name="NUnit.Util.Tests.MemorySettingsStorageTests.MakeSubStorages" executed="True" result="Success" success="True" time="0.000" asserts="2" />
+                          <test-case name="NUnit.Util.Tests.MemorySettingsStorageTests.RemoveSettings" executed="True" result="Success" success="True" time="0.001" asserts="3" />
+                          <test-case name="NUnit.Util.Tests.MemorySettingsStorageTests.SaveAndLoadSettings" executed="True" result="Success" success="True" time="0.000" asserts="4" />
+                          <test-case name="NUnit.Util.Tests.MemorySettingsStorageTests.SubstorageSettings" executed="True" result="Success" success="True" time="0.000" asserts="5" />
+                          <test-case name="NUnit.Util.Tests.MemorySettingsStorageTests.TypeSafeSettings" executed="True" result="Success" success="True" time="0.001" asserts="3" />
+                        </results>
+                      </test-suite>
+                      <test-suite type="TestFixture" name="NUnitProjectLoad" executed="True" result="Success" success="True" time="0.078" asserts="0">
+                        <results>
+                          <test-case name="NUnit.Util.Tests.NUnitProjectLoad.FromAssembly" executed="True" result="Success" success="True" time="0.006" asserts="5" />
+                          <test-case name="NUnit.Util.Tests.NUnitProjectLoad.LoadEmptyConfigs" executed="True" result="Success" success="True" time="0.031" asserts="3" />
+                          <test-case name="NUnit.Util.Tests.NUnitProjectLoad.LoadEmptyProject" executed="True" result="Success" success="True" time="0.004" asserts="1" />
+                          <test-case name="NUnit.Util.Tests.NUnitProjectLoad.LoadNormalProject" executed="True" result="Success" success="True" time="0.006" asserts="7" />
+                          <test-case name="NUnit.Util.Tests.NUnitProjectLoad.LoadProjectWithManualBinPath" executed="True" result="Success" success="True" time="0.004" asserts="2" />
+                          <test-case name="NUnit.Util.Tests.NUnitProjectLoad.SaveClearsAssemblyWrapper" executed="True" result="Success" success="True" time="0.016" asserts="1" />
+                        </results>
+                      </test-suite>
+                      <test-suite type="TestFixture" name="NUnitProjectSave" executed="True" result="Success" success="True" time="0.019" asserts="0">
+                        <results>
+                          <test-case name="NUnit.Util.Tests.NUnitProjectSave.SaveEmptyConfigs" executed="True" result="Success" success="True" time="0.005" asserts="1" />
+                          <test-case name="NUnit.Util.Tests.NUnitProjectSave.SaveEmptyProject" executed="True" result="Success" success="True" time="0.004" asserts="1" />
+                          <test-case name="NUnit.Util.Tests.NUnitProjectSave.SaveNormalProject" executed="True" result="Success" success="True" time="0.006" asserts="1" />
+                        </results>
+                      </test-suite>
+                      <test-suite type="TestFixture" name="NUnitProjectTests" executed="True" result="Success" success="True" time="0.102" asserts="0">
+                        <results>
+                          <test-case name="NUnit.Util.Tests.NUnitProjectTests.AddConfigMakesProjectDirty" executed="True" result="Success" success="True" time="0.001" asserts="1" />
+                          <test-case name="NUnit.Util.Tests.NUnitProjectTests.CanAddAssemblies" executed="True" result="Success" success="True" time="0.001" asserts="3" />
+                          <test-case name="NUnit.Util.Tests.NUnitProjectTests.CanAddConfigs" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Util.Tests.NUnitProjectTests.CanSetActiveConfig" executed="True" result="Success" success="True" time="0.001" asserts="1" />
+                          <test-case name="NUnit.Util.Tests.NUnitProjectTests.CanSetAppBase" executed="True" result="Success" success="True" time="0.001" asserts="1" />
+                          <test-case name="NUnit.Util.Tests.NUnitProjectTests.ConfigurationFileFromAssemblies" executed="True" result="Success" success="True" time="0.001" asserts="1" />
+                          <test-case name="NUnit.Util.Tests.NUnitProjectTests.ConfigurationFileFromAssembly" executed="True" result="Success" success="True" time="0.001" asserts="1" />
+                          <test-case name="NUnit.Util.Tests.NUnitProjectTests.DefaultActiveConfig" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Util.Tests.NUnitProjectTests.DefaultApplicationBase" executed="True" result="Success" success="True" time="0.003" asserts="1" />
+                          <test-case name="NUnit.Util.Tests.NUnitProjectTests.DefaultConfigurationFile" executed="True" result="Success" success="True" time="0.004" asserts="2" />
+                          <test-case name="NUnit.Util.Tests.NUnitProjectTests.DefaultProjectName" executed="True" result="Success" success="True" time="0.003" asserts="1" />
+                          <test-case name="NUnit.Util.Tests.NUnitProjectTests.IsProjectFile" executed="True" result="Success" success="True" time="0.001" asserts="2" />
+                          <test-case name="NUnit.Util.Tests.NUnitProjectTests.LoadMakesProjectNotDirty" executed="True" result="Success" success="True" time="0.005" asserts="1" />
+                          <test-case name="NUnit.Util.Tests.NUnitProjectTests.NewProjectDefaultPath" executed="True" result="Success" success="True" time="0.000" asserts="3" />
+                          <test-case name="NUnit.Util.Tests.NUnitProjectTests.NewProjectIsEmpty" executed="True" result="Success" success="True" time="0.001" asserts="2" />
+                          <test-case name="NUnit.Util.Tests.NUnitProjectTests.NewProjectIsNotDirty" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Util.Tests.NUnitProjectTests.NewProjectNotLoadable" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Util.Tests.NUnitProjectTests.RemoveActiveConfig" executed="True" result="Success" success="True" time="0.001" asserts="1" />
+                          <test-case name="NUnit.Util.Tests.NUnitProjectTests.RemoveConfigMakesProjectDirty" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Util.Tests.NUnitProjectTests.RenameActiveConfig" executed="True" result="Success" success="True" time="0.001" asserts="1" />
+                          <test-case name="NUnit.Util.Tests.NUnitProjectTests.RenameConfigMakesProjectDirty" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Util.Tests.NUnitProjectTests.SaveAndLoadConfigsWithAssemblies" executed="True" result="Success" success="True" time="0.005" asserts="8" />
+                          <test-case name="NUnit.Util.Tests.NUnitProjectTests.SaveAndLoadEmptyConfigs" executed="True" result="Success" success="True" time="0.006" asserts="4" />
+                          <test-case name="NUnit.Util.Tests.NUnitProjectTests.SaveAndLoadEmptyProject" executed="True" result="Success" success="True" time="0.005" asserts="2" />
+                          <test-case name="NUnit.Util.Tests.NUnitProjectTests.SaveMakesProjectNotDirty" executed="True" result="Success" success="True" time="0.003" asserts="1" />
+                          <test-case name="NUnit.Util.Tests.NUnitProjectTests.SaveSetsProjectPath" executed="True" result="Success" success="True" time="0.004" asserts="2" />
+                          <test-case name="NUnit.Util.Tests.NUnitProjectTests.SettingActiveConfigMakesProjectDirty" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                        </results>
+                      </test-suite>
+                      <test-suite type="TestFixture" name="NUnitRegistryTests" executed="True" result="Success" success="True" time="0.044" asserts="0">
+                        <results>
+                          <test-case name="NUnit.Util.Tests.NUnitRegistryTests.CurrentUser" executed="True" result="Success" success="True" time="0.001" asserts="2" />
+                          <test-case name="NUnit.Util.Tests.NUnitRegistryTests.CurrentUserTestMode" executed="True" result="Success" success="True" time="0.001" asserts="2" />
+                          <test-case name="NUnit.Util.Tests.NUnitRegistryTests.TestClearRoutines" executed="True" result="Success" success="True" time="0.036" asserts="2" />
+                        </results>
+                      </test-suite>
+                      <test-suite type="TestFixture" name="PathUtilTests" executed="True" result="Success" success="True" time="0.001" asserts="0">
+                        <results>
+                          <test-case name="NUnit.Util.Tests.PathUtilTests.CheckDefaults" executed="True" result="Success" success="True" time="0.000" asserts="2" />
+                        </results>
+                      </test-suite>
+                      <test-suite type="TestFixture" name="PathUtilTests_Unix" executed="True" result="Success" success="True" time="0.025" asserts="0">
+                        <results>
+                          <test-case name="NUnit.Util.Tests.PathUtilTests_Unix.Canonicalize" executed="True" result="Success" success="True" time="0.000" asserts="5" />
+                          <test-case name="NUnit.Util.Tests.PathUtilTests_Unix.IsAssemblyFileType" executed="True" result="Success" success="True" time="0.001" asserts="3" />
+                          <test-case name="NUnit.Util.Tests.PathUtilTests_Unix.PathFromUri" executed="True" result="Success" success="True" time="0.001" asserts="2" />
+                          <test-case name="NUnit.Util.Tests.PathUtilTests_Unix.RelativePath" executed="True" result="Success" success="True" time="0.001" asserts="10" />
+                          <test-case name="NUnit.Util.Tests.PathUtilTests_Unix.SamePath" executed="True" result="Success" success="True" time="0.001" asserts="4" />
+                          <test-case name="NUnit.Util.Tests.PathUtilTests_Unix.SamePathOrUnder" executed="True" result="Success" success="True" time="0.001" asserts="7" />
+                        </results>
+                      </test-suite>
+                      <test-suite type="TestFixture" name="PathUtilTests_Windows" executed="True" result="Success" success="True" time="0.022" asserts="0">
+                        <results>
+                          <test-case name="NUnit.Util.Tests.PathUtilTests_Windows.Canonicalize" executed="True" result="Success" success="True" time="0.000" asserts="5" />
+                          <test-case name="NUnit.Util.Tests.PathUtilTests_Windows.IsAssemblyFileType" executed="True" result="Success" success="True" time="0.001" asserts="3" />
+                          <test-case name="NUnit.Util.Tests.PathUtilTests_Windows.PathFromUri" executed="True" result="Success" success="True" time="0.001" asserts="2" />
+                          <test-case name="NUnit.Util.Tests.PathUtilTests_Windows.RelativePath" executed="True" result="Success" success="True" time="0.001" asserts="12" />
+                          <test-case name="NUnit.Util.Tests.PathUtilTests_Windows.SamePath" executed="True" result="Success" success="True" time="0.000" asserts="4" />
+                          <test-case name="NUnit.Util.Tests.PathUtilTests_Windows.SamePathOrUnder" executed="True" result="Success" success="True" time="0.000" asserts="9" />
+                        </results>
+                      </test-suite>
+                      <test-suite type="TestFixture" name="ProcessRunnerTests" executed="True" result="Success" success="True" time="9.057" asserts="1">
+                        <properties>
+                          <property name="Timeout" value="30000" />
+                        </properties>
+                        <results>
+                          <test-case name="NUnit.Util.Tests.ProcessRunnerTests.BasicRunnerTests.CheckRunnerID" executed="True" result="Success" success="True" time="0.004" asserts="1" />
+                          <test-case name="NUnit.Util.Tests.ProcessRunnerTests.BasicRunnerTests.CountTestCases" executed="True" result="Success" success="True" time="1.416" asserts="1" />
+                          <test-case name="NUnit.Util.Tests.ProcessRunnerTests.BasicRunnerTests.CountTestCasesAcrossMultipleAssemblies" executed="True" result="Success" success="True" time="0.516" asserts="1" />
+                          <test-case name="NUnit.Util.Tests.ProcessRunnerTests.BasicRunnerTests.LoadAndReloadAssembly" executed="True" result="Success" success="True" time="0.870" asserts="2" />
+                          <test-case name="NUnit.Util.Tests.ProcessRunnerTests.BasicRunnerTests.LoadAssemblyWithFixture" executed="True" result="Success" success="True" time="0.432" asserts="1" />
+                          <test-case name="NUnit.Util.Tests.ProcessRunnerTests.BasicRunnerTests.LoadAssemblyWithoutNamespaces" executed="True" result="Success" success="True" time="0.464" asserts="4" />
+                          <test-case name="NUnit.Util.Tests.ProcessRunnerTests.BasicRunnerTests.LoadAssemblyWithSuite" executed="True" result="Success" success="True" time="0.425" asserts="1" />
+                          <test-case name="NUnit.Util.Tests.ProcessRunnerTests.BasicRunnerTests.LoadMultipleAssemblies" executed="True" result="Success" success="True" time="0.459" asserts="1" />
+                          <test-case name="NUnit.Util.Tests.ProcessRunnerTests.BasicRunnerTests.LoadMultipleAssembliesWithFixture" executed="True" result="Success" success="True" time="0.465" asserts="1" />
+                          <test-case name="NUnit.Util.Tests.ProcessRunnerTests.BasicRunnerTests.LoadMultipleAssembliesWithSuite" executed="True" result="Success" success="True" time="0.431" asserts="1" />
+                          <test-case name="NUnit.Util.Tests.ProcessRunnerTests.BasicRunnerTests.RunAssembly" executed="True" result="Success" success="True" time="0.582" asserts="1" />
+                          <test-case name="NUnit.Util.Tests.ProcessRunnerTests.BasicRunnerTests.RunAssemblyUsingBeginAndEndRun" executed="True" result="Success" success="True" time="0.577" asserts="2" />
+                          <test-case name="NUnit.Util.Tests.ProcessRunnerTests.BasicRunnerTests.RunMultipleAssemblies" executed="True" result="Success" success="True" time="0.623" asserts="1" />
+                          <test-case name="NUnit.Util.Tests.ProcessRunnerTests.BasicRunnerTests.RunMultipleAssembliesUsingBeginAndEndRun" executed="True" result="Success" success="True" time="0.638" asserts="2" />
+                          <test-case name="NUnit.Util.Tests.ProcessRunnerTests.TestProcessIsReused" executed="True" result="Success" success="True" time="1.024" asserts="2" />
+                        </results>
+                      </test-suite>
+                      <test-suite type="TestFixture" name="ProjectConfigTests" executed="True" result="Success" success="True" time="0.082" asserts="0">
+                        <results>
+                          <test-case name="NUnit.Util.Tests.ProjectConfigTests.AbsoluteBasePath" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Util.Tests.ProjectConfigTests.AbsoluteConfigurationFile" executed="True" result="Success" success="True" time="0.001" asserts="1" />
+                          <test-case name="NUnit.Util.Tests.ProjectConfigTests.AddingConfigMarksProjectDirty" executed="True" result="Success" success="True" time="0.001" asserts="1" />
+                          <test-case name="NUnit.Util.Tests.ProjectConfigTests.AddingInitialConfigRequiresReload" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Util.Tests.ProjectConfigTests.AddingSubsequentConfigDoesNotRequireReload" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Util.Tests.ProjectConfigTests.AddToActiveConfigMarksProjectDirty" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Util.Tests.ProjectConfigTests.AddToActiveConfigRequiresReload" executed="True" result="Success" success="True" time="0.001" asserts="1" />
+                          <test-case name="NUnit.Util.Tests.ProjectConfigTests.AddToInactiveConfigDoesNotRequireReload" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Util.Tests.ProjectConfigTests.AddToInactiveConfigMarksProjectDirty" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Util.Tests.ProjectConfigTests.CanAddAssemblies" executed="True" result="Success" success="True" time="0.001" asserts="3" />
+                          <test-case name="NUnit.Util.Tests.ProjectConfigTests.DefaultConfigurationFile" executed="True" result="Success" success="True" time="0.000" asserts="2" />
+                          <test-case name="NUnit.Util.Tests.ProjectConfigTests.EmptyConfig" executed="True" result="Success" success="True" time="0.000" asserts="2" />
+                          <test-case name="NUnit.Util.Tests.ProjectConfigTests.ManualPrivateBinPath" executed="True" result="Success" success="True" time="0.001" asserts="1" />
+                          <test-case name="NUnit.Util.Tests.ProjectConfigTests.NoBasePathSet" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Util.Tests.ProjectConfigTests.NoPrivateBinPath" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Util.Tests.ProjectConfigTests.RelativeBasePath" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Util.Tests.ProjectConfigTests.RelativeConfigurationFile" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Util.Tests.ProjectConfigTests.RemoveActiveConfigMarksProjectDirty" executed="True" result="Success" success="True" time="0.001" asserts="1" />
+                          <test-case name="NUnit.Util.Tests.ProjectConfigTests.RemoveActiveConfigRequiresReload" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Util.Tests.ProjectConfigTests.RemoveInactiveConfigDoesNotRequireReload" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Util.Tests.ProjectConfigTests.RemoveInactiveConfigMarksProjectDirty" executed="True" result="Success" success="True" time="0.001" asserts="1" />
+                          <test-case name="NUnit.Util.Tests.ProjectConfigTests.RenameActiveConfigMarksProjectDirty" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Util.Tests.ProjectConfigTests.RenameActiveConfigRequiresReload" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Util.Tests.ProjectConfigTests.RenameInactiveConfigDoesNotRequireReload" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Util.Tests.ProjectConfigTests.RenameInctiveConfigMarksProjectDirty" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Util.Tests.ProjectConfigTests.SettingActiveConfigApplicationBaseMarksProjectDirty" executed="True" result="Success" success="True" time="0.001" asserts="1" />
+                          <test-case name="NUnit.Util.Tests.ProjectConfigTests.SettingActiveConfigApplicationBaseRequiresReload" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Util.Tests.ProjectConfigTests.SettingActiveConfigBinPathTypeMarksProjectDirty" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Util.Tests.ProjectConfigTests.SettingActiveConfigBinPathTypeRequiresReload" executed="True" result="Success" success="True" time="0.001" asserts="1" />
+                          <test-case name="NUnit.Util.Tests.ProjectConfigTests.SettingActiveConfigConfigurationFileMarksProjectDirty" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Util.Tests.ProjectConfigTests.SettingActiveConfigConfigurationFileRequiresReload" executed="True" result="Success" success="True" time="0.001" asserts="1" />
+                          <test-case name="NUnit.Util.Tests.ProjectConfigTests.SettingActiveConfigPrivateBinPathMarksProjectDirty" executed="True" result="Success" success="True" time="0.001" asserts="1" />
+                          <test-case name="NUnit.Util.Tests.ProjectConfigTests.SettingActiveConfigPrivateBinPathRequiresReload" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Util.Tests.ProjectConfigTests.SettingInactiveConfigApplicationBaseDoesNotRequireReload" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Util.Tests.ProjectConfigTests.SettingInactiveConfigApplicationBaseMarksProjectDirty" executed="True" result="Success" success="True" time="0.001" asserts="1" />
+                          <test-case name="NUnit.Util.Tests.ProjectConfigTests.SettingInactiveConfigBinPathTypeDoesNotRequireReload" executed="True" result="Success" success="True" time="0.001" asserts="1" />
+                          <test-case name="NUnit.Util.Tests.ProjectConfigTests.SettingInactiveConfigBinPathTypeMarksProjectDirty" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Util.Tests.ProjectConfigTests.SettingInactiveConfigConfigurationFileDoesNotRequireReload" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Util.Tests.ProjectConfigTests.SettingInactiveConfigConfigurationFileMarksProjectDirty" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Util.Tests.ProjectConfigTests.SettingInactiveConfigPrivateBinPathDoesNotRequireReload" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Util.Tests.ProjectConfigTests.SettingInactiveConfigPrivateBinPathMarksProjectDirty" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Util.Tests.ProjectConfigTests.ToArray" executed="True" result="Success" success="True" time="0.000" asserts="2" />
+                        </results>
+                      </test-suite>
+                      <test-suite type="TestFixture" name="RecentFileEntryTests" executed="True" result="Success" success="True" time="0.014" asserts="0">
+                        <results>
+                          <test-case name="NUnit.Util.Tests.RecentFileEntryTests.CanCreateFromFileNameAndVersion" executed="True" result="Success" success="True" time="0.001" asserts="2" />
+                          <test-case name="NUnit.Util.Tests.RecentFileEntryTests.CanCreateFromSimpleFileName" executed="True" result="Success" success="True" time="0.000" asserts="2" />
+                          <test-case name="NUnit.Util.Tests.RecentFileEntryTests.CanParseFileNamePlusVersionString" executed="True" result="Success" success="True" time="0.001" asserts="2" />
+                          <test-case name="NUnit.Util.Tests.RecentFileEntryTests.CanParseFileNameWithCommaPlusVersionString" executed="True" result="Success" success="True" time="0.001" asserts="2" />
+                          <test-case name="NUnit.Util.Tests.RecentFileEntryTests.CanParseSimpleFileName" executed="True" result="Success" success="True" time="0.001" asserts="2" />
+                          <test-case name="NUnit.Util.Tests.RecentFileEntryTests.CanParseSimpleFileNameWithComma" executed="True" result="Success" success="True" time="0.001" asserts="2" />
+                          <test-case name="NUnit.Util.Tests.RecentFileEntryTests.EntryCanDisplayItself" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                        </results>
+                      </test-suite>
+                      <test-suite type="TestFixture" name="RecentFilesTests" executed="True" result="Success" success="True" time="0.047" asserts="0">
+                        <results>
+                          <test-case name="NUnit.Util.Tests.RecentFilesTests.AddMaxItems" executed="True" result="Success" success="True" time="0.003" asserts="7" />
+                          <test-case name="NUnit.Util.Tests.RecentFilesTests.AddSingleItem" executed="True" result="Success" success="True" time="0.001" asserts="3" />
+                          <test-case name="NUnit.Util.Tests.RecentFilesTests.AddTooManyItems" executed="True" result="Success" success="True" time="0.001" asserts="7" />
+                          <test-case name="NUnit.Util.Tests.RecentFilesTests.CountAtMax" executed="True" result="Success" success="True" time="0.001" asserts="1" />
+                          <test-case name="NUnit.Util.Tests.RecentFilesTests.CountAtMin" executed="True" result="Success" success="True" time="0.002" asserts="1" />
+                          <test-case name="NUnit.Util.Tests.RecentFilesTests.CountDefault" executed="True" result="Success" success="True" time="0.001" asserts="1" />
+                          <test-case name="NUnit.Util.Tests.RecentFilesTests.CountOverMax" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Util.Tests.RecentFilesTests.CountUnderMin" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Util.Tests.RecentFilesTests.EmptyList" executed="True" result="Success" success="True" time="0.000" asserts="3" />
+                          <test-case name="NUnit.Util.Tests.RecentFilesTests.IncreaseSize" executed="True" result="Success" success="True" time="0.000" asserts="12" />
+                          <test-case name="NUnit.Util.Tests.RecentFilesTests.IncreaseSizeAfterAdd" executed="True" result="Success" success="True" time="0.001" asserts="8" />
+                          <test-case name="NUnit.Util.Tests.RecentFilesTests.ReduceSize" executed="True" result="Success" success="True" time="0.000" asserts="5" />
+                          <test-case name="NUnit.Util.Tests.RecentFilesTests.ReduceSizeAfterAdd" executed="True" result="Success" success="True" time="0.000" asserts="4" />
+                          <test-case name="NUnit.Util.Tests.RecentFilesTests.RemoveFirstProject" executed="True" result="Success" success="True" time="0.001" asserts="3" />
+                          <test-case name="NUnit.Util.Tests.RecentFilesTests.RemoveLastProject" executed="True" result="Success" success="True" time="0.001" asserts="5" />
+                          <test-case name="NUnit.Util.Tests.RecentFilesTests.RemoveMultipleProjects" executed="True" result="Success" success="True" time="0.001" asserts="3" />
+                          <test-case name="NUnit.Util.Tests.RecentFilesTests.RemoveOneProject" executed="True" result="Success" success="True" time="0.000" asserts="4" />
+                          <test-case name="NUnit.Util.Tests.RecentFilesTests.ReorderLastProject" executed="True" result="Success" success="True" time="0.000" asserts="6" />
+                          <test-case name="NUnit.Util.Tests.RecentFilesTests.ReorderMultipleProjects" executed="True" result="Success" success="True" time="0.000" asserts="6" />
+                          <test-case name="NUnit.Util.Tests.RecentFilesTests.ReorderSameProject" executed="True" result="Success" success="True" time="0.000" asserts="6" />
+                          <test-case name="NUnit.Util.Tests.RecentFilesTests.ReorderSingleProject" executed="True" result="Success" success="True" time="0.000" asserts="6" />
+                          <test-case name="NUnit.Util.Tests.RecentFilesTests.ReorderWithListNotFull" executed="True" result="Success" success="True" time="0.000" asserts="4" />
+                        </results>
+                      </test-suite>
+                      <test-suite type="TestFixture" name="RegistrySettingsStorageTests" executed="True" result="Success" success="True" time="0.017" asserts="0">
+                        <results>
+                          <test-case name="NUnit.Util.Tests.RegistrySettingsStorageTests.MakeSubStorages" executed="True" result="Success" success="True" time="0.002" asserts="4" />
+                          <test-case name="NUnit.Util.Tests.RegistrySettingsStorageTests.RemoveSettings" executed="True" result="Success" success="True" time="0.002" asserts="3" />
+                          <test-case name="NUnit.Util.Tests.RegistrySettingsStorageTests.SaveAndLoadSettings" executed="True" result="Success" success="True" time="0.001" asserts="6" />
+                          <test-case name="NUnit.Util.Tests.RegistrySettingsStorageTests.StorageHasCorrectKey" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Util.Tests.RegistrySettingsStorageTests.SubstorageSettings" executed="True" result="Success" success="True" time="0.001" asserts="5" />
+                          <test-case name="NUnit.Util.Tests.RegistrySettingsStorageTests.TypeSafeSettings" executed="True" result="Success" success="True" time="0.001" asserts="3" />
+                        </results>
+                      </test-suite>
+                      <test-suite type="TestFixture" name="RemoteTestAgentTests" executed="True" result="Success" success="True" time="0.051" asserts="0">
+                        <results>
+                          <test-case name="NUnit.Util.Tests.RemoteTestAgentTests.AgentReturnsProcessId" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Util.Tests.RemoteTestAgentTests.CanLocateAgentExecutable" executed="True" result="Success" success="True" time="0.001" asserts="1" />
+                          <test-case name="NUnit.Util.Tests.RemoteTestAgentTests.CanLocateAgentExeForAllInstalledVersions" executed="True" result="Success" success="True" time="0.040" asserts="5" />
+                          <test-case name="NUnit.Util.Tests.RemoteTestAgentTests.CanLocateBinDirForAllInstalledVersions" executed="True" result="Success" success="True" time="0.002" asserts="5" />
+                        </results>
+                      </test-suite>
+                      <test-suite type="TestFixture" name="RemoteTestResultTest" executed="True" result="Success" success="True" time="0.567" asserts="0">
+                        <results>
+                          <test-case name="NUnit.Util.Tests.RemoteTestResultTest.ResultStillValidAfterDomainUnload" executed="True" result="Success" success="True" time="0.565" asserts="3" />
+                        </results>
+                      </test-suite>
+                      <test-suite type="TestFixture" name="RuntimeFrameworkSelectorTests" executed="True" result="Success" success="True" time="0.052" asserts="0">
+                        <results>
+                          <test-suite type="Theory" name="RequestForSpecificFrameworkIsHonored" executed="True" result="Success" success="True" time="0.028" asserts="0">
+                            <results>
+                              <test-case name="NUnit.Util.Tests.RuntimeFrameworkSelectorTests.RequestForSpecificFrameworkIsHonored(net-1.0)" executed="True" result="Success" success="True" time="0.003" asserts="2" />
+                              <test-case name="NUnit.Util.Tests.RuntimeFrameworkSelectorTests.RequestForSpecificFrameworkIsHonored(net-1.1)" executed="True" result="Success" success="True" time="0.000" asserts="2" />
+                              <test-case name="NUnit.Util.Tests.RuntimeFrameworkSelectorTests.RequestForSpecificFrameworkIsHonored(net-2.0)" executed="True" result="Success" success="True" time="0.000" asserts="2" />
+                              <test-case name="NUnit.Util.Tests.RuntimeFrameworkSelectorTests.RequestForSpecificFrameworkIsHonored(net-4.0)" executed="True" result="Success" success="True" time="0.000" asserts="2" />
+                              <test-case name="NUnit.Util.Tests.RuntimeFrameworkSelectorTests.RequestForSpecificFrameworkIsHonored(mono-1.0)" executed="True" result="Success" success="True" time="0.001" asserts="2" />
+                              <test-case name="NUnit.Util.Tests.RuntimeFrameworkSelectorTests.RequestForSpecificFrameworkIsHonored(mono-2.0)" executed="True" result="Success" success="True" time="0.000" asserts="2" />
+                              <test-case name="NUnit.Util.Tests.RuntimeFrameworkSelectorTests.RequestForSpecificFrameworkIsHonored(v1.1)" executed="True" result="Inconclusive" success="False" time="0.009" asserts="0">
+                                <reason>
+                                  <message><![CDATA[  Expected: not Any
+  But was:  Any
+]]></message>
+                                </reason>
+                              </test-case>
+                              <test-case name="NUnit.Util.Tests.RuntimeFrameworkSelectorTests.RequestForSpecificFrameworkIsHonored(v2.0)" executed="True" result="Inconclusive" success="False" time="0.001" asserts="0">
+                                <reason>
+                                  <message><![CDATA[  Expected: not Any
+  But was:  Any
+]]></message>
+                                </reason>
+                              </test-case>
+                              <test-case name="NUnit.Util.Tests.RuntimeFrameworkSelectorTests.RequestForSpecificFrameworkIsHonored(v4.0)" executed="True" result="Inconclusive" success="False" time="0.001" asserts="0">
+                                <reason>
+                                  <message><![CDATA[  Expected: not Any
+  But was:  Any
+]]></message>
+                                </reason>
+                              </test-case>
+                            </results>
+                          </test-suite>
+                          <test-suite type="Theory" name="RequestForSpecificVersionIsHonored" executed="True" result="Success" success="True" time="0.021" asserts="0">
+                            <results>
+                              <test-case name="NUnit.Util.Tests.RuntimeFrameworkSelectorTests.RequestForSpecificVersionIsHonored(net-1.0)" executed="True" result="Inconclusive" success="False" time="0.002" asserts="0">
+                                <reason>
+                                  <message><![CDATA[  Expected: Any
+  But was:  Net
+]]></message>
+                                </reason>
+                              </test-case>
+                              <test-case name="NUnit.Util.Tests.RuntimeFrameworkSelectorTests.RequestForSpecificVersionIsHonored(net-1.1)" executed="True" result="Inconclusive" success="False" time="0.001" asserts="0">
+                                <reason>
+                                  <message><![CDATA[  Expected: Any
+  But was:  Net
+]]></message>
+                                </reason>
+                              </test-case>
+                              <test-case name="NUnit.Util.Tests.RuntimeFrameworkSelectorTests.RequestForSpecificVersionIsHonored(net-2.0)" executed="True" result="Inconclusive" success="False" time="0.000" asserts="0">
+                                <reason>
+                                  <message><![CDATA[  Expected: Any
+  But was:  Net
+]]></message>
+                                </reason>
+                              </test-case>
+                              <test-case name="NUnit.Util.Tests.RuntimeFrameworkSelectorTests.RequestForSpecificVersionIsHonored(net-4.0)" executed="True" result="Inconclusive" success="False" time="0.001" asserts="0">
+                                <reason>
+                                  <message><![CDATA[  Expected: Any
+  But was:  Net
+]]></message>
+                                </reason>
+                              </test-case>
+                              <test-case name="NUnit.Util.Tests.RuntimeFrameworkSelectorTests.RequestForSpecificVersionIsHonored(mono-1.0)" executed="True" result="Inconclusive" success="False" time="0.001" asserts="0">
+                                <reason>
+                                  <message><![CDATA[  Expected: Any
+  But was:  Mono
+]]></message>
+                                </reason>
+                              </test-case>
+                              <test-case name="NUnit.Util.Tests.RuntimeFrameworkSelectorTests.RequestForSpecificVersionIsHonored(mono-2.0)" executed="True" result="Inconclusive" success="False" time="0.000" asserts="0">
+                                <reason>
+                                  <message><![CDATA[  Expected: Any
+  But was:  Mono
+]]></message>
+                                </reason>
+                              </test-case>
+                              <test-case name="NUnit.Util.Tests.RuntimeFrameworkSelectorTests.RequestForSpecificVersionIsHonored(v1.1)" executed="True" result="Success" success="True" time="0.000" asserts="2" />
+                              <test-case name="NUnit.Util.Tests.RuntimeFrameworkSelectorTests.RequestForSpecificVersionIsHonored(v2.0)" executed="True" result="Success" success="True" time="0.000" asserts="2" />
+                              <test-case name="NUnit.Util.Tests.RuntimeFrameworkSelectorTests.RequestForSpecificVersionIsHonored(v4.0)" executed="True" result="Success" success="True" time="0.000" asserts="2" />
+                            </results>
+                          </test-suite>
+                        </results>
+                      </test-suite>
+                      <test-suite type="TestFixture" name="ServerUtilityTests" executed="True" result="Success" success="True" time="0.033" asserts="0">
+                        <results>
+                          <test-case name="NUnit.Util.Tests.ServerUtilityTests.CanGetTcpChannelOnSpecifiedPort" executed="True" result="Success" success="True" time="0.029" asserts="5" />
+                          <test-case name="NUnit.Util.Tests.ServerUtilityTests.CanGetTcpChannelOnUnpecifiedPort" executed="True" result="Success" success="True" time="0.001" asserts="4" />
+                        </results>
+                      </test-suite>
+                      <test-suite type="TestFixture" name="SettingsGroupTests" executed="True" result="Success" success="True" time="0.019" asserts="0">
+                        <results>
+                          <test-case name="NUnit.Util.Tests.SettingsGroupTests.BadSetting" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Util.Tests.SettingsGroupTests.DefaultSettings" executed="True" result="Success" success="True" time="0.001" asserts="7" />
+                          <test-case name="NUnit.Util.Tests.SettingsGroupTests.SubGroupSettings" executed="True" result="Success" success="True" time="0.001" asserts="7" />
+                          <test-case name="NUnit.Util.Tests.SettingsGroupTests.TopLevelSettings" executed="True" result="Success" success="True" time="0.001" asserts="5" />
+                          <test-case name="NUnit.Util.Tests.SettingsGroupTests.TypeSafeSettings" executed="True" result="Success" success="True" time="0.000" asserts="3" />
+                        </results>
+                      </test-suite>
+                      <test-suite type="TestFixture" name="SummaryResultFixture" executed="True" result="Success" success="True" time="0.021" asserts="0">
+                        <results>
+                          <test-case name="NUnit.Util.Tests.SummaryResultFixture.SummaryMatchesResult" executed="True" result="Success" success="True" time="0.019" asserts="9" />
+                        </results>
+                      </test-suite>
+                      <test-suite type="TestFixture" name="TestAgencyTests" executed="True" result="Success" success="True" time="0.735" asserts="0">
+                        <results>
+                          <test-case name="NUnit.Util.Tests.TestAgencyTests.CanConnectToAgency" executed="True" result="Success" success="True" time="0.002" asserts="2" />
+                          <test-case name="NUnit.Util.Tests.TestAgencyTests.CanLaunchAndConnectToAgent" executed="True" result="Success" success="True" time="0.725" asserts="1" />
+                        </results>
+                      </test-suite>
+                      <test-suite type="TestFixture" name="TestDomainFixture" executed="True" result="Success" success="True" time="0.564" asserts="0">
+                        <results>
+                          <test-case name="NUnit.Util.Tests.TestDomainFixture.AppDomainIsSetUpCorrectly" executed="True" result="Success" success="True" time="0.003" asserts="8" />
+                          <test-case name="NUnit.Util.Tests.TestDomainFixture.AssemblyIsLoadedCorrectly" executed="True" result="Success" success="True" time="0.001" asserts="2" />
+                          <test-case name="NUnit.Util.Tests.TestDomainFixture.CanRunMockAssemblyTests" executed="True" result="Success" success="True" time="0.132" asserts="5" />
+                        </results>
+                      </test-suite>
+                      <test-suite type="TestFixture" name="TestDomainRunnerTests" executed="True" result="Success" success="True" time="6.599" asserts="1">
+                        <results>
+                          <test-case name="NUnit.Util.Tests.TestDomainRunnerTests.BasicRunnerTests.CheckRunnerID" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Util.Tests.TestDomainRunnerTests.BasicRunnerTests.CountTestCases" executed="True" result="Success" success="True" time="0.409" asserts="1" />
+                          <test-case name="NUnit.Util.Tests.TestDomainRunnerTests.BasicRunnerTests.CountTestCasesAcrossMultipleAssemblies" executed="True" result="Success" success="True" time="0.461" asserts="1" />
+                          <test-case name="NUnit.Util.Tests.TestDomainRunnerTests.BasicRunnerTests.LoadAndReloadAssembly" executed="True" result="Success" success="True" time="0.852" asserts="2" />
+                          <test-case name="NUnit.Util.Tests.TestDomainRunnerTests.BasicRunnerTests.LoadAssemblyWithFixture" executed="True" result="Success" success="True" time="0.388" asserts="1" />
+                          <test-case name="NUnit.Util.Tests.TestDomainRunnerTests.BasicRunnerTests.LoadAssemblyWithoutNamespaces" executed="True" result="Success" success="True" time="0.422" asserts="4" />
+                          <test-case name="NUnit.Util.Tests.TestDomainRunnerTests.BasicRunnerTests.LoadAssemblyWithSuite" executed="True" result="Success" success="True" time="0.387" asserts="1" />
+                          <test-case name="NUnit.Util.Tests.TestDomainRunnerTests.BasicRunnerTests.LoadMultipleAssemblies" executed="True" result="Success" success="True" time="0.471" asserts="1" />
+                          <test-case name="NUnit.Util.Tests.TestDomainRunnerTests.BasicRunnerTests.LoadMultipleAssembliesWithFixture" executed="True" result="Success" success="True" time="0.451" asserts="1" />
+                          <test-case name="NUnit.Util.Tests.TestDomainRunnerTests.BasicRunnerTests.LoadMultipleAssembliesWithSuite" executed="True" result="Success" success="True" time="0.416" asserts="1" />
+                          <test-case name="NUnit.Util.Tests.TestDomainRunnerTests.BasicRunnerTests.RunAssembly" executed="True" result="Success" success="True" time="0.563" asserts="1" />
+                          <test-case name="NUnit.Util.Tests.TestDomainRunnerTests.BasicRunnerTests.RunAssemblyUsingBeginAndEndRun" executed="True" result="Success" success="True" time="0.544" asserts="2" />
+                          <test-case name="NUnit.Util.Tests.TestDomainRunnerTests.BasicRunnerTests.RunMultipleAssemblies" executed="True" result="Success" success="True" time="0.601" asserts="1" />
+                          <test-case name="NUnit.Util.Tests.TestDomainRunnerTests.BasicRunnerTests.RunMultipleAssembliesUsingBeginAndEndRun" executed="True" result="Success" success="True" time="0.581" asserts="2" />
+                        </results>
+                      </test-suite>
+                      <test-suite type="TestFixture" name="TestDomainTests" executed="True" result="Success" success="True" time="3.365" asserts="0">
+                        <results>
+                          <test-case name="NUnit.Util.Tests.TestDomainTests.BasePathOverrideIsHonored" executed="True" result="Success" success="True" time="0.783" asserts="1" />
+                          <test-case name="NUnit.Util.Tests.TestDomainTests.BinPathOverrideIsHonored" executed="True" result="Success" success="True" time="0.421" asserts="1" />
+                          <test-case name="NUnit.Util.Tests.TestDomainTests.ConfigFileOverrideIsHonored" executed="True" result="Success" success="True" time="0.430" asserts="1" />
+                          <test-case name="NUnit.Util.Tests.TestDomainTests.FileNotFound" executed="True" result="Success" success="True" time="0.512" asserts="0" />
+                          <test-case name="NUnit.Util.Tests.TestDomainTests.InvalidTestFixture" executed="True" result="Success" success="True" time="0.348" asserts="1" />
+                          <test-case name="NUnit.Util.Tests.TestDomainTests.SpecificTestFixture" executed="True" result="Success" success="True" time="0.506" asserts="4" />
+                          <test-case name="NUnit.Util.Tests.TestDomainTests.TurnOffShadowCopy" executed="True" result="Success" success="True" time="0.351" asserts="1" />
+                        </results>
+                      </test-suite>
+                      <test-suite type="TestFixture" name="TestDomainTests_Multiple" executed="True" result="Success" success="True" time="0.592" asserts="0">
+                        <results>
+                          <test-case name="NUnit.Util.Tests.TestDomainTests_Multiple.AssemblyNodes" executed="True" result="Success" success="True" time="0.001" asserts="2" />
+                          <test-case name="NUnit.Util.Tests.TestDomainTests_Multiple.BuildSuite" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Util.Tests.TestDomainTests_Multiple.RootNode" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Util.Tests.TestDomainTests_Multiple.RunMultipleAssemblies" executed="True" result="Success" success="True" time="0.134" asserts="1" />
+                          <test-case name="NUnit.Util.Tests.TestDomainTests_Multiple.TestCaseCount" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                        </results>
+                      </test-suite>
+                      <test-suite type="TestFixture" name="TestDomainTests_MultipleFixture" executed="True" result="Success" success="True" time="0.428" asserts="0">
+                        <results>
+                          <test-case name="NUnit.Util.Tests.TestDomainTests_MultipleFixture.LoadFixture" executed="True" result="Success" success="True" time="0.427" asserts="1" />
+                        </results>
+                      </test-suite>
+                      <test-suite type="TestFixture" name="TestLoaderAssemblyTests" executed="True" result="Success" success="True" time="2.540" asserts="0">
+                        <results>
+                          <test-case name="NUnit.Util.Tests.TestLoaderAssemblyTests.AssemblyWithNoTests" executed="True" result="Success" success="True" time="0.524" asserts="4" />
+                          <test-case name="NUnit.Util.Tests.TestLoaderAssemblyTests.FileNotFound" executed="True" result="Success" success="True" time="0.002" asserts="5" />
+                          <test-case name="NUnit.Util.Tests.TestLoaderAssemblyTests.LoadProject" executed="True" result="Success" success="True" time="0.001" asserts="5" />
+                          <test-case name="NUnit.Util.Tests.TestLoaderAssemblyTests.LoadTest" executed="True" result="Success" success="True" time="0.545" asserts="6" />
+                          <test-case name="NUnit.Util.Tests.TestLoaderAssemblyTests.RunTest" executed="True" result="Success" success="True" time="1.024" asserts="9" />
+                          <test-case name="NUnit.Util.Tests.TestLoaderAssemblyTests.UnloadProject" executed="True" result="Success" success="True" time="0.001" asserts="5" />
+                          <test-case name="NUnit.Util.Tests.TestLoaderAssemblyTests.UnloadTest" executed="True" result="Success" success="True" time="0.428" asserts="3" />
+                        </results>
+                      </test-suite>
+                      <test-suite type="TestFixture" name="TestLoaderWatcherTests" executed="True" result="Success" success="True" time="2.911" asserts="0">
+                        <results>
+                          <test-case name="NUnit.Util.Tests.TestLoaderWatcherTests.LoadShouldStartWatcher" executed="True" result="Success" success="True" time="0.412" asserts="3" />
+                          <test-case name="NUnit.Util.Tests.TestLoaderWatcherTests.LoadShouldStartWatcherDependingOnSettings" executed="True" result="Success" success="True" time="0.406" asserts="2" />
+                          <test-case name="NUnit.Util.Tests.TestLoaderWatcherTests.ReloadShouldStartWatcher" executed="True" result="Success" success="True" time="0.825" asserts="3" />
+                          <test-case name="NUnit.Util.Tests.TestLoaderWatcherTests.ReloadShouldStartWatcherDependingOnSettings" executed="True" result="Success" success="True" time="0.836" asserts="2" />
+                          <test-case name="NUnit.Util.Tests.TestLoaderWatcherTests.UnloadShouldStopWatcherAndFreeResources" executed="True" result="Success" success="True" time="0.422" asserts="3" />
+                        </results>
+                      </test-suite>
+                      <test-suite type="TestFixture" name="TestRunnerFactoryTests" executed="True" result="Success" success="True" time="0.006" asserts="0">
+                        <results>
+                          <test-case name="NUnit.Util.Tests.TestRunnerFactoryTests.DifferentRuntimeUsesProcessRunner" executed="True" result="Success" success="True" time="0.001" asserts="1" />
+                          <test-case name="NUnit.Util.Tests.TestRunnerFactoryTests.DifferentVersionUsesProcessRunner" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Util.Tests.TestRunnerFactoryTests.SameFrameworkUsesTestDomain" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                        </results>
+                      </test-suite>
+                      <test-suite type="TestFixture" name="VisualStudioConverterTests" executed="True" result="Success" success="True" time="0.190" asserts="0">
+                        <results>
+                          <test-case name="NUnit.Util.Tests.VisualStudioConverterTests.FromCppProject" executed="True" result="Success" success="True" time="0.058" asserts="5" />
+                          <test-case name="NUnit.Util.Tests.VisualStudioConverterTests.FromCSharpProject" executed="True" result="Success" success="True" time="0.005" asserts="5" />
+                          <test-case name="NUnit.Util.Tests.VisualStudioConverterTests.FromJsharpProject" executed="True" result="Success" success="True" time="0.004" asserts="5" />
+                          <test-case name="NUnit.Util.Tests.VisualStudioConverterTests.FromMakefileProject" executed="True" result="Success" success="True" time="0.005" asserts="3" />
+                          <test-case name="NUnit.Util.Tests.VisualStudioConverterTests.FromProjectWithHebrewFileIncluded" executed="True" result="Success" success="True" time="0.012" asserts="5" />
+                          <test-case name="NUnit.Util.Tests.VisualStudioConverterTests.FromVBProject" executed="True" result="Success" success="True" time="0.004" asserts="5" />
+                          <test-case name="NUnit.Util.Tests.VisualStudioConverterTests.FromVSSolution2003" executed="True" result="Success" success="True" time="0.026" asserts="7" />
+                          <test-case name="NUnit.Util.Tests.VisualStudioConverterTests.FromVSSolution2005" executed="True" result="Success" success="True" time="0.030" asserts="7" />
+                          <test-case name="NUnit.Util.Tests.VisualStudioConverterTests.FromWebApplication" executed="True" result="Success" success="True" time="0.009" asserts="3" />
+                          <test-case name="NUnit.Util.Tests.VisualStudioConverterTests.WithUnmanagedCpp" executed="True" result="Success" success="True" time="0.014" asserts="5" />
+                        </results>
+                      </test-suite>
+                      <test-suite type="TestFixture" name="VSProjectTests" executed="True" result="Success" success="True" time="0.132" asserts="0">
+                        <results>
+                          <test-case name="NUnit.Util.Tests.VSProjectTests.FileNotFoundError" executed="True" result="Success" success="True" time="0.002" asserts="0" />
+                          <test-case name="NUnit.Util.Tests.VSProjectTests.GenerateCorrectExtensionsFromVCProjectVS2005" executed="True" result="Success" success="True" time="0.005" asserts="4" />
+                          <test-case name="NUnit.Util.Tests.VSProjectTests.InvalidProjectFormat" executed="True" result="Success" success="True" time="0.005" asserts="0" />
+                          <test-case name="NUnit.Util.Tests.VSProjectTests.InvalidXmlFormat" executed="True" result="Success" success="True" time="0.025" asserts="0" />
+                          <test-case name="NUnit.Util.Tests.VSProjectTests.LoadCppProject" executed="True" result="Success" success="True" time="0.004" asserts="3" />
+                          <test-case name="NUnit.Util.Tests.VSProjectTests.LoadCppProjectVS2005" executed="True" result="Success" success="True" time="0.004" asserts="3" />
+                          <test-case name="NUnit.Util.Tests.VSProjectTests.LoadCppProjectWithMacros" executed="True" result="Success" success="True" time="0.005" asserts="4" />
+                          <test-case name="NUnit.Util.Tests.VSProjectTests.LoadCsharpProject" executed="True" result="Success" success="True" time="0.004" asserts="3" />
+                          <test-case name="NUnit.Util.Tests.VSProjectTests.LoadCsharpProjectVS2005" executed="True" result="Success" success="True" time="0.004" asserts="3" />
+                          <test-case name="NUnit.Util.Tests.VSProjectTests.LoadInvalidFileType" executed="True" result="Success" success="True" time="0.001" asserts="0" />
+                          <test-case name="NUnit.Util.Tests.VSProjectTests.LoadJsharpProject" executed="True" result="Success" success="True" time="0.004" asserts="3" />
+                          <test-case name="NUnit.Util.Tests.VSProjectTests.LoadJsharpProjectVS2005" executed="True" result="Success" success="True" time="0.003" asserts="3" />
+                          <test-case name="NUnit.Util.Tests.VSProjectTests.LoadProjectWithHebrewFileIncluded" executed="True" result="Success" success="True" time="0.003" asserts="3" />
+                          <test-case name="NUnit.Util.Tests.VSProjectTests.LoadVbProject" executed="True" result="Success" success="True" time="0.003" asserts="3" />
+                          <test-case name="NUnit.Util.Tests.VSProjectTests.LoadVbProjectVS2005" executed="True" result="Success" success="True" time="0.004" asserts="3" />
+                          <test-case name="NUnit.Util.Tests.VSProjectTests.MissingAttributes" executed="True" result="Success" success="True" time="0.005" asserts="0" />
+                          <test-case name="NUnit.Util.Tests.VSProjectTests.NoConfigurations" executed="True" result="Success" success="True" time="0.005" asserts="1" />
+                          <test-case name="NUnit.Util.Tests.VSProjectTests.NotWebProject" executed="True" result="Success" success="True" time="0.000" asserts="2" />
+                          <test-case name="NUnit.Util.Tests.VSProjectTests.ProjectExtensions" executed="True" result="Success" success="True" time="0.001" asserts="4" />
+                          <test-case name="NUnit.Util.Tests.VSProjectTests.SolutionExtension" executed="True" result="Success" success="True" time="0.000" asserts="2" />
+                        </results>
+                      </test-suite>
+                      <test-suite type="TestFixture" name="XmlResultWriterTest" executed="True" result="Success" success="True" time="0.066" asserts="0">
+                        <results>
+                          <test-case name="NUnit.Util.Tests.XmlResultWriterTest.FailingTestHasCorrectInformation" executed="True" result="Success" success="True" time="0.003" asserts="7" />
+                          <test-case name="NUnit.Util.Tests.XmlResultWriterTest.HasMultipleCategories" executed="True" result="Success" success="True" time="0.001" asserts="2" />
+                          <test-case name="NUnit.Util.Tests.XmlResultWriterTest.HasMultipleProperties" executed="True" result="Success" success="True" time="0.002" asserts="2" />
+                          <test-case name="NUnit.Util.Tests.XmlResultWriterTest.HasSingleCategory" executed="True" result="Success" success="True" time="0.001" asserts="3" />
+                          <test-case name="NUnit.Util.Tests.XmlResultWriterTest.HasSingleProperty" executed="True" result="Success" success="True" time="0.001" asserts="3" />
+                          <test-case name="NUnit.Util.Tests.XmlResultWriterTest.IgnoredTestHasCorrectInformation" executed="True" result="Success" success="True" time="0.001" asserts="5" />
+                          <test-case name="NUnit.Util.Tests.XmlResultWriterTest.InconclusiveTestHasCorrectInformation" executed="True" result="Success" success="True" time="0.001" asserts="6" />
+                          <test-case name="NUnit.Util.Tests.XmlResultWriterTest.PassingTestHasCorrectInformation" executed="True" result="Success" success="True" time="0.001" asserts="6" />
+                          <test-case name="NUnit.Util.Tests.XmlResultWriterTest.SuiteResultHasCategories" executed="True" result="Success" success="True" time="0.002" asserts="3" />
+                          <test-case name="NUnit.Util.Tests.XmlResultWriterTest.TestHasCultureInfo" executed="True" result="Success" success="True" time="0.000" asserts="5" />
+                          <test-case name="NUnit.Util.Tests.XmlResultWriterTest.TestHasEnvironmentInfo" executed="True" result="Success" success="True" time="0.000" asserts="9" />
+                        </results>
+                      </test-suite>
+                    </results>
+                  </test-suite>
+                </results>
+              </test-suite>
+            </results>
+          </test-suite>
+        </results>
+      </test-suite>
+      <test-suite type="Assembly" name="C:\Program Files\NUnit 2.5.10\bin\net-2.0\tests/nunit.mocks.tests.dll" executed="True" result="Success" success="True" time="0.176" asserts="0">
+        <results>
+          <test-suite type="Namespace" name="NUnit" executed="True" result="Success" success="True" time="0.172" asserts="0">
+            <results>
+              <test-suite type="Namespace" name="Mocks" executed="True" result="Success" success="True" time="0.172" asserts="0">
+                <results>
+                  <test-suite type="Namespace" name="Tests" executed="True" result="Success" success="True" time="0.172" asserts="0">
+                    <results>
+                      <test-suite type="TestFixture" name="DynamicMockTests" executed="True" result="Success" success="True" time="0.089" asserts="0">
+                        <results>
+                          <test-case name="NUnit.Mocks.Tests.DynamicMockTests.CallMethod" executed="True" result="Success" success="True" time="0.009" asserts="0" />
+                          <test-case name="NUnit.Mocks.Tests.DynamicMockTests.CallMethodWithArgs" executed="True" result="Success" success="True" time="0.000" asserts="0" />
+                          <test-case name="NUnit.Mocks.Tests.DynamicMockTests.CreateMockForMBRClass" executed="True" result="Success" success="True" time="0.010" asserts="13" />
+                          <test-case name="NUnit.Mocks.Tests.DynamicMockTests.CreateMockForNonMBRClassFails" executed="True" result="Success" success="True" time="0.021" asserts="0" />
+                          <test-case name="NUnit.Mocks.Tests.DynamicMockTests.DefaultReturnValues" executed="True" result="Success" success="True" time="0.005" asserts="5" />
+                          <test-case name="NUnit.Mocks.Tests.DynamicMockTests.ExpectedMethod" executed="True" result="Success" success="True" time="0.001" asserts="2" />
+                          <test-case name="NUnit.Mocks.Tests.DynamicMockTests.ExpectedMethodNotCalled" executed="True" result="Success" success="True" time="0.003" asserts="1" />
+                          <test-case name="NUnit.Mocks.Tests.DynamicMockTests.MethodWithReturnValue" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Mocks.Tests.DynamicMockTests.MockHasDefaultName" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Mocks.Tests.DynamicMockTests.MockHasNonDefaultName" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Mocks.Tests.DynamicMockTests.OverrideMethodOnDynamicMock" executed="True" result="Success" success="True" time="0.001" asserts="1" />
+                          <test-case name="NUnit.Mocks.Tests.DynamicMockTests.RefParameter" executed="True" result="Success" success="True" time="0.002" asserts="2" />
+                          <test-case name="NUnit.Mocks.Tests.DynamicMockTests.WrongReturnType" executed="True" result="Success" success="True" time="0.002" asserts="0" />
+                        </results>
+                      </test-suite>
+                      <test-suite type="TestFixture" name="MockTests" executed="True" result="Success" success="True" time="0.078" asserts="0">
+                        <results>
+                          <test-case name="NUnit.Mocks.Tests.MockTests.CallMultipleMethodsInDifferentOrder" executed="True" result="Success" success="True" time="0.000" asserts="6" />
+                          <test-case name="NUnit.Mocks.Tests.MockTests.CallMultipleMethodsSomeWithoutExpectations" executed="True" result="Success" success="True" time="0.000" asserts="5" />
+                          <test-case name="NUnit.Mocks.Tests.MockTests.ChangeExpectAndReturnToFixedReturn" executed="True" result="Success" success="True" time="0.000" asserts="8" />
+                          <test-case name="NUnit.Mocks.Tests.MockTests.ChangeFixedReturnToExpectAndReturn" executed="True" result="Success" success="True" time="0.001" asserts="9" />
+                          <test-case name="NUnit.Mocks.Tests.MockTests.ConstraintArgumentSucceeds" executed="True" result="Success" success="True" time="0.003" asserts="3" />
+                          <test-case name="NUnit.Mocks.Tests.MockTests.ConstraintArgumentThatFails" executed="True" result="Success" success="True" time="0.001" asserts="3" />
+                          <test-case name="NUnit.Mocks.Tests.MockTests.ExpectAndReturn" executed="True" result="Success" success="True" time="0.000" asserts="4" />
+                          <test-case name="NUnit.Mocks.Tests.MockTests.ExpectAndReturnNull" executed="True" result="Success" success="True" time="0.000" asserts="4" />
+                          <test-case name="NUnit.Mocks.Tests.MockTests.ExpectAndReturnWithArgument" executed="True" result="Success" success="True" time="0.000" asserts="5" />
+                          <test-case name="NUnit.Mocks.Tests.MockTests.ExpectAndReturnWithWrongArgument" executed="True" result="Success" success="True" time="0.004" asserts="3" />
+                          <test-case name="NUnit.Mocks.Tests.MockTests.ExpectAndThrowException" executed="True" result="Success" success="True" time="0.001" asserts="2" />
+                          <test-case name="NUnit.Mocks.Tests.MockTests.ExpectNoCallFails" executed="True" result="Success" success="True" time="0.001" asserts="0" />
+                          <test-case name="NUnit.Mocks.Tests.MockTests.ExpectNoCallSucceeds" executed="True" result="Success" success="True" time="0.001" asserts="0" />
+                          <test-case name="NUnit.Mocks.Tests.MockTests.FailWithParametersSpecified" executed="True" result="Success" success="True" time="0.001" asserts="2" />
+                          <test-case name="NUnit.Mocks.Tests.MockTests.IgnoreArguments" executed="True" result="Success" success="True" time="0.000" asserts="2" />
+                          <test-case name="NUnit.Mocks.Tests.MockTests.MethodNotCalled" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Mocks.Tests.MockTests.MockHasName" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Mocks.Tests.MockTests.MultipleCallsToSameMethod" executed="True" result="Success" success="True" time="0.000" asserts="4" />
+                          <test-case name="NUnit.Mocks.Tests.MockTests.MultipleExpectAndReturn" executed="True" result="Success" success="True" time="0.001" asserts="10" />
+                          <test-case name="NUnit.Mocks.Tests.MockTests.MultipleExpectations" executed="True" result="Success" success="True" time="0.001" asserts="12" />
+                          <test-case name="NUnit.Mocks.Tests.MockTests.NotEnoughCalls" executed="True" result="Success" success="True" time="0.001" asserts="3" />
+                          <test-case name="NUnit.Mocks.Tests.MockTests.OneExpectation" executed="True" result="Success" success="True" time="0.000" asserts="2" />
+                          <test-case name="NUnit.Mocks.Tests.MockTests.RequireArguments" executed="True" result="Success" success="True" time="0.001" asserts="2" />
+                          <test-case name="NUnit.Mocks.Tests.MockTests.SetReturnValue" executed="True" result="Success" success="True" time="0.001" asserts="1" />
+                          <test-case name="NUnit.Mocks.Tests.MockTests.SetReturnValueMultipleTimesOnMultipleMethods" executed="True" result="Success" success="True" time="0.001" asserts="7" />
+                          <test-case name="NUnit.Mocks.Tests.MockTests.SetReturnValueRepeatedCalls" executed="True" result="Success" success="True" time="0.000" asserts="3" />
+                          <test-case name="NUnit.Mocks.Tests.MockTests.SetReturnValueWithoutCalling" executed="True" result="Success" success="True" time="0.000" asserts="0" />
+                          <test-case name="NUnit.Mocks.Tests.MockTests.StrictDefaultsToFalse" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Mocks.Tests.MockTests.StrictMode" executed="True" result="Success" success="True" time="0.001" asserts="2" />
+                          <test-case name="NUnit.Mocks.Tests.MockTests.StrictMode_ExceptionsCaught" executed="True" result="Success" success="True" time="0.001" asserts="4" />
+                          <test-case name="NUnit.Mocks.Tests.MockTests.TooManyCalls" executed="True" result="Success" success="True" time="0.000" asserts="3" />
+                          <test-case name="NUnit.Mocks.Tests.MockTests.UnexpectedCallsIgnored" executed="True" result="Success" success="True" time="0.000" asserts="0" />
+                          <test-case name="NUnit.Mocks.Tests.MockTests.VerifyNewMock" executed="True" result="Success" success="True" time="0.000" asserts="0" />
+                        </results>
+                      </test-suite>
+                    </results>
+                  </test-suite>
+                </results>
+              </test-suite>
+            </results>
+          </test-suite>
+        </results>
+      </test-suite>
+      <test-suite type="Assembly" name="C:\Program Files\NUnit 2.5.10\bin\net-2.0\tests/nunit-console.tests.dll" executed="True" result="Success" success="True" time="8.932" asserts="0">
+        <results>
+          <test-suite type="Namespace" name="NUnit" executed="True" result="Success" success="True" time="8.928" asserts="0">
+            <results>
+              <test-suite type="Namespace" name="ConsoleRunner" executed="True" result="Success" success="True" time="8.928" asserts="0">
+                <results>
+                  <test-suite type="Namespace" name="Tests" executed="True" result="Success" success="True" time="8.927" asserts="0">
+                    <results>
+                      <test-suite type="TestFixture" name="CommandLineTests" executed="True" result="Success" success="True" time="0.147" asserts="0">
+                        <results>
+                          <test-case name="NUnit.ConsoleRunner.Tests.CommandLineTests.AllowForwardSlashDefaultsCorrectly" executed="True" result="Success" success="True" time="0.072" asserts="1" />
+                          <test-case name="NUnit.ConsoleRunner.Tests.CommandLineTests.AssemblyAloneIsValid" executed="True" result="Success" success="True" time="0.002" asserts="1" />
+                          <test-case name="NUnit.ConsoleRunner.Tests.CommandLineTests.AssemblyName" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.ConsoleRunner.Tests.CommandLineTests.FileNameWithoutXmlParameterLooksLikeParameter" executed="True" result="Success" success="True" time="0.002" asserts="2" />
+                          <test-case name="NUnit.ConsoleRunner.Tests.CommandLineTests.FixtureNamePlusAssemblyIsValid" executed="True" result="Success" success="True" time="0.004" asserts="3" />
+                          <test-case name="NUnit.ConsoleRunner.Tests.CommandLineTests.HelpTextUsesCorrectDelimiterForPlatform" executed="True" result="Success" success="True" time="0.003" asserts="2" />
+                          <test-case name="NUnit.ConsoleRunner.Tests.CommandLineTests.InvalidCommandLineParms" executed="True" result="Success" success="True" time="0.002" asserts="1" />
+                          <test-case name="NUnit.ConsoleRunner.Tests.CommandLineTests.InvalidOption" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.ConsoleRunner.Tests.CommandLineTests.NoFixtureNameProvided" executed="True" result="Success" success="True" time="0.001" asserts="1" />
+                          <test-case name="NUnit.ConsoleRunner.Tests.CommandLineTests.NoParametersCount" executed="True" result="Success" success="True" time="0.001" asserts="1" />
+                          <test-case name="NUnit.ConsoleRunner.Tests.CommandLineTests.OptionsAreRecognized" executed="True" result="Success" success="True" time="0.015" asserts="100" />
+                          <test-case name="NUnit.ConsoleRunner.Tests.CommandLineTests.XmlParameter" executed="True" result="Success" success="True" time="0.001" asserts="3" />
+                          <test-case name="NUnit.ConsoleRunner.Tests.CommandLineTests.XmlParameterWithFullPath" executed="True" result="Success" success="True" time="0.001" asserts="3" />
+                          <test-case name="NUnit.ConsoleRunner.Tests.CommandLineTests.XmlParameterWithFullPathUsingEqualSign" executed="True" result="Success" success="True" time="0.000" asserts="3" />
+                          <test-case name="NUnit.ConsoleRunner.Tests.CommandLineTests.XmlParameterWithoutFileNameIsInvalid" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                        </results>
+                      </test-suite>
+                      <test-suite type="TestFixture" name="CommandLineTests_MultipleAssemblies" executed="True" result="Success" success="True" time="0.010" asserts="0">
+                        <results>
+                          <test-case name="NUnit.ConsoleRunner.Tests.CommandLineTests_MultipleAssemblies.CheckParameters" executed="True" result="Success" success="True" time="0.000" asserts="2" />
+                          <test-case name="NUnit.ConsoleRunner.Tests.CommandLineTests_MultipleAssemblies.FixtureParameters" executed="True" result="Success" success="True" time="0.000" asserts="3" />
+                          <test-case name="NUnit.ConsoleRunner.Tests.CommandLineTests_MultipleAssemblies.FixtureValidate" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.ConsoleRunner.Tests.CommandLineTests_MultipleAssemblies.MultipleAssemblyValidate" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.ConsoleRunner.Tests.CommandLineTests_MultipleAssemblies.ParameterCount" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                        </results>
+                      </test-suite>
+                      <test-suite type="TestFixture" name="ConsoleRunnerTest" executed="True" result="Success" success="True" time="8.737" asserts="0">
+                        <results>
+                          <test-case name="NUnit.ConsoleRunner.Tests.ConsoleRunnerTest.AssemblyNotFound" executed="True" result="Success" success="True" time="0.166" asserts="1" />
+                          <test-case name="NUnit.ConsoleRunner.Tests.ConsoleRunnerTest.Bug1073539Test" executed="True" result="Success" success="True" time="0.763" asserts="1" />
+                          <test-case name="NUnit.ConsoleRunner.Tests.ConsoleRunnerTest.Bug1311644Test" executed="True" result="Success" success="True" time="0.605" asserts="1" />
+                          <test-case name="NUnit.ConsoleRunner.Tests.ConsoleRunnerTest.CanRunWithMultipleTestDomains" executed="True" result="Success" success="True" time="1.326" asserts="2" />
+                          <test-case name="NUnit.ConsoleRunner.Tests.ConsoleRunnerTest.CanRunWithMultipleTestDomains_NoThread" executed="True" result="Success" success="True" time="1.293" asserts="2" />
+                          <test-case name="NUnit.ConsoleRunner.Tests.ConsoleRunnerTest.CanRunWithoutTestDomain" executed="True" result="Success" success="True" time="0.080" asserts="2" />
+                          <test-case name="NUnit.ConsoleRunner.Tests.ConsoleRunnerTest.CanRunWithoutTestDomain_NoThread" executed="True" result="Success" success="True" time="0.061" asserts="2" />
+                          <test-case name="NUnit.ConsoleRunner.Tests.ConsoleRunnerTest.CanRunWithSingleTestDomain" executed="True" result="Success" success="True" time="0.681" asserts="2" />
+                          <test-case name="NUnit.ConsoleRunner.Tests.ConsoleRunnerTest.CanRunWithSingleTestDomain_NoThread" executed="True" result="Success" success="True" time="0.626" asserts="2" />
+                          <test-case name="NUnit.ConsoleRunner.Tests.ConsoleRunnerTest.FailureFixture" executed="True" result="Success" success="True" time="0.529" asserts="1" />
+                          <test-case name="NUnit.ConsoleRunner.Tests.ConsoleRunnerTest.InvalidFixture" executed="True" result="Success" success="True" time="0.431" asserts="1" />
+                          <test-case name="NUnit.ConsoleRunner.Tests.ConsoleRunnerTest.MultiFailureFixture" executed="True" result="Success" success="True" time="0.534" asserts="1" />
+                          <test-case name="NUnit.ConsoleRunner.Tests.ConsoleRunnerTest.OneOfTwoAssembliesNotFound" executed="True" result="Success" success="True" time="0.012" asserts="1" />
+                          <test-case name="NUnit.ConsoleRunner.Tests.ConsoleRunnerTest.SuccessFixture" executed="True" result="Success" success="True" time="0.520" asserts="1" />
+                          <test-case name="NUnit.ConsoleRunner.Tests.ConsoleRunnerTest.XmlResult" executed="True" result="Success" success="True" time="0.528" asserts="2" />
+                          <test-case name="NUnit.ConsoleRunner.Tests.ConsoleRunnerTest.XmlToConsole" executed="True" result="Success" success="True" time="0.523" asserts="2" />
+                        </results>
+                      </test-suite>
+                      <test-suite type="TestFixture" name="TestNameParserTests" executed="True" result="Success" success="True" time="0.023" asserts="0">
+                        <results>
+                          <test-suite type="ParameterizedTest" name="SingleName" executed="True" result="Success" success="True" time="0.015" asserts="0">
+                            <results>
+                              <test-case name="NUnit.ConsoleRunner.Tests.TestNameParserTests.SingleName(&quot;Test.Namespace.Fixture.Method&lt;int,int&gt;()&quot;)" executed="True" result="Success" success="True" time="0.001" asserts="3" />
+                              <test-case name="NUnit.ConsoleRunner.Tests.TestNameParserTests.SingleName(&quot;Test.Namespace.Fixture.Method,&quot;)" executed="True" result="Success" success="True" time="0.000" asserts="3" />
+                              <test-case name="NUnit.ConsoleRunner.Tests.TestNameParserTests.SingleName(&quot;  Test.Namespace.Fixture.Method  &quot;)" executed="True" result="Success" success="True" time="0.000" asserts="3" />
+                              <test-case name="NUnit.ConsoleRunner.Tests.TestNameParserTests.SingleName(&quot;  Test.Namespace.Fixture.Method  ,&quot;)" executed="True" result="Success" success="True" time="0.000" asserts="3" />
+                              <test-case name="NUnit.ConsoleRunner.Tests.TestNameParserTests.SingleName(&quot;Test.Namespace.Fixture.Method()&quot;)" executed="True" result="Success" success="True" time="0.000" asserts="3" />
+                              <test-case name="NUnit.ConsoleRunner.Tests.TestNameParserTests.SingleName(&quot;Test.Namespace.Fixture.Method(\&quot;string,argument\&quot;)&quot;)" executed="True" result="Success" success="True" time="0.000" asserts="3" />
+                              <test-case name="NUnit.ConsoleRunner.Tests.TestNameParserTests.SingleName(&quot;Test.Namespace.Fixture.Method(1,2,3)&quot;)" executed="True" result="Success" success="True" time="0.000" asserts="3" />
+                              <test-case name="NUnit.ConsoleRunner.Tests.TestNameParserTests.SingleName(&quot;Test.Namespace.Fixture.Method&quot;)" executed="True" result="Success" success="True" time="0.000" asserts="3" />
+                              <test-case name="NUnit.ConsoleRunner.Tests.TestNameParserTests.SingleName(&quot;Test.Namespace.Fixture.Method(\&quot;)\&quot;)&quot;)" executed="True" result="Success" success="True" time="0.000" asserts="3" />
+                            </results>
+                          </test-suite>
+                          <test-suite type="ParameterizedTest" name="TwoNames" executed="True" result="Success" success="True" time="0.006" asserts="0">
+                            <results>
+                              <test-case name="NUnit.ConsoleRunner.Tests.TestNameParserTests.TwoNames(&quot;Test.Namespace.Fixture.Method1&quot;,&quot;Test.Namespace.Fixture.Method2&quot;)" executed="True" result="Success" success="True" time="0.000" asserts="4" />
+                              <test-case name="NUnit.ConsoleRunner.Tests.TestNameParserTests.TwoNames(&quot;Test.Namespace.Fixture.Method1(\&quot;(\&quot;)&quot;,&quot;Test.Namespace.Fixture.Method2(\&quot;&lt;\&quot;)&quot;)" executed="True" result="Success" success="True" time="0.000" asserts="4" />
+                              <test-case name="NUnit.ConsoleRunner.Tests.TestNameParserTests.TwoNames(&quot;Test.Namespace.Fixture.Method1&quot;,&quot;Test.Namespace.Fixture.Method2,&quot;)" executed="True" result="Success" success="True" time="0.000" asserts="4" />
+                              <test-case name="NUnit.ConsoleRunner.Tests.TestNameParserTests.TwoNames(&quot;Test.Namespace.Fixture.Method1(1,2)&quot;,&quot;Test.Namespace.Fixture.Method2(3,4)&quot;)" executed="True" result="Success" success="True" time="0.000" asserts="4" />
+                            </results>
+                          </test-suite>
+                        </results>
+                      </test-suite>
+                    </results>
+                  </test-suite>
+                </results>
+              </test-suite>
+            </results>
+          </test-suite>
+        </results>
+      </test-suite>
+      <test-suite type="Assembly" name="C:\Program Files\NUnit 2.5.10\bin\net-2.0\tests/nunit.uiexception.tests.dll" executed="True" result="Success" success="True" time="1.649" asserts="0">
+        <results>
+          <test-suite type="Namespace" name="NUnit" executed="True" result="Success" success="True" time="1.645" asserts="0">
+            <results>
+              <test-suite type="Namespace" name="UiException" executed="True" result="Success" success="True" time="1.644" asserts="0">
+                <results>
+                  <test-suite type="Namespace" name="Tests" executed="True" result="Success" success="True" time="1.644" asserts="0">
+                    <results>
+                      <test-suite type="Namespace" name="CodeFormatters" executed="True" result="Success" success="True" time="0.353" asserts="0">
+                        <results>
+                          <test-suite type="TestFixture" name="TestCodeFormatterCollection" executed="True" result="Success" success="True" time="0.061" asserts="0">
+                            <results>
+                              <test-case name="NUnit.UiException.Tests.CodeFormatters.TestCodeFormatterCollection.Clear" executed="True" result="Success" success="True" time="0.014" asserts="1" />
+                              <test-case name="NUnit.UiException.Tests.CodeFormatters.TestCodeFormatterCollection.ContainsFormatterFromExtension" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                              <test-case name="NUnit.UiException.Tests.CodeFormatters.TestCodeFormatterCollection.Indexer_Can_Throw_UnknownExtensionException" executed="True" result="Success" success="True" time="0.003" asserts="0" />
+                              <test-case name="NUnit.UiException.Tests.CodeFormatters.TestCodeFormatterCollection.ItemIndexer_Can_Throw_NullExtensionException" executed="True" result="Success" success="True" time="0.001" asserts="0" />
+                              <test-case name="NUnit.UiException.Tests.CodeFormatters.TestCodeFormatterCollection.Register_Can_Throw_NullExtensionException" executed="True" result="Success" success="True" time="0.001" asserts="0" />
+                              <test-case name="NUnit.UiException.Tests.CodeFormatters.TestCodeFormatterCollection.Register_Can_Throw_NullFormatterException" executed="True" result="Success" success="True" time="0.001" asserts="0" />
+                              <test-case name="NUnit.UiException.Tests.CodeFormatters.TestCodeFormatterCollection.Register_Check_Extension_Case" executed="True" result="Success" success="True" time="0.001" asserts="0" />
+                              <test-case name="NUnit.UiException.Tests.CodeFormatters.TestCodeFormatterCollection.Register_Check_Extension_Is_Not_Empty" executed="True" result="Success" success="True" time="0.001" asserts="0" />
+                              <test-case name="NUnit.UiException.Tests.CodeFormatters.TestCodeFormatterCollection.Register_Check_Extension_Not_Contain_Dot_Character" executed="True" result="Success" success="True" time="0.001" asserts="0" />
+                              <test-case name="NUnit.UiException.Tests.CodeFormatters.TestCodeFormatterCollection.Register_Check_Multiple_Extension_Definition" executed="True" result="Success" success="True" time="0.001" asserts="0" />
+                              <test-case name="NUnit.UiException.Tests.CodeFormatters.TestCodeFormatterCollection.Remove" executed="True" result="Success" success="True" time="0.002" asserts="4" />
+                              <test-case name="NUnit.UiException.Tests.CodeFormatters.TestCodeFormatterCollection.Remove_Is_Not_Case_Sensitive" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                              <test-case name="NUnit.UiException.Tests.CodeFormatters.TestCodeFormatterCollection.StringIndexer_Can_Throw_NullExtensionException" executed="True" result="Success" success="True" time="0.001" asserts="0" />
+                              <test-case name="NUnit.UiException.Tests.CodeFormatters.TestCodeFormatterCollection.Test_Default" executed="True" result="Success" success="True" time="0.003" asserts="10" />
+                            </results>
+                          </test-suite>
+                          <test-suite type="TestFixture" name="TestCSharpCodeFormatter" executed="True" result="Success" success="True" time="0.042" asserts="0">
+                            <results>
+                              <test-case name="NUnit.UiException.Tests.CodeFormatters.TestCSharpCodeFormatter.Format_Can_Throw_CSharpNullException" executed="True" result="Success" success="True" time="0.001" asserts="0" />
+                              <test-case name="NUnit.UiException.Tests.CodeFormatters.TestCSharpCodeFormatter.Test_Conserve_Intermediary_Spaces" executed="True" result="Success" success="True" time="0.019" asserts="9" />
+                              <test-case name="NUnit.UiException.Tests.CodeFormatters.TestCSharpCodeFormatter.Test_Default" executed="True" result="Success" success="True" time="0.006" asserts="4" />
+                              <test-case name="NUnit.UiException.Tests.CodeFormatters.TestCSharpCodeFormatter.Test_Format" executed="True" result="Success" success="True" time="0.003" asserts="1" />
+                              <test-case name="NUnit.UiException.Tests.CodeFormatters.TestCSharpCodeFormatter.Test_Format_2" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                              <test-case name="NUnit.UiException.Tests.CodeFormatters.TestCSharpCodeFormatter.Test_Format_3" executed="True" result="Success" success="True" time="0.000" asserts="2" />
+                              <test-case name="NUnit.UiException.Tests.CodeFormatters.TestCSharpCodeFormatter.Test_PreProcess" executed="True" result="Success" success="True" time="0.001" asserts="3" />
+                            </results>
+                          </test-suite>
+                          <test-suite type="TestFixture" name="TestFormattedCode" executed="True" result="Success" success="True" time="0.026" asserts="0">
+                            <results>
+                              <test-case name="NUnit.UiException.Tests.CodeFormatters.TestFormattedCode.CheckData_Can_Throw_NullDataException" executed="True" result="Success" success="True" time="0.003" asserts="0" />
+                              <test-case name="NUnit.UiException.Tests.CodeFormatters.TestFormattedCode.CheckData_IndexArray_And_TagArray_Count_Must_Match" executed="True" result="Success" success="True" time="0.001" asserts="0" />
+                              <test-case name="NUnit.UiException.Tests.CodeFormatters.TestFormattedCode.CheckData_LineArray_Values_Must_Always_Grow_Up" executed="True" result="Success" success="True" time="0.000" asserts="0" />
+                              <test-case name="NUnit.UiException.Tests.CodeFormatters.TestFormattedCode.CheckData_LineArray_Values_Must_Be_In_IndexArray_Count" executed="True" result="Success" success="True" time="0.001" asserts="0" />
+                              <test-case name="NUnit.UiException.Tests.CodeFormatters.TestFormattedCode.Empty" executed="True" result="Success" success="True" time="0.001" asserts="2" />
+                              <test-case name="NUnit.UiException.Tests.CodeFormatters.TestFormattedCode.Test_ComplexCollection" executed="True" result="Success" success="True" time="0.003" asserts="22" />
+                              <test-case name="NUnit.UiException.Tests.CodeFormatters.TestFormattedCode.Test_Equals" executed="True" result="Success" success="True" time="0.001" asserts="10" />
+                              <test-case name="NUnit.UiException.Tests.CodeFormatters.TestFormattedCode.Test_MaxLength" executed="True" result="Success" success="True" time="0.000" asserts="3" />
+                              <test-case name="NUnit.UiException.Tests.CodeFormatters.TestFormattedCode.Test_SimpleCollection" executed="True" result="Success" success="True" time="0.002" asserts="17" />
+                            </results>
+                          </test-suite>
+                          <test-suite type="TestFixture" name="TestGeneralCodeFormatter" executed="True" result="Success" success="True" time="0.085" asserts="0">
+                            <results>
+                              <test-case name="NUnit.UiException.Tests.CodeFormatters.TestGeneralCodeFormatter.All_Formatters_Have_Unique_Language_Value" executed="True" result="Success" success="True" time="0.003" asserts="2" />
+                              <test-case name="NUnit.UiException.Tests.CodeFormatters.TestGeneralCodeFormatter.All_Formatters_Should_Have_Overwrite_Behavior" executed="True" result="Success" success="True" time="0.003" asserts="2" />
+                              <test-case name="NUnit.UiException.Tests.CodeFormatters.TestGeneralCodeFormatter.All_Formatters_Should_PreProcess_Tab_Character" executed="True" result="Success" success="True" time="0.002" asserts="2" />
+                              <test-case name="NUnit.UiException.Tests.CodeFormatters.TestGeneralCodeFormatter.Any_Formatter_Should_Format_Any_Text" executed="True" result="Success" success="True" time="0.028" asserts="6" />
+                              <test-case name="NUnit.UiException.Tests.CodeFormatters.TestGeneralCodeFormatter.DefaultFormatter" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                              <test-case name="NUnit.UiException.Tests.CodeFormatters.TestGeneralCodeFormatter.DefaultFormatter_Can_Throw_FormatterNullException" executed="True" result="Success" success="True" time="0.001" asserts="0" />
+                              <test-case name="NUnit.UiException.Tests.CodeFormatters.TestGeneralCodeFormatter.Format" executed="True" result="Success" success="True" time="0.001" asserts="2" />
+                              <test-case name="NUnit.UiException.Tests.CodeFormatters.TestGeneralCodeFormatter.Format_Can_Throw_CodeNullException" executed="True" result="Success" success="True" time="0.001" asserts="0" />
+                              <test-case name="NUnit.UiException.Tests.CodeFormatters.TestGeneralCodeFormatter.Format_Can_Throw_LanguageNameNullException" executed="True" result="Success" success="True" time="0.000" asserts="0" />
+                              <test-case name="NUnit.UiException.Tests.CodeFormatters.TestGeneralCodeFormatter.Format_Pick_Best_Formatter" executed="True" result="Success" success="True" time="0.011" asserts="2" />
+                              <test-case name="NUnit.UiException.Tests.CodeFormatters.TestGeneralCodeFormatter.FormatFromExtension_Can_Throw_CodeNullException" executed="True" result="Success" success="True" time="0.001" asserts="0" />
+                              <test-case name="NUnit.UiException.Tests.CodeFormatters.TestGeneralCodeFormatter.FormatFromExtension_Can_Throw_ExtensionNullException" executed="True" result="Success" success="True" time="0.001" asserts="0" />
+                              <test-case name="NUnit.UiException.Tests.CodeFormatters.TestGeneralCodeFormatter.GetFormatterFromExtension_Can_Throw_ExtensionNullException" executed="True" result="Success" success="True" time="0.000" asserts="0" />
+                              <test-case name="NUnit.UiException.Tests.CodeFormatters.TestGeneralCodeFormatter.GetFormatterFromLanguage_Can_Throw_LanguageNullException" executed="True" result="Success" success="True" time="0.001" asserts="0" />
+                              <test-case name="NUnit.UiException.Tests.CodeFormatters.TestGeneralCodeFormatter.GetFormatterFroms" executed="True" result="Success" success="True" time="0.001" asserts="4" />
+                              <test-case name="NUnit.UiException.Tests.CodeFormatters.TestGeneralCodeFormatter.LanguageFromExtension" executed="True" result="Success" success="True" time="0.001" asserts="3" />
+                              <test-case name="NUnit.UiException.Tests.CodeFormatters.TestGeneralCodeFormatter.Test_Default" executed="True" result="Success" success="True" time="0.000" asserts="3" />
+                            </results>
+                          </test-suite>
+                          <test-suite type="TestFixture" name="TestLexer" executed="True" result="Success" success="True" time="0.031" asserts="0">
+                            <results>
+                              <test-case name="NUnit.UiException.Tests.CodeFormatters.TestLexer.Test_Default" executed="True" result="Success" success="True" time="0.000" asserts="3" />
+                              <test-case name="NUnit.UiException.Tests.CodeFormatters.TestLexer.Test_Dot_Character" executed="True" result="Success" success="True" time="0.002" asserts="5" />
+                              <test-case name="NUnit.UiException.Tests.CodeFormatters.TestLexer.Test_SetText_Throws_NullArgumentException" executed="True" result="Success" success="True" time="0.001" asserts="0" />
+                              <test-case name="NUnit.UiException.Tests.CodeFormatters.TestLexer.Test_Split_ColonCharacter" executed="True" result="Success" success="True" time="0.001" asserts="20" />
+                              <test-case name="NUnit.UiException.Tests.CodeFormatters.TestLexer.Test_Split_CommentC" executed="True" result="Success" success="True" time="0.000" asserts="10" />
+                              <test-case name="NUnit.UiException.Tests.CodeFormatters.TestLexer.Test_Split_CommentCpp" executed="True" result="Success" success="True" time="0.001" asserts="5" />
+                              <test-case name="NUnit.UiException.Tests.CodeFormatters.TestLexer.Test_Split_DoubleQuote" executed="True" result="Success" success="True" time="0.001" asserts="19" />
+                              <test-case name="NUnit.UiException.Tests.CodeFormatters.TestLexer.Test_Split_Equals" executed="True" result="Success" success="True" time="0.000" asserts="5" />
+                              <test-case name="NUnit.UiException.Tests.CodeFormatters.TestLexer.Test_Split_New_Line" executed="True" result="Success" success="True" time="0.000" asserts="5" />
+                              <test-case name="NUnit.UiException.Tests.CodeFormatters.TestLexer.Test_Split_NumberSign" executed="True" result="Success" success="True" time="0.000" asserts="5" />
+                              <test-case name="NUnit.UiException.Tests.CodeFormatters.TestLexer.Test_Split_SingleQuote" executed="True" result="Success" success="True" time="0.001" asserts="5" />
+                              <test-case name="NUnit.UiException.Tests.CodeFormatters.TestLexer.Test_Split_WhiteSpaces" executed="True" result="Success" success="True" time="0.001" asserts="35" />
+                              <test-case name="NUnit.UiException.Tests.CodeFormatters.TestLexer.Test_Split_Words" executed="True" result="Success" success="True" time="0.000" asserts="10" />
+                            </results>
+                          </test-suite>
+                          <test-suite type="TestFixture" name="TestPlainTextCodeFormatter" executed="True" result="Success" success="True" time="0.009" asserts="0">
+                            <results>
+                              <test-case name="NUnit.UiException.Tests.CodeFormatters.TestPlainTextCodeFormatter.Format_Can_Throw_CodeNullException" executed="True" result="Success" success="True" time="0.001" asserts="0" />
+                              <test-case name="NUnit.UiException.Tests.CodeFormatters.TestPlainTextCodeFormatter.Format_HelloWorld" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                              <test-case name="NUnit.UiException.Tests.CodeFormatters.TestPlainTextCodeFormatter.Format_Lines" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                              <test-case name="NUnit.UiException.Tests.CodeFormatters.TestPlainTextCodeFormatter.Test_Language" executed="True" result="Success" success="True" time="0.001" asserts="1" />
+                              <test-case name="NUnit.UiException.Tests.CodeFormatters.TestPlainTextCodeFormatter.Test_PreProcess" executed="True" result="Success" success="True" time="0.000" asserts="3" />
+                            </results>
+                          </test-suite>
+                          <test-suite type="TestFixture" name="TestToken" executed="True" result="Success" success="True" time="0.002" asserts="0">
+                            <results>
+                              <test-case name="NUnit.UiException.Tests.CodeFormatters.TestToken.Test_Equals" executed="True" result="Success" success="True" time="0.001" asserts="6" />
+                            </results>
+                          </test-suite>
+                          <test-suite type="TestFixture" name="TestTokenClassifier" executed="True" result="Success" success="True" time="0.044" asserts="0">
+                            <results>
+                              <test-case name="NUnit.UiException.Tests.CodeFormatters.TestTokenClassifier.test_AcceptToken" executed="True" result="Success" success="True" time="0.004" asserts="60" />
+                              <test-case name="NUnit.UiException.Tests.CodeFormatters.TestTokenClassifier.Test_Classification_Cases" executed="True" result="Success" success="True" time="0.003" asserts="32" />
+                              <test-case name="NUnit.UiException.Tests.CodeFormatters.TestTokenClassifier.Test_Classify" executed="True" result="Success" success="True" time="0.003" asserts="60" />
+                              <test-case name="NUnit.UiException.Tests.CodeFormatters.TestTokenClassifier.Test_Classify_As_Keyword" executed="True" result="Success" success="True" time="0.010" asserts="81" />
+                              <test-case name="NUnit.UiException.Tests.CodeFormatters.TestTokenClassifier.Test_Classify_Can_Throw_ArgumentNullException" executed="True" result="Success" success="True" time="0.001" asserts="0" />
+                              <test-case name="NUnit.UiException.Tests.CodeFormatters.TestTokenClassifier.Test_Classify_Throw_NullArgException" executed="True" result="Success" success="True" time="0.000" asserts="0" />
+                              <test-case name="NUnit.UiException.Tests.CodeFormatters.TestTokenClassifier.Test_Escaping_sequence" executed="True" result="Success" success="True" time="0.006" asserts="61" />
+                              <test-case name="NUnit.UiException.Tests.CodeFormatters.TestTokenClassifier.Test_NewState" executed="True" result="Success" success="True" time="0.005" asserts="40" />
+                              <test-case name="NUnit.UiException.Tests.CodeFormatters.TestTokenClassifier.Test_Reset" executed="True" result="Success" success="True" time="0.001" asserts="1" />
+                            </results>
+                          </test-suite>
+                          <test-suite type="TestFixture" name="TestTokenDictionary" executed="True" result="Success" success="True" time="0.035" asserts="0">
+                            <results>
+                              <test-case name="NUnit.UiException.Tests.CodeFormatters.TestTokenDictionary.Add_can_throw_AlreadyDefinedException" executed="True" result="Success" success="True" time="0.004" asserts="2" />
+                              <test-case name="NUnit.UiException.Tests.CodeFormatters.TestTokenDictionary.Add_can_throw_EmptySequenceException" executed="True" result="Success" success="True" time="0.001" asserts="2" />
+                              <test-case name="NUnit.UiException.Tests.CodeFormatters.TestTokenDictionary.Add_can_throw_InvalidSortException" executed="True" result="Success" success="True" time="0.001" asserts="2" />
+                              <test-case name="NUnit.UiException.Tests.CodeFormatters.TestTokenDictionary.Add_can_throw_NullValueException" executed="True" result="Success" success="True" time="0.001" asserts="2" />
+                              <test-case name="NUnit.UiException.Tests.CodeFormatters.TestTokenDictionary.add_token" executed="True" result="Success" success="True" time="0.001" asserts="3" />
+                              <test-case name="NUnit.UiException.Tests.CodeFormatters.TestTokenDictionary.PopulateTokenStartingWith" executed="True" result="Success" success="True" time="0.002" asserts="14" />
+                              <test-case name="NUnit.UiException.Tests.CodeFormatters.TestTokenDictionary.PopulateTokenStartingWith_can_throw_NullOutputException" executed="True" result="Success" success="True" time="0.001" asserts="2" />
+                              <test-case name="NUnit.UiException.Tests.CodeFormatters.TestTokenDictionary.PopulateTokenStartingWith_can_throw_NullStarterException" executed="True" result="Success" success="True" time="0.001" asserts="2" />
+                              <test-case name="NUnit.UiException.Tests.CodeFormatters.TestTokenDictionary.test_default" executed="True" result="Success" success="True" time="0.000" asserts="3" />
+                              <test-case name="NUnit.UiException.Tests.CodeFormatters.TestTokenDictionary.TryMatch_can_throw_NullPredictionException" executed="True" result="Success" success="True" time="0.001" asserts="2" />
+                              <test-case name="NUnit.UiException.Tests.CodeFormatters.TestTokenDictionary.TryMatch_can_throw_NullTextException" executed="True" result="Success" success="True" time="0.001" asserts="2" />
+                              <test-case name="NUnit.UiException.Tests.CodeFormatters.TestTokenDictionary.TryMatch_no_prediction" executed="True" result="Success" success="True" time="0.001" asserts="146" />
+                              <test-case name="NUnit.UiException.Tests.CodeFormatters.TestTokenDictionary.TryMatch_prediction" executed="True" result="Success" success="True" time="0.001" asserts="19" />
+                            </results>
+                          </test-suite>
+                        </results>
+                      </test-suite>
+                      <test-suite type="Namespace" name="Controls" executed="True" result="Success" success="True" time="1.081" asserts="0">
+                        <results>
+                          <test-suite type="TestFixture" name="TestCodeBox" executed="True" result="Success" success="True" time="0.438" asserts="0">
+                            <results>
+                              <test-case name="NUnit.UiException.Tests.Controls.TestCodeBox.Can_Disable_ShowCurrentLine" executed="True" result="Success" success="True" time="0.394" asserts="3" />
+                              <test-case name="NUnit.UiException.Tests.Controls.TestCodeBox.Can_Set_Back_And_Fore_Colors" executed="True" result="Success" success="True" time="0.005" asserts="2" />
+                              <test-case name="NUnit.UiException.Tests.Controls.TestCodeBox.Changing_Font_Causes_Reformatting" executed="True" result="Success" success="True" time="0.009" asserts="24" />
+                              <test-case name="NUnit.UiException.Tests.Controls.TestCodeBox.Changing_Language_Causes_Reformatting" executed="True" result="Success" success="True" time="0.003" asserts="34" />
+                              <test-case name="NUnit.UiException.Tests.Controls.TestCodeBox.CurrentLine" executed="True" result="Success" success="True" time="0.005" asserts="30" />
+                              <test-case name="NUnit.UiException.Tests.Controls.TestCodeBox.DefaultState" executed="True" result="Success" success="True" time="0.004" asserts="11" />
+                              <test-case name="NUnit.UiException.Tests.Controls.TestCodeBox.Format_Text_With_Language" executed="True" result="Success" success="True" time="0.001" asserts="25" />
+                              <test-case name="NUnit.UiException.Tests.Controls.TestCodeBox.OnPaint" executed="True" result="Success" success="True" time="0.003" asserts="19" />
+                            </results>
+                          </test-suite>
+                          <test-suite type="TestFixture" name="TestCodeRenderingContext" executed="True" result="Success" success="True" time="0.010" asserts="0">
+                            <results>
+                              <test-case name="NUnit.UiException.Tests.Controls.TestCodeRenderingContext.Can_Change_Colors" executed="True" result="Success" success="True" time="0.006" asserts="43" />
+                              <test-case name="NUnit.UiException.Tests.Controls.TestCodeRenderingContext.DefaultState" executed="True" result="Success" success="True" time="0.002" asserts="38" />
+                            </results>
+                          </test-suite>
+                          <test-suite type="TestFixture" name="TestDefaultCodeRenderer" executed="True" result="Success" success="True" time="0.022" asserts="0">
+                            <results>
+                              <test-case name="NUnit.UiException.Tests.Controls.TestDefaultCodeRenderer.DrawToGraphics_Can_Raise_ArgumentNullException" executed="True" result="Success" success="True" time="0.004" asserts="2" />
+                              <test-case name="NUnit.UiException.Tests.Controls.TestDefaultCodeRenderer.GetDocumentSize" executed="True" result="Success" success="True" time="0.001" asserts="4" />
+                              <test-case name="NUnit.UiException.Tests.Controls.TestDefaultCodeRenderer.GetDocumentSize_Can_Raise_ArgumentNullException" executed="True" result="Success" success="True" time="0.001" asserts="3" />
+                              <test-case name="NUnit.UiException.Tests.Controls.TestDefaultCodeRenderer.LineIndexToYCoordinate" executed="True" result="Success" success="True" time="0.001" asserts="4" />
+                              <test-case name="NUnit.UiException.Tests.Controls.TestDefaultCodeRenderer.LineIndexToYCoordinate_Can_Raise_ArgumentNullException" executed="True" result="Success" success="True" time="0.000" asserts="2" />
+                              <test-case name="NUnit.UiException.Tests.Controls.TestDefaultCodeRenderer.ViewportLines" executed="True" result="Success" success="True" time="0.005" asserts="32" />
+                            </results>
+                          </test-suite>
+                          <test-suite type="TestFixture" name="TestDefaultErrorListRenderer" executed="True" result="Success" success="True" time="0.083" asserts="0">
+                            <results>
+                              <test-case name="NUnit.UiException.Tests.Controls.TestDefaultErrorListRenderer.DefaultState" executed="True" result="Success" success="True" time="0.013" asserts="2" />
+                              <test-case name="NUnit.UiException.Tests.Controls.TestDefaultErrorListRenderer.DrawToGraphics_Can_Throw_ArgumentNullException" executed="True" result="Success" success="True" time="0.004" asserts="2" />
+                              <test-case name="NUnit.UiException.Tests.Controls.TestDefaultErrorListRenderer.GetDocumentSize" executed="True" result="Success" success="True" time="0.002" asserts="5" />
+                              <test-case name="NUnit.UiException.Tests.Controls.TestDefaultErrorListRenderer.IsDirty" executed="True" result="Success" success="True" time="0.048" asserts="7" />
+                              <test-case name="NUnit.UiException.Tests.Controls.TestDefaultErrorListRenderer.ItemAt" executed="True" result="Success" success="True" time="0.003" asserts="7" />
+                              <test-case name="NUnit.UiException.Tests.Controls.TestDefaultErrorListRenderer.MeasureItem" executed="True" result="Success" success="True" time="0.003" asserts="6" />
+                            </results>
+                          </test-suite>
+                          <test-suite type="TestFixture" name="TestErrorBrowser" executed="True" result="Success" success="True" time="0.138" asserts="0">
+                            <results>
+                              <test-case name="NUnit.UiException.Tests.Controls.TestErrorBrowser.Can_Raise_ErrorSourceChanged" executed="True" result="Success" success="True" time="0.095" asserts="3" />
+                              <test-case name="NUnit.UiException.Tests.Controls.TestErrorBrowser.Cannot_Register_Null_Display" executed="True" result="Success" success="True" time="0.002" asserts="0" />
+                              <test-case name="NUnit.UiException.Tests.Controls.TestErrorBrowser.DefaultState" executed="True" result="Success" success="True" time="0.002" asserts="10" />
+                              <test-case name="NUnit.UiException.Tests.Controls.TestErrorBrowser.ErrorDisplay_Plugins_life_cycle_events" executed="True" result="Success" success="True" time="0.024" asserts="55" />
+                              <test-case name="NUnit.UiException.Tests.Controls.TestErrorBrowser.LayoutPanel_Auto_Resizes_When_Parent_Sizes_Change" executed="True" result="Success" success="True" time="0.006" asserts="4" />
+                            </results>
+                          </test-suite>
+                          <test-suite type="TestFixture" name="TestErrorList" executed="True" result="Success" success="True" time="0.049" asserts="0">
+                            <results>
+                              <test-case name="NUnit.UiException.Tests.Controls.TestErrorList.AutoSelectFirstItem" executed="True" result="Success" success="True" time="0.003" asserts="4" />
+                              <test-case name="NUnit.UiException.Tests.Controls.TestErrorList.CanReportInvalidItems" executed="True" result="Success" success="True" time="0.001" asserts="3" />
+                              <test-case name="NUnit.UiException.Tests.Controls.TestErrorList.Click_Can_Select_Item" executed="True" result="Success" success="True" time="0.002" asserts="23" />
+                              <test-case name="NUnit.UiException.Tests.Controls.TestErrorList.CurrentSelection" executed="True" result="Success" success="True" time="0.002" asserts="10" />
+                              <test-case name="NUnit.UiException.Tests.Controls.TestErrorList.DefaultState" executed="True" result="Success" success="True" time="0.001" asserts="7" />
+                              <test-case name="NUnit.UiException.Tests.Controls.TestErrorList.DrawItem" executed="True" result="Success" success="True" time="0.015" asserts="39" />
+                              <test-case name="NUnit.UiException.Tests.Controls.TestErrorList.Invoking_DrawToGraphics" executed="True" result="Success" success="True" time="0.003" asserts="22" />
+                              <test-case name="NUnit.UiException.Tests.Controls.TestErrorList.ListOrderPolicy" executed="True" result="Success" success="True" time="0.005" asserts="22" />
+                              <test-case name="NUnit.UiException.Tests.Controls.TestErrorList.Populate_StackTraceSource" executed="True" result="Success" success="True" time="0.002" asserts="11" />
+                            </results>
+                          </test-suite>
+                          <test-suite type="TestFixture" name="TestErrorPanelLayout" executed="True" result="Success" success="True" time="0.009" asserts="0">
+                            <results>
+                              <test-case name="NUnit.UiException.Tests.Controls.TestErrorPanelLayout.Can_Layout_Child_Controls_When_Size_Changed" executed="True" result="Success" success="True" time="0.001" asserts="16" />
+                              <test-case name="NUnit.UiException.Tests.Controls.TestErrorPanelLayout.DefaultState" executed="True" result="Success" success="True" time="0.000" asserts="13" />
+                              <test-case name="NUnit.UiException.Tests.Controls.TestErrorPanelLayout.Setting_Content" executed="True" result="Success" success="True" time="0.001" asserts="21" />
+                              <test-case name="NUnit.UiException.Tests.Controls.TestErrorPanelLayout.Setting_Toolbar" executed="True" result="Success" success="True" time="0.001" asserts="14" />
+                            </results>
+                          </test-suite>
+                          <test-suite type="TestFixture" name="TestErrorToolbar" executed="True" result="Success" success="True" time="0.100" asserts="0">
+                            <results>
+                              <test-case name="NUnit.UiException.Tests.Controls.TestErrorToolbar.Cannot_Register_Null_Display" executed="True" result="Success" success="True" time="0.002" asserts="2" />
+                              <test-case name="NUnit.UiException.Tests.Controls.TestErrorToolbar.Cannot_Select_UnRegistered_Display" executed="True" result="Success" success="True" time="0.001" asserts="0" />
+                              <test-case name="NUnit.UiException.Tests.Controls.TestErrorToolbar.DefaultState" executed="True" result="Success" success="True" time="0.002" asserts="8" />
+                              <test-case name="NUnit.UiException.Tests.Controls.TestErrorToolbar.NewStripButton" executed="True" result="Success" success="True" time="0.004" asserts="1" />
+                              <test-case name="NUnit.UiException.Tests.Controls.TestErrorToolbar.PluginItem_Click_Raises_SelectedRenderedChanged" executed="True" result="Success" success="True" time="0.019" asserts="4" />
+                              <test-case name="NUnit.UiException.Tests.Controls.TestErrorToolbar.Registering_displays_adds_ToolStripItem" executed="True" result="Success" success="True" time="0.053" asserts="30" />
+                              <test-case name="NUnit.UiException.Tests.Controls.TestErrorToolbar.SelectedDisplay" executed="True" result="Success" success="True" time="0.002" asserts="9" />
+                              <test-case name="NUnit.UiException.Tests.Controls.TestErrorToolbar.Set_Or_Unset_Check_Flag_On_Selection" executed="True" result="Success" success="True" time="0.003" asserts="6" />
+                            </results>
+                          </test-suite>
+                          <test-suite type="TestFixture" name="TestSourceCodeDisplay" executed="True" result="Success" success="True" time="0.038" asserts="0">
+                            <results>
+                              <test-case name="NUnit.UiException.Tests.Controls.TestSourceCodeDisplay.CanReportFileException" executed="True" result="Success" success="True" time="0.007" asserts="2" />
+                              <test-case name="NUnit.UiException.Tests.Controls.TestSourceCodeDisplay.DefaultState" executed="True" result="Success" success="True" time="0.004" asserts="15" />
+                              <test-case name="NUnit.UiException.Tests.Controls.TestSourceCodeDisplay.ListOrderPolicy" executed="True" result="Success" success="True" time="0.002" asserts="14" />
+                              <test-case name="NUnit.UiException.Tests.Controls.TestSourceCodeDisplay.SelectedItemChanged" executed="True" result="Success" success="True" time="0.008" asserts="26" />
+                              <test-case name="NUnit.UiException.Tests.Controls.TestSourceCodeDisplay.SplitOrientation" executed="True" result="Success" success="True" time="0.004" asserts="4" />
+                              <test-case name="NUnit.UiException.Tests.Controls.TestSourceCodeDisplay.SplitterDistance" executed="True" result="Success" success="True" time="0.003" asserts="2" />
+                            </results>
+                          </test-suite>
+                          <test-suite type="TestFixture" name="TestSplitterBox" executed="True" result="Success" success="True" time="0.029" asserts="0">
+                            <results>
+                              <test-case name="NUnit.UiException.Tests.Controls.TestSplitterBox.CanChangeDefaultControl1" executed="True" result="Success" success="True" time="0.003" asserts="48" />
+                              <test-case name="NUnit.UiException.Tests.Controls.TestSplitterBox.CanChangeDefaultControl2" executed="True" result="Success" success="True" time="0.000" asserts="48" />
+                              <test-case name="NUnit.UiException.Tests.Controls.TestSplitterBox.ChangingSizeInvokeDoLayout" executed="True" result="Success" success="True" time="0.000" asserts="28" />
+                              <test-case name="NUnit.UiException.Tests.Controls.TestSplitterBox.CollapseControl" executed="True" result="Success" success="True" time="0.005" asserts="82" />
+                              <test-case name="NUnit.UiException.Tests.Controls.TestSplitterBox.DefaultState" executed="True" result="Success" success="True" time="0.001" asserts="51" />
+                              <test-case name="NUnit.UiException.Tests.Controls.TestSplitterBox.MouseActions" executed="True" result="Success" success="True" time="0.004" asserts="6" />
+                              <test-case name="NUnit.UiException.Tests.Controls.TestSplitterBox.OrientationAffectsLayout" executed="True" result="Success" success="True" time="0.000" asserts="25" />
+                              <test-case name="NUnit.UiException.Tests.Controls.TestSplitterBox.PointToSplit" executed="True" result="Success" success="True" time="0.001" asserts="75" />
+                              <test-case name="NUnit.UiException.Tests.Controls.TestSplitterBox.SplitterDistance" executed="True" result="Success" success="True" time="0.001" asserts="81" />
+                            </results>
+                          </test-suite>
+                          <test-suite type="TestFixture" name="TestStackTraceDisplay" executed="True" result="Success" success="True" time="0.145" asserts="0">
+                            <results>
+                              <test-case name="NUnit.UiException.Tests.Controls.TestStackTraceDisplay.CopyToClipBoard" executed="True" result="Success" success="True" time="0.127" asserts="4">
+                                <properties>
+                                  <property name="APARTMENT_STATE" value="STA" />
+                                </properties>
+                              </test-case>
+                              <test-case name="NUnit.UiException.Tests.Controls.TestStackTraceDisplay.DefaultState" executed="True" result="Success" success="True" time="0.002" asserts="10" />
+                              <test-case name="NUnit.UiException.Tests.Controls.TestStackTraceDisplay.FeedingDisplayWithGarbageDoesNotMakeItCrash" executed="True" result="Success" success="True" time="0.002" asserts="1" />
+                              <test-case name="NUnit.UiException.Tests.Controls.TestStackTraceDisplay.OnStackTraceChanged" executed="True" result="Success" success="True" time="0.002" asserts="3" />
+                            </results>
+                          </test-suite>
+                        </results>
+                      </test-suite>
+                      <test-suite type="Namespace" name="StackTraceAnalyzers" executed="True" result="Success" success="True" time="0.068" asserts="0">
+                        <results>
+                          <test-suite type="TestFixture" name="TestFunctionParser" executed="True" result="Success" success="True" time="0.016" asserts="0">
+                            <results>
+                              <test-case name="NUnit.UiException.Tests.StackTraceAnalyzers.TestFunctionParser.Test_Ability_To_Parse_Mono_Stack_Trace" executed="True" result="Success" success="True" time="0.001" asserts="2" />
+                              <test-case name="NUnit.UiException.Tests.StackTraceAnalyzers.TestFunctionParser.Test_Ability_To_Parse_Regular_Function_Values" executed="True" result="Success" success="True" time="0.000" asserts="7" />
+                              <test-case name="NUnit.UiException.Tests.StackTraceAnalyzers.TestFunctionParser.Test_Fail_To_Parse_Odd_Function_Values" executed="True" result="Success" success="True" time="0.000" asserts="5" />
+                              <test-case name="NUnit.UiException.Tests.StackTraceAnalyzers.TestFunctionParser.TestIErrorParser.Test_IErrorParser_Can_Throw_ArgsNullException" executed="True" result="Success" success="True" time="0.002" asserts="10" />
+                              <test-case name="NUnit.UiException.Tests.StackTraceAnalyzers.TestFunctionParser.TestIErrorParser.Test_IErrorParser_Can_Throw_ParserNullException" executed="True" result="Success" success="True" time="0.001" asserts="10" />
+                            </results>
+                          </test-suite>
+                          <test-suite type="TestFixture" name="TestIErrorParser" executed="True" result="Success" success="True" time="0.004" asserts="0">
+                            <results>
+                              <test-case name="NUnit.UiException.Tests.StackTraceAnalyzers.TestIErrorParser.Test_IErrorParser_Can_Throw_ArgsNullException" executed="True" result="Success" success="True" time="0.000" asserts="10" />
+                              <test-case name="NUnit.UiException.Tests.StackTraceAnalyzers.TestIErrorParser.Test_IErrorParser_Can_Throw_ParserNullException" executed="True" result="Success" success="True" time="0.000" asserts="10" />
+                            </results>
+                          </test-suite>
+                          <test-suite type="TestFixture" name="TestLineNumberParser" executed="True" result="Success" success="True" time="0.008" asserts="0">
+                            <results>
+                              <test-case name="NUnit.UiException.Tests.StackTraceAnalyzers.TestLineNumberParser.Test_Ability_To_Parse_Regular_Line_Number_Values" executed="True" result="Success" success="True" time="0.000" asserts="10" />
+                              <test-case name="NUnit.UiException.Tests.StackTraceAnalyzers.TestLineNumberParser.Test_Ability_To_Reject_Odd_Line_Number_Values" executed="True" result="Success" success="True" time="0.000" asserts="5" />
+                              <test-case name="NUnit.UiException.Tests.StackTraceAnalyzers.TestLineNumberParser.TestIErrorParser.Test_IErrorParser_Can_Throw_ArgsNullException" executed="True" result="Success" success="True" time="0.001" asserts="10" />
+                              <test-case name="NUnit.UiException.Tests.StackTraceAnalyzers.TestLineNumberParser.TestIErrorParser.Test_IErrorParser_Can_Throw_ParserNullException" executed="True" result="Success" success="True" time="0.001" asserts="10" />
+                            </results>
+                          </test-suite>
+                          <test-suite type="TestFixture" name="TestPathParser" executed="True" result="Success" success="True" time="0.007" asserts="0">
+                            <results>
+                              <test-case name="NUnit.UiException.Tests.StackTraceAnalyzers.TestPathParser.Test_Ability_To_Handle_Unix_Path_Like_Values" executed="True" result="Success" success="True" time="0.001" asserts="4" />
+                              <test-case name="NUnit.UiException.Tests.StackTraceAnalyzers.TestPathParser.Test_Ability_To_Handle_Windows_Path_Like_Values" executed="True" result="Success" success="True" time="0.001" asserts="4" />
+                              <test-case name="NUnit.UiException.Tests.StackTraceAnalyzers.TestPathParser.TestIErrorParser.Test_IErrorParser_Can_Throw_ArgsNullException" executed="True" result="Success" success="True" time="0.001" asserts="12" />
+                              <test-case name="NUnit.UiException.Tests.StackTraceAnalyzers.TestPathParser.TestIErrorParser.Test_IErrorParser_Can_Throw_ParserNullException" executed="True" result="Success" success="True" time="0.001" asserts="12" />
+                            </results>
+                          </test-suite>
+                          <test-suite type="TestFixture" name="TestUnixPathParser" executed="True" result="Success" success="True" time="0.008" asserts="0">
+                            <results>
+                              <test-case name="NUnit.UiException.Tests.StackTraceAnalyzers.TestUnixPathParser.Test_Ability_To_Parse_Regular_Unix_Like_Path_Values" executed="True" result="Success" success="True" time="0.001" asserts="21" />
+                              <test-case name="NUnit.UiException.Tests.StackTraceAnalyzers.TestUnixPathParser.Test_Inability_To_Parse_Non_Unix_Like_Path_Values" executed="True" result="Success" success="True" time="0.001" asserts="6" />
+                              <test-case name="NUnit.UiException.Tests.StackTraceAnalyzers.TestUnixPathParser.TestIErrorParser.Test_IErrorParser_Can_Throw_ArgsNullException" executed="True" result="Success" success="True" time="0.001" asserts="11" />
+                              <test-case name="NUnit.UiException.Tests.StackTraceAnalyzers.TestUnixPathParser.TestIErrorParser.Test_IErrorParser_Can_Throw_ParserNullException" executed="True" result="Success" success="True" time="0.001" asserts="11" />
+                            </results>
+                          </test-suite>
+                          <test-suite type="TestFixture" name="TestWindowsPathParser" executed="True" result="Success" success="True" time="0.008" asserts="0">
+                            <results>
+                              <test-case name="NUnit.UiException.Tests.StackTraceAnalyzers.TestWindowsPathParser.Test_Ability_To_Parse_Regular_Windows_Path" executed="True" result="Success" success="True" time="0.002" asserts="21" />
+                              <test-case name="NUnit.UiException.Tests.StackTraceAnalyzers.TestWindowsPathParser.Test_Inability_To_Parse_Non_Windows_Like_Path_Values" executed="True" result="Success" success="True" time="0.001" asserts="6" />
+                              <test-case name="NUnit.UiException.Tests.StackTraceAnalyzers.TestWindowsPathParser.TestIErrorParser.Test_IErrorParser_Can_Throw_ArgsNullException" executed="True" result="Success" success="True" time="0.001" asserts="11" />
+                              <test-case name="NUnit.UiException.Tests.StackTraceAnalyzers.TestWindowsPathParser.TestIErrorParser.Test_IErrorParser_Can_Throw_ParserNullException" executed="True" result="Success" success="True" time="0.000" asserts="11" />
+                            </results>
+                          </test-suite>
+                        </results>
+                      </test-suite>
+                      <test-suite type="TestFixture" name="TestDefaultTextManager" executed="True" result="Success" success="True" time="0.008" asserts="0">
+                        <results>
+                          <test-case name="NUnit.UiException.Tests.TestDefaultTextManager.Test_CodeBlockCollection" executed="True" result="Success" success="True" time="0.002" asserts="15" />
+                          <test-case name="NUnit.UiException.Tests.TestDefaultTextManager.Test_Default" executed="True" result="Success" success="True" time="0.000" asserts="3" />
+                          <test-case name="NUnit.UiException.Tests.TestDefaultTextManager.Test_MaxLength" executed="True" result="Success" success="True" time="0.001" asserts="3" />
+                        </results>
+                      </test-suite>
+                      <test-suite type="TestFixture" name="TestErrorItem" executed="True" result="Success" success="True" time="0.027" asserts="0">
+                        <results>
+                          <test-case name="NUnit.UiException.Tests.TestErrorItem.Can_Set_Properties" executed="True" result="Success" success="True" time="0.001" asserts="10" />
+                          <test-case name="NUnit.UiException.Tests.TestErrorItem.Ctor_2" executed="True" result="Success" success="True" time="0.000" asserts="10" />
+                          <test-case name="NUnit.UiException.Tests.TestErrorItem.Ctor_Throws_NullPathException" executed="True" result="Success" success="True" time="0.001" asserts="0" />
+                          <test-case name="NUnit.UiException.Tests.TestErrorItem.Ctor_With_Line_0" executed="True" result="Success" success="True" time="0.001" asserts="0" />
+                          <test-case name="NUnit.UiException.Tests.TestErrorItem.ReadFile" executed="True" result="Success" success="True" time="0.005" asserts="2" />
+                          <test-case name="NUnit.UiException.Tests.TestErrorItem.ReadFile_Throws_FileNotExistException" executed="True" result="Success" success="True" time="0.001" asserts="0" />
+                          <test-case name="NUnit.UiException.Tests.TestErrorItem.Test_Equals" executed="True" result="Success" success="True" time="0.000" asserts="8" />
+                          <test-case name="NUnit.UiException.Tests.TestErrorItem.Test_FileExtension" executed="True" result="Success" success="True" time="0.000" asserts="5" />
+                          <test-case name="NUnit.UiException.Tests.TestErrorItem.Test_MethodName" executed="True" result="Success" success="True" time="0.003" asserts="15" />
+                        </results>
+                      </test-suite>
+                      <test-suite type="TestFixture" name="TestErrorItemCollection" executed="True" result="Success" success="True" time="0.029" asserts="0">
+                        <results>
+                          <test-case name="NUnit.UiException.Tests.TestErrorItemCollection.Test_Add_Throws_NullItemException" executed="True" result="Success" success="True" time="0.006" asserts="0" />
+                          <test-case name="NUnit.UiException.Tests.TestErrorItemCollection.Test_Clear" executed="True" result="Success" success="True" time="0.005" asserts="2" />
+                          <test-case name="NUnit.UiException.Tests.TestErrorItemCollection.Test_Contains" executed="True" result="Success" success="True" time="0.005" asserts="3" />
+                          <test-case name="NUnit.UiException.Tests.TestErrorItemCollection.Test_TraceItems" executed="True" result="Success" success="True" time="0.006" asserts="7" />
+                        </results>
+                      </test-suite>
+                      <test-suite type="TestFixture" name="TestPaintLineLocation" executed="True" result="Success" success="True" time="0.007" asserts="0">
+                        <results>
+                          <test-case name="NUnit.UiException.Tests.TestPaintLineLocation.Test_Equals" executed="True" result="Success" success="True" time="0.002" asserts="8" />
+                          <test-case name="NUnit.UiException.Tests.TestPaintLineLocation.Test_PaintLineLocation" executed="True" result="Success" success="True" time="0.001" asserts="3" />
+                          <test-case name="NUnit.UiException.Tests.TestPaintLineLocation.Test_SetText_Throws_NullTextException" executed="True" result="Success" success="True" time="0.001" asserts="0" />
+                        </results>
+                      </test-suite>
+                      <test-suite type="TestFixture" name="TestStackTraceParser" executed="True" result="Success" success="True" time="0.028" asserts="0">
+                        <results>
+                          <test-case name="NUnit.UiException.Tests.TestStackTraceParser.Test_Ability_To_Handle_Different_Path_System_Syntaxes" executed="True" result="Success" success="True" time="0.001" asserts="3" />
+                          <test-case name="NUnit.UiException.Tests.TestStackTraceParser.Test_Ability_To_Handle_Files_With_Unknown_Extension" executed="True" result="Success" success="True" time="0.001" asserts="2" />
+                          <test-case name="NUnit.UiException.Tests.TestStackTraceParser.Test_Analysis_Does_Not_Depend_Upon_File_Extension" executed="True" result="Success" success="True" time="0.001" asserts="2" />
+                          <test-case name="NUnit.UiException.Tests.TestStackTraceParser.Test_Default" executed="True" result="Success" success="True" time="0.000" asserts="2" />
+                          <test-case name="NUnit.UiException.Tests.TestStackTraceParser.Test_English_Stack" executed="True" result="Success" success="True" time="0.000" asserts="2" />
+                          <test-case name="NUnit.UiException.Tests.TestStackTraceParser.Test_Missing_Line_Number" executed="True" result="Success" success="True" time="0.000" asserts="2" />
+                          <test-case name="NUnit.UiException.Tests.TestStackTraceParser.Test_Parse" executed="True" result="Success" success="True" time="0.001" asserts="3" />
+                          <test-case name="NUnit.UiException.Tests.TestStackTraceParser.Test_Parse_MultipleExtension" executed="True" result="Success" success="True" time="0.001" asserts="6" />
+                          <test-case name="NUnit.UiException.Tests.TestStackTraceParser.Test_Parse_Null" executed="True" result="Success" success="True" time="0.000" asserts="0" />
+                          <test-case name="NUnit.UiException.Tests.TestStackTraceParser.Test_Parse_With_Real_Life_Samples" executed="True" result="Success" success="True" time="0.001" asserts="5" />
+                          <test-case name="NUnit.UiException.Tests.TestStackTraceParser.Test_Trace_When_Missing_File" executed="True" result="Success" success="True" time="0.000" asserts="5" />
+                        </results>
+                      </test-suite>
+                    </results>
+                  </test-suite>
+                </results>
+              </test-suite>
+            </results>
+          </test-suite>
+        </results>
+      </test-suite>
+      <test-suite type="Assembly" name="C:\Program Files\NUnit 2.5.10\bin\net-2.0\tests/nunit.uikit.tests.dll" executed="True" result="Success" success="True" time="2.582" asserts="0">
+        <results>
+          <test-suite type="Namespace" name="NUnit" executed="True" result="Success" success="True" time="2.578" asserts="0">
+            <results>
+              <test-suite type="Namespace" name="UiKit" executed="True" result="Success" success="True" time="2.578" asserts="0">
+                <results>
+                  <test-suite type="Namespace" name="Tests" executed="True" result="Success" success="True" time="2.578" asserts="0">
+                    <results>
+                      <test-suite type="TestFixture" name="AddConfigurationDialogTests" executed="True" result="Success" success="True" time="0.523" asserts="0">
+                        <results>
+                          <test-case name="NUnit.UiKit.Tests.AddConfigurationDialogTests.CheckComboBox" executed="True" result="Success" success="True" time="0.402" asserts="5" />
+                          <test-case name="NUnit.UiKit.Tests.AddConfigurationDialogTests.CheckForControls" executed="True" result="Success" success="True" time="0.001" asserts="0" />
+                          <test-case name="NUnit.UiKit.Tests.AddConfigurationDialogTests.CheckTextBox" executed="True" result="Success" success="True" time="0.001" asserts="1" />
+                          <test-case name="NUnit.UiKit.Tests.AddConfigurationDialogTests.TestComplexEntry" executed="True" result="Success" success="True" time="0.090" asserts="2" />
+                          <test-case name="NUnit.UiKit.Tests.AddConfigurationDialogTests.TestSimpleEntry" executed="True" result="Success" success="True" time="0.014" asserts="2" />
+                        </results>
+                      </test-suite>
+                      <test-suite type="TestFixture" name="ErrorDisplayTests" executed="True" result="Success" success="True" time="0.248" asserts="0">
+                        <results>
+                          <test-case name="NUnit.UiKit.Tests.ErrorDisplayTests.ControlsArePositionedCorrectly" executed="True" result="Success" success="True" time="0.000" asserts="0" />
+                          <test-case name="NUnit.UiKit.Tests.ErrorDisplayTests.ControlsExist" executed="True" result="Success" success="True" time="0.000" asserts="0" />
+                        </results>
+                      </test-suite>
+                      <test-suite type="TestFixture" name="LongRunningOperationDisplayTests" executed="True" result="Success" success="True" time="0.019" asserts="0">
+                        <results>
+                          <test-case name="NUnit.UiKit.Tests.LongRunningOperationDisplayTests.CreateDisplay" executed="True" result="Success" success="True" time="0.018" asserts="2" />
+                        </results>
+                      </test-suite>
+                      <test-suite type="TestFixture" name="ProgressBarTests" executed="True" result="Success" success="True" time="0.102" asserts="0">
+                        <results>
+                          <test-case name="NUnit.UiKit.Tests.ProgressBarTests.TestProgressDisplay" executed="True" result="Success" success="True" time="0.073" asserts="5" />
+                        </results>
+                      </test-suite>
+                      <test-suite type="TestFixture" name="RecentFileMenuHandlerTests" executed="True" result="Success" success="True" time="0.010" asserts="0">
+                        <results>
+                          <test-case name="NUnit.UiKit.Tests.RecentFileMenuHandlerTests.DisableOnLoadWhenEmpty" executed="True" result="Success" success="True" time="0.002" asserts="1" />
+                          <test-case name="NUnit.UiKit.Tests.RecentFileMenuHandlerTests.EnableOnLoadWhenNotEmpty" executed="True" result="Success" success="True" time="0.002" asserts="1" />
+                          <test-case name="NUnit.UiKit.Tests.RecentFileMenuHandlerTests.LoadMenuItems" executed="True" result="Success" success="True" time="0.000" asserts="2" />
+                        </results>
+                      </test-suite>
+                      <test-suite type="TestFixture" name="StatusBarTests" executed="True" result="Success" success="True" time="0.153" asserts="0">
+                        <results>
+                          <test-case name="NUnit.UiKit.Tests.StatusBarTests.TestConstruction" executed="True" result="Success" success="True" time="0.039" asserts="5" />
+                          <test-case name="NUnit.UiKit.Tests.StatusBarTests.TestFinalDisplay" executed="True" result="Success" success="True" time="0.041" asserts="5" />
+                          <test-case name="NUnit.UiKit.Tests.StatusBarTests.TestInitialization" executed="True" result="Success" success="True" time="0.026" asserts="10" />
+                          <test-case name="NUnit.UiKit.Tests.StatusBarTests.TestProgressDisplay" executed="True" result="Success" success="True" time="0.040" asserts="5" />
+                        </results>
+                      </test-suite>
+                      <test-suite type="TestFixture" name="TestSuiteTreeNodeTests" executed="True" result="Success" success="True" time="0.058" asserts="0">
+                        <results>
+                          <test-case name="NUnit.UiKit.Tests.TestSuiteTreeNodeTests.ClearNestedResults" executed="True" result="Success" success="True" time="0.013" asserts="8" />
+                          <test-case name="NUnit.UiKit.Tests.TestSuiteTreeNodeTests.ClearResult" executed="True" result="Success" success="True" time="0.003" asserts="5" />
+                          <test-case name="NUnit.UiKit.Tests.TestSuiteTreeNodeTests.ConstructFromTestInfo" executed="True" result="Success" success="True" time="0.004" asserts="6" />
+                          <test-case name="NUnit.UiKit.Tests.TestSuiteTreeNodeTests.ResultNotSet" executed="True" result="Success" success="True" time="0.003" asserts="2" />
+                          <test-case name="NUnit.UiKit.Tests.TestSuiteTreeNodeTests.SetResult_Failure" executed="True" result="Success" success="True" time="0.004" asserts="3" />
+                          <test-case name="NUnit.UiKit.Tests.TestSuiteTreeNodeTests.SetResult_Ignore" executed="True" result="Success" success="True" time="0.004" asserts="4" />
+                          <test-case name="NUnit.UiKit.Tests.TestSuiteTreeNodeTests.SetResult_Inconclusive" executed="True" result="Success" success="True" time="0.003" asserts="4" />
+                          <test-case name="NUnit.UiKit.Tests.TestSuiteTreeNodeTests.SetResult_Skipped" executed="True" result="Success" success="True" time="0.003" asserts="3" />
+                          <test-case name="NUnit.UiKit.Tests.TestSuiteTreeNodeTests.SetResult_Success" executed="True" result="Success" success="True" time="0.003" asserts="3" />
+                        </results>
+                      </test-suite>
+                      <test-suite type="TestFixture" name="TestSuiteTreeViewReloadTests" executed="True" result="Success" success="True" time="0.621" asserts="0">
+                        <results>
+                          <test-case name="NUnit.UiKit.Tests.TestSuiteTreeViewReloadTests.CanReloadAfterChangingOrder" executed="True" result="Success" success="True" time="0.146" asserts="178" />
+                          <test-case name="NUnit.UiKit.Tests.TestSuiteTreeViewReloadTests.CanReloadAfterDeletingBranch" executed="True" result="Success" success="True" time="0.044" asserts="137" />
+                          <test-case name="NUnit.UiKit.Tests.TestSuiteTreeViewReloadTests.CanReloadAfterDeletingOneTestCase" executed="True" result="Success" success="True" time="0.041" asserts="175" />
+                          <test-case name="NUnit.UiKit.Tests.TestSuiteTreeViewReloadTests.CanReloadAfterDeletingThreeTestCases" executed="True" result="Success" success="True" time="0.048" asserts="169" />
+                          <test-case name="NUnit.UiKit.Tests.TestSuiteTreeViewReloadTests.CanReloadAfterInsertingTestCase" executed="True" result="Success" success="True" time="0.041" asserts="181" />
+                          <test-case name="NUnit.UiKit.Tests.TestSuiteTreeViewReloadTests.CanReloadAfterInsertingTestFixture" executed="True" result="Success" success="True" time="0.042" asserts="182" />
+                          <test-case name="NUnit.UiKit.Tests.TestSuiteTreeViewReloadTests.CanReloadAfterMultipleChanges" executed="True" result="Success" success="True" time="0.043" asserts="179" />
+                          <test-case name="NUnit.UiKit.Tests.TestSuiteTreeViewReloadTests.CanReloadAfterTurningOffAutoNamespaces" executed="True" result="Success" success="True" time="0.072" asserts="159" />
+                          <test-case name="NUnit.UiKit.Tests.TestSuiteTreeViewReloadTests.CanReloadWithoutChange" executed="True" result="Success" success="True" time="0.042" asserts="177" />
+                          <test-case name="NUnit.UiKit.Tests.TestSuiteTreeViewReloadTests.ReloadTreeWithWrongTest" executed="True" result="Success" success="True" time="0.043" asserts="0" />
+                          <test-case name="NUnit.UiKit.Tests.TestSuiteTreeViewReloadTests.VerifyCheckTreeWorks" executed="True" result="Success" success="True" time="0.040" asserts="177" />
+                        </results>
+                      </test-suite>
+                      <test-suite type="TestFixture" name="TestSuiteTreeViewTests" executed="True" result="Success" success="True" time="0.231" asserts="0">
+                        <results>
+                          <test-case name="NUnit.UiKit.Tests.TestSuiteTreeViewTests.BuildFromResult" executed="True" result="Success" success="True" time="0.050" asserts="15" />
+                          <test-case name="NUnit.UiKit.Tests.TestSuiteTreeViewTests.BuildTreeView" executed="True" result="Success" success="True" time="0.043" asserts="5" />
+                          <test-case name="NUnit.UiKit.Tests.TestSuiteTreeViewTests.ClearTree" executed="True" result="Success" success="True" time="0.040" asserts="1" />
+                          <test-case name="NUnit.UiKit.Tests.TestSuiteTreeViewTests.ProcessChecks" executed="True" result="Success" success="True" time="0.045" asserts="7" />
+                          <test-case name="NUnit.UiKit.Tests.TestSuiteTreeViewTests.SetTestResult" executed="True" result="Success" success="True" time="0.043" asserts="3" />
+                        </results>
+                      </test-suite>
+                      <test-suite type="TestFixture" name="TestTreeTests" executed="True" result="Success" success="True" time="0.042" asserts="0">
+                        <results>
+                          <test-case name="NUnit.UiKit.Tests.TestTreeTests.SameCategoryShouldNotBeSelectedMoreThanOnce" executed="True" result="Success" success="True" time="0.041" asserts="4" />
+                        </results>
+                      </test-suite>
+                      <test-suite type="TestFixture" name="VisualStateTests" executed="True" result="Success" success="True" time="0.552" asserts="0">
+                        <results>
+                          <test-case name="NUnit.UiKit.Tests.VisualStateTests.SaveAndRestoreVisualState" executed="True" result="Success" success="True" time="0.550" asserts="5" />
+                        </results>
+                      </test-suite>
+                    </results>
+                  </test-suite>
+                </results>
+              </test-suite>
+            </results>
+          </test-suite>
+        </results>
+      </test-suite>
+      <test-suite type="Assembly" name="C:\Program Files\NUnit 2.5.10\bin\net-2.0\tests/nunit-gui.tests.dll" executed="True" result="Success" success="True" time="0.890" asserts="0">
+        <results>
+          <test-suite type="Namespace" name="NUnit" executed="True" result="Success" success="True" time="0.886" asserts="0">
+            <results>
+              <test-suite type="Namespace" name="Gui" executed="True" result="Success" success="True" time="0.885" asserts="0">
+                <results>
+                  <test-suite type="Namespace" name="Tests" executed="True" result="Success" success="True" time="0.885" asserts="0">
+                    <results>
+                      <test-suite type="TestFixture" name="CommandLineTests" executed="True" result="Success" success="True" time="0.104" asserts="0">
+                        <results>
+                          <test-case name="NUnit.Gui.Tests.CommandLineTests.AssemblyName" executed="True" result="Success" success="True" time="0.073" asserts="1" />
+                          <test-case name="NUnit.Gui.Tests.CommandLineTests.Help" executed="True" result="Success" success="True" time="0.003" asserts="1" />
+                          <test-case name="NUnit.Gui.Tests.CommandLineTests.HelpTextUsesCorrectDelimiterForPlatform" executed="True" result="Success" success="True" time="0.002" asserts="1" />
+                          <test-case name="NUnit.Gui.Tests.CommandLineTests.InvalidArgs" executed="True" result="Success" success="True" time="0.001" asserts="1" />
+                          <test-case name="NUnit.Gui.Tests.CommandLineTests.InvalidCommandLineParms" executed="True" result="Success" success="True" time="0.001" asserts="1" />
+                          <test-case name="NUnit.Gui.Tests.CommandLineTests.NoNameValuePairs" executed="True" result="Success" success="True" time="0.001" asserts="1" />
+                          <test-case name="NUnit.Gui.Tests.CommandLineTests.NoParametersCount" executed="True" result="Success" success="True" time="0.001" asserts="1" />
+                          <test-case name="NUnit.Gui.Tests.CommandLineTests.ShortHelp" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Gui.Tests.CommandLineTests.ValidateSuccessful" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                        </results>
+                      </test-suite>
+                      <test-suite type="TestFixture" name="ExceptionDetailsFormTests" executed="True" result="Success" success="True" time="0.308" asserts="0">
+                        <results>
+                          <test-case name="NUnit.Gui.Tests.ExceptionDetailsFormTests.ControlsArePositionedCorrectly" executed="True" result="Success" success="True" time="0.002" asserts="0" />
+                          <test-case name="NUnit.Gui.Tests.ExceptionDetailsFormTests.ControlsExist" executed="True" result="Success" success="True" time="0.001" asserts="0" />
+                          <test-case name="NUnit.Gui.Tests.ExceptionDetailsFormTests.MessageDisplaysCorrectly" executed="True" result="Success" success="True" time="0.103" asserts="1" />
+                        </results>
+                      </test-suite>
+                      <test-suite type="TestFixture" name="ProjectEditorTests" executed="True" result="Success" success="True" time="0.468" asserts="0">
+                        <results>
+                          <test-case name="NUnit.Gui.Tests.ProjectEditorTests.CheckControls" executed="True" result="Success" success="True" time="0.246" asserts="0" />
+                          <test-case name="NUnit.Gui.Tests.ProjectEditorTests.InitialFieldValues" executed="True" result="Success" success="True" time="0.219" asserts="2" />
+                        </results>
+                      </test-suite>
+                    </results>
+                  </test-suite>
+                </results>
+              </test-suite>
+            </results>
+          </test-suite>
+        </results>
+      </test-suite>
+      <test-suite type="Assembly" name="C:\Program Files\NUnit 2.5.10\bin\net-2.0\tests/nunit.fixtures.tests.dll" executed="True" result="Success" success="True" time="0.057" asserts="0">
+        <results>
+          <test-suite type="Namespace" name="NUnit" executed="True" result="Success" success="True" time="0.053" asserts="0">
+            <results>
+              <test-suite type="Namespace" name="Fixtures" executed="True" result="Success" success="True" time="0.053" asserts="0">
+                <results>
+                  <test-suite type="Namespace" name="Tests" executed="True" result="Success" success="True" time="0.053" asserts="0">
+                    <results>
+                      <test-suite type="TestFixture" name="TestTreeTests" executed="True" result="Success" success="True" time="0.051" asserts="0">
+                        <results>
+                          <test-case name="NUnit.Fixtures.Tests.TestTreeTests.MatchingTreesAreEqual" executed="True" result="Success" success="True" time="0.012" asserts="3" />
+                          <test-case name="NUnit.Fixtures.Tests.TestTreeTests.NonMatchingTreesAreNotEqual" executed="True" result="Success" success="True" time="0.005" asserts="3" />
+                        </results>
+                      </test-suite>
+                    </results>
+                  </test-suite>
+                </results>
+              </test-suite>
+            </results>
+          </test-suite>
+        </results>
+      </test-suite>
+    </results>
+  </test-suite>
+</test-results>

--- a/src/test-nunit-summary.exe/TestInput/TestResult-2.5.2.xml
+++ b/src/test-nunit-summary.exe/TestInput/TestResult-2.5.2.xml
@@ -1,0 +1,5155 @@
+﻿<?xml version="1.0" encoding="utf-8" standalone="no"?>
+<!--This file represents the results of running a test suite-->
+<test-results name="C:\Program Files\NUnit 2.5.2\bin\net-2.0\NUnitTests.nunit" total="2625" errors="0" failures="0" not-run="2" inconclusive="7" ignored="0" skipped="2" invalid="0" date="2009-12-02" time="06:48:50">
+  <environment nunit-version="2.5.2.9222" clr-version="2.0.50727.3053" os-version="Microsoft Windows NT 5.1.2600 Service Pack 2" platform="Win32NT" cwd="C:\Program Files\NUnit 2.5.2\bin\net-2.0" machine-name="FERRARI" user="Charlie" user-domain="FERRARI" />
+  <culture-info current-culture="en-US" current-uiculture="en-US" />
+  <test-suite name="C:\Program Files\NUnit 2.5.2\bin\net-2.0\NUnitTests.nunit" executed="True" success="True" time="181.688" asserts="0">
+    <results>
+      <test-suite name="C:\Program Files\NUnit 2.5.2\bin\net-2.0\tests/nunit.framework.tests.dll" executed="True" success="True" time="18.422" asserts="0">
+        <results>
+          <test-suite name="NUnit" executed="True" success="True" time="18.422" asserts="0">
+            <results>
+              <test-suite name="Framework" executed="True" success="True" time="18.422" asserts="0">
+                <results>
+                  <test-suite name="Constraints" executed="True" success="True" time="10.875" asserts="0">
+                    <results>
+                      <test-suite name="Tests" executed="True" success="True" time="10.719" asserts="0">
+                        <results>
+                          <test-suite name="AfterConstraintTest" executed="True" success="True" time="6.328" asserts="0">
+                            <results>
+                              <test-suite name="FailsWithBadDelegates" executed="True" success="True" time="1.016" asserts="0">
+                                <results>
+                                  <test-case name="NUnit.Framework.Constraints.Tests.AfterConstraintTest.FailsWithBadDelegates(NUnit.Framework.Constraints.ActualValueDelegate)" executed="True" success="True" time="0.500" asserts="1" />
+                                  <test-case name="NUnit.Framework.Constraints.Tests.AfterConstraintTest.FailsWithBadDelegates(NUnit.Framework.Constraints.ActualValueDelegate)" executed="True" success="True" time="0.500" asserts="1" />
+                                </results>
+                              </test-suite>
+                              <test-suite name="FailsWithBadValues" executed="True" success="True" time="1.516" asserts="0">
+                                <results>
+                                  <test-case name="NUnit.Framework.Constraints.Tests.AfterConstraintTest.FailsWithBadValues(False)" executed="True" success="True" time="0.500" asserts="1" />
+                                  <test-case name="NUnit.Framework.Constraints.Tests.AfterConstraintTest.FailsWithBadValues(0)" executed="True" success="True" time="0.500" asserts="1" />
+                                  <test-case name="NUnit.Framework.Constraints.Tests.AfterConstraintTest.FailsWithBadValues(null)" executed="True" success="True" time="0.500" asserts="1" />
+                                </results>
+                              </test-suite>
+                              <test-case name="NUnit.Framework.Constraints.Tests.AfterConstraintTest.ProvidesProperDescription" executed="True" success="True" time="0.000" asserts="1" />
+                              <test-suite name="ProvidesProperFailureMessage" executed="True" success="True" time="1.500" asserts="0">
+                                <results>
+                                  <test-case name="NUnit.Framework.Constraints.Tests.AfterConstraintTest.ProvidesProperFailureMessage(False,&quot;False&quot;)" executed="True" success="True" time="0.500" asserts="1" />
+                                  <test-case name="NUnit.Framework.Constraints.Tests.AfterConstraintTest.ProvidesProperFailureMessage(0,&quot;0&quot;)" executed="True" success="True" time="0.500" asserts="1" />
+                                  <test-case name="NUnit.Framework.Constraints.Tests.AfterConstraintTest.ProvidesProperFailureMessage(null,&quot;null&quot;)" executed="True" success="True" time="0.500" asserts="1" />
+                                </results>
+                              </test-suite>
+                              <test-case name="NUnit.Framework.Constraints.Tests.AfterConstraintTest.ProvidesProperStringRepresentation" executed="True" success="True" time="0.000" asserts="1" />
+                              <test-case name="NUnit.Framework.Constraints.Tests.AfterConstraintTest.SimpleTest" executed="True" success="True" time="0.625" asserts="1" />
+                              <test-case name="NUnit.Framework.Constraints.Tests.AfterConstraintTest.SimpleTestUsingReference" executed="True" success="True" time="0.609" asserts="1" />
+                              <test-suite name="SucceedsWithGoodDelegates" executed="True" success="True" time="0.500" asserts="0">
+                                <results>
+                                  <test-case name="NUnit.Framework.Constraints.Tests.AfterConstraintTest.SucceedsWithGoodDelegates(NUnit.Framework.Constraints.ActualValueDelegate)" executed="True" success="True" time="0.500" asserts="1" />
+                                </results>
+                              </test-suite>
+                              <test-suite name="SucceedsWithGoodValues" executed="True" success="True" time="0.500" asserts="0">
+                                <results>
+                                  <test-case name="NUnit.Framework.Constraints.Tests.AfterConstraintTest.SucceedsWithGoodValues(True)" executed="True" success="True" time="0.500" asserts="1" />
+                                </results>
+                              </test-suite>
+                              <test-case name="NUnit.Framework.Constraints.Tests.AfterConstraintTest.ThatOverload_DoesNotAcceptNegativeDelayValues" executed="True" success="True" time="0.000" asserts="0" />
+                              <test-case name="NUnit.Framework.Constraints.Tests.AfterConstraintTest.ThatOverload_ZeroDelayIsAllowed" executed="True" success="True" time="0.000" asserts="1" />
+                            </results>
+                          </test-suite>
+                          <test-suite name="AllItemsTests" executed="True" success="True" time="0.078" asserts="0">
+                            <results>
+                              <test-case name="NUnit.Framework.Constraints.Tests.AllItemsTests.AllItemsAreInRange" executed="True" success="True" time="0.016" asserts="1" />
+                              <test-case name="NUnit.Framework.Constraints.Tests.AllItemsTests.AllItemsAreInRange_UsingComparisonOfT" executed="True" success="True" time="0.000" asserts="1" />
+                              <test-case name="NUnit.Framework.Constraints.Tests.AllItemsTests.AllItemsAreInRange_UsingIComparer" executed="True" success="True" time="0.000" asserts="1" />
+                              <test-case name="NUnit.Framework.Constraints.Tests.AllItemsTests.AllItemsAreInRange_UsingIComparerOfT" executed="True" success="True" time="0.000" asserts="1" />
+                              <test-case name="NUnit.Framework.Constraints.Tests.AllItemsTests.AllItemsAreInRangeFailureMessage" executed="True" success="True" time="0.000" asserts="2" />
+                              <test-case name="NUnit.Framework.Constraints.Tests.AllItemsTests.AllItemsAreInstancesOfType" executed="True" success="True" time="0.000" asserts="1" />
+                              <test-case name="NUnit.Framework.Constraints.Tests.AllItemsTests.AllItemsAreInstancesOfTypeFailureMessage" executed="True" success="True" time="0.000" asserts="2" />
+                              <test-case name="NUnit.Framework.Constraints.Tests.AllItemsTests.AllItemsAreNotNull" executed="True" success="True" time="0.016" asserts="1" />
+                              <test-case name="NUnit.Framework.Constraints.Tests.AllItemsTests.AllItemsAreNotNullFails" executed="True" success="True" time="0.016" asserts="2" />
+                            </results>
+                          </test-suite>
+                          <test-suite name="AndTest" executed="True" success="True" time="0.000" asserts="0">
+                            <results>
+                              <test-case name="NUnit.Framework.Constraints.Tests.AndTest.CanCombineTestsWithAndOperator" executed="True" success="True" time="0.000" asserts="1" />
+                              <test-suite name="FailsWithBadValues" executed="True" success="True" time="0.000" asserts="0">
+                                <results>
+                                  <test-case name="NUnit.Framework.Constraints.Tests.AndTest.FailsWithBadValues(37)" executed="True" success="True" time="0.000" asserts="1" />
+                                  <test-case name="NUnit.Framework.Constraints.Tests.AndTest.FailsWithBadValues(53)" executed="True" success="True" time="0.000" asserts="1" />
+                                </results>
+                              </test-suite>
+                              <test-case name="NUnit.Framework.Constraints.Tests.AndTest.ProvidesProperDescription" executed="True" success="True" time="0.000" asserts="1" />
+                              <test-suite name="ProvidesProperFailureMessage" executed="True" success="True" time="0.000" asserts="0">
+                                <results>
+                                  <test-case name="NUnit.Framework.Constraints.Tests.AndTest.ProvidesProperFailureMessage(37,&quot;37&quot;)" executed="True" success="True" time="0.000" asserts="1" />
+                                  <test-case name="NUnit.Framework.Constraints.Tests.AndTest.ProvidesProperFailureMessage(53,&quot;53&quot;)" executed="True" success="True" time="0.000" asserts="1" />
+                                </results>
+                              </test-suite>
+                              <test-case name="NUnit.Framework.Constraints.Tests.AndTest.ProvidesProperStringRepresentation" executed="True" success="True" time="0.000" asserts="1" />
+                              <test-suite name="SucceedsWithGoodValues" executed="True" success="True" time="0.000" asserts="0">
+                                <results>
+                                  <test-case name="NUnit.Framework.Constraints.Tests.AndTest.SucceedsWithGoodValues(42)" executed="True" success="True" time="0.000" asserts="1" />
+                                </results>
+                              </test-suite>
+                            </results>
+                          </test-suite>
+                          <test-suite name="AssignableFromTest" executed="True" success="True" time="0.016" asserts="0">
+                            <results>
+                              <test-suite name="FailsWithBadValues" executed="True" success="True" time="0.000" asserts="0">
+                                <results>
+                                  <test-case name="NUnit.Framework.Constraints.Tests.AssignableFromTest.FailsWithBadValues(NUnit.Framework.Constraints.Tests.D2)" executed="True" success="True" time="0.000" asserts="1" />
+                                </results>
+                              </test-suite>
+                              <test-case name="NUnit.Framework.Constraints.Tests.AssignableFromTest.ProvidesProperDescription" executed="True" success="True" time="0.000" asserts="1" />
+                              <test-suite name="ProvidesProperFailureMessage" executed="True" success="True" time="0.000" asserts="0">
+                                <results>
+                                  <test-case name="NUnit.Framework.Constraints.Tests.AssignableFromTest.ProvidesProperFailureMessage(NUnit.Framework.Constraints.Tests.D2,&quot;&lt;NUnit.Framework.Constraints.Tests.D2&gt;&quot;)" executed="True" success="True" time="0.000" asserts="1" />
+                                </results>
+                              </test-suite>
+                              <test-case name="NUnit.Framework.Constraints.Tests.AssignableFromTest.ProvidesProperStringRepresentation" executed="True" success="True" time="0.000" asserts="1" />
+                              <test-suite name="SucceedsWithGoodValues" executed="True" success="True" time="0.000" asserts="0">
+                                <results>
+                                  <test-case name="NUnit.Framework.Constraints.Tests.AssignableFromTest.SucceedsWithGoodValues(NUnit.Framework.Constraints.Tests.D1)" executed="True" success="True" time="0.000" asserts="1" />
+                                  <test-case name="NUnit.Framework.Constraints.Tests.AssignableFromTest.SucceedsWithGoodValues(NUnit.Framework.Constraints.Tests.B)" executed="True" success="True" time="0.000" asserts="1" />
+                                </results>
+                              </test-suite>
+                            </results>
+                          </test-suite>
+                          <test-suite name="AssignableToTest" executed="True" success="True" time="0.000" asserts="0">
+                            <results>
+                              <test-suite name="FailsWithBadValues" executed="True" success="True" time="0.000" asserts="0">
+                                <results>
+                                  <test-case name="NUnit.Framework.Constraints.Tests.AssignableToTest.FailsWithBadValues(NUnit.Framework.Constraints.Tests.B)" executed="True" success="True" time="0.000" asserts="1" />
+                                </results>
+                              </test-suite>
+                              <test-case name="NUnit.Framework.Constraints.Tests.AssignableToTest.ProvidesProperDescription" executed="True" success="True" time="0.000" asserts="1" />
+                              <test-suite name="ProvidesProperFailureMessage" executed="True" success="True" time="0.000" asserts="0">
+                                <results>
+                                  <test-case name="NUnit.Framework.Constraints.Tests.AssignableToTest.ProvidesProperFailureMessage(NUnit.Framework.Constraints.Tests.B,&quot;&lt;NUnit.Framework.Constraints.Tests.B&gt;&quot;)" executed="True" success="True" time="0.000" asserts="1" />
+                                </results>
+                              </test-suite>
+                              <test-case name="NUnit.Framework.Constraints.Tests.AssignableToTest.ProvidesProperStringRepresentation" executed="True" success="True" time="0.000" asserts="1" />
+                              <test-suite name="SucceedsWithGoodValues" executed="True" success="True" time="0.000" asserts="0">
+                                <results>
+                                  <test-case name="NUnit.Framework.Constraints.Tests.AssignableToTest.SucceedsWithGoodValues(NUnit.Framework.Constraints.Tests.D1)" executed="True" success="True" time="0.000" asserts="1" />
+                                  <test-case name="NUnit.Framework.Constraints.Tests.AssignableToTest.SucceedsWithGoodValues(NUnit.Framework.Constraints.Tests.D2)" executed="True" success="True" time="0.000" asserts="1" />
+                                </results>
+                              </test-suite>
+                            </results>
+                          </test-suite>
+                          <test-suite name="AttributeExistsConstraintTest" executed="True" success="True" time="0.125" asserts="0">
+                            <results>
+                              <test-case name="NUnit.Framework.Constraints.Tests.AttributeExistsConstraintTest.AttributeExistsOnMethodInfo" executed="True" success="True" time="0.000" asserts="1" />
+                              <test-case name="NUnit.Framework.Constraints.Tests.AttributeExistsConstraintTest.AttributeTestPropertyValueOnMethodInfo" description="my description" executed="True" success="True" time="0.000" asserts="1" />
+                              <test-suite name="FailsWithBadValues" executed="True" success="True" time="0.000" asserts="0">
+                                <results>
+                                  <test-case name="NUnit.Framework.Constraints.Tests.AttributeExistsConstraintTest.FailsWithBadValues(NUnit.Framework.Constraints.Tests.D2)" executed="True" success="True" time="0.000" asserts="1" />
+                                </results>
+                              </test-suite>
+                              <test-case name="NUnit.Framework.Constraints.Tests.AttributeExistsConstraintTest.NonAttributeThrowsException" executed="True" success="True" time="0.125" asserts="0" />
+                              <test-case name="NUnit.Framework.Constraints.Tests.AttributeExistsConstraintTest.ProvidesProperDescription" executed="True" success="True" time="0.000" asserts="1" />
+                              <test-suite name="ProvidesProperFailureMessage" executed="True" success="True" time="0.000" asserts="0">
+                                <results>
+                                  <test-case name="NUnit.Framework.Constraints.Tests.AttributeExistsConstraintTest.ProvidesProperFailureMessage(NUnit.Framework.Constraints.Tests.D2,&quot;&lt;NUnit.Framework.Constraints.Tests.D2&gt;&quot;)" executed="True" success="True" time="0.000" asserts="1" />
+                                </results>
+                              </test-suite>
+                              <test-case name="NUnit.Framework.Constraints.Tests.AttributeExistsConstraintTest.ProvidesProperStringRepresentation" executed="True" success="True" time="0.000" asserts="1" />
+                              <test-suite name="SucceedsWithGoodValues" executed="True" success="True" time="0.000" asserts="0">
+                                <results>
+                                  <test-case name="NUnit.Framework.Constraints.Tests.AttributeExistsConstraintTest.SucceedsWithGoodValues(NUnit.Framework.Constraints.Tests.AttributeExistsConstraintTest)" executed="True" success="True" time="0.000" asserts="1" />
+                                </results>
+                              </test-suite>
+                            </results>
+                          </test-suite>
+                          <test-suite name="BinarySerializableTest" executed="True" success="True" time="0.047" asserts="0">
+                            <results>
+                              <test-suite name="FailsWithBadValues" executed="True" success="True" time="0.000" asserts="0">
+                                <results>
+                                  <test-case name="NUnit.Framework.Constraints.Tests.BinarySerializableTest.FailsWithBadValues(NUnit.Framework.Constraints.Tests.InternalClass)" executed="True" success="True" time="0.000" asserts="1" />
+                                </results>
+                              </test-suite>
+                              <test-suite name="InvalidDataThrowsArgumentException" executed="True" success="True" time="0.000" asserts="0">
+                                <results>
+                                  <test-case name="NUnit.Framework.Constraints.Tests.BinarySerializableTest.InvalidDataThrowsArgumentException(null)" executed="True" success="True" time="0.000" asserts="0" />
+                                </results>
+                              </test-suite>
+                              <test-case name="NUnit.Framework.Constraints.Tests.BinarySerializableTest.ProvidesProperDescription" executed="True" success="True" time="0.000" asserts="1" />
+                              <test-suite name="ProvidesProperFailureMessage" executed="True" success="True" time="0.000" asserts="0">
+                                <results>
+                                  <test-case name="NUnit.Framework.Constraints.Tests.BinarySerializableTest.ProvidesProperFailureMessage(NUnit.Framework.Constraints.Tests.InternalClass,&quot;&lt;InternalClass&gt;&quot;)" executed="True" success="True" time="0.000" asserts="1" />
+                                </results>
+                              </test-suite>
+                              <test-case name="NUnit.Framework.Constraints.Tests.BinarySerializableTest.ProvidesProperStringRepresentation" executed="True" success="True" time="0.000" asserts="1" />
+                              <test-suite name="SucceedsWithGoodValues" executed="True" success="True" time="0.047" asserts="0">
+                                <results>
+                                  <test-case name="NUnit.Framework.Constraints.Tests.BinarySerializableTest.SucceedsWithGoodValues(1)" executed="True" success="True" time="0.016" asserts="1" />
+                                  <test-case name="NUnit.Framework.Constraints.Tests.BinarySerializableTest.SucceedsWithGoodValues(&quot;a&quot;)" executed="True" success="True" time="0.000" asserts="1" />
+                                  <test-case name="NUnit.Framework.Constraints.Tests.BinarySerializableTest.SucceedsWithGoodValues(System.Collections.ArrayList)" executed="True" success="True" time="0.000" asserts="1" />
+                                  <test-case name="NUnit.Framework.Constraints.Tests.BinarySerializableTest.SucceedsWithGoodValues(NUnit.Framework.Constraints.Tests.InternalWithSerializableAttributeClass)" executed="True" success="True" time="0.031" asserts="1" />
+                                </results>
+                              </test-suite>
+                            </results>
+                          </test-suite>
+                          <test-suite name="CollectionContainsTests" executed="True" success="True" time="0.047" asserts="0">
+                            <results>
+                              <test-case name="NUnit.Framework.Constraints.Tests.CollectionContainsTests.CanTestContentsOfArray" executed="True" success="True" time="0.016" asserts="1" />
+                              <test-case name="NUnit.Framework.Constraints.Tests.CollectionContainsTests.CanTestContentsOfArrayList" executed="True" success="True" time="0.000" asserts="1" />
+                              <test-case name="NUnit.Framework.Constraints.Tests.CollectionContainsTests.CanTestContentsOfCollectionNotImplementingIList" executed="True" success="True" time="0.016" asserts="1" />
+                              <test-case name="NUnit.Framework.Constraints.Tests.CollectionContainsTests.CanTestContentsOfSortedList" executed="True" success="True" time="0.000" asserts="2" />
+                              <test-case name="NUnit.Framework.Constraints.Tests.CollectionContainsTests.IgnoreCaseIsHonored" executed="True" success="True" time="0.000" asserts="1" />
+                            </results>
+                          </test-suite>
+                          <test-suite name="CollectionEquivalentTests" executed="True" success="True" time="0.000" asserts="0">
+                            <results>
+                              <test-case name="NUnit.Framework.Constraints.Tests.CollectionEquivalentTests.EqualCollectionsAreEquivalent" executed="True" success="True" time="0.000" asserts="1" />
+                              <test-case name="NUnit.Framework.Constraints.Tests.CollectionEquivalentTests.EquivalentFailsWithDuplicateElementInActual" executed="True" success="True" time="0.000" asserts="1" />
+                              <test-case name="NUnit.Framework.Constraints.Tests.CollectionEquivalentTests.EquivalentFailsWithDuplicateElementInExpected" executed="True" success="True" time="0.000" asserts="1" />
+                              <test-case name="NUnit.Framework.Constraints.Tests.CollectionEquivalentTests.EquivalentHandlesNull" executed="True" success="True" time="0.000" asserts="1" />
+                              <test-case name="NUnit.Framework.Constraints.Tests.CollectionEquivalentTests.EquivalentHonorsIgnoreCase" executed="True" success="True" time="0.000" asserts="1" />
+                              <test-case name="NUnit.Framework.Constraints.Tests.CollectionEquivalentTests.EquivalentIgnoresOrder" executed="True" success="True" time="0.000" asserts="1" />
+                              <test-case name="NUnit.Framework.Constraints.Tests.CollectionEquivalentTests.WorksWithCollectionsOfArrays" executed="True" success="True" time="0.000" asserts="2" />
+                            </results>
+                          </test-suite>
+                          <test-suite name="CollectionOrderedTests" executed="True" success="True" time="0.078" asserts="0">
+                            <results>
+                              <test-case name="NUnit.Framework.Constraints.Tests.CollectionOrderedTests.IsOrdered" executed="True" success="True" time="0.000" asserts="1" />
+                              <test-case name="NUnit.Framework.Constraints.Tests.CollectionOrderedTests.IsOrdered_2" executed="True" success="True" time="0.000" asserts="1" />
+                              <test-case name="NUnit.Framework.Constraints.Tests.CollectionOrderedTests.IsOrdered_Allows_adjacent_equal_values" executed="True" success="True" time="0.000" asserts="1" />
+                              <test-case name="NUnit.Framework.Constraints.Tests.CollectionOrderedTests.IsOrdered_AtLeastOneArgMustImplementIComparable" executed="True" success="True" time="0.000" asserts="1" />
+                              <test-case name="NUnit.Framework.Constraints.Tests.CollectionOrderedTests.IsOrdered_Fails" executed="True" success="True" time="0.016" asserts="2" />
+                              <test-case name="NUnit.Framework.Constraints.Tests.CollectionOrderedTests.IsOrdered_Handles_custom_comparison" executed="True" success="True" time="0.000" asserts="2" />
+                              <test-case name="NUnit.Framework.Constraints.Tests.CollectionOrderedTests.IsOrdered_Handles_custom_comparison2" executed="True" success="True" time="0.000" asserts="2" />
+                              <test-case name="NUnit.Framework.Constraints.Tests.CollectionOrderedTests.IsOrdered_Handles_null" executed="True" success="True" time="0.016" asserts="1" />
+                              <test-case name="NUnit.Framework.Constraints.Tests.CollectionOrderedTests.IsOrdered_TypesMustBeComparable" executed="True" success="True" time="0.000" asserts="1" />
+                              <test-case name="NUnit.Framework.Constraints.Tests.CollectionOrderedTests.IsOrderedBy" executed="True" success="True" time="0.000" asserts="1" />
+                              <test-case name="NUnit.Framework.Constraints.Tests.CollectionOrderedTests.IsOrderedBy_Comparer" executed="True" success="True" time="0.000" asserts="1" />
+                              <test-case name="NUnit.Framework.Constraints.Tests.CollectionOrderedTests.IsOrderedBy_Handles_heterogeneous_classes_as_long_as_the_property_is_of_same_type" executed="True" success="True" time="0.000" asserts="1" />
+                              <test-case name="NUnit.Framework.Constraints.Tests.CollectionOrderedTests.IsOrderedDescending" executed="True" success="True" time="0.000" asserts="1" />
+                              <test-case name="NUnit.Framework.Constraints.Tests.CollectionOrderedTests.IsOrderedDescending_2" executed="True" success="True" time="0.000" asserts="1" />
+                              <test-case name="NUnit.Framework.Constraints.Tests.CollectionOrderedTests.UsesProvidedComparerOfT" executed="True" success="True" time="0.000" asserts="2" />
+                              <test-case name="NUnit.Framework.Constraints.Tests.CollectionOrderedTests.UsesProvidedComparisonOfT" executed="True" success="True" time="0.000" asserts="2" />
+                            </results>
+                          </test-suite>
+                          <test-suite name="ComparerTests" executed="True" success="True" time="0.016" asserts="0">
+                            <results>
+                              <test-suite name="EqualItems" executed="True" success="True" time="0.016" asserts="0">
+                                <results>
+                                  <test-case name="NUnit.Framework.Constraints.Tests.ComparerTests.EqualItems(4,4.0f)" executed="True" success="True" time="0.000" asserts="2" />
+                                  <test-case name="NUnit.Framework.Constraints.Tests.ComparerTests.EqualItems(4.0f,4)" executed="True" success="True" time="0.000" asserts="2" />
+                                  <test-case name="NUnit.Framework.Constraints.Tests.ComparerTests.EqualItems(4.0f,4.0d)" executed="True" success="True" time="0.000" asserts="2" />
+                                  <test-case name="NUnit.Framework.Constraints.Tests.ComparerTests.EqualItems(null,null)" executed="True" success="True" time="0.000" asserts="2" />
+                                  <test-case name="NUnit.Framework.Constraints.Tests.ComparerTests.EqualItems(4,4)" executed="True" success="True" time="0.000" asserts="2" />
+                                  <test-case name="NUnit.Framework.Constraints.Tests.ComparerTests.EqualItems(4.0f,4.0f)" executed="True" success="True" time="0.000" asserts="2" />
+                                  <test-case name="NUnit.Framework.Constraints.Tests.ComparerTests.EqualItems(4,4.0d)" executed="True" success="True" time="0.000" asserts="2" />
+                                  <test-case name="NUnit.Framework.Constraints.Tests.ComparerTests.EqualItems(4.0d,4.0f)" executed="True" success="True" time="0.000" asserts="2" />
+                                  <test-case name="NUnit.Framework.Constraints.Tests.ComparerTests.EqualItems(4.0d,4.0d)" executed="True" success="True" time="0.000" asserts="2" />
+                                  <test-case name="NUnit.Framework.Constraints.Tests.ComparerTests.EqualItems(4.0d,4)" executed="True" success="True" time="0.000" asserts="2" />
+                                  <test-case name="NUnit.Framework.Constraints.Tests.ComparerTests.EqualItems(null,null)" executed="True" success="True" time="0.000" asserts="2" />
+                                </results>
+                              </test-suite>
+                              <test-suite name="SpecialFloatingPointValues" executed="True" success="True" time="0.000" asserts="0">
+                                <results>
+                                  <test-case name="NUnit.Framework.Constraints.Tests.ComparerTests.SpecialFloatingPointValues(double.NegativeInfinity)" executed="True" success="True" time="0.000" asserts="1" />
+                                  <test-case name="NUnit.Framework.Constraints.Tests.ComparerTests.SpecialFloatingPointValues(float.NegativeInfinity)" executed="True" success="True" time="0.000" asserts="1" />
+                                  <test-case name="NUnit.Framework.Constraints.Tests.ComparerTests.SpecialFloatingPointValues(double.PositiveInfinity)" executed="True" success="True" time="0.000" asserts="1" />
+                                  <test-case name="NUnit.Framework.Constraints.Tests.ComparerTests.SpecialFloatingPointValues(float.NaN)" executed="True" success="True" time="0.000" asserts="1" />
+                                  <test-case name="NUnit.Framework.Constraints.Tests.ComparerTests.SpecialFloatingPointValues(double.NaN)" executed="True" success="True" time="0.000" asserts="1" />
+                                  <test-case name="NUnit.Framework.Constraints.Tests.ComparerTests.SpecialFloatingPointValues(float.PositiveInfinity)" executed="True" success="True" time="0.000" asserts="1" />
+                                </results>
+                              </test-suite>
+                              <test-suite name="UnequalItems" executed="True" success="True" time="0.000" asserts="0">
+                                <results>
+                                  <test-case name="NUnit.Framework.Constraints.Tests.ComparerTests.UnequalItems(4,2)" executed="True" success="True" time="0.000" asserts="4" />
+                                  <test-case name="NUnit.Framework.Constraints.Tests.ComparerTests.UnequalItems(4,null)" executed="True" success="True" time="0.000" asserts="4" />
+                                  <test-case name="NUnit.Framework.Constraints.Tests.ComparerTests.UnequalItems(4.0d,2.0d)" executed="True" success="True" time="0.000" asserts="4" />
+                                  <test-case name="NUnit.Framework.Constraints.Tests.ComparerTests.UnequalItems(4,null)" executed="True" success="True" time="0.000" asserts="4" />
+                                  <test-case name="NUnit.Framework.Constraints.Tests.ComparerTests.UnequalItems(4.0f,2.0f)" executed="True" success="True" time="0.000" asserts="4" />
+                                  <test-case name="NUnit.Framework.Constraints.Tests.ComparerTests.UnequalItems(4,2.0d)" executed="True" success="True" time="0.000" asserts="4" />
+                                  <test-case name="NUnit.Framework.Constraints.Tests.ComparerTests.UnequalItems(4,2.0f)" executed="True" success="True" time="0.000" asserts="4" />
+                                  <test-case name="NUnit.Framework.Constraints.Tests.ComparerTests.UnequalItems(4.0d,2)" executed="True" success="True" time="0.000" asserts="4" />
+                                  <test-case name="NUnit.Framework.Constraints.Tests.ComparerTests.UnequalItems(4.0d,2.0f)" executed="True" success="True" time="0.000" asserts="4" />
+                                  <test-case name="NUnit.Framework.Constraints.Tests.ComparerTests.UnequalItems(4.0f,2)" executed="True" success="True" time="0.000" asserts="4" />
+                                  <test-case name="NUnit.Framework.Constraints.Tests.ComparerTests.UnequalItems(4.0f,2.0d)" executed="True" success="True" time="0.000" asserts="4" />
+                                </results>
+                              </test-suite>
+                            </results>
+                          </test-suite>
+                          <test-suite name="EmptyConstraintTest" executed="True" success="True" time="0.000" asserts="0">
+                            <results>
+                              <test-suite name="FailsWithBadValues" executed="True" success="True" time="0.000" asserts="0">
+                                <results>
+                                  <test-case name="NUnit.Framework.Constraints.Tests.EmptyConstraintTest.FailsWithBadValues(&quot;Hello&quot;)" executed="True" success="True" time="0.000" asserts="1" />
+                                  <test-case name="NUnit.Framework.Constraints.Tests.EmptyConstraintTest.FailsWithBadValues(System.Object[])" executed="True" success="True" time="0.000" asserts="1" />
+                                </results>
+                              </test-suite>
+                              <test-suite name="InvalidDataThrowsArgumentException" executed="True" success="True" time="0.000" asserts="0">
+                                <results>
+                                  <test-case name="NUnit.Framework.Constraints.Tests.EmptyConstraintTest.InvalidDataThrowsArgumentException(null)" executed="True" success="True" time="0.000" asserts="0" />
+                                  <test-case name="NUnit.Framework.Constraints.Tests.EmptyConstraintTest.InvalidDataThrowsArgumentException(5)" executed="True" success="True" time="0.000" asserts="0" />
+                                </results>
+                              </test-suite>
+                              <test-case name="NUnit.Framework.Constraints.Tests.EmptyConstraintTest.ProvidesProperDescription" executed="True" success="True" time="0.000" asserts="1" />
+                              <test-suite name="ProvidesProperFailureMessage" executed="True" success="True" time="0.000" asserts="0">
+                                <results>
+                                  <test-case name="NUnit.Framework.Constraints.Tests.EmptyConstraintTest.ProvidesProperFailureMessage(&quot;Hello&quot;,&quot;\&quot;Hello\&quot;&quot;)" executed="True" success="True" time="0.000" asserts="1" />
+                                  <test-case name="NUnit.Framework.Constraints.Tests.EmptyConstraintTest.ProvidesProperFailureMessage(System.Object[],&quot;&lt; 1, 2, 3 &gt;&quot;)" executed="True" success="True" time="0.000" asserts="1" />
+                                </results>
+                              </test-suite>
+                              <test-case name="NUnit.Framework.Constraints.Tests.EmptyConstraintTest.ProvidesProperStringRepresentation" executed="True" success="True" time="0.000" asserts="1" />
+                              <test-suite name="SucceedsWithGoodValues" executed="True" success="True" time="0.000" asserts="0">
+                                <results>
+                                  <test-case name="NUnit.Framework.Constraints.Tests.EmptyConstraintTest.SucceedsWithGoodValues(&quot;&quot;)" executed="True" success="True" time="0.000" asserts="1" />
+                                  <test-case name="NUnit.Framework.Constraints.Tests.EmptyConstraintTest.SucceedsWithGoodValues(System.Object[])" executed="True" success="True" time="0.000" asserts="1" />
+                                  <test-case name="NUnit.Framework.Constraints.Tests.EmptyConstraintTest.SucceedsWithGoodValues(System.Collections.ArrayList)" executed="True" success="True" time="0.000" asserts="1" />
+                                  <test-case name="NUnit.Framework.Constraints.Tests.EmptyConstraintTest.SucceedsWithGoodValues(System.Collections.Generic.List`1[System.Int32])" executed="True" success="True" time="0.000" asserts="1" />
+                                </results>
+                              </test-suite>
+                            </results>
+                          </test-suite>
+                          <test-suite name="EndsWithTest" executed="True" success="True" time="0.000" asserts="0">
+                            <results>
+                              <test-suite name="FailsWithBadValues" executed="True" success="True" time="0.000" asserts="0">
+                                <results>
+                                  <test-case name="NUnit.Framework.Constraints.Tests.EndsWithTest.FailsWithBadValues(&quot;goodbye&quot;)" executed="True" success="True" time="0.000" asserts="1" />
+                                  <test-case name="NUnit.Framework.Constraints.Tests.EndsWithTest.FailsWithBadValues(&quot;What the hell?&quot;)" executed="True" success="True" time="0.000" asserts="1" />
+                                  <test-case name="NUnit.Framework.Constraints.Tests.EndsWithTest.FailsWithBadValues(&quot;hello there&quot;)" executed="True" success="True" time="0.000" asserts="1" />
+                                  <test-case name="NUnit.Framework.Constraints.Tests.EndsWithTest.FailsWithBadValues(&quot;say hello to fred&quot;)" executed="True" success="True" time="0.000" asserts="1" />
+                                  <test-case name="NUnit.Framework.Constraints.Tests.EndsWithTest.FailsWithBadValues(&quot;&quot;)" executed="True" success="True" time="0.000" asserts="1" />
+                                  <test-case name="NUnit.Framework.Constraints.Tests.EndsWithTest.FailsWithBadValues(null)" executed="True" success="True" time="0.000" asserts="1" />
+                                </results>
+                              </test-suite>
+                              <test-case name="NUnit.Framework.Constraints.Tests.EndsWithTest.ProvidesProperDescription" executed="True" success="True" time="0.000" asserts="1" />
+                              <test-suite name="ProvidesProperFailureMessage" executed="True" success="True" time="0.000" asserts="0">
+                                <results>
+                                  <test-case name="NUnit.Framework.Constraints.Tests.EndsWithTest.ProvidesProperFailureMessage(&quot;goodbye&quot;,&quot;\&quot;goodbye\&quot;&quot;)" executed="True" success="True" time="0.000" asserts="1" />
+                                  <test-case name="NUnit.Framework.Constraints.Tests.EndsWithTest.ProvidesProperFailureMessage(&quot;What the hell?&quot;,&quot;\&quot;What the hell?\&quot;&quot;)" executed="True" success="True" time="0.000" asserts="1" />
+                                  <test-case name="NUnit.Framework.Constraints.Tests.EndsWithTest.ProvidesProperFailureMessage(&quot;hello there&quot;,&quot;\&quot;hello there\&quot;&quot;)" executed="True" success="True" time="0.000" asserts="1" />
+                                  <test-case name="NUnit.Framework.Constraints.Tests.EndsWithTest.ProvidesProperFailureMessage(&quot;say hello to fred&quot;,&quot;\&quot;say hello to fred\&quot;&quot;)" executed="True" success="True" time="0.000" asserts="1" />
+                                  <test-case name="NUnit.Framework.Constraints.Tests.EndsWithTest.ProvidesProperFailureMessage(&quot;&quot;,&quot;&lt;string.Empty&gt;&quot;)" executed="True" success="True" time="0.000" asserts="1" />
+                                  <test-case name="NUnit.Framework.Constraints.Tests.EndsWithTest.ProvidesProperFailureMessage(null,&quot;null&quot;)" executed="True" success="True" time="0.000" asserts="1" />
+                                </results>
+                              </test-suite>
+                              <test-case name="NUnit.Framework.Constraints.Tests.EndsWithTest.ProvidesProperStringRepresentation" executed="True" success="True" time="0.000" asserts="1" />
+                              <test-suite name="SucceedsWithGoodValues" executed="True" success="True" time="0.000" asserts="0">
+                                <results>
+                                  <test-case name="NUnit.Framework.Constraints.Tests.EndsWithTest.SucceedsWithGoodValues(&quot;hello&quot;)" executed="True" success="True" time="0.000" asserts="1" />
+                                  <test-case name="NUnit.Framework.Constraints.Tests.EndsWithTest.SucceedsWithGoodValues(&quot;I said hello&quot;)" executed="True" success="True" time="0.000" asserts="1" />
+                                </results>
+                              </test-suite>
+                            </results>
+                          </test-suite>
+                          <test-suite name="EndsWithTestIgnoringCase" executed="True" success="True" time="0.000" asserts="0">
+                            <results>
+                              <test-suite name="FailsWithBadValues" executed="True" success="True" time="0.000" asserts="0">
+                                <results>
+                                  <test-case name="NUnit.Framework.Constraints.Tests.EndsWithTestIgnoringCase.FailsWithBadValues(&quot;goodbye&quot;)" executed="True" success="True" time="0.000" asserts="1" />
+                                  <test-case name="NUnit.Framework.Constraints.Tests.EndsWithTestIgnoringCase.FailsWithBadValues(&quot;What the hell?&quot;)" executed="True" success="True" time="0.000" asserts="1" />
+                                  <test-case name="NUnit.Framework.Constraints.Tests.EndsWithTestIgnoringCase.FailsWithBadValues(&quot;hello there&quot;)" executed="True" success="True" time="0.000" asserts="1" />
+                                  <test-case name="NUnit.Framework.Constraints.Tests.EndsWithTestIgnoringCase.FailsWithBadValues(&quot;say hello to fred&quot;)" executed="True" success="True" time="0.000" asserts="1" />
+                                  <test-case name="NUnit.Framework.Constraints.Tests.EndsWithTestIgnoringCase.FailsWithBadValues(&quot;&quot;)" executed="True" success="True" time="0.000" asserts="1" />
+                                  <test-case name="NUnit.Framework.Constraints.Tests.EndsWithTestIgnoringCase.FailsWithBadValues(null)" executed="True" success="True" time="0.000" asserts="1" />
+                                </results>
+                              </test-suite>
+                              <test-case name="NUnit.Framework.Constraints.Tests.EndsWithTestIgnoringCase.ProvidesProperDescription" executed="True" success="True" time="0.000" asserts="1" />
+                              <test-suite name="ProvidesProperFailureMessage" executed="True" success="True" time="0.000" asserts="0">
+                                <results>
+                                  <test-case name="NUnit.Framework.Constraints.Tests.EndsWithTestIgnoringCase.ProvidesProperFailureMessage(&quot;goodbye&quot;,&quot;\&quot;goodbye\&quot;&quot;)" executed="True" success="True" time="0.000" asserts="1" />
+                                  <test-case name="NUnit.Framework.Constraints.Tests.EndsWithTestIgnoringCase.ProvidesProperFailureMessage(&quot;What the hell?&quot;,&quot;\&quot;What the hell?\&quot;&quot;)" executed="True" success="True" time="0.000" asserts="1" />
+                                  <test-case name="NUnit.Framework.Constraints.Tests.EndsWithTestIgnoringCase.ProvidesProperFailureMessage(&quot;hello there&quot;,&quot;\&quot;hello there\&quot;&quot;)" executed="True" success="True" time="0.000" asserts="1" />
+                                  <test-case name="NUnit.Framework.Constraints.Tests.EndsWithTestIgnoringCase.ProvidesProperFailureMessage(&quot;say hello to fred&quot;,&quot;\&quot;say hello to fred\&quot;&quot;)" executed="True" success="True" time="0.000" asserts="1" />
+                                  <test-case name="NUnit.Framework.Constraints.Tests.EndsWithTestIgnoringCase.ProvidesProperFailureMessage(&quot;&quot;,&quot;&lt;string.Empty&gt;&quot;)" executed="True" success="True" time="0.000" asserts="1" />
+                                  <test-case name="NUnit.Framework.Constraints.Tests.EndsWithTestIgnoringCase.ProvidesProperFailureMessage(null,&quot;null&quot;)" executed="True" success="True" time="0.000" asserts="1" />
+                                </results>
+                              </test-suite>
+                              <test-case name="NUnit.Framework.Constraints.Tests.EndsWithTestIgnoringCase.ProvidesProperStringRepresentation" executed="True" success="True" time="0.000" asserts="1" />
+                              <test-suite name="SucceedsWithGoodValues" executed="True" success="True" time="0.000" asserts="0">
+                                <results>
+                                  <test-case name="NUnit.Framework.Constraints.Tests.EndsWithTestIgnoringCase.SucceedsWithGoodValues(&quot;HELLO&quot;)" executed="True" success="True" time="0.000" asserts="1" />
+                                  <test-case name="NUnit.Framework.Constraints.Tests.EndsWithTestIgnoringCase.SucceedsWithGoodValues(&quot;I said Hello&quot;)" executed="True" success="True" time="0.000" asserts="1" />
+                                </results>
+                              </test-suite>
+                            </results>
+                          </test-suite>
+                          <test-suite name="EqualConstraintTest" executed="True" success="True" time="0.250" asserts="0">
+                            <results>
+                              <test-case name="NUnit.Framework.Constraints.Tests.EqualConstraintTest.CanMatchDates" executed="True" success="True" time="0.000" asserts="1" />
+                              <test-case name="NUnit.Framework.Constraints.Tests.EqualConstraintTest.CanMatchDatesWithinDays" executed="True" success="True" time="0.000" asserts="1" />
+                              <test-case name="NUnit.Framework.Constraints.Tests.EqualConstraintTest.CanMatchDatesWithinHours" executed="True" success="True" time="0.000" asserts="1" />
+                              <test-case name="NUnit.Framework.Constraints.Tests.EqualConstraintTest.CanMatchDatesWithinMilliseconds" executed="True" success="True" time="0.000" asserts="1" />
+                              <test-case name="NUnit.Framework.Constraints.Tests.EqualConstraintTest.CanMatchDatesWithinMinutes" executed="True" success="True" time="0.000" asserts="1" />
+                              <test-case name="NUnit.Framework.Constraints.Tests.EqualConstraintTest.CanMatchDatesWithinSeconds" executed="True" success="True" time="0.000" asserts="1" />
+                              <test-case name="NUnit.Framework.Constraints.Tests.EqualConstraintTest.CanMatchDatesWithinTicks" executed="True" success="True" time="0.141" asserts="1" />
+                              <test-case name="NUnit.Framework.Constraints.Tests.EqualConstraintTest.CanMatchDatesWithinTimeSpan" executed="True" success="True" time="0.000" asserts="1" />
+                              <test-suite name="CanMatchDoublesWithRelativeTolerance" executed="True" success="True" time="0.000" asserts="0">
+                                <results>
+                                  <test-case name="NUnit.Framework.Constraints.Tests.EqualConstraintTest.CanMatchDoublesWithRelativeTolerance(10500.0d)" executed="True" success="True" time="0.000" asserts="1" />
+                                  <test-case name="NUnit.Framework.Constraints.Tests.EqualConstraintTest.CanMatchDoublesWithRelativeTolerance(9500.0d)" executed="True" success="True" time="0.000" asserts="1" />
+                                  <test-case name="NUnit.Framework.Constraints.Tests.EqualConstraintTest.CanMatchDoublesWithRelativeTolerance(10000.0d)" executed="True" success="True" time="0.000" asserts="1" />
+                                </results>
+                              </test-suite>
+                              <test-suite name="CanMatchDoublesWithUlpTolerance" executed="True" success="True" time="0.000" asserts="0">
+                                <results>
+                                  <test-case name="NUnit.Framework.Constraints.Tests.EqualConstraintTest.CanMatchDoublesWithUlpTolerance(2E+16.0d)" executed="True" success="True" time="0.000" asserts="1" />
+                                  <test-case name="NUnit.Framework.Constraints.Tests.EqualConstraintTest.CanMatchDoublesWithUlpTolerance(2E+16.0d)" executed="True" success="True" time="0.000" asserts="1" />
+                                </results>
+                              </test-suite>
+                              <test-suite name="CanMatchSinglesWithRelativeTolerance" executed="True" success="True" time="0.000" asserts="0">
+                                <results>
+                                  <test-case name="NUnit.Framework.Constraints.Tests.EqualConstraintTest.CanMatchSinglesWithRelativeTolerance(10000.0f)" executed="True" success="True" time="0.000" asserts="1" />
+                                  <test-case name="NUnit.Framework.Constraints.Tests.EqualConstraintTest.CanMatchSinglesWithRelativeTolerance(9500.0f)" executed="True" success="True" time="0.000" asserts="1" />
+                                  <test-case name="NUnit.Framework.Constraints.Tests.EqualConstraintTest.CanMatchSinglesWithRelativeTolerance(10500.0f)" executed="True" success="True" time="0.000" asserts="1" />
+                                </results>
+                              </test-suite>
+                              <test-suite name="CanMatchSinglesWithUlpTolerance" executed="True" success="True" time="0.000" asserts="0">
+                                <results>
+                                  <test-case name="NUnit.Framework.Constraints.Tests.EqualConstraintTest.CanMatchSinglesWithUlpTolerance(2E+07.0f)" executed="True" success="True" time="0.000" asserts="1" />
+                                  <test-case name="NUnit.Framework.Constraints.Tests.EqualConstraintTest.CanMatchSinglesWithUlpTolerance(2E+07.0f)" executed="True" success="True" time="0.000" asserts="1" />
+                                </results>
+                              </test-suite>
+                              <test-suite name="CanMatchSpecialFloatingPointValues" executed="True" success="True" time="0.000" asserts="0">
+                                <results>
+                                  <test-case name="NUnit.Framework.Constraints.Tests.EqualConstraintTest.CanMatchSpecialFloatingPointValues(double.NaN)" executed="True" success="True" time="0.000" asserts="1" />
+                                  <test-case name="NUnit.Framework.Constraints.Tests.EqualConstraintTest.CanMatchSpecialFloatingPointValues(double.NegativeInfinity)" executed="True" success="True" time="0.000" asserts="1" />
+                                  <test-case name="NUnit.Framework.Constraints.Tests.EqualConstraintTest.CanMatchSpecialFloatingPointValues(float.NaN)" executed="True" success="True" time="0.000" asserts="1" />
+                                  <test-case name="NUnit.Framework.Constraints.Tests.EqualConstraintTest.CanMatchSpecialFloatingPointValues(float.PositiveInfinity)" executed="True" success="True" time="0.000" asserts="1" />
+                                  <test-case name="NUnit.Framework.Constraints.Tests.EqualConstraintTest.CanMatchSpecialFloatingPointValues(double.PositiveInfinity)" executed="True" success="True" time="0.000" asserts="1" />
+                                  <test-case name="NUnit.Framework.Constraints.Tests.EqualConstraintTest.CanMatchSpecialFloatingPointValues(float.NegativeInfinity)" executed="True" success="True" time="0.000" asserts="1" />
+                                </results>
+                              </test-suite>
+                              <test-case name="NUnit.Framework.Constraints.Tests.EqualConstraintTest.CanMatchTimeSpanWithinMinutes" executed="True" success="True" time="0.000" asserts="1" />
+                              <test-case name="NUnit.Framework.Constraints.Tests.EqualConstraintTest.ErrorIfDaysPrecedesWithin" executed="True" success="True" time="0.000" asserts="0" />
+                              <test-case name="NUnit.Framework.Constraints.Tests.EqualConstraintTest.ErrorIfHoursPrecedesWithin" executed="True" success="True" time="0.000" asserts="0" />
+                              <test-case name="NUnit.Framework.Constraints.Tests.EqualConstraintTest.ErrorIfMillisecondsPrecedesWithin" executed="True" success="True" time="0.000" asserts="0" />
+                              <test-case name="NUnit.Framework.Constraints.Tests.EqualConstraintTest.ErrorIfMinutesPrecedesWithin" executed="True" success="True" time="0.000" asserts="0" />
+                              <test-case name="NUnit.Framework.Constraints.Tests.EqualConstraintTest.ErrorIfPercentPrecedesWithin" executed="True" success="True" time="0.031" asserts="0" />
+                              <test-case name="NUnit.Framework.Constraints.Tests.EqualConstraintTest.ErrorIfSecondsPrecedesWithin" executed="True" success="True" time="0.016" asserts="0" />
+                              <test-case name="NUnit.Framework.Constraints.Tests.EqualConstraintTest.ErrorIfTicksPrecedesWithin" executed="True" success="True" time="0.000" asserts="0" />
+                              <test-case name="NUnit.Framework.Constraints.Tests.EqualConstraintTest.ErrorIfUlpsIsUsedOnDecimal" executed="True" success="True" time="0.000" asserts="1" />
+                              <test-suite name="ErrorIfUlpsIsUsedOnIntegralType" executed="True" success="True" time="0.000" asserts="0">
+                                <results>
+                                  <test-case name="NUnit.Framework.Constraints.Tests.EqualConstraintTest.ErrorIfUlpsIsUsedOnIntegralType(1000)" executed="True" success="True" time="0.000" asserts="1" />
+                                  <test-case name="NUnit.Framework.Constraints.Tests.EqualConstraintTest.ErrorIfUlpsIsUsedOnIntegralType(1000)" executed="True" success="True" time="0.000" asserts="1" />
+                                  <test-case name="NUnit.Framework.Constraints.Tests.EqualConstraintTest.ErrorIfUlpsIsUsedOnIntegralType(1000L)" executed="True" success="True" time="0.000" asserts="1" />
+                                  <test-case name="NUnit.Framework.Constraints.Tests.EqualConstraintTest.ErrorIfUlpsIsUsedOnIntegralType(1000UL)" executed="True" success="True" time="0.000" asserts="1" />
+                                </results>
+                              </test-suite>
+                              <test-case name="NUnit.Framework.Constraints.Tests.EqualConstraintTest.ErrorIfUlpsPrecedesWithin" executed="True" success="True" time="0.000" asserts="0" />
+                              <test-case name="NUnit.Framework.Constraints.Tests.EqualConstraintTest.ErrorWithPercentAndUlpsToleranceModes" executed="True" success="True" time="0.000" asserts="0" />
+                              <test-case name="NUnit.Framework.Constraints.Tests.EqualConstraintTest.ErrorWithUlpsAndPercentToleranceModes" executed="True" success="True" time="0.000" asserts="0" />
+                              <test-suite name="FailsOnDoublesOutsideOfRelativeTolerance" executed="True" success="True" time="0.000" asserts="0">
+                                <results>
+                                  <test-case name="NUnit.Framework.Constraints.Tests.EqualConstraintTest.FailsOnDoublesOutsideOfRelativeTolerance(8500.0d)" executed="True" success="True" time="0.000" asserts="1" />
+                                  <test-case name="NUnit.Framework.Constraints.Tests.EqualConstraintTest.FailsOnDoublesOutsideOfRelativeTolerance(11500.0d)" executed="True" success="True" time="0.000" asserts="1" />
+                                </results>
+                              </test-suite>
+                              <test-suite name="FailsOnDoublesOutsideOfUlpTolerance" executed="True" success="True" time="0.016" asserts="0">
+                                <results>
+                                  <test-case name="NUnit.Framework.Constraints.Tests.EqualConstraintTest.FailsOnDoublesOutsideOfUlpTolerance(2E+16.0d)" executed="True" success="True" time="0.000" asserts="1" />
+                                  <test-case name="NUnit.Framework.Constraints.Tests.EqualConstraintTest.FailsOnDoublesOutsideOfUlpTolerance(2E+16.0d)" executed="True" success="True" time="0.000" asserts="1" />
+                                </results>
+                              </test-suite>
+                              <test-suite name="FailsOnSinglesOutsideOfRelativeTolerance" executed="True" success="True" time="0.000" asserts="0">
+                                <results>
+                                  <test-case name="NUnit.Framework.Constraints.Tests.EqualConstraintTest.FailsOnSinglesOutsideOfRelativeTolerance(8500.0f)" executed="True" success="True" time="0.000" asserts="1" />
+                                  <test-case name="NUnit.Framework.Constraints.Tests.EqualConstraintTest.FailsOnSinglesOutsideOfRelativeTolerance(11500.0f)" executed="True" success="True" time="0.000" asserts="1" />
+                                </results>
+                              </test-suite>
+                              <test-suite name="FailsOnSinglesOutsideOfUlpTolerance" executed="True" success="True" time="0.000" asserts="0">
+                                <results>
+                                  <test-case name="NUnit.Framework.Constraints.Tests.EqualConstraintTest.FailsOnSinglesOutsideOfUlpTolerance(2E+07.0f)" executed="True" success="True" time="0.000" asserts="1" />
+                                  <test-case name="NUnit.Framework.Constraints.Tests.EqualConstraintTest.FailsOnSinglesOutsideOfUlpTolerance(2E+07.0f)" executed="True" success="True" time="0.000" asserts="1" />
+                                </results>
+                              </test-suite>
+                              <test-suite name="FailsWithBadValues" executed="True" success="True" time="0.016" asserts="0">
+                                <results>
+                                  <test-case name="NUnit.Framework.Constraints.Tests.EqualConstraintTest.FailsWithBadValues(5)" executed="True" success="True" time="0.000" asserts="1" />
+                                  <test-case name="NUnit.Framework.Constraints.Tests.EqualConstraintTest.FailsWithBadValues(null)" executed="True" success="True" time="0.000" asserts="1" />
+                                  <test-case name="NUnit.Framework.Constraints.Tests.EqualConstraintTest.FailsWithBadValues(&quot;Hello&quot;)" executed="True" success="True" time="0.000" asserts="1" />
+                                  <test-case name="NUnit.Framework.Constraints.Tests.EqualConstraintTest.FailsWithBadValues(double.NaN)" executed="True" success="True" time="0.000" asserts="1" />
+                                  <test-case name="NUnit.Framework.Constraints.Tests.EqualConstraintTest.FailsWithBadValues(double.PositiveInfinity)" executed="True" success="True" time="0.000" asserts="1" />
+                                </results>
+                              </test-suite>
+                              <test-case name="NUnit.Framework.Constraints.Tests.EqualConstraintTest.ProvidesProperDescription" executed="True" success="True" time="0.000" asserts="1" />
+                              <test-suite name="ProvidesProperFailureMessage" executed="True" success="True" time="0.000" asserts="0">
+                                <results>
+                                  <test-case name="NUnit.Framework.Constraints.Tests.EqualConstraintTest.ProvidesProperFailureMessage(5,&quot;5&quot;)" executed="True" success="True" time="0.000" asserts="1" />
+                                  <test-case name="NUnit.Framework.Constraints.Tests.EqualConstraintTest.ProvidesProperFailureMessage(null,&quot;null&quot;)" executed="True" success="True" time="0.000" asserts="1" />
+                                  <test-case name="NUnit.Framework.Constraints.Tests.EqualConstraintTest.ProvidesProperFailureMessage(&quot;Hello&quot;,&quot;\&quot;Hello\&quot;&quot;)" executed="True" success="True" time="0.000" asserts="1" />
+                                  <test-case name="NUnit.Framework.Constraints.Tests.EqualConstraintTest.ProvidesProperFailureMessage(double.NaN,&quot;NaN&quot;)" executed="True" success="True" time="0.000" asserts="1" />
+                                  <test-case name="NUnit.Framework.Constraints.Tests.EqualConstraintTest.ProvidesProperFailureMessage(double.PositiveInfinity,&quot;Infinity&quot;)" executed="True" success="True" time="0.000" asserts="1" />
+                                </results>
+                              </test-suite>
+                              <test-case name="NUnit.Framework.Constraints.Tests.EqualConstraintTest.ProvidesProperStringRepresentation" executed="True" success="True" time="0.000" asserts="1" />
+                              <test-suite name="SucceedsWithGoodValues" executed="True" success="True" time="0.000" asserts="0">
+                                <results>
+                                  <test-case name="NUnit.Framework.Constraints.Tests.EqualConstraintTest.SucceedsWithGoodValues(4)" executed="True" success="True" time="0.000" asserts="1" />
+                                  <test-case name="NUnit.Framework.Constraints.Tests.EqualConstraintTest.SucceedsWithGoodValues(4.0f)" executed="True" success="True" time="0.000" asserts="1" />
+                                  <test-case name="NUnit.Framework.Constraints.Tests.EqualConstraintTest.SucceedsWithGoodValues(4.0d)" executed="True" success="True" time="0.000" asserts="1" />
+                                  <test-case name="NUnit.Framework.Constraints.Tests.EqualConstraintTest.SucceedsWithGoodValues(4.0000m)" executed="True" success="True" time="0.000" asserts="1" />
+                                </results>
+                              </test-suite>
+                              <test-case name="NUnit.Framework.Constraints.Tests.EqualConstraintTest.UsesProvidedComparerOfT" executed="True" success="True" time="0.000" asserts="2" />
+                              <test-case name="NUnit.Framework.Constraints.Tests.EqualConstraintTest.UsesProvidedComparisonOfT" executed="True" success="True" time="0.000" asserts="2" />
+                              <test-case name="NUnit.Framework.Constraints.Tests.EqualConstraintTest.UsesProvidedEqualityComparer" executed="True" success="True" time="0.000" asserts="2" />
+                              <test-case name="NUnit.Framework.Constraints.Tests.EqualConstraintTest.UsesProvidedEqualityComparerOfT" executed="True" success="True" time="0.000" asserts="2" />
+                              <test-case name="NUnit.Framework.Constraints.Tests.EqualConstraintTest.UsesProvidedIComparer" executed="True" success="True" time="0.000" asserts="2" />
+                            </results>
+                          </test-suite>
+                          <test-suite name="EqualTest" executed="True" success="True" time="0.063" asserts="0">
+                            <results>
+                              <test-case name="NUnit.Framework.Constraints.Tests.EqualTest.FailedStringMatchShowsFailurePosition" executed="True" success="True" time="0.016" asserts="2" />
+                              <test-case name="NUnit.Framework.Constraints.Tests.EqualTest.LongStringsAreTruncated" executed="True" success="True" time="0.047" asserts="2" />
+                              <test-case name="NUnit.Framework.Constraints.Tests.EqualTest.LongStringsAreTruncatedAtBothEndsIfNecessary" executed="True" success="True" time="0.000" asserts="2" />
+                              <test-case name="NUnit.Framework.Constraints.Tests.EqualTest.LongStringsAreTruncatedAtFrontEndIfNecessary" executed="True" success="True" time="0.000" asserts="2" />
+                              <test-case name="NUnit.Framework.Constraints.Tests.EqualTest.TestPropertyWithPrivateSetter" executed="True" success="True" time="0.000" asserts="1" />
+                            </results>
+                          </test-suite>
+                          <test-suite name="ExactTypeTest" executed="True" success="True" time="0.016" asserts="0">
+                            <results>
+                              <test-suite name="FailsWithBadValues" executed="True" success="True" time="0.016" asserts="0">
+                                <results>
+                                  <test-case name="NUnit.Framework.Constraints.Tests.ExactTypeTest.FailsWithBadValues(NUnit.Framework.Constraints.Tests.B)" executed="True" success="True" time="0.000" asserts="1" />
+                                  <test-case name="NUnit.Framework.Constraints.Tests.ExactTypeTest.FailsWithBadValues(NUnit.Framework.Constraints.Tests.D2)" executed="True" success="True" time="0.000" asserts="1" />
+                                </results>
+                              </test-suite>
+                              <test-case name="NUnit.Framework.Constraints.Tests.ExactTypeTest.ProvidesProperDescription" executed="True" success="True" time="0.000" asserts="1" />
+                              <test-suite name="ProvidesProperFailureMessage" executed="True" success="True" time="0.000" asserts="0">
+                                <results>
+                                  <test-case name="NUnit.Framework.Constraints.Tests.ExactTypeTest.ProvidesProperFailureMessage(NUnit.Framework.Constraints.Tests.B,&quot;&lt;NUnit.Framework.Constraints.Tests.B&gt;&quot;)" executed="True" success="True" time="0.000" asserts="1" />
+                                  <test-case name="NUnit.Framework.Constraints.Tests.ExactTypeTest.ProvidesProperFailureMessage(NUnit.Framework.Constraints.Tests.D2,&quot;&lt;NUnit.Framework.Constraints.Tests.D2&gt;&quot;)" executed="True" success="True" time="0.000" asserts="1" />
+                                </results>
+                              </test-suite>
+                              <test-case name="NUnit.Framework.Constraints.Tests.ExactTypeTest.ProvidesProperStringRepresentation" executed="True" success="True" time="0.000" asserts="1" />
+                              <test-suite name="SucceedsWithGoodValues" executed="True" success="True" time="0.000" asserts="0">
+                                <results>
+                                  <test-case name="NUnit.Framework.Constraints.Tests.ExactTypeTest.SucceedsWithGoodValues(NUnit.Framework.Constraints.Tests.D1)" executed="True" success="True" time="0.000" asserts="1" />
+                                </results>
+                              </test-suite>
+                            </results>
+                          </test-suite>
+                          <test-suite name="FalseConstraintTest" executed="True" success="True" time="0.016" asserts="0">
+                            <results>
+                              <test-suite name="FailsWithBadValues" executed="True" success="True" time="0.016" asserts="0">
+                                <results>
+                                  <test-case name="NUnit.Framework.Constraints.Tests.FalseConstraintTest.FailsWithBadValues(null)" executed="True" success="True" time="0.000" asserts="1" />
+                                  <test-case name="NUnit.Framework.Constraints.Tests.FalseConstraintTest.FailsWithBadValues(&quot;hello&quot;)" executed="True" success="True" time="0.000" asserts="1" />
+                                  <test-case name="NUnit.Framework.Constraints.Tests.FalseConstraintTest.FailsWithBadValues(True)" executed="True" success="True" time="0.000" asserts="1" />
+                                  <test-case name="NUnit.Framework.Constraints.Tests.FalseConstraintTest.FailsWithBadValues(True)" executed="True" success="True" time="0.000" asserts="1" />
+                                </results>
+                              </test-suite>
+                              <test-case name="NUnit.Framework.Constraints.Tests.FalseConstraintTest.ProvidesProperDescription" executed="True" success="True" time="0.000" asserts="1" />
+                              <test-suite name="ProvidesProperFailureMessage" executed="True" success="True" time="0.000" asserts="0">
+                                <results>
+                                  <test-case name="NUnit.Framework.Constraints.Tests.FalseConstraintTest.ProvidesProperFailureMessage(null,&quot;null&quot;)" executed="True" success="True" time="0.000" asserts="1" />
+                                  <test-case name="NUnit.Framework.Constraints.Tests.FalseConstraintTest.ProvidesProperFailureMessage(&quot;hello&quot;,&quot;\&quot;hello\&quot;&quot;)" executed="True" success="True" time="0.000" asserts="1" />
+                                  <test-case name="NUnit.Framework.Constraints.Tests.FalseConstraintTest.ProvidesProperFailureMessage(True,&quot;True&quot;)" executed="True" success="True" time="0.000" asserts="1" />
+                                  <test-case name="NUnit.Framework.Constraints.Tests.FalseConstraintTest.ProvidesProperFailureMessage(True,&quot;True&quot;)" executed="True" success="True" time="0.000" asserts="1" />
+                                </results>
+                              </test-suite>
+                              <test-case name="NUnit.Framework.Constraints.Tests.FalseConstraintTest.ProvidesProperStringRepresentation" executed="True" success="True" time="0.000" asserts="1" />
+                              <test-suite name="SucceedsWithGoodValues" executed="True" success="True" time="0.000" asserts="0">
+                                <results>
+                                  <test-case name="NUnit.Framework.Constraints.Tests.FalseConstraintTest.SucceedsWithGoodValues(False)" executed="True" success="True" time="0.000" asserts="1" />
+                                  <test-case name="NUnit.Framework.Constraints.Tests.FalseConstraintTest.SucceedsWithGoodValues(False)" executed="True" success="True" time="0.000" asserts="1" />
+                                </results>
+                              </test-suite>
+                            </results>
+                          </test-suite>
+                          <test-suite name="FloatingPointNumericsTest" executed="True" success="True" time="0.000" asserts="0">
+                            <results>
+                              <test-case name="NUnit.Framework.Constraints.Tests.FloatingPointNumericsTest.DoubleEqualityWithUlps" executed="True" success="True" time="0.000" asserts="4" />
+                              <test-case name="NUnit.Framework.Constraints.Tests.FloatingPointNumericsTest.FloatEqualityWithUlps" executed="True" success="True" time="0.000" asserts="4" />
+                              <test-case name="NUnit.Framework.Constraints.Tests.FloatingPointNumericsTest.MirroredDoubleReinterpretation" executed="True" success="True" time="0.000" asserts="1" />
+                              <test-case name="NUnit.Framework.Constraints.Tests.FloatingPointNumericsTest.MirroredFloatReinterpretation" executed="True" success="True" time="0.000" asserts="1" />
+                              <test-case name="NUnit.Framework.Constraints.Tests.FloatingPointNumericsTest.MirroredIntegerReinterpretation" executed="True" success="True" time="0.000" asserts="1" />
+                              <test-case name="NUnit.Framework.Constraints.Tests.FloatingPointNumericsTest.MirroredLongReinterpretation" executed="True" success="True" time="0.000" asserts="1" />
+                            </results>
+                          </test-suite>
+                          <test-suite name="GreaterThanOrEqualTest" executed="True" success="True" time="0.000" asserts="0">
+                            <results>
+                              <test-case name="NUnit.Framework.Constraints.Tests.GreaterThanOrEqualTest.CanCompareIComparables" executed="True" success="True" time="0.000" asserts="1" />
+                              <test-case name="NUnit.Framework.Constraints.Tests.GreaterThanOrEqualTest.CanCompareIComparablesOfT" executed="True" success="True" time="0.000" asserts="1" />
+                              <test-suite name="FailsWithBadValues" executed="True" success="True" time="0.000" asserts="0">
+                                <results>
+                                  <test-case name="NUnit.Framework.Constraints.Tests.GreaterThanOrEqualTest.FailsWithBadValues(4)" executed="True" success="True" time="0.000" asserts="1" />
+                                </results>
+                              </test-suite>
+                              <test-suite name="InvalidDataThrowsArgumentException" executed="True" success="True" time="0.000" asserts="0">
+                                <results>
+                                  <test-case name="NUnit.Framework.Constraints.Tests.GreaterThanOrEqualTest.InvalidDataThrowsArgumentException(null)" executed="True" success="True" time="0.000" asserts="0" />
+                                  <test-case name="NUnit.Framework.Constraints.Tests.GreaterThanOrEqualTest.InvalidDataThrowsArgumentException(&quot;xxx&quot;)" executed="True" success="True" time="0.000" asserts="0" />
+                                </results>
+                              </test-suite>
+                              <test-case name="NUnit.Framework.Constraints.Tests.GreaterThanOrEqualTest.ProvidesProperDescription" executed="True" success="True" time="0.000" asserts="1" />
+                              <test-suite name="ProvidesProperFailureMessage" executed="True" success="True" time="0.000" asserts="0">
+                                <results>
+                                  <test-case name="NUnit.Framework.Constraints.Tests.GreaterThanOrEqualTest.ProvidesProperFailureMessage(4,&quot;4&quot;)" executed="True" success="True" time="0.000" asserts="1" />
+                                </results>
+                              </test-suite>
+                              <test-case name="NUnit.Framework.Constraints.Tests.GreaterThanOrEqualTest.ProvidesProperStringRepresentation" executed="True" success="True" time="0.000" asserts="1" />
+                              <test-suite name="SucceedsWithGoodValues" executed="True" success="True" time="0.000" asserts="0">
+                                <results>
+                                  <test-case name="NUnit.Framework.Constraints.Tests.GreaterThanOrEqualTest.SucceedsWithGoodValues(6)" executed="True" success="True" time="0.000" asserts="1" />
+                                  <test-case name="NUnit.Framework.Constraints.Tests.GreaterThanOrEqualTest.SucceedsWithGoodValues(5)" executed="True" success="True" time="0.000" asserts="1" />
+                                </results>
+                              </test-suite>
+                              <test-case name="NUnit.Framework.Constraints.Tests.GreaterThanOrEqualTest.UsesProvidedComparerOfT" executed="True" success="True" time="0.000" asserts="1" />
+                              <test-case name="NUnit.Framework.Constraints.Tests.GreaterThanOrEqualTest.UsesProvidedComparisonOfT" executed="True" success="True" time="0.000" asserts="1" />
+                              <test-case name="NUnit.Framework.Constraints.Tests.GreaterThanOrEqualTest.UsesProvidedIComparer" executed="True" success="True" time="0.000" asserts="1" />
+                            </results>
+                          </test-suite>
+                          <test-suite name="GreaterThanTest" executed="True" success="True" time="0.063" asserts="0">
+                            <results>
+                              <test-case name="NUnit.Framework.Constraints.Tests.GreaterThanTest.CanCompareIComparables" executed="True" success="True" time="0.000" asserts="1" />
+                              <test-case name="NUnit.Framework.Constraints.Tests.GreaterThanTest.CanCompareIComparablesOfT" executed="True" success="True" time="0.000" asserts="1" />
+                              <test-suite name="FailsWithBadValues" executed="True" success="True" time="0.000" asserts="0">
+                                <results>
+                                  <test-case name="NUnit.Framework.Constraints.Tests.GreaterThanTest.FailsWithBadValues(4)" executed="True" success="True" time="0.000" asserts="1" />
+                                  <test-case name="NUnit.Framework.Constraints.Tests.GreaterThanTest.FailsWithBadValues(5)" executed="True" success="True" time="0.000" asserts="1" />
+                                </results>
+                              </test-suite>
+                              <test-suite name="InvalidDataThrowsArgumentException" executed="True" success="True" time="0.063" asserts="0">
+                                <results>
+                                  <test-case name="NUnit.Framework.Constraints.Tests.GreaterThanTest.InvalidDataThrowsArgumentException(null)" executed="True" success="True" time="0.063" asserts="0" />
+                                  <test-case name="NUnit.Framework.Constraints.Tests.GreaterThanTest.InvalidDataThrowsArgumentException(&quot;xxx&quot;)" executed="True" success="True" time="0.000" asserts="0" />
+                                </results>
+                              </test-suite>
+                              <test-case name="NUnit.Framework.Constraints.Tests.GreaterThanTest.ProvidesProperDescription" executed="True" success="True" time="0.000" asserts="1" />
+                              <test-suite name="ProvidesProperFailureMessage" executed="True" success="True" time="0.000" asserts="0">
+                                <results>
+                                  <test-case name="NUnit.Framework.Constraints.Tests.GreaterThanTest.ProvidesProperFailureMessage(4,&quot;4&quot;)" executed="True" success="True" time="0.000" asserts="1" />
+                                  <test-case name="NUnit.Framework.Constraints.Tests.GreaterThanTest.ProvidesProperFailureMessage(5,&quot;5&quot;)" executed="True" success="True" time="0.000" asserts="1" />
+                                </results>
+                              </test-suite>
+                              <test-case name="NUnit.Framework.Constraints.Tests.GreaterThanTest.ProvidesProperStringRepresentation" executed="True" success="True" time="0.000" asserts="1" />
+                              <test-suite name="SucceedsWithGoodValues" executed="True" success="True" time="0.000" asserts="0">
+                                <results>
+                                  <test-case name="NUnit.Framework.Constraints.Tests.GreaterThanTest.SucceedsWithGoodValues(6)" executed="True" success="True" time="0.000" asserts="1" />
+                                  <test-case name="NUnit.Framework.Constraints.Tests.GreaterThanTest.SucceedsWithGoodValues(5.001d)" executed="True" success="True" time="0.000" asserts="1" />
+                                </results>
+                              </test-suite>
+                              <test-case name="NUnit.Framework.Constraints.Tests.GreaterThanTest.UsesProvidedComparerOfT" executed="True" success="True" time="0.000" asserts="1" />
+                              <test-case name="NUnit.Framework.Constraints.Tests.GreaterThanTest.UsesProvidedComparisonOfT" executed="True" success="True" time="0.000" asserts="1" />
+                              <test-case name="NUnit.Framework.Constraints.Tests.GreaterThanTest.UsesProvidedIComparer" executed="True" success="True" time="0.000" asserts="1" />
+                            </results>
+                          </test-suite>
+                          <test-suite name="InstanceOfTypeTest" executed="True" success="True" time="0.000" asserts="0">
+                            <results>
+                              <test-suite name="FailsWithBadValues" executed="True" success="True" time="0.000" asserts="0">
+                                <results>
+                                  <test-case name="NUnit.Framework.Constraints.Tests.InstanceOfTypeTest.FailsWithBadValues(NUnit.Framework.Constraints.Tests.B)" executed="True" success="True" time="0.000" asserts="1" />
+                                </results>
+                              </test-suite>
+                              <test-case name="NUnit.Framework.Constraints.Tests.InstanceOfTypeTest.ProvidesProperDescription" executed="True" success="True" time="0.000" asserts="1" />
+                              <test-suite name="ProvidesProperFailureMessage" executed="True" success="True" time="0.000" asserts="0">
+                                <results>
+                                  <test-case name="NUnit.Framework.Constraints.Tests.InstanceOfTypeTest.ProvidesProperFailureMessage(NUnit.Framework.Constraints.Tests.B,&quot;&lt;NUnit.Framework.Constraints.Tests.B&gt;&quot;)" executed="True" success="True" time="0.000" asserts="1" />
+                                </results>
+                              </test-suite>
+                              <test-case name="NUnit.Framework.Constraints.Tests.InstanceOfTypeTest.ProvidesProperStringRepresentation" executed="True" success="True" time="0.000" asserts="1" />
+                              <test-suite name="SucceedsWithGoodValues" executed="True" success="True" time="0.000" asserts="0">
+                                <results>
+                                  <test-case name="NUnit.Framework.Constraints.Tests.InstanceOfTypeTest.SucceedsWithGoodValues(NUnit.Framework.Constraints.Tests.D1)" executed="True" success="True" time="0.000" asserts="1" />
+                                  <test-case name="NUnit.Framework.Constraints.Tests.InstanceOfTypeTest.SucceedsWithGoodValues(NUnit.Framework.Constraints.Tests.D2)" executed="True" success="True" time="0.000" asserts="1" />
+                                </results>
+                              </test-suite>
+                            </results>
+                          </test-suite>
+                          <test-suite name="LessThanOrEqualTest" executed="True" success="True" time="0.000" asserts="0">
+                            <results>
+                              <test-case name="NUnit.Framework.Constraints.Tests.LessThanOrEqualTest.CanCompareIComparables" executed="True" success="True" time="0.000" asserts="1" />
+                              <test-case name="NUnit.Framework.Constraints.Tests.LessThanOrEqualTest.CanCompareIComparablesOfT" executed="True" success="True" time="0.000" asserts="1" />
+                              <test-suite name="FailsWithBadValues" executed="True" success="True" time="0.000" asserts="0">
+                                <results>
+                                  <test-case name="NUnit.Framework.Constraints.Tests.LessThanOrEqualTest.FailsWithBadValues(6)" executed="True" success="True" time="0.000" asserts="1" />
+                                </results>
+                              </test-suite>
+                              <test-suite name="InvalidDataThrowsArgumentException" executed="True" success="True" time="0.000" asserts="0">
+                                <results>
+                                  <test-case name="NUnit.Framework.Constraints.Tests.LessThanOrEqualTest.InvalidDataThrowsArgumentException(null)" executed="True" success="True" time="0.000" asserts="0" />
+                                  <test-case name="NUnit.Framework.Constraints.Tests.LessThanOrEqualTest.InvalidDataThrowsArgumentException(&quot;xxx&quot;)" executed="True" success="True" time="0.000" asserts="0" />
+                                </results>
+                              </test-suite>
+                              <test-case name="NUnit.Framework.Constraints.Tests.LessThanOrEqualTest.ProvidesProperDescription" executed="True" success="True" time="0.000" asserts="1" />
+                              <test-suite name="ProvidesProperFailureMessage" executed="True" success="True" time="0.000" asserts="0">
+                                <results>
+                                  <test-case name="NUnit.Framework.Constraints.Tests.LessThanOrEqualTest.ProvidesProperFailureMessage(6,&quot;6&quot;)" executed="True" success="True" time="0.000" asserts="1" />
+                                </results>
+                              </test-suite>
+                              <test-case name="NUnit.Framework.Constraints.Tests.LessThanOrEqualTest.ProvidesProperStringRepresentation" executed="True" success="True" time="0.000" asserts="1" />
+                              <test-suite name="SucceedsWithGoodValues" executed="True" success="True" time="0.000" asserts="0">
+                                <results>
+                                  <test-case name="NUnit.Framework.Constraints.Tests.LessThanOrEqualTest.SucceedsWithGoodValues(4)" executed="True" success="True" time="0.000" asserts="1" />
+                                  <test-case name="NUnit.Framework.Constraints.Tests.LessThanOrEqualTest.SucceedsWithGoodValues(5)" executed="True" success="True" time="0.000" asserts="1" />
+                                </results>
+                              </test-suite>
+                              <test-case name="NUnit.Framework.Constraints.Tests.LessThanOrEqualTest.UsesProvidedComparerOfT" executed="True" success="True" time="0.000" asserts="1" />
+                              <test-case name="NUnit.Framework.Constraints.Tests.LessThanOrEqualTest.UsesProvidedComparisonOfT" executed="True" success="True" time="0.000" asserts="1" />
+                              <test-case name="NUnit.Framework.Constraints.Tests.LessThanOrEqualTest.UsesProvidedIComparer" executed="True" success="True" time="0.000" asserts="1" />
+                            </results>
+                          </test-suite>
+                          <test-suite name="LessThanTest" executed="True" success="True" time="0.016" asserts="0">
+                            <results>
+                              <test-case name="NUnit.Framework.Constraints.Tests.LessThanTest.CanCompareIComparables" executed="True" success="True" time="0.000" asserts="1" />
+                              <test-case name="NUnit.Framework.Constraints.Tests.LessThanTest.CanCompareIComparablesOfT" executed="True" success="True" time="0.000" asserts="1" />
+                              <test-suite name="FailsWithBadValues" executed="True" success="True" time="0.000" asserts="0">
+                                <results>
+                                  <test-case name="NUnit.Framework.Constraints.Tests.LessThanTest.FailsWithBadValues(6)" executed="True" success="True" time="0.000" asserts="1" />
+                                  <test-case name="NUnit.Framework.Constraints.Tests.LessThanTest.FailsWithBadValues(5)" executed="True" success="True" time="0.000" asserts="1" />
+                                </results>
+                              </test-suite>
+                              <test-suite name="InvalidDataThrowsArgumentException" executed="True" success="True" time="0.000" asserts="0">
+                                <results>
+                                  <test-case name="NUnit.Framework.Constraints.Tests.LessThanTest.InvalidDataThrowsArgumentException(null)" executed="True" success="True" time="0.000" asserts="0" />
+                                  <test-case name="NUnit.Framework.Constraints.Tests.LessThanTest.InvalidDataThrowsArgumentException(&quot;xxx&quot;)" executed="True" success="True" time="0.000" asserts="0" />
+                                </results>
+                              </test-suite>
+                              <test-case name="NUnit.Framework.Constraints.Tests.LessThanTest.ProvidesProperDescription" executed="True" success="True" time="0.000" asserts="1" />
+                              <test-suite name="ProvidesProperFailureMessage" executed="True" success="True" time="0.000" asserts="0">
+                                <results>
+                                  <test-case name="NUnit.Framework.Constraints.Tests.LessThanTest.ProvidesProperFailureMessage(6,&quot;6&quot;)" executed="True" success="True" time="0.000" asserts="1" />
+                                  <test-case name="NUnit.Framework.Constraints.Tests.LessThanTest.ProvidesProperFailureMessage(5,&quot;5&quot;)" executed="True" success="True" time="0.000" asserts="1" />
+                                </results>
+                              </test-suite>
+                              <test-case name="NUnit.Framework.Constraints.Tests.LessThanTest.ProvidesProperStringRepresentation" executed="True" success="True" time="0.000" asserts="1" />
+                              <test-suite name="SucceedsWithGoodValues" executed="True" success="True" time="0.000" asserts="0">
+                                <results>
+                                  <test-case name="NUnit.Framework.Constraints.Tests.LessThanTest.SucceedsWithGoodValues(4)" executed="True" success="True" time="0.000" asserts="1" />
+                                  <test-case name="NUnit.Framework.Constraints.Tests.LessThanTest.SucceedsWithGoodValues(4.999d)" executed="True" success="True" time="0.000" asserts="1" />
+                                </results>
+                              </test-suite>
+                              <test-case name="NUnit.Framework.Constraints.Tests.LessThanTest.UsesProvidedComparerOfT" executed="True" success="True" time="0.000" asserts="1" />
+                              <test-case name="NUnit.Framework.Constraints.Tests.LessThanTest.UsesProvidedComparisonOfT" executed="True" success="True" time="0.000" asserts="1" />
+                              <test-case name="NUnit.Framework.Constraints.Tests.LessThanTest.UsesProvidedIComparer" executed="True" success="True" time="0.000" asserts="1" />
+                            </results>
+                          </test-suite>
+                          <test-suite name="MsgUtilTests" executed="True" success="True" time="0.000" asserts="0">
+                            <results>
+                              <test-case name="NUnit.Framework.Constraints.Tests.MsgUtilTests.ClipExpectedAndActual_StringsDoNotFitInLine" executed="True" success="True" time="0.000" asserts="4" />
+                              <test-case name="NUnit.Framework.Constraints.Tests.MsgUtilTests.ClipExpectedAndActual_StringsFitInLine" executed="True" success="True" time="0.000" asserts="4" />
+                              <test-case name="NUnit.Framework.Constraints.Tests.MsgUtilTests.ClipExpectedAndActual_StringTailsFitInLine" executed="True" success="True" time="0.000" asserts="1" />
+                              <test-suite name="EscapeControlCharsTest" executed="True" success="True" time="0.000" asserts="0">
+                                <results>
+                                  <test-case name="NUnit.Framework.Constraints.Tests.MsgUtilTests.EscapeControlCharsTest(&quot;\0&quot;,&quot;\\0&quot;)" executed="True" success="True" time="0.000" asserts="1" />
+                                  <test-case name="NUnit.Framework.Constraints.Tests.MsgUtilTests.EscapeControlCharsTest(&quot;\\r\\n&quot;,&quot;\\\\r\\\\n&quot;)" executed="True" success="True" time="0.000" asserts="1" />
+                                  <test-case name="NUnit.Framework.Constraints.Tests.MsgUtilTests.EscapeControlCharsTest(&quot;\n\n\n&quot;,&quot;\\n\\n\\n&quot;)" executed="True" success="True" time="0.000" asserts="1" />
+                                  <test-case name="NUnit.Framework.Constraints.Tests.MsgUtilTests.EscapeControlCharsTest(&quot;\r\r&quot;,&quot;\\r\\r&quot;)" executed="True" success="True" time="0.000" asserts="1" />
+                                  <test-case name="NUnit.Framework.Constraints.Tests.MsgUtilTests.EscapeControlCharsTest(&quot;\r\r\r&quot;,&quot;\\r\\r\\r&quot;)" executed="True" success="True" time="0.000" asserts="1" />
+                                  <test-case name="NUnit.Framework.Constraints.Tests.MsgUtilTests.EscapeControlCharsTest(&quot;\r\n&quot;,&quot;\\r\\n&quot;)" executed="True" success="True" time="0.000" asserts="1" />
+                                  <test-case name="NUnit.Framework.Constraints.Tests.MsgUtilTests.EscapeControlCharsTest(&quot;\n\r&quot;,&quot;\\n\\r&quot;)" executed="True" success="True" time="0.000" asserts="1" />
+                                  <test-case name="NUnit.Framework.Constraints.Tests.MsgUtilTests.EscapeControlCharsTest(&quot;This is a\rtest message&quot;,&quot;This is a\\rtest message&quot;)" executed="True" success="True" time="0.000" asserts="1" />
+                                  <test-case name="NUnit.Framework.Constraints.Tests.MsgUtilTests.EscapeControlCharsTest(&quot;&quot;,&quot;&quot;)" executed="True" success="True" time="0.000" asserts="1" />
+                                  <test-case name="NUnit.Framework.Constraints.Tests.MsgUtilTests.EscapeControlCharsTest(null,null)" executed="True" success="True" time="0.000" asserts="1" />
+                                  <test-case name="NUnit.Framework.Constraints.Tests.MsgUtilTests.EscapeControlCharsTest(&quot;\t&quot;,&quot;\\t&quot;)" executed="True" success="True" time="0.000" asserts="1" />
+                                  <test-case name="NUnit.Framework.Constraints.Tests.MsgUtilTests.EscapeControlCharsTest(&quot;\t\n&quot;,&quot;\\t\\n&quot;)" executed="True" success="True" time="0.000" asserts="1" />
+                                  <test-case name="NUnit.Framework.Constraints.Tests.MsgUtilTests.EscapeControlCharsTest(&quot;\a&quot;,&quot;\\a&quot;)" executed="True" success="True" time="0.000" asserts="1" />
+                                  <test-case name="NUnit.Framework.Constraints.Tests.MsgUtilTests.EscapeControlCharsTest(&quot;\n\n&quot;,&quot;\\n\\n&quot;)" executed="True" success="True" time="0.000" asserts="1" />
+                                  <test-case name="NUnit.Framework.Constraints.Tests.MsgUtilTests.EscapeControlCharsTest(&quot;\b&quot;,&quot;\\b&quot;)" executed="True" success="True" time="0.000" asserts="1" />
+                                  <test-case name="NUnit.Framework.Constraints.Tests.MsgUtilTests.EscapeControlCharsTest(&quot;\f&quot;,&quot;\\f&quot;)" executed="True" success="True" time="0.000" asserts="1" />
+                                  <test-case name="NUnit.Framework.Constraints.Tests.MsgUtilTests.EscapeControlCharsTest(&quot;\v&quot;,&quot;\\v&quot;)" executed="True" success="True" time="0.000" asserts="1" />
+                                  <test-case name="NUnit.Framework.Constraints.Tests.MsgUtilTests.EscapeControlCharsTest(&quot;\x0085&quot;,&quot;\\x0085&quot;)" description="Next line character" executed="True" success="True" time="0.000" asserts="1" />
+                                  <test-case name="NUnit.Framework.Constraints.Tests.MsgUtilTests.EscapeControlCharsTest(&quot;\x2028&quot;,&quot;\\x2028&quot;)" description="Line separator character" executed="True" success="True" time="0.000" asserts="1" />
+                                  <test-case name="NUnit.Framework.Constraints.Tests.MsgUtilTests.EscapeControlCharsTest(&quot;\x2029&quot;,&quot;\\x2029&quot;)" description="Paragraph separator character" executed="True" success="True" time="0.000" asserts="1" />
+                                  <test-case name="NUnit.Framework.Constraints.Tests.MsgUtilTests.EscapeControlCharsTest(&quot;\r&quot;,&quot;\\r&quot;)" executed="True" success="True" time="0.000" asserts="1" />
+                                  <test-case name="NUnit.Framework.Constraints.Tests.MsgUtilTests.EscapeControlCharsTest(&quot;\n&quot;,&quot;\\n&quot;)" executed="True" success="True" time="0.000" asserts="1" />
+                                </results>
+                              </test-suite>
+                              <test-suite name="TestClipString" executed="True" success="True" time="0.000" asserts="0">
+                                <results>
+                                  <test-case name="NUnit.Framework.Constraints.Tests.MsgUtilTests.NoClippingNeeded" executed="True" success="True" time="0.000" asserts="1" />
+                                  <test-case name="NUnit.Framework.Constraints.Tests.MsgUtilTests.ClipAtEnd" executed="True" success="True" time="0.000" asserts="1" />
+                                  <test-case name="NUnit.Framework.Constraints.Tests.MsgUtilTests.ClipAtStart" executed="True" success="True" time="0.000" asserts="1" />
+                                  <test-case name="NUnit.Framework.Constraints.Tests.MsgUtilTests.ClipAtStartAndEnd" executed="True" success="True" time="0.000" asserts="1" />
+                                </results>
+                              </test-suite>
+                            </results>
+                          </test-suite>
+                          <test-suite name="NaNConstraintTest" executed="True" success="True" time="0.000" asserts="0">
+                            <results>
+                              <test-suite name="FailsWithBadValues" executed="True" success="True" time="0.000" asserts="0">
+                                <results>
+                                  <test-case name="NUnit.Framework.Constraints.Tests.NaNConstraintTest.FailsWithBadValues(null)" executed="True" success="True" time="0.000" asserts="1" />
+                                  <test-case name="NUnit.Framework.Constraints.Tests.NaNConstraintTest.FailsWithBadValues(&quot;hello&quot;)" executed="True" success="True" time="0.000" asserts="1" />
+                                  <test-case name="NUnit.Framework.Constraints.Tests.NaNConstraintTest.FailsWithBadValues(42)" executed="True" success="True" time="0.000" asserts="1" />
+                                  <test-case name="NUnit.Framework.Constraints.Tests.NaNConstraintTest.FailsWithBadValues(double.PositiveInfinity)" executed="True" success="True" time="0.000" asserts="1" />
+                                  <test-case name="NUnit.Framework.Constraints.Tests.NaNConstraintTest.FailsWithBadValues(double.NegativeInfinity)" executed="True" success="True" time="0.000" asserts="1" />
+                                  <test-case name="NUnit.Framework.Constraints.Tests.NaNConstraintTest.FailsWithBadValues(float.PositiveInfinity)" executed="True" success="True" time="0.000" asserts="1" />
+                                  <test-case name="NUnit.Framework.Constraints.Tests.NaNConstraintTest.FailsWithBadValues(float.NegativeInfinity)" executed="True" success="True" time="0.000" asserts="1" />
+                                </results>
+                              </test-suite>
+                              <test-case name="NUnit.Framework.Constraints.Tests.NaNConstraintTest.ProvidesProperDescription" executed="True" success="True" time="0.000" asserts="1" />
+                              <test-suite name="ProvidesProperFailureMessage" executed="True" success="True" time="0.000" asserts="0">
+                                <results>
+                                  <test-case name="NUnit.Framework.Constraints.Tests.NaNConstraintTest.ProvidesProperFailureMessage(null,&quot;null&quot;)" executed="True" success="True" time="0.000" asserts="1" />
+                                  <test-case name="NUnit.Framework.Constraints.Tests.NaNConstraintTest.ProvidesProperFailureMessage(&quot;hello&quot;,&quot;\&quot;hello\&quot;&quot;)" executed="True" success="True" time="0.000" asserts="1" />
+                                  <test-case name="NUnit.Framework.Constraints.Tests.NaNConstraintTest.ProvidesProperFailureMessage(42,&quot;42&quot;)" executed="True" success="True" time="0.000" asserts="1" />
+                                  <test-case name="NUnit.Framework.Constraints.Tests.NaNConstraintTest.ProvidesProperFailureMessage(double.PositiveInfinity,&quot;Infinity&quot;)" executed="True" success="True" time="0.000" asserts="1" />
+                                  <test-case name="NUnit.Framework.Constraints.Tests.NaNConstraintTest.ProvidesProperFailureMessage(double.NegativeInfinity,&quot;-Infinity&quot;)" executed="True" success="True" time="0.000" asserts="1" />
+                                  <test-case name="NUnit.Framework.Constraints.Tests.NaNConstraintTest.ProvidesProperFailureMessage(float.PositiveInfinity,&quot;Infinity&quot;)" executed="True" success="True" time="0.000" asserts="1" />
+                                  <test-case name="NUnit.Framework.Constraints.Tests.NaNConstraintTest.ProvidesProperFailureMessage(float.NegativeInfinity,&quot;-Infinity&quot;)" executed="True" success="True" time="0.000" asserts="1" />
+                                </results>
+                              </test-suite>
+                              <test-case name="NUnit.Framework.Constraints.Tests.NaNConstraintTest.ProvidesProperStringRepresentation" executed="True" success="True" time="0.000" asserts="1" />
+                              <test-suite name="SucceedsWithGoodValues" executed="True" success="True" time="0.000" asserts="0">
+                                <results>
+                                  <test-case name="NUnit.Framework.Constraints.Tests.NaNConstraintTest.SucceedsWithGoodValues(double.NaN)" executed="True" success="True" time="0.000" asserts="1" />
+                                  <test-case name="NUnit.Framework.Constraints.Tests.NaNConstraintTest.SucceedsWithGoodValues(float.NaN)" executed="True" success="True" time="0.000" asserts="1" />
+                                </results>
+                              </test-suite>
+                            </results>
+                          </test-suite>
+                          <test-suite name="NotTest" executed="True" success="True" time="0.125" asserts="0">
+                            <results>
+                              <test-case name="NUnit.Framework.Constraints.Tests.NotTest.CanUseNotOperator" executed="True" success="True" time="0.000" asserts="1" />
+                              <test-suite name="FailsWithBadValues" executed="True" success="True" time="0.000" asserts="0">
+                                <results>
+                                  <test-case name="NUnit.Framework.Constraints.Tests.NotTest.FailsWithBadValues(null)" executed="True" success="True" time="0.000" asserts="1" />
+                                </results>
+                              </test-suite>
+                              <test-case name="NUnit.Framework.Constraints.Tests.NotTest.NotHonorsIgnoreCaseUsingConstructors" executed="True" success="True" time="0.000" asserts="1" />
+                              <test-case name="NUnit.Framework.Constraints.Tests.NotTest.NotHonorsIgnoreCaseUsingPrefixNotation" executed="True" success="True" time="0.109" asserts="1" />
+                              <test-case name="NUnit.Framework.Constraints.Tests.NotTest.NotHonorsTolerance" executed="True" success="True" time="0.000" asserts="1" />
+                              <test-case name="NUnit.Framework.Constraints.Tests.NotTest.ProvidesProperDescription" executed="True" success="True" time="0.000" asserts="1" />
+                              <test-suite name="ProvidesProperFailureMessage" executed="True" success="True" time="0.000" asserts="0">
+                                <results>
+                                  <test-case name="NUnit.Framework.Constraints.Tests.NotTest.ProvidesProperFailureMessage(null,&quot;null&quot;)" executed="True" success="True" time="0.000" asserts="1" />
+                                </results>
+                              </test-suite>
+                              <test-case name="NUnit.Framework.Constraints.Tests.NotTest.ProvidesProperStringRepresentation" executed="True" success="True" time="0.000" asserts="1" />
+                              <test-suite name="SucceedsWithGoodValues" executed="True" success="True" time="0.000" asserts="0">
+                                <results>
+                                  <test-case name="NUnit.Framework.Constraints.Tests.NotTest.SucceedsWithGoodValues(42)" executed="True" success="True" time="0.000" asserts="1" />
+                                  <test-case name="NUnit.Framework.Constraints.Tests.NotTest.SucceedsWithGoodValues(&quot;Hello&quot;)" executed="True" success="True" time="0.000" asserts="1" />
+                                </results>
+                              </test-suite>
+                            </results>
+                          </test-suite>
+                          <test-suite name="NullConstraintTest" executed="True" success="True" time="0.000" asserts="0">
+                            <results>
+                              <test-suite name="FailsWithBadValues" executed="True" success="True" time="0.000" asserts="0">
+                                <results>
+                                  <test-case name="NUnit.Framework.Constraints.Tests.NullConstraintTest.FailsWithBadValues(&quot;hello&quot;)" executed="True" success="True" time="0.000" asserts="1" />
+                                </results>
+                              </test-suite>
+                              <test-case name="NUnit.Framework.Constraints.Tests.NullConstraintTest.ProvidesProperDescription" executed="True" success="True" time="0.000" asserts="1" />
+                              <test-suite name="ProvidesProperFailureMessage" executed="True" success="True" time="0.000" asserts="0">
+                                <results>
+                                  <test-case name="NUnit.Framework.Constraints.Tests.NullConstraintTest.ProvidesProperFailureMessage(&quot;hello&quot;,&quot;\&quot;hello\&quot;&quot;)" executed="True" success="True" time="0.000" asserts="1" />
+                                </results>
+                              </test-suite>
+                              <test-case name="NUnit.Framework.Constraints.Tests.NullConstraintTest.ProvidesProperStringRepresentation" executed="True" success="True" time="0.000" asserts="1" />
+                              <test-suite name="SucceedsWithGoodValues" executed="True" success="True" time="0.000" asserts="0">
+                                <results>
+                                  <test-case name="NUnit.Framework.Constraints.Tests.NullConstraintTest.SucceedsWithGoodValues(null)" executed="True" success="True" time="0.000" asserts="1" />
+                                </results>
+                              </test-suite>
+                            </results>
+                          </test-suite>
+                          <test-suite name="NullOrEmptyStringConstraintTest" executed="True" success="True" time="0.000" asserts="0">
+                            <results>
+                              <test-suite name="FailsWithBadValues" executed="True" success="True" time="0.000" asserts="0">
+                                <results>
+                                  <test-case name="NUnit.Framework.Constraints.Tests.NullOrEmptyStringConstraintTest.FailsWithBadValues(&quot;Hello&quot;)" executed="True" success="True" time="0.000" asserts="1" />
+                                </results>
+                              </test-suite>
+                              <test-suite name="InvalidDataThrowsArgumentException" executed="True" success="True" time="0.000" asserts="0">
+                                <results>
+                                  <test-case name="NUnit.Framework.Constraints.Tests.NullOrEmptyStringConstraintTest.InvalidDataThrowsArgumentException(5)" executed="True" success="True" time="0.000" asserts="0" />
+                                </results>
+                              </test-suite>
+                              <test-case name="NUnit.Framework.Constraints.Tests.NullOrEmptyStringConstraintTest.ProvidesProperDescription" executed="True" success="True" time="0.000" asserts="1" />
+                              <test-suite name="ProvidesProperFailureMessage" executed="True" success="True" time="0.000" asserts="0">
+                                <results>
+                                  <test-case name="NUnit.Framework.Constraints.Tests.NullOrEmptyStringConstraintTest.ProvidesProperFailureMessage(&quot;Hello&quot;,&quot;\&quot;Hello\&quot;&quot;)" executed="True" success="True" time="0.000" asserts="1" />
+                                </results>
+                              </test-suite>
+                              <test-case name="NUnit.Framework.Constraints.Tests.NullOrEmptyStringConstraintTest.ProvidesProperStringRepresentation" executed="True" success="True" time="0.000" asserts="1" />
+                              <test-suite name="SucceedsWithGoodValues" executed="True" success="True" time="0.000" asserts="0">
+                                <results>
+                                  <test-case name="NUnit.Framework.Constraints.Tests.NullOrEmptyStringConstraintTest.SucceedsWithGoodValues(&quot;&quot;)" executed="True" success="True" time="0.000" asserts="1" />
+                                  <test-case name="NUnit.Framework.Constraints.Tests.NullOrEmptyStringConstraintTest.SucceedsWithGoodValues(null)" executed="True" success="True" time="0.000" asserts="1" />
+                                </results>
+                              </test-suite>
+                            </results>
+                          </test-suite>
+                          <test-suite name="NumericsTest" executed="True" success="True" time="0.078" asserts="0">
+                            <results>
+                              <test-case name="NUnit.Framework.Constraints.Tests.NumericsTest.CanMatchDecimalWithoutToleranceMode" executed="True" success="True" time="0.000" asserts="1" />
+                              <test-case name="NUnit.Framework.Constraints.Tests.NumericsTest.CanMatchDecimalWithPercentage" executed="True" success="True" time="0.000" asserts="3" />
+                              <test-suite name="CanMatchIntegralsWithPercentage" executed="True" success="True" time="0.000" asserts="0">
+                                <results>
+                                  <test-case name="NUnit.Framework.Constraints.Tests.NumericsTest.CanMatchIntegralsWithPercentage(10500L)" executed="True" success="True" time="0.000" asserts="1" />
+                                  <test-case name="NUnit.Framework.Constraints.Tests.NumericsTest.CanMatchIntegralsWithPercentage(10000L)" executed="True" success="True" time="0.000" asserts="1" />
+                                  <test-case name="NUnit.Framework.Constraints.Tests.NumericsTest.CanMatchIntegralsWithPercentage(9500UL)" executed="True" success="True" time="0.000" asserts="1" />
+                                  <test-case name="NUnit.Framework.Constraints.Tests.NumericsTest.CanMatchIntegralsWithPercentage(10500)" executed="True" success="True" time="0.000" asserts="1" />
+                                  <test-case name="NUnit.Framework.Constraints.Tests.NumericsTest.CanMatchIntegralsWithPercentage(10000)" executed="True" success="True" time="0.000" asserts="1" />
+                                  <test-case name="NUnit.Framework.Constraints.Tests.NumericsTest.CanMatchIntegralsWithPercentage(9500L)" executed="True" success="True" time="0.000" asserts="1" />
+                                  <test-case name="NUnit.Framework.Constraints.Tests.NumericsTest.CanMatchIntegralsWithPercentage(10500UL)" executed="True" success="True" time="0.000" asserts="1" />
+                                  <test-case name="NUnit.Framework.Constraints.Tests.NumericsTest.CanMatchIntegralsWithPercentage(9500)" executed="True" success="True" time="0.000" asserts="1" />
+                                  <test-case name="NUnit.Framework.Constraints.Tests.NumericsTest.CanMatchIntegralsWithPercentage(10000UL)" executed="True" success="True" time="0.000" asserts="1" />
+                                  <test-case name="NUnit.Framework.Constraints.Tests.NumericsTest.CanMatchIntegralsWithPercentage(10000)" executed="True" success="True" time="0.000" asserts="1" />
+                                  <test-case name="NUnit.Framework.Constraints.Tests.NumericsTest.CanMatchIntegralsWithPercentage(10500)" executed="True" success="True" time="0.000" asserts="1" />
+                                  <test-case name="NUnit.Framework.Constraints.Tests.NumericsTest.CanMatchIntegralsWithPercentage(9500)" executed="True" success="True" time="0.000" asserts="1" />
+                                </results>
+                              </test-suite>
+                              <test-suite name="CanMatchWithoutToleranceMode" executed="True" success="True" time="0.000" asserts="0">
+                                <results>
+                                  <test-case name="NUnit.Framework.Constraints.Tests.NumericsTest.CanMatchWithoutToleranceMode(123456789UL)" executed="True" success="True" time="0.000" asserts="1" />
+                                  <test-case name="NUnit.Framework.Constraints.Tests.NumericsTest.CanMatchWithoutToleranceMode(123456789L)" executed="True" success="True" time="0.000" asserts="1" />
+                                  <test-case name="NUnit.Framework.Constraints.Tests.NumericsTest.CanMatchWithoutToleranceMode(123456789)" executed="True" success="True" time="0.000" asserts="1" />
+                                  <test-case name="NUnit.Framework.Constraints.Tests.NumericsTest.CanMatchWithoutToleranceMode(123456789)" executed="True" success="True" time="0.000" asserts="1" />
+                                  <test-case name="NUnit.Framework.Constraints.Tests.NumericsTest.CanMatchWithoutToleranceMode(1234.568f)" executed="True" success="True" time="0.000" asserts="1" />
+                                  <test-case name="NUnit.Framework.Constraints.Tests.NumericsTest.CanMatchWithoutToleranceMode(1234.5678d)" executed="True" success="True" time="0.000" asserts="1" />
+                                </results>
+                              </test-suite>
+                              <test-case name="NUnit.Framework.Constraints.Tests.NumericsTest.FailsOnDecimalAbovePercentage" executed="True" success="True" time="0.000" asserts="1" />
+                              <test-case name="NUnit.Framework.Constraints.Tests.NumericsTest.FailsOnDecimalBelowPercentage" executed="True" success="True" time="0.063" asserts="1" />
+                              <test-suite name="FailsOnIntegralsOutsideOfPercentage" executed="True" success="True" time="0.016" asserts="0">
+                                <results>
+                                  <test-case name="NUnit.Framework.Constraints.Tests.NumericsTest.FailsOnIntegralsOutsideOfPercentage(8500)" executed="True" success="True" time="0.000" asserts="1" />
+                                  <test-case name="NUnit.Framework.Constraints.Tests.NumericsTest.FailsOnIntegralsOutsideOfPercentage(8500)" executed="True" success="True" time="0.000" asserts="1" />
+                                  <test-case name="NUnit.Framework.Constraints.Tests.NumericsTest.FailsOnIntegralsOutsideOfPercentage(11500)" executed="True" success="True" time="0.000" asserts="1" />
+                                  <test-case name="NUnit.Framework.Constraints.Tests.NumericsTest.FailsOnIntegralsOutsideOfPercentage(11500UL)" executed="True" success="True" time="0.016" asserts="1" />
+                                  <test-case name="NUnit.Framework.Constraints.Tests.NumericsTest.FailsOnIntegralsOutsideOfPercentage(11500)" executed="True" success="True" time="0.000" asserts="1" />
+                                  <test-case name="NUnit.Framework.Constraints.Tests.NumericsTest.FailsOnIntegralsOutsideOfPercentage(8500L)" executed="True" success="True" time="0.000" asserts="1" />
+                                  <test-case name="NUnit.Framework.Constraints.Tests.NumericsTest.FailsOnIntegralsOutsideOfPercentage(11500L)" executed="True" success="True" time="0.000" asserts="1" />
+                                  <test-case name="NUnit.Framework.Constraints.Tests.NumericsTest.FailsOnIntegralsOutsideOfPercentage(8500UL)" executed="True" success="True" time="0.000" asserts="1" />
+                                </results>
+                              </test-suite>
+                            </results>
+                          </test-suite>
+                          <test-suite name="OrTest" executed="True" success="True" time="0.000" asserts="0">
+                            <results>
+                              <test-case name="NUnit.Framework.Constraints.Tests.OrTest.CanCombineTestsWithOrOperator" executed="True" success="True" time="0.000" asserts="1" />
+                              <test-suite name="FailsWithBadValues" executed="True" success="True" time="0.000" asserts="0">
+                                <results>
+                                  <test-case name="NUnit.Framework.Constraints.Tests.OrTest.FailsWithBadValues(37)" executed="True" success="True" time="0.000" asserts="1" />
+                                </results>
+                              </test-suite>
+                              <test-case name="NUnit.Framework.Constraints.Tests.OrTest.ProvidesProperDescription" executed="True" success="True" time="0.000" asserts="1" />
+                              <test-suite name="ProvidesProperFailureMessage" executed="True" success="True" time="0.000" asserts="0">
+                                <results>
+                                  <test-case name="NUnit.Framework.Constraints.Tests.OrTest.ProvidesProperFailureMessage(37,&quot;37&quot;)" executed="True" success="True" time="0.000" asserts="1" />
+                                </results>
+                              </test-suite>
+                              <test-case name="NUnit.Framework.Constraints.Tests.OrTest.ProvidesProperStringRepresentation" executed="True" success="True" time="0.000" asserts="1" />
+                              <test-suite name="SucceedsWithGoodValues" executed="True" success="True" time="0.000" asserts="0">
+                                <results>
+                                  <test-case name="NUnit.Framework.Constraints.Tests.OrTest.SucceedsWithGoodValues(99)" executed="True" success="True" time="0.000" asserts="1" />
+                                  <test-case name="NUnit.Framework.Constraints.Tests.OrTest.SucceedsWithGoodValues(42)" executed="True" success="True" time="0.000" asserts="1" />
+                                </results>
+                              </test-suite>
+                            </results>
+                          </test-suite>
+                          <test-suite name="PropertyExistsTest" executed="True" success="True" time="0.000" asserts="0">
+                            <results>
+                              <test-suite name="FailsWithBadValues" executed="True" success="True" time="0.000" asserts="0">
+                                <results>
+                                  <test-case name="NUnit.Framework.Constraints.Tests.PropertyExistsTest.FailsWithBadValues(42)" executed="True" success="True" time="0.000" asserts="1" />
+                                  <test-case name="NUnit.Framework.Constraints.Tests.PropertyExistsTest.FailsWithBadValues(System.Collections.ArrayList)" executed="True" success="True" time="0.000" asserts="1" />
+                                  <test-case name="NUnit.Framework.Constraints.Tests.PropertyExistsTest.FailsWithBadValues(System.Int32)" executed="True" success="True" time="0.000" asserts="1" />
+                                </results>
+                              </test-suite>
+                              <test-suite name="InvalidDataThrowsException" executed="True" success="True" time="0.000" asserts="0">
+                                <results>
+                                  <test-case name="NUnit.Framework.Constraints.Tests.PropertyExistsTest.InvalidDataThrowsException(null)" executed="True" success="True" time="0.000" asserts="0" />
+                                </results>
+                              </test-suite>
+                              <test-case name="NUnit.Framework.Constraints.Tests.PropertyExistsTest.ProvidesProperDescription" executed="True" success="True" time="0.000" asserts="1" />
+                              <test-suite name="ProvidesProperFailureMessage" executed="True" success="True" time="0.000" asserts="0">
+                                <results>
+                                  <test-case name="NUnit.Framework.Constraints.Tests.PropertyExistsTest.ProvidesProperFailureMessage(42,&quot;&lt;System.Int32&gt;&quot;)" executed="True" success="True" time="0.000" asserts="1" />
+                                  <test-case name="NUnit.Framework.Constraints.Tests.PropertyExistsTest.ProvidesProperFailureMessage(System.Collections.ArrayList,&quot;&lt;System.Collections.ArrayList&gt;&quot;)" executed="True" success="True" time="0.000" asserts="1" />
+                                  <test-case name="NUnit.Framework.Constraints.Tests.PropertyExistsTest.ProvidesProperFailureMessage(System.Int32,&quot;&lt;System.Int32&gt;&quot;)" executed="True" success="True" time="0.000" asserts="1" />
+                                </results>
+                              </test-suite>
+                              <test-case name="NUnit.Framework.Constraints.Tests.PropertyExistsTest.ProvidesProperStringRepresentation" executed="True" success="True" time="0.000" asserts="1" />
+                              <test-suite name="SucceedsWithGoodValues" executed="True" success="True" time="0.000" asserts="0">
+                                <results>
+                                  <test-case name="NUnit.Framework.Constraints.Tests.PropertyExistsTest.SucceedsWithGoodValues(System.Int32[])" executed="True" success="True" time="0.000" asserts="1" />
+                                  <test-case name="NUnit.Framework.Constraints.Tests.PropertyExistsTest.SucceedsWithGoodValues(&quot;hello&quot;)" executed="True" success="True" time="0.000" asserts="1" />
+                                  <test-case name="NUnit.Framework.Constraints.Tests.PropertyExistsTest.SucceedsWithGoodValues(System.Array)" executed="True" success="True" time="0.000" asserts="1" />
+                                </results>
+                              </test-suite>
+                            </results>
+                          </test-suite>
+                          <test-suite name="PropertyTest" executed="True" success="True" time="0.047" asserts="0">
+                            <results>
+                              <test-suite name="FailsWithBadValues" executed="True" success="True" time="0.000" asserts="0">
+                                <results>
+                                  <test-case name="NUnit.Framework.Constraints.Tests.PropertyTest.FailsWithBadValues(System.Int32[])" executed="True" success="True" time="0.000" asserts="1" />
+                                  <test-case name="NUnit.Framework.Constraints.Tests.PropertyTest.FailsWithBadValues(&quot;goodbye&quot;)" executed="True" success="True" time="0.000" asserts="1" />
+                                </results>
+                              </test-suite>
+                              <test-suite name="InvalidDataThrowsException" executed="True" success="True" time="0.047" asserts="0">
+                                <results>
+                                  <test-case name="NUnit.Framework.Constraints.Tests.PropertyTest.InvalidDataThrowsException(null)" executed="True" success="True" time="0.000" asserts="0" />
+                                  <test-case name="NUnit.Framework.Constraints.Tests.PropertyTest.InvalidDataThrowsException(42)" executed="True" success="True" time="0.000" asserts="0" />
+                                  <test-case name="NUnit.Framework.Constraints.Tests.PropertyTest.InvalidDataThrowsException(System.Collections.ArrayList)" executed="True" success="True" time="0.031" asserts="0" />
+                                </results>
+                              </test-suite>
+                              <test-case name="NUnit.Framework.Constraints.Tests.PropertyTest.ProvidesProperDescription" executed="True" success="True" time="0.000" asserts="1" />
+                              <test-suite name="ProvidesProperFailureMessage" executed="True" success="True" time="0.000" asserts="0">
+                                <results>
+                                  <test-case name="NUnit.Framework.Constraints.Tests.PropertyTest.ProvidesProperFailureMessage(System.Int32[],&quot;3&quot;)" executed="True" success="True" time="0.000" asserts="1" />
+                                  <test-case name="NUnit.Framework.Constraints.Tests.PropertyTest.ProvidesProperFailureMessage(&quot;goodbye&quot;,&quot;7&quot;)" executed="True" success="True" time="0.000" asserts="1" />
+                                </results>
+                              </test-suite>
+                              <test-case name="NUnit.Framework.Constraints.Tests.PropertyTest.ProvidesProperStringRepresentation" executed="True" success="True" time="0.000" asserts="1" />
+                              <test-suite name="SucceedsWithGoodValues" executed="True" success="True" time="0.000" asserts="0">
+                                <results>
+                                  <test-case name="NUnit.Framework.Constraints.Tests.PropertyTest.SucceedsWithGoodValues(System.Int32[])" executed="True" success="True" time="0.000" asserts="1" />
+                                  <test-case name="NUnit.Framework.Constraints.Tests.PropertyTest.SucceedsWithGoodValues(&quot;hello&quot;)" executed="True" success="True" time="0.000" asserts="1" />
+                                </results>
+                              </test-suite>
+                            </results>
+                          </test-suite>
+                          <test-suite name="RangeConstraintTest" executed="True" success="True" time="0.031" asserts="0">
+                            <results>
+                              <test-suite name="FailsWithBadValues" executed="True" success="True" time="0.016" asserts="0">
+                                <results>
+                                  <test-case name="NUnit.Framework.Constraints.Tests.RangeConstraintTest.FailsWithBadValues(4)" executed="True" success="True" time="0.000" asserts="1" />
+                                  <test-case name="NUnit.Framework.Constraints.Tests.RangeConstraintTest.FailsWithBadValues(43)" executed="True" success="True" time="0.000" asserts="1" />
+                                </results>
+                              </test-suite>
+                              <test-suite name="InvalidDataThrowsArgumentException" executed="True" success="True" time="0.016" asserts="0">
+                                <results>
+                                  <test-case name="NUnit.Framework.Constraints.Tests.RangeConstraintTest.InvalidDataThrowsArgumentException(null)" executed="True" success="True" time="0.000" asserts="0" />
+                                  <test-case name="NUnit.Framework.Constraints.Tests.RangeConstraintTest.InvalidDataThrowsArgumentException(&quot;xxx&quot;)" executed="True" success="True" time="0.000" asserts="0" />
+                                </results>
+                              </test-suite>
+                              <test-case name="NUnit.Framework.Constraints.Tests.RangeConstraintTest.ProvidesProperDescription" executed="True" success="True" time="0.000" asserts="1" />
+                              <test-suite name="ProvidesProperFailureMessage" executed="True" success="True" time="0.000" asserts="0">
+                                <results>
+                                  <test-case name="NUnit.Framework.Constraints.Tests.RangeConstraintTest.ProvidesProperFailureMessage(4,&quot;4&quot;)" executed="True" success="True" time="0.000" asserts="1" />
+                                  <test-case name="NUnit.Framework.Constraints.Tests.RangeConstraintTest.ProvidesProperFailureMessage(43,&quot;43&quot;)" executed="True" success="True" time="0.000" asserts="1" />
+                                </results>
+                              </test-suite>
+                              <test-case name="NUnit.Framework.Constraints.Tests.RangeConstraintTest.ProvidesProperStringRepresentation" executed="True" success="True" time="0.000" asserts="1" />
+                              <test-suite name="SucceedsWithGoodValues" executed="True" success="True" time="0.000" asserts="0">
+                                <results>
+                                  <test-case name="NUnit.Framework.Constraints.Tests.RangeConstraintTest.SucceedsWithGoodValues(5)" executed="True" success="True" time="0.000" asserts="1" />
+                                  <test-case name="NUnit.Framework.Constraints.Tests.RangeConstraintTest.SucceedsWithGoodValues(23)" executed="True" success="True" time="0.000" asserts="1" />
+                                  <test-case name="NUnit.Framework.Constraints.Tests.RangeConstraintTest.SucceedsWithGoodValues(42)" executed="True" success="True" time="0.000" asserts="1" />
+                                </results>
+                              </test-suite>
+                              <test-case name="NUnit.Framework.Constraints.Tests.RangeConstraintTest.UsesProvidedComparerOfT" executed="True" success="True" time="0.000" asserts="2" />
+                              <test-case name="NUnit.Framework.Constraints.Tests.RangeConstraintTest.UsesProvidedComparisonOfT" executed="True" success="True" time="0.000" asserts="2" />
+                              <test-case name="NUnit.Framework.Constraints.Tests.RangeConstraintTest.UsesProvidedIComparer" executed="True" success="True" time="0.000" asserts="2" />
+                            </results>
+                          </test-suite>
+                          <test-suite name="SameAsTest" executed="True" success="True" time="0.000" asserts="0">
+                            <results>
+                              <test-suite name="FailsWithBadValues" executed="True" success="True" time="0.000" asserts="0">
+                                <results>
+                                  <test-case name="NUnit.Framework.Constraints.Tests.SameAsTest.FailsWithBadValues(System.Object)" executed="True" success="True" time="0.000" asserts="1" />
+                                  <test-case name="NUnit.Framework.Constraints.Tests.SameAsTest.FailsWithBadValues(3)" executed="True" success="True" time="0.000" asserts="1" />
+                                  <test-case name="NUnit.Framework.Constraints.Tests.SameAsTest.FailsWithBadValues(&quot;Hello&quot;)" executed="True" success="True" time="0.000" asserts="1" />
+                                </results>
+                              </test-suite>
+                              <test-case name="NUnit.Framework.Constraints.Tests.SameAsTest.ProvidesProperDescription" executed="True" success="True" time="0.000" asserts="1" />
+                              <test-suite name="ProvidesProperFailureMessage" executed="True" success="True" time="0.000" asserts="0">
+                                <results>
+                                  <test-case name="NUnit.Framework.Constraints.Tests.SameAsTest.ProvidesProperFailureMessage(System.Object,&quot;&lt;System.Object&gt;&quot;)" executed="True" success="True" time="0.000" asserts="1" />
+                                  <test-case name="NUnit.Framework.Constraints.Tests.SameAsTest.ProvidesProperFailureMessage(3,&quot;3&quot;)" executed="True" success="True" time="0.000" asserts="1" />
+                                  <test-case name="NUnit.Framework.Constraints.Tests.SameAsTest.ProvidesProperFailureMessage(&quot;Hello&quot;,&quot;\&quot;Hello\&quot;&quot;)" executed="True" success="True" time="0.000" asserts="1" />
+                                </results>
+                              </test-suite>
+                              <test-case name="NUnit.Framework.Constraints.Tests.SameAsTest.ProvidesProperStringRepresentation" executed="True" success="True" time="0.000" asserts="1" />
+                              <test-suite name="SucceedsWithGoodValues" executed="True" success="True" time="0.000" asserts="0">
+                                <results>
+                                  <test-case name="NUnit.Framework.Constraints.Tests.SameAsTest.SucceedsWithGoodValues(System.Object)" executed="True" success="True" time="0.000" asserts="1" />
+                                </results>
+                              </test-suite>
+                            </results>
+                          </test-suite>
+                          <test-suite name="SamePathOrUnderTest_Linux" executed="True" success="True" time="0.000" asserts="0">
+                            <results>
+                              <test-suite name="FailsWithBadValues" executed="True" success="True" time="0.000" asserts="0">
+                                <results>
+                                  <test-case name="NUnit.Framework.Constraints.Tests.SamePathOrUnderTest_Linux.FailsWithBadValues(123)" executed="True" success="True" time="0.000" asserts="1" />
+                                  <test-case name="NUnit.Framework.Constraints.Tests.SamePathOrUnderTest_Linux.FailsWithBadValues(&quot;/Folder1/Folder2&quot;)" executed="True" success="True" time="0.000" asserts="1" />
+                                  <test-case name="NUnit.Framework.Constraints.Tests.SamePathOrUnderTest_Linux.FailsWithBadValues(&quot;/FOLDER1/./junk/../Folder2&quot;)" executed="True" success="True" time="0.000" asserts="1" />
+                                  <test-case name="NUnit.Framework.Constraints.Tests.SamePathOrUnderTest_Linux.FailsWithBadValues(&quot;/FOLDER1/./junk/../Folder2/temp/../Folder3&quot;)" executed="True" success="True" time="0.000" asserts="1" />
+                                  <test-case name="NUnit.Framework.Constraints.Tests.SamePathOrUnderTest_Linux.FailsWithBadValues(&quot;/folder1/folder3&quot;)" executed="True" success="True" time="0.000" asserts="1" />
+                                  <test-case name="NUnit.Framework.Constraints.Tests.SamePathOrUnderTest_Linux.FailsWithBadValues(&quot;/folder1/./folder2/../folder3&quot;)" executed="True" success="True" time="0.000" asserts="1" />
+                                  <test-case name="NUnit.Framework.Constraints.Tests.SamePathOrUnderTest_Linux.FailsWithBadValues(&quot;/folder1&quot;)" executed="True" success="True" time="0.000" asserts="1" />
+                                </results>
+                              </test-suite>
+                              <test-case name="NUnit.Framework.Constraints.Tests.SamePathOrUnderTest_Linux.ProvidesProperDescription" executed="True" success="True" time="0.000" asserts="1" />
+                              <test-suite name="ProvidesProperFailureMessage" executed="True" success="True" time="0.000" asserts="0">
+                                <results>
+                                  <test-case name="NUnit.Framework.Constraints.Tests.SamePathOrUnderTest_Linux.ProvidesProperFailureMessage(123,&quot;123&quot;)" executed="True" success="True" time="0.000" asserts="1" />
+                                  <test-case name="NUnit.Framework.Constraints.Tests.SamePathOrUnderTest_Linux.ProvidesProperFailureMessage(&quot;/Folder1/Folder2&quot;,&quot;\&quot;/Folder1/Folder2\&quot;&quot;)" executed="True" success="True" time="0.000" asserts="1" />
+                                  <test-case name="NUnit.Framework.Constraints.Tests.SamePathOrUnderTest_Linux.ProvidesProperFailureMessage(&quot;/FOLDER1/./junk/../Folder2&quot;,&quot;\&quot;/FOLDER1/./junk/../Folder2\&quot;&quot;)" executed="True" success="True" time="0.000" asserts="1" />
+                                  <test-case name="NUnit.Framework.Constraints.Tests.SamePathOrUnderTest_Linux.ProvidesProperFailureMessage(&quot;/FOLDER1/./junk/../Folder2/temp/../Folder3&quot;,&quot;\&quot;/FOLDER1/./junk/../Folder2/temp/../Folder3\&quot;&quot;)" executed="True" success="True" time="0.000" asserts="1" />
+                                  <test-case name="NUnit.Framework.Constraints.Tests.SamePathOrUnderTest_Linux.ProvidesProperFailureMessage(&quot;/folder1/folder3&quot;,&quot;\&quot;/folder1/folder3\&quot;&quot;)" executed="True" success="True" time="0.000" asserts="1" />
+                                  <test-case name="NUnit.Framework.Constraints.Tests.SamePathOrUnderTest_Linux.ProvidesProperFailureMessage(&quot;/folder1/./folder2/../folder3&quot;,&quot;\&quot;/folder1/./folder2/../folder3\&quot;&quot;)" executed="True" success="True" time="0.000" asserts="1" />
+                                  <test-case name="NUnit.Framework.Constraints.Tests.SamePathOrUnderTest_Linux.ProvidesProperFailureMessage(&quot;/folder1&quot;,&quot;\&quot;/folder1\&quot;&quot;)" executed="True" success="True" time="0.000" asserts="1" />
+                                </results>
+                              </test-suite>
+                              <test-case name="NUnit.Framework.Constraints.Tests.SamePathOrUnderTest_Linux.ProvidesProperStringRepresentation" executed="True" success="True" time="0.000" asserts="1" />
+                              <test-suite name="SucceedsWithGoodValues" executed="True" success="True" time="0.000" asserts="0">
+                                <results>
+                                  <test-case name="NUnit.Framework.Constraints.Tests.SamePathOrUnderTest_Linux.SucceedsWithGoodValues(&quot;/folder1/folder2&quot;)" executed="True" success="True" time="0.000" asserts="1" />
+                                  <test-case name="NUnit.Framework.Constraints.Tests.SamePathOrUnderTest_Linux.SucceedsWithGoodValues(&quot;/folder1/./folder2&quot;)" executed="True" success="True" time="0.000" asserts="1" />
+                                  <test-case name="NUnit.Framework.Constraints.Tests.SamePathOrUnderTest_Linux.SucceedsWithGoodValues(&quot;/folder1/junk/../folder2&quot;)" executed="True" success="True" time="0.000" asserts="1" />
+                                  <test-case name="NUnit.Framework.Constraints.Tests.SamePathOrUnderTest_Linux.SucceedsWithGoodValues(&quot;\\folder1\\folder2&quot;)" executed="True" success="True" time="0.000" asserts="1" />
+                                  <test-case name="NUnit.Framework.Constraints.Tests.SamePathOrUnderTest_Linux.SucceedsWithGoodValues(&quot;/folder1/folder2/folder3&quot;)" executed="True" success="True" time="0.000" asserts="1" />
+                                  <test-case name="NUnit.Framework.Constraints.Tests.SamePathOrUnderTest_Linux.SucceedsWithGoodValues(&quot;/folder1/./folder2/folder3&quot;)" executed="True" success="True" time="0.000" asserts="1" />
+                                  <test-case name="NUnit.Framework.Constraints.Tests.SamePathOrUnderTest_Linux.SucceedsWithGoodValues(&quot;/folder1/junk/../folder2/folder3&quot;)" executed="True" success="True" time="0.000" asserts="1" />
+                                  <test-case name="NUnit.Framework.Constraints.Tests.SamePathOrUnderTest_Linux.SucceedsWithGoodValues(&quot;\\folder1\\folder2\\folder3&quot;)" executed="True" success="True" time="0.000" asserts="1" />
+                                </results>
+                              </test-suite>
+                            </results>
+                          </test-suite>
+                          <test-suite name="SamePathOrUnderTest_Windows" executed="True" success="True" time="0.000" asserts="0">
+                            <results>
+                              <test-suite name="FailsWithBadValues" executed="True" success="True" time="0.000" asserts="0">
+                                <results>
+                                  <test-case name="NUnit.Framework.Constraints.Tests.SamePathOrUnderTest_Windows.FailsWithBadValues(123)" executed="True" success="True" time="0.000" asserts="1" />
+                                  <test-case name="NUnit.Framework.Constraints.Tests.SamePathOrUnderTest_Windows.FailsWithBadValues(&quot;C:\\folder1\\folder3&quot;)" executed="True" success="True" time="0.000" asserts="1" />
+                                  <test-case name="NUnit.Framework.Constraints.Tests.SamePathOrUnderTest_Windows.FailsWithBadValues(&quot;C:\\folder1\\.\\folder2\\..\\file.temp&quot;)" executed="True" success="True" time="0.000" asserts="1" />
+                                </results>
+                              </test-suite>
+                              <test-case name="NUnit.Framework.Constraints.Tests.SamePathOrUnderTest_Windows.ProvidesProperDescription" executed="True" success="True" time="0.000" asserts="1" />
+                              <test-suite name="ProvidesProperFailureMessage" executed="True" success="True" time="0.000" asserts="0">
+                                <results>
+                                  <test-case name="NUnit.Framework.Constraints.Tests.SamePathOrUnderTest_Windows.ProvidesProperFailureMessage(123,&quot;123&quot;)" executed="True" success="True" time="0.000" asserts="1" />
+                                  <test-case name="NUnit.Framework.Constraints.Tests.SamePathOrUnderTest_Windows.ProvidesProperFailureMessage(&quot;C:\\folder1\\folder3&quot;,&quot;\&quot;C:\\folder1\\folder3\&quot;&quot;)" executed="True" success="True" time="0.000" asserts="1" />
+                                  <test-case name="NUnit.Framework.Constraints.Tests.SamePathOrUnderTest_Windows.ProvidesProperFailureMessage(&quot;C:\\folder1\\.\\folder2\\..\\file.temp&quot;,&quot;\&quot;C:\\folder1\\.\\folder2\\..\\file.temp\&quot;&quot;)" executed="True" success="True" time="0.000" asserts="1" />
+                                </results>
+                              </test-suite>
+                              <test-case name="NUnit.Framework.Constraints.Tests.SamePathOrUnderTest_Windows.ProvidesProperStringRepresentation" executed="True" success="True" time="0.000" asserts="1" />
+                              <test-suite name="SucceedsWithGoodValues" executed="True" success="True" time="0.000" asserts="0">
+                                <results>
+                                  <test-case name="NUnit.Framework.Constraints.Tests.SamePathOrUnderTest_Windows.SucceedsWithGoodValues(&quot;C:\\folder1\\folder2&quot;)" executed="True" success="True" time="0.000" asserts="1" />
+                                  <test-case name="NUnit.Framework.Constraints.Tests.SamePathOrUnderTest_Windows.SucceedsWithGoodValues(&quot;C:\\Folder1\\Folder2&quot;)" executed="True" success="True" time="0.000" asserts="1" />
+                                  <test-case name="NUnit.Framework.Constraints.Tests.SamePathOrUnderTest_Windows.SucceedsWithGoodValues(&quot;C:\\folder1\\.\\folder2&quot;)" executed="True" success="True" time="0.000" asserts="1" />
+                                  <test-case name="NUnit.Framework.Constraints.Tests.SamePathOrUnderTest_Windows.SucceedsWithGoodValues(&quot;C:\\folder1\\junk\\..\\folder2&quot;)" executed="True" success="True" time="0.000" asserts="1" />
+                                  <test-case name="NUnit.Framework.Constraints.Tests.SamePathOrUnderTest_Windows.SucceedsWithGoodValues(&quot;C:\\FOLDER1\\.\\junk\\..\\Folder2&quot;)" executed="True" success="True" time="0.000" asserts="1" />
+                                  <test-case name="NUnit.Framework.Constraints.Tests.SamePathOrUnderTest_Windows.SucceedsWithGoodValues(&quot;C:/folder1/folder2&quot;)" executed="True" success="True" time="0.000" asserts="1" />
+                                  <test-case name="NUnit.Framework.Constraints.Tests.SamePathOrUnderTest_Windows.SucceedsWithGoodValues(&quot;C:\\folder1\\folder2\\folder3&quot;)" executed="True" success="True" time="0.000" asserts="1" />
+                                  <test-case name="NUnit.Framework.Constraints.Tests.SamePathOrUnderTest_Windows.SucceedsWithGoodValues(&quot;C:\\folder1\\.\\folder2\\folder3&quot;)" executed="True" success="True" time="0.000" asserts="1" />
+                                  <test-case name="NUnit.Framework.Constraints.Tests.SamePathOrUnderTest_Windows.SucceedsWithGoodValues(&quot;C:\\folder1\\junk\\..\\folder2\\folder3&quot;)" executed="True" success="True" time="0.000" asserts="1" />
+                                  <test-case name="NUnit.Framework.Constraints.Tests.SamePathOrUnderTest_Windows.SucceedsWithGoodValues(&quot;C:\\FOLDER1\\.\\junk\\..\\Folder2\\temp\\..\\Folder3&quot;)" executed="True" success="True" time="0.000" asserts="1" />
+                                  <test-case name="NUnit.Framework.Constraints.Tests.SamePathOrUnderTest_Windows.SucceedsWithGoodValues(&quot;C:/folder1/folder2/folder3&quot;)" executed="True" success="True" time="0.000" asserts="1" />
+                                </results>
+                              </test-suite>
+                            </results>
+                          </test-suite>
+                          <test-suite name="SamePathTest_Linux" executed="True" success="True" time="0.000" asserts="0">
+                            <results>
+                              <test-suite name="FailsWithBadValues" executed="True" success="True" time="0.000" asserts="0">
+                                <results>
+                                  <test-case name="NUnit.Framework.Constraints.Tests.SamePathTest_Linux.FailsWithBadValues(123)" executed="True" success="True" time="0.000" asserts="1" />
+                                  <test-case name="NUnit.Framework.Constraints.Tests.SamePathTest_Linux.FailsWithBadValues(&quot;/folder2/file.tmp&quot;)" executed="True" success="True" time="0.000" asserts="1" />
+                                  <test-case name="NUnit.Framework.Constraints.Tests.SamePathTest_Linux.FailsWithBadValues(&quot;/folder1/./folder2/../file.temp&quot;)" executed="True" success="True" time="0.000" asserts="1" />
+                                  <test-case name="NUnit.Framework.Constraints.Tests.SamePathTest_Linux.FailsWithBadValues(&quot;/Folder1/File.TMP&quot;)" executed="True" success="True" time="0.000" asserts="1" />
+                                  <test-case name="NUnit.Framework.Constraints.Tests.SamePathTest_Linux.FailsWithBadValues(&quot;/FOLDER1/./folder2/../File.TMP&quot;)" executed="True" success="True" time="0.000" asserts="1" />
+                                </results>
+                              </test-suite>
+                              <test-case name="NUnit.Framework.Constraints.Tests.SamePathTest_Linux.ProvidesProperDescription" executed="True" success="True" time="0.000" asserts="1" />
+                              <test-suite name="ProvidesProperFailureMessage" executed="True" success="True" time="0.000" asserts="0">
+                                <results>
+                                  <test-case name="NUnit.Framework.Constraints.Tests.SamePathTest_Linux.ProvidesProperFailureMessage(123,&quot;123&quot;)" executed="True" success="True" time="0.000" asserts="1" />
+                                  <test-case name="NUnit.Framework.Constraints.Tests.SamePathTest_Linux.ProvidesProperFailureMessage(&quot;/folder2/file.tmp&quot;,&quot;\&quot;/folder2/file.tmp\&quot;&quot;)" executed="True" success="True" time="0.000" asserts="1" />
+                                  <test-case name="NUnit.Framework.Constraints.Tests.SamePathTest_Linux.ProvidesProperFailureMessage(&quot;/folder1/./folder2/../file.temp&quot;,&quot;\&quot;/folder1/./folder2/../file.temp\&quot;&quot;)" executed="True" success="True" time="0.000" asserts="1" />
+                                  <test-case name="NUnit.Framework.Constraints.Tests.SamePathTest_Linux.ProvidesProperFailureMessage(&quot;/Folder1/File.TMP&quot;,&quot;\&quot;/Folder1/File.TMP\&quot;&quot;)" executed="True" success="True" time="0.000" asserts="1" />
+                                  <test-case name="NUnit.Framework.Constraints.Tests.SamePathTest_Linux.ProvidesProperFailureMessage(&quot;/FOLDER1/./folder2/../File.TMP&quot;,&quot;\&quot;/FOLDER1/./folder2/../File.TMP\&quot;&quot;)" executed="True" success="True" time="0.000" asserts="1" />
+                                </results>
+                              </test-suite>
+                              <test-case name="NUnit.Framework.Constraints.Tests.SamePathTest_Linux.ProvidesProperStringRepresentation" executed="True" success="True" time="0.000" asserts="1" />
+                              <test-suite name="SucceedsWithGoodValues" executed="True" success="True" time="0.000" asserts="0">
+                                <results>
+                                  <test-case name="NUnit.Framework.Constraints.Tests.SamePathTest_Linux.SucceedsWithGoodValues(&quot;/folder1/file.tmp&quot;)" executed="True" success="True" time="0.000" asserts="1" />
+                                  <test-case name="NUnit.Framework.Constraints.Tests.SamePathTest_Linux.SucceedsWithGoodValues(&quot;/folder1/./file.tmp&quot;)" executed="True" success="True" time="0.000" asserts="1" />
+                                  <test-case name="NUnit.Framework.Constraints.Tests.SamePathTest_Linux.SucceedsWithGoodValues(&quot;/folder1/folder2/../file.tmp&quot;)" executed="True" success="True" time="0.000" asserts="1" />
+                                  <test-case name="NUnit.Framework.Constraints.Tests.SamePathTest_Linux.SucceedsWithGoodValues(&quot;/folder1/./folder2/../file.tmp&quot;)" executed="True" success="True" time="0.000" asserts="1" />
+                                  <test-case name="NUnit.Framework.Constraints.Tests.SamePathTest_Linux.SucceedsWithGoodValues(&quot;\\folder1\\file.tmp&quot;)" executed="True" success="True" time="0.000" asserts="1" />
+                                </results>
+                              </test-suite>
+                            </results>
+                          </test-suite>
+                          <test-suite name="SamePathTest_Windows" executed="True" success="True" time="0.000" asserts="0">
+                            <results>
+                              <test-suite name="FailsWithBadValues" executed="True" success="True" time="0.000" asserts="0">
+                                <results>
+                                  <test-case name="NUnit.Framework.Constraints.Tests.SamePathTest_Windows.FailsWithBadValues(123)" executed="True" success="True" time="0.000" asserts="1" />
+                                  <test-case name="NUnit.Framework.Constraints.Tests.SamePathTest_Windows.FailsWithBadValues(&quot;C:\\folder2\\file.tmp&quot;)" executed="True" success="True" time="0.000" asserts="1" />
+                                  <test-case name="NUnit.Framework.Constraints.Tests.SamePathTest_Windows.FailsWithBadValues(&quot;C:\\folder1\\.\\folder2\\..\\file.temp&quot;)" executed="True" success="True" time="0.000" asserts="1" />
+                                </results>
+                              </test-suite>
+                              <test-case name="NUnit.Framework.Constraints.Tests.SamePathTest_Windows.ProvidesProperDescription" executed="True" success="True" time="0.000" asserts="1" />
+                              <test-suite name="ProvidesProperFailureMessage" executed="True" success="True" time="0.000" asserts="0">
+                                <results>
+                                  <test-case name="NUnit.Framework.Constraints.Tests.SamePathTest_Windows.ProvidesProperFailureMessage(123,&quot;123&quot;)" executed="True" success="True" time="0.000" asserts="1" />
+                                  <test-case name="NUnit.Framework.Constraints.Tests.SamePathTest_Windows.ProvidesProperFailureMessage(&quot;C:\\folder2\\file.tmp&quot;,&quot;\&quot;C:\\folder2\\file.tmp\&quot;&quot;)" executed="True" success="True" time="0.000" asserts="1" />
+                                  <test-case name="NUnit.Framework.Constraints.Tests.SamePathTest_Windows.ProvidesProperFailureMessage(&quot;C:\\folder1\\.\\folder2\\..\\file.temp&quot;,&quot;\&quot;C:\\folder1\\.\\folder2\\..\\file.temp\&quot;&quot;)" executed="True" success="True" time="0.000" asserts="1" />
+                                </results>
+                              </test-suite>
+                              <test-case name="NUnit.Framework.Constraints.Tests.SamePathTest_Windows.ProvidesProperStringRepresentation" executed="True" success="True" time="0.000" asserts="1" />
+                              <test-suite name="SucceedsWithGoodValues" executed="True" success="True" time="0.000" asserts="0">
+                                <results>
+                                  <test-case name="NUnit.Framework.Constraints.Tests.SamePathTest_Windows.SucceedsWithGoodValues(&quot;C:\\folder1\\file.tmp&quot;)" executed="True" success="True" time="0.000" asserts="1" />
+                                  <test-case name="NUnit.Framework.Constraints.Tests.SamePathTest_Windows.SucceedsWithGoodValues(&quot;C:\\Folder1\\File.TMP&quot;)" executed="True" success="True" time="0.000" asserts="1" />
+                                  <test-case name="NUnit.Framework.Constraints.Tests.SamePathTest_Windows.SucceedsWithGoodValues(&quot;C:\\folder1\\.\\file.tmp&quot;)" executed="True" success="True" time="0.000" asserts="1" />
+                                  <test-case name="NUnit.Framework.Constraints.Tests.SamePathTest_Windows.SucceedsWithGoodValues(&quot;C:\\folder1\\folder2\\..\\file.tmp&quot;)" executed="True" success="True" time="0.000" asserts="1" />
+                                  <test-case name="NUnit.Framework.Constraints.Tests.SamePathTest_Windows.SucceedsWithGoodValues(&quot;C:\\FOLDER1\\.\\folder2\\..\\File.TMP&quot;)" executed="True" success="True" time="0.000" asserts="1" />
+                                  <test-case name="NUnit.Framework.Constraints.Tests.SamePathTest_Windows.SucceedsWithGoodValues(&quot;C:/folder1/file.tmp&quot;)" executed="True" success="True" time="0.000" asserts="1" />
+                                </results>
+                              </test-suite>
+                            </results>
+                          </test-suite>
+                          <test-suite name="StartsWithTest" executed="True" success="True" time="0.016" asserts="0">
+                            <results>
+                              <test-suite name="FailsWithBadValues" executed="True" success="True" time="0.016" asserts="0">
+                                <results>
+                                  <test-case name="NUnit.Framework.Constraints.Tests.StartsWithTest.FailsWithBadValues(&quot;goodbye&quot;)" executed="True" success="True" time="0.016" asserts="1" />
+                                  <test-case name="NUnit.Framework.Constraints.Tests.StartsWithTest.FailsWithBadValues(&quot;HELLO THERE&quot;)" executed="True" success="True" time="0.000" asserts="1" />
+                                  <test-case name="NUnit.Framework.Constraints.Tests.StartsWithTest.FailsWithBadValues(&quot;I said hello&quot;)" executed="True" success="True" time="0.000" asserts="1" />
+                                  <test-case name="NUnit.Framework.Constraints.Tests.StartsWithTest.FailsWithBadValues(&quot;say hello to fred&quot;)" executed="True" success="True" time="0.000" asserts="1" />
+                                  <test-case name="NUnit.Framework.Constraints.Tests.StartsWithTest.FailsWithBadValues(&quot;&quot;)" executed="True" success="True" time="0.000" asserts="1" />
+                                  <test-case name="NUnit.Framework.Constraints.Tests.StartsWithTest.FailsWithBadValues(null)" executed="True" success="True" time="0.000" asserts="1" />
+                                </results>
+                              </test-suite>
+                              <test-case name="NUnit.Framework.Constraints.Tests.StartsWithTest.ProvidesProperDescription" executed="True" success="True" time="0.000" asserts="1" />
+                              <test-suite name="ProvidesProperFailureMessage" executed="True" success="True" time="0.000" asserts="0">
+                                <results>
+                                  <test-case name="NUnit.Framework.Constraints.Tests.StartsWithTest.ProvidesProperFailureMessage(&quot;goodbye&quot;,&quot;\&quot;goodbye\&quot;&quot;)" executed="True" success="True" time="0.000" asserts="1" />
+                                  <test-case name="NUnit.Framework.Constraints.Tests.StartsWithTest.ProvidesProperFailureMessage(&quot;HELLO THERE&quot;,&quot;\&quot;HELLO THERE\&quot;&quot;)" executed="True" success="True" time="0.000" asserts="1" />
+                                  <test-case name="NUnit.Framework.Constraints.Tests.StartsWithTest.ProvidesProperFailureMessage(&quot;I said hello&quot;,&quot;\&quot;I said hello\&quot;&quot;)" executed="True" success="True" time="0.000" asserts="1" />
+                                  <test-case name="NUnit.Framework.Constraints.Tests.StartsWithTest.ProvidesProperFailureMessage(&quot;say hello to fred&quot;,&quot;\&quot;say hello to fred\&quot;&quot;)" executed="True" success="True" time="0.000" asserts="1" />
+                                  <test-case name="NUnit.Framework.Constraints.Tests.StartsWithTest.ProvidesProperFailureMessage(&quot;&quot;,&quot;&lt;string.Empty&gt;&quot;)" executed="True" success="True" time="0.000" asserts="1" />
+                                  <test-case name="NUnit.Framework.Constraints.Tests.StartsWithTest.ProvidesProperFailureMessage(null,&quot;null&quot;)" executed="True" success="True" time="0.000" asserts="1" />
+                                </results>
+                              </test-suite>
+                              <test-case name="NUnit.Framework.Constraints.Tests.StartsWithTest.ProvidesProperStringRepresentation" executed="True" success="True" time="0.000" asserts="1" />
+                              <test-suite name="SucceedsWithGoodValues" executed="True" success="True" time="0.000" asserts="0">
+                                <results>
+                                  <test-case name="NUnit.Framework.Constraints.Tests.StartsWithTest.SucceedsWithGoodValues(&quot;hello&quot;)" executed="True" success="True" time="0.000" asserts="1" />
+                                  <test-case name="NUnit.Framework.Constraints.Tests.StartsWithTest.SucceedsWithGoodValues(&quot;hello there&quot;)" executed="True" success="True" time="0.000" asserts="1" />
+                                </results>
+                              </test-suite>
+                            </results>
+                          </test-suite>
+                          <test-suite name="StartsWithTestIgnoringCase" executed="True" success="True" time="0.000" asserts="0">
+                            <results>
+                              <test-suite name="FailsWithBadValues" executed="True" success="True" time="0.000" asserts="0">
+                                <results>
+                                  <test-case name="NUnit.Framework.Constraints.Tests.StartsWithTestIgnoringCase.FailsWithBadValues(&quot;goodbye&quot;)" executed="True" success="True" time="0.000" asserts="1" />
+                                  <test-case name="NUnit.Framework.Constraints.Tests.StartsWithTestIgnoringCase.FailsWithBadValues(&quot;What the hell?&quot;)" executed="True" success="True" time="0.000" asserts="1" />
+                                  <test-case name="NUnit.Framework.Constraints.Tests.StartsWithTestIgnoringCase.FailsWithBadValues(&quot;I said hello&quot;)" executed="True" success="True" time="0.000" asserts="1" />
+                                  <test-case name="NUnit.Framework.Constraints.Tests.StartsWithTestIgnoringCase.FailsWithBadValues(&quot;say Hello to fred&quot;)" executed="True" success="True" time="0.000" asserts="1" />
+                                  <test-case name="NUnit.Framework.Constraints.Tests.StartsWithTestIgnoringCase.FailsWithBadValues(&quot;&quot;)" executed="True" success="True" time="0.000" asserts="1" />
+                                  <test-case name="NUnit.Framework.Constraints.Tests.StartsWithTestIgnoringCase.FailsWithBadValues(null)" executed="True" success="True" time="0.000" asserts="1" />
+                                </results>
+                              </test-suite>
+                              <test-case name="NUnit.Framework.Constraints.Tests.StartsWithTestIgnoringCase.ProvidesProperDescription" executed="True" success="True" time="0.000" asserts="1" />
+                              <test-suite name="ProvidesProperFailureMessage" executed="True" success="True" time="0.000" asserts="0">
+                                <results>
+                                  <test-case name="NUnit.Framework.Constraints.Tests.StartsWithTestIgnoringCase.ProvidesProperFailureMessage(&quot;goodbye&quot;,&quot;\&quot;goodbye\&quot;&quot;)" executed="True" success="True" time="0.000" asserts="1" />
+                                  <test-case name="NUnit.Framework.Constraints.Tests.StartsWithTestIgnoringCase.ProvidesProperFailureMessage(&quot;What the hell?&quot;,&quot;\&quot;What the hell?\&quot;&quot;)" executed="True" success="True" time="0.000" asserts="1" />
+                                  <test-case name="NUnit.Framework.Constraints.Tests.StartsWithTestIgnoringCase.ProvidesProperFailureMessage(&quot;I said hello&quot;,&quot;\&quot;I said hello\&quot;&quot;)" executed="True" success="True" time="0.000" asserts="1" />
+                                  <test-case name="NUnit.Framework.Constraints.Tests.StartsWithTestIgnoringCase.ProvidesProperFailureMessage(&quot;say Hello to fred&quot;,&quot;\&quot;say Hello to fred\&quot;&quot;)" executed="True" success="True" time="0.000" asserts="1" />
+                                  <test-case name="NUnit.Framework.Constraints.Tests.StartsWithTestIgnoringCase.ProvidesProperFailureMessage(&quot;&quot;,&quot;&lt;string.Empty&gt;&quot;)" executed="True" success="True" time="0.000" asserts="1" />
+                                  <test-case name="NUnit.Framework.Constraints.Tests.StartsWithTestIgnoringCase.ProvidesProperFailureMessage(null,&quot;null&quot;)" executed="True" success="True" time="0.000" asserts="1" />
+                                </results>
+                              </test-suite>
+                              <test-case name="NUnit.Framework.Constraints.Tests.StartsWithTestIgnoringCase.ProvidesProperStringRepresentation" executed="True" success="True" time="0.000" asserts="1" />
+                              <test-suite name="SucceedsWithGoodValues" executed="True" success="True" time="0.000" asserts="0">
+                                <results>
+                                  <test-case name="NUnit.Framework.Constraints.Tests.StartsWithTestIgnoringCase.SucceedsWithGoodValues(&quot;Hello&quot;)" executed="True" success="True" time="0.000" asserts="1" />
+                                  <test-case name="NUnit.Framework.Constraints.Tests.StartsWithTestIgnoringCase.SucceedsWithGoodValues(&quot;HELLO there&quot;)" executed="True" success="True" time="0.000" asserts="1" />
+                                </results>
+                              </test-suite>
+                            </results>
+                          </test-suite>
+                          <test-suite name="SubstringTest" executed="True" success="True" time="0.016" asserts="0">
+                            <results>
+                              <test-suite name="FailsWithBadValues" executed="True" success="True" time="0.000" asserts="0">
+                                <results>
+                                  <test-case name="NUnit.Framework.Constraints.Tests.SubstringTest.FailsWithBadValues(&quot;goodbye&quot;)" executed="True" success="True" time="0.000" asserts="1" />
+                                  <test-case name="NUnit.Framework.Constraints.Tests.SubstringTest.FailsWithBadValues(&quot;HELLO&quot;)" executed="True" success="True" time="0.000" asserts="1" />
+                                  <test-case name="NUnit.Framework.Constraints.Tests.SubstringTest.FailsWithBadValues(&quot;What the hell?&quot;)" executed="True" success="True" time="0.000" asserts="1" />
+                                  <test-case name="NUnit.Framework.Constraints.Tests.SubstringTest.FailsWithBadValues(&quot;&quot;)" executed="True" success="True" time="0.000" asserts="1" />
+                                  <test-case name="NUnit.Framework.Constraints.Tests.SubstringTest.FailsWithBadValues(null)" executed="True" success="True" time="0.000" asserts="1" />
+                                </results>
+                              </test-suite>
+                              <test-case name="NUnit.Framework.Constraints.Tests.SubstringTest.ProvidesProperDescription" executed="True" success="True" time="0.000" asserts="1" />
+                              <test-suite name="ProvidesProperFailureMessage" executed="True" success="True" time="0.000" asserts="0">
+                                <results>
+                                  <test-case name="NUnit.Framework.Constraints.Tests.SubstringTest.ProvidesProperFailureMessage(&quot;goodbye&quot;,&quot;\&quot;goodbye\&quot;&quot;)" executed="True" success="True" time="0.000" asserts="1" />
+                                  <test-case name="NUnit.Framework.Constraints.Tests.SubstringTest.ProvidesProperFailureMessage(&quot;HELLO&quot;,&quot;\&quot;HELLO\&quot;&quot;)" executed="True" success="True" time="0.000" asserts="1" />
+                                  <test-case name="NUnit.Framework.Constraints.Tests.SubstringTest.ProvidesProperFailureMessage(&quot;What the hell?&quot;,&quot;\&quot;What the hell?\&quot;&quot;)" executed="True" success="True" time="0.000" asserts="1" />
+                                  <test-case name="NUnit.Framework.Constraints.Tests.SubstringTest.ProvidesProperFailureMessage(&quot;&quot;,&quot;&lt;string.Empty&gt;&quot;)" executed="True" success="True" time="0.000" asserts="1" />
+                                  <test-case name="NUnit.Framework.Constraints.Tests.SubstringTest.ProvidesProperFailureMessage(null,&quot;null&quot;)" executed="True" success="True" time="0.000" asserts="1" />
+                                </results>
+                              </test-suite>
+                              <test-case name="NUnit.Framework.Constraints.Tests.SubstringTest.ProvidesProperStringRepresentation" executed="True" success="True" time="0.000" asserts="1" />
+                              <test-suite name="SucceedsWithGoodValues" executed="True" success="True" time="0.000" asserts="0">
+                                <results>
+                                  <test-case name="NUnit.Framework.Constraints.Tests.SubstringTest.SucceedsWithGoodValues(&quot;hello&quot;)" executed="True" success="True" time="0.000" asserts="1" />
+                                  <test-case name="NUnit.Framework.Constraints.Tests.SubstringTest.SucceedsWithGoodValues(&quot;hello there&quot;)" executed="True" success="True" time="0.000" asserts="1" />
+                                  <test-case name="NUnit.Framework.Constraints.Tests.SubstringTest.SucceedsWithGoodValues(&quot;I said hello&quot;)" executed="True" success="True" time="0.000" asserts="1" />
+                                  <test-case name="NUnit.Framework.Constraints.Tests.SubstringTest.SucceedsWithGoodValues(&quot;say hello to fred&quot;)" executed="True" success="True" time="0.000" asserts="1" />
+                                </results>
+                              </test-suite>
+                            </results>
+                          </test-suite>
+                          <test-suite name="SubstringTestIgnoringCase" executed="True" success="True" time="0.000" asserts="0">
+                            <results>
+                              <test-suite name="FailsWithBadValues" executed="True" success="True" time="0.000" asserts="0">
+                                <results>
+                                  <test-case name="NUnit.Framework.Constraints.Tests.SubstringTestIgnoringCase.FailsWithBadValues(&quot;goodbye&quot;)" executed="True" success="True" time="0.000" asserts="1" />
+                                  <test-case name="NUnit.Framework.Constraints.Tests.SubstringTestIgnoringCase.FailsWithBadValues(&quot;What the hell?&quot;)" executed="True" success="True" time="0.000" asserts="1" />
+                                  <test-case name="NUnit.Framework.Constraints.Tests.SubstringTestIgnoringCase.FailsWithBadValues(&quot;&quot;)" executed="True" success="True" time="0.000" asserts="1" />
+                                  <test-case name="NUnit.Framework.Constraints.Tests.SubstringTestIgnoringCase.FailsWithBadValues(null)" executed="True" success="True" time="0.000" asserts="1" />
+                                </results>
+                              </test-suite>
+                              <test-case name="NUnit.Framework.Constraints.Tests.SubstringTestIgnoringCase.ProvidesProperDescription" executed="True" success="True" time="0.000" asserts="1" />
+                              <test-suite name="ProvidesProperFailureMessage" executed="True" success="True" time="0.000" asserts="0">
+                                <results>
+                                  <test-case name="NUnit.Framework.Constraints.Tests.SubstringTestIgnoringCase.ProvidesProperFailureMessage(&quot;goodbye&quot;,&quot;\&quot;goodbye\&quot;&quot;)" executed="True" success="True" time="0.000" asserts="1" />
+                                  <test-case name="NUnit.Framework.Constraints.Tests.SubstringTestIgnoringCase.ProvidesProperFailureMessage(&quot;What the hell?&quot;,&quot;\&quot;What the hell?\&quot;&quot;)" executed="True" success="True" time="0.000" asserts="1" />
+                                  <test-case name="NUnit.Framework.Constraints.Tests.SubstringTestIgnoringCase.ProvidesProperFailureMessage(&quot;&quot;,&quot;&lt;string.Empty&gt;&quot;)" executed="True" success="True" time="0.000" asserts="1" />
+                                  <test-case name="NUnit.Framework.Constraints.Tests.SubstringTestIgnoringCase.ProvidesProperFailureMessage(null,&quot;null&quot;)" executed="True" success="True" time="0.000" asserts="1" />
+                                </results>
+                              </test-suite>
+                              <test-case name="NUnit.Framework.Constraints.Tests.SubstringTestIgnoringCase.ProvidesProperStringRepresentation" executed="True" success="True" time="0.000" asserts="1" />
+                              <test-suite name="SucceedsWithGoodValues" executed="True" success="True" time="0.000" asserts="0">
+                                <results>
+                                  <test-case name="NUnit.Framework.Constraints.Tests.SubstringTestIgnoringCase.SucceedsWithGoodValues(&quot;Hello&quot;)" executed="True" success="True" time="0.000" asserts="1" />
+                                  <test-case name="NUnit.Framework.Constraints.Tests.SubstringTestIgnoringCase.SucceedsWithGoodValues(&quot;HellO there&quot;)" executed="True" success="True" time="0.000" asserts="1" />
+                                  <test-case name="NUnit.Framework.Constraints.Tests.SubstringTestIgnoringCase.SucceedsWithGoodValues(&quot;I said HELLO&quot;)" executed="True" success="True" time="0.000" asserts="1" />
+                                  <test-case name="NUnit.Framework.Constraints.Tests.SubstringTestIgnoringCase.SucceedsWithGoodValues(&quot;say hello to fred&quot;)" executed="True" success="True" time="0.000" asserts="1" />
+                                </results>
+                              </test-suite>
+                            </results>
+                          </test-suite>
+                          <test-suite name="ThrowsConstraintTest_ExactType" executed="True" success="True" time="0.000" asserts="0">
+                            <results>
+                              <test-suite name="FailsWithBadValues" executed="True" success="True" time="0.000" asserts="0">
+                                <results>
+                                  <test-case name="NUnit.Framework.Constraints.Tests.ThrowsConstraintTest_ExactType.FailsWithBadValues(NUnit.Framework.TestDelegate)" executed="True" success="True" time="0.000" asserts="1" />
+                                  <test-case name="NUnit.Framework.Constraints.Tests.ThrowsConstraintTest_ExactType.FailsWithBadValues(NUnit.Framework.TestDelegate)" executed="True" success="True" time="0.000" asserts="1" />
+                                  <test-case name="NUnit.Framework.Constraints.Tests.ThrowsConstraintTest_ExactType.FailsWithBadValues(NUnit.Framework.TestDelegate)" executed="True" success="True" time="0.000" asserts="1" />
+                                </results>
+                              </test-suite>
+                              <test-case name="NUnit.Framework.Constraints.Tests.ThrowsConstraintTest_ExactType.ProvidesProperDescription" executed="True" success="True" time="0.000" asserts="1" />
+                              <test-suite name="ProvidesProperFailureMessage" executed="True" success="True" time="0.000" asserts="0">
+                                <results>
+                                  <test-case name="NUnit.Framework.Constraints.Tests.ThrowsConstraintTest_ExactType.ProvidesProperFailureMessage(NUnit.Framework.TestDelegate,&quot;&lt;System.ApplicationException&gt;&quot;)" executed="True" success="True" time="0.000" asserts="1" />
+                                  <test-case name="NUnit.Framework.Constraints.Tests.ThrowsConstraintTest_ExactType.ProvidesProperFailureMessage(NUnit.Framework.TestDelegate,&quot;no exception thrown&quot;)" executed="True" success="True" time="0.000" asserts="1" />
+                                  <test-case name="NUnit.Framework.Constraints.Tests.ThrowsConstraintTest_ExactType.ProvidesProperFailureMessage(NUnit.Framework.TestDelegate,&quot;&lt;System.Exception&gt;&quot;)" executed="True" success="True" time="0.000" asserts="1" />
+                                </results>
+                              </test-suite>
+                              <test-case name="NUnit.Framework.Constraints.Tests.ThrowsConstraintTest_ExactType.ProvidesProperStringRepresentation" executed="True" success="True" time="0.000" asserts="1" />
+                              <test-suite name="SucceedsWithGoodValues" executed="True" success="True" time="0.000" asserts="0">
+                                <results>
+                                  <test-case name="NUnit.Framework.Constraints.Tests.ThrowsConstraintTest_ExactType.SucceedsWithGoodValues(NUnit.Framework.TestDelegate)" executed="True" success="True" time="0.000" asserts="1" />
+                                </results>
+                              </test-suite>
+                            </results>
+                          </test-suite>
+                          <test-suite name="ThrowsConstraintTest_InstanceOfType" executed="True" success="True" time="0.000" asserts="0">
+                            <results>
+                              <test-suite name="FailsWithBadValues" executed="True" success="True" time="0.000" asserts="0">
+                                <results>
+                                  <test-case name="NUnit.Framework.Constraints.Tests.ThrowsConstraintTest_InstanceOfType.FailsWithBadValues(NUnit.Framework.TestDelegate)" executed="True" success="True" time="0.000" asserts="1" />
+                                  <test-case name="NUnit.Framework.Constraints.Tests.ThrowsConstraintTest_InstanceOfType.FailsWithBadValues(NUnit.Framework.TestDelegate)" executed="True" success="True" time="0.000" asserts="1" />
+                                  <test-case name="NUnit.Framework.Constraints.Tests.ThrowsConstraintTest_InstanceOfType.FailsWithBadValues(NUnit.Framework.TestDelegate)" executed="True" success="True" time="0.000" asserts="1" />
+                                </results>
+                              </test-suite>
+                              <test-case name="NUnit.Framework.Constraints.Tests.ThrowsConstraintTest_InstanceOfType.ProvidesProperDescription" executed="True" success="True" time="0.000" asserts="1" />
+                              <test-suite name="ProvidesProperFailureMessage" executed="True" success="True" time="0.000" asserts="0">
+                                <results>
+                                  <test-case name="NUnit.Framework.Constraints.Tests.ThrowsConstraintTest_InstanceOfType.ProvidesProperFailureMessage(NUnit.Framework.TestDelegate,&quot;&lt;System.ArgumentException&gt;&quot;)" executed="True" success="True" time="0.000" asserts="1" />
+                                  <test-case name="NUnit.Framework.Constraints.Tests.ThrowsConstraintTest_InstanceOfType.ProvidesProperFailureMessage(NUnit.Framework.TestDelegate,&quot;no exception thrown&quot;)" executed="True" success="True" time="0.000" asserts="1" />
+                                  <test-case name="NUnit.Framework.Constraints.Tests.ThrowsConstraintTest_InstanceOfType.ProvidesProperFailureMessage(NUnit.Framework.TestDelegate,&quot;&lt;System.Exception&gt;&quot;)" executed="True" success="True" time="0.000" asserts="1" />
+                                </results>
+                              </test-suite>
+                              <test-case name="NUnit.Framework.Constraints.Tests.ThrowsConstraintTest_InstanceOfType.ProvidesProperStringRepresentation" executed="True" success="True" time="0.000" asserts="1" />
+                              <test-suite name="SucceedsWithGoodValues" executed="True" success="True" time="0.000" asserts="0">
+                                <results>
+                                  <test-case name="NUnit.Framework.Constraints.Tests.ThrowsConstraintTest_InstanceOfType.SucceedsWithGoodValues(NUnit.Framework.TestDelegate)" executed="True" success="True" time="0.000" asserts="1" />
+                                  <test-case name="NUnit.Framework.Constraints.Tests.ThrowsConstraintTest_InstanceOfType.SucceedsWithGoodValues(NUnit.Framework.TestDelegate)" executed="True" success="True" time="0.000" asserts="1" />
+                                </results>
+                              </test-suite>
+                            </results>
+                          </test-suite>
+                          <test-suite name="ThrowsConstraintTest_WithConstraint" executed="True" success="True" time="0.000" asserts="0">
+                            <results>
+                              <test-suite name="FailsWithBadValues" executed="True" success="True" time="0.000" asserts="0">
+                                <results>
+                                  <test-case name="NUnit.Framework.Constraints.Tests.ThrowsConstraintTest_WithConstraint.FailsWithBadValues(NUnit.Framework.TestDelegate)" executed="True" success="True" time="0.000" asserts="1" />
+                                  <test-case name="NUnit.Framework.Constraints.Tests.ThrowsConstraintTest_WithConstraint.FailsWithBadValues(NUnit.Framework.TestDelegate)" executed="True" success="True" time="0.000" asserts="1" />
+                                  <test-case name="NUnit.Framework.Constraints.Tests.ThrowsConstraintTest_WithConstraint.FailsWithBadValues(NUnit.Framework.TestDelegate)" executed="True" success="True" time="0.000" asserts="1" />
+                                </results>
+                              </test-suite>
+                              <test-case name="NUnit.Framework.Constraints.Tests.ThrowsConstraintTest_WithConstraint.ProvidesProperDescription" executed="True" success="True" time="0.000" asserts="1" />
+                              <test-suite name="ProvidesProperFailureMessage" executed="True" success="True" time="0.000" asserts="0">
+                                <results>
+                                  <test-case name="NUnit.Framework.Constraints.Tests.ThrowsConstraintTest_WithConstraint.ProvidesProperFailureMessage(NUnit.Framework.TestDelegate,&quot;&lt;System.ApplicationException&gt;&quot;)" executed="True" success="True" time="0.000" asserts="1" />
+                                  <test-case name="NUnit.Framework.Constraints.Tests.ThrowsConstraintTest_WithConstraint.ProvidesProperFailureMessage(NUnit.Framework.TestDelegate,&quot;no exception thrown&quot;)" executed="True" success="True" time="0.000" asserts="1" />
+                                  <test-case name="NUnit.Framework.Constraints.Tests.ThrowsConstraintTest_WithConstraint.ProvidesProperFailureMessage(NUnit.Framework.TestDelegate,&quot;&lt;System.Exception&gt;&quot;)" executed="True" success="True" time="0.000" asserts="1" />
+                                </results>
+                              </test-suite>
+                              <test-case name="NUnit.Framework.Constraints.Tests.ThrowsConstraintTest_WithConstraint.ProvidesProperStringRepresentation" executed="True" success="True" time="0.000" asserts="1" />
+                              <test-suite name="SucceedsWithGoodValues" executed="True" success="True" time="0.000" asserts="0">
+                                <results>
+                                  <test-case name="NUnit.Framework.Constraints.Tests.ThrowsConstraintTest_WithConstraint.SucceedsWithGoodValues(NUnit.Framework.TestDelegate)" executed="True" success="True" time="0.000" asserts="1" />
+                                </results>
+                              </test-suite>
+                            </results>
+                          </test-suite>
+                          <test-suite name="TrueConstraintTest" executed="True" success="True" time="0.000" asserts="0">
+                            <results>
+                              <test-suite name="FailsWithBadValues" executed="True" success="True" time="0.000" asserts="0">
+                                <results>
+                                  <test-case name="NUnit.Framework.Constraints.Tests.TrueConstraintTest.FailsWithBadValues(null)" executed="True" success="True" time="0.000" asserts="1" />
+                                  <test-case name="NUnit.Framework.Constraints.Tests.TrueConstraintTest.FailsWithBadValues(&quot;hello&quot;)" executed="True" success="True" time="0.000" asserts="1" />
+                                  <test-case name="NUnit.Framework.Constraints.Tests.TrueConstraintTest.FailsWithBadValues(False)" executed="True" success="True" time="0.000" asserts="1" />
+                                  <test-case name="NUnit.Framework.Constraints.Tests.TrueConstraintTest.FailsWithBadValues(False)" executed="True" success="True" time="0.000" asserts="1" />
+                                </results>
+                              </test-suite>
+                              <test-case name="NUnit.Framework.Constraints.Tests.TrueConstraintTest.ProvidesProperDescription" executed="True" success="True" time="0.000" asserts="1" />
+                              <test-suite name="ProvidesProperFailureMessage" executed="True" success="True" time="0.000" asserts="0">
+                                <results>
+                                  <test-case name="NUnit.Framework.Constraints.Tests.TrueConstraintTest.ProvidesProperFailureMessage(null,&quot;null&quot;)" executed="True" success="True" time="0.000" asserts="1" />
+                                  <test-case name="NUnit.Framework.Constraints.Tests.TrueConstraintTest.ProvidesProperFailureMessage(&quot;hello&quot;,&quot;\&quot;hello\&quot;&quot;)" executed="True" success="True" time="0.000" asserts="1" />
+                                  <test-case name="NUnit.Framework.Constraints.Tests.TrueConstraintTest.ProvidesProperFailureMessage(False,&quot;False&quot;)" executed="True" success="True" time="0.000" asserts="1" />
+                                  <test-case name="NUnit.Framework.Constraints.Tests.TrueConstraintTest.ProvidesProperFailureMessage(False,&quot;False&quot;)" executed="True" success="True" time="0.000" asserts="1" />
+                                </results>
+                              </test-suite>
+                              <test-case name="NUnit.Framework.Constraints.Tests.TrueConstraintTest.ProvidesProperStringRepresentation" executed="True" success="True" time="0.000" asserts="1" />
+                              <test-suite name="SucceedsWithGoodValues" executed="True" success="True" time="0.000" asserts="0">
+                                <results>
+                                  <test-case name="NUnit.Framework.Constraints.Tests.TrueConstraintTest.SucceedsWithGoodValues(True)" executed="True" success="True" time="0.000" asserts="1" />
+                                  <test-case name="NUnit.Framework.Constraints.Tests.TrueConstraintTest.SucceedsWithGoodValues(True)" executed="True" success="True" time="0.000" asserts="1" />
+                                </results>
+                              </test-suite>
+                            </results>
+                          </test-suite>
+                          <test-suite name="XmlSerializableTest" executed="True" success="True" time="2.875" asserts="0">
+                            <results>
+                              <test-suite name="FailsWithBadValues" executed="True" success="True" time="1.422" asserts="0">
+                                <results>
+                                  <test-case name="NUnit.Framework.Constraints.Tests.XmlSerializableTest.FailsWithBadValues(System.Collections.Generic.Dictionary`2[System.String,System.String])" executed="True" success="True" time="0.688" asserts="1" />
+                                  <test-case name="NUnit.Framework.Constraints.Tests.XmlSerializableTest.FailsWithBadValues(NUnit.Framework.Constraints.Tests.InternalClass)" executed="True" success="True" time="0.453" asserts="1" />
+                                  <test-case name="NUnit.Framework.Constraints.Tests.XmlSerializableTest.FailsWithBadValues(NUnit.Framework.Constraints.Tests.InternalWithSerializableAttributeClass)" executed="True" success="True" time="0.281" asserts="1" />
+                                </results>
+                              </test-suite>
+                              <test-suite name="InvalidDataThrowsArgumentException" executed="True" success="True" time="0.000" asserts="0">
+                                <results>
+                                  <test-case name="NUnit.Framework.Constraints.Tests.XmlSerializableTest.InvalidDataThrowsArgumentException(null)" executed="True" success="True" time="0.000" asserts="0" />
+                                </results>
+                              </test-suite>
+                              <test-case name="NUnit.Framework.Constraints.Tests.XmlSerializableTest.ProvidesProperDescription" executed="True" success="True" time="0.000" asserts="1" />
+                              <test-suite name="ProvidesProperFailureMessage" executed="True" success="True" time="0.750" asserts="0">
+                                <results>
+                                  <test-case name="NUnit.Framework.Constraints.Tests.XmlSerializableTest.ProvidesProperFailureMessage(System.Collections.Generic.Dictionary`2[System.String,System.String],&quot;&lt;Dictionary`2&gt;&quot;)" executed="True" success="True" time="0.250" asserts="1" />
+                                  <test-case name="NUnit.Framework.Constraints.Tests.XmlSerializableTest.ProvidesProperFailureMessage(NUnit.Framework.Constraints.Tests.InternalClass,&quot;&lt;InternalClass&gt;&quot;)" executed="True" success="True" time="0.250" asserts="1" />
+                                  <test-case name="NUnit.Framework.Constraints.Tests.XmlSerializableTest.ProvidesProperFailureMessage(NUnit.Framework.Constraints.Tests.InternalWithSerializableAttributeClass,&quot;&lt;InternalWithSerializableAttributeClass&gt;&quot;)" executed="True" success="True" time="0.250" asserts="1" />
+                                </results>
+                              </test-suite>
+                              <test-case name="NUnit.Framework.Constraints.Tests.XmlSerializableTest.ProvidesProperStringRepresentation" executed="True" success="True" time="0.000" asserts="1" />
+                              <test-suite name="SucceedsWithGoodValues" executed="True" success="True" time="0.703" asserts="0">
+                                <results>
+                                  <test-case name="NUnit.Framework.Constraints.Tests.XmlSerializableTest.SucceedsWithGoodValues(1)" executed="True" success="True" time="0.031" asserts="1" />
+                                  <test-case name="NUnit.Framework.Constraints.Tests.XmlSerializableTest.SucceedsWithGoodValues(&quot;a&quot;)" executed="True" success="True" time="0.000" asserts="1" />
+                                  <test-case name="NUnit.Framework.Constraints.Tests.XmlSerializableTest.SucceedsWithGoodValues(System.Collections.ArrayList)" executed="True" success="True" time="0.672" asserts="1" />
+                                </results>
+                              </test-suite>
+                            </results>
+                          </test-suite>
+                        </results>
+                      </test-suite>
+                    </results>
+                  </test-suite>
+                  <test-suite name="Syntax" executed="True" success="True" time="5.219" asserts="0">
+                    <results>
+                      <test-suite name="AfterSyntaxUsingActualPassedByRef" executed="True" success="True" time="1.438" asserts="0">
+                        <results>
+                          <test-case name="NUnit.Framework.Syntax.AfterSyntaxUsingActualPassedByRef.EqualToTest" executed="True" success="True" time="0.203" asserts="1" />
+                          <test-case name="NUnit.Framework.Syntax.AfterSyntaxUsingActualPassedByRef.GreaterTest" executed="True" success="True" time="0.203" asserts="1" />
+                          <test-case name="NUnit.Framework.Syntax.AfterSyntaxUsingActualPassedByRef.HasMemberTest" executed="True" success="True" time="0.203" asserts="1" />
+                          <test-case name="NUnit.Framework.Syntax.AfterSyntaxUsingActualPassedByRef.NullTest" executed="True" success="True" time="0.203" asserts="1" />
+                          <test-case name="NUnit.Framework.Syntax.AfterSyntaxUsingActualPassedByRef.SameAsTest" executed="True" success="True" time="0.203" asserts="1" />
+                          <test-case name="NUnit.Framework.Syntax.AfterSyntaxUsingActualPassedByRef.TextTest" executed="True" success="True" time="0.203" asserts="1" />
+                          <test-case name="NUnit.Framework.Syntax.AfterSyntaxUsingActualPassedByRef.TrueTest" executed="True" success="True" time="0.203" asserts="1" />
+                        </results>
+                      </test-suite>
+                      <test-suite name="AfterSyntaxUsingAnonymousDelegates" executed="True" success="True" time="1.453" asserts="0">
+                        <results>
+                          <test-case name="NUnit.Framework.Syntax.AfterSyntaxUsingAnonymousDelegates.EqualToTest" executed="True" success="True" time="0.203" asserts="1" />
+                          <test-case name="NUnit.Framework.Syntax.AfterSyntaxUsingAnonymousDelegates.GreaterTest" executed="True" success="True" time="0.203" asserts="1" />
+                          <test-case name="NUnit.Framework.Syntax.AfterSyntaxUsingAnonymousDelegates.HasMemberTest" executed="True" success="True" time="0.203" asserts="1" />
+                          <test-case name="NUnit.Framework.Syntax.AfterSyntaxUsingAnonymousDelegates.NullTest" executed="True" success="True" time="0.203" asserts="1" />
+                          <test-case name="NUnit.Framework.Syntax.AfterSyntaxUsingAnonymousDelegates.SameAsTest" executed="True" success="True" time="0.203" asserts="1" />
+                          <test-case name="NUnit.Framework.Syntax.AfterSyntaxUsingAnonymousDelegates.TextTest" executed="True" success="True" time="0.203" asserts="1" />
+                          <test-case name="NUnit.Framework.Syntax.AfterSyntaxUsingAnonymousDelegates.TrueTest" executed="True" success="True" time="0.203" asserts="1" />
+                        </results>
+                      </test-suite>
+                      <test-suite name="AfterTest_AndOperator" executed="True" success="True" time="0.016" asserts="0">
+                        <results>
+                          <test-case name="NUnit.Framework.Syntax.AfterTest_AndOperator.SupportedByConstraintBuilder" executed="True" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Framework.Syntax.AfterTest_AndOperator.SupportedByInheritedSyntax" executed="True" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Framework.Syntax.AfterTest_AndOperator.SupportedByStaticSyntax" executed="True" success="True" time="0.000" asserts="1" />
+                        </results>
+                      </test-suite>
+                      <test-suite name="AfterTest_ProperyTest" executed="True" success="True" time="0.000" asserts="0">
+                        <results>
+                          <test-case name="NUnit.Framework.Syntax.AfterTest_ProperyTest.SupportedByConstraintBuilder" executed="True" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Framework.Syntax.AfterTest_ProperyTest.SupportedByInheritedSyntax" executed="True" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Framework.Syntax.AfterTest_ProperyTest.SupportedByStaticSyntax" executed="True" success="True" time="0.000" asserts="1" />
+                        </results>
+                      </test-suite>
+                      <test-suite name="AfterTest_SimpleConstraint" executed="True" success="True" time="0.000" asserts="0">
+                        <results>
+                          <test-case name="NUnit.Framework.Syntax.AfterTest_SimpleConstraint.SupportedByConstraintBuilder" executed="True" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Framework.Syntax.AfterTest_SimpleConstraint.SupportedByInheritedSyntax" executed="True" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Framework.Syntax.AfterTest_SimpleConstraint.SupportedByStaticSyntax" executed="True" success="True" time="0.000" asserts="1" />
+                        </results>
+                      </test-suite>
+                      <test-suite name="AllTest" executed="True" success="True" time="0.016" asserts="0">
+                        <results>
+                          <test-case name="NUnit.Framework.Syntax.AllTest.SupportedByConstraintBuilder" executed="True" success="True" time="0.016" asserts="1" />
+                          <test-case name="NUnit.Framework.Syntax.AllTest.SupportedByInheritedSyntax" executed="True" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Framework.Syntax.AllTest.SupportedByStaticSyntax" executed="True" success="True" time="0.000" asserts="1" />
+                        </results>
+                      </test-suite>
+                      <test-suite name="AndIsEvaluatedBeforeFollowingOr" executed="True" success="True" time="0.000" asserts="0">
+                        <results>
+                          <test-case name="NUnit.Framework.Syntax.AndIsEvaluatedBeforeFollowingOr.SupportedByConstraintBuilder" executed="True" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Framework.Syntax.AndIsEvaluatedBeforeFollowingOr.SupportedByInheritedSyntax" executed="True" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Framework.Syntax.AndIsEvaluatedBeforeFollowingOr.SupportedByStaticSyntax" executed="True" success="True" time="0.000" asserts="1" />
+                        </results>
+                      </test-suite>
+                      <test-suite name="AndIsEvaluatedBeforePrecedingOr" executed="True" success="True" time="0.000" asserts="0">
+                        <results>
+                          <test-case name="NUnit.Framework.Syntax.AndIsEvaluatedBeforePrecedingOr.SupportedByConstraintBuilder" executed="True" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Framework.Syntax.AndIsEvaluatedBeforePrecedingOr.SupportedByInheritedSyntax" executed="True" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Framework.Syntax.AndIsEvaluatedBeforePrecedingOr.SupportedByStaticSyntax" executed="True" success="True" time="0.000" asserts="1" />
+                        </results>
+                      </test-suite>
+                      <test-suite name="AndOperatorOverride" executed="True" success="True" time="0.000" asserts="0">
+                        <results>
+                          <test-case name="NUnit.Framework.Syntax.AndOperatorOverride.SupportedByConstraintBuilder" executed="True" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Framework.Syntax.AndOperatorOverride.SupportedByInheritedSyntax" executed="True" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Framework.Syntax.AndOperatorOverride.SupportedByStaticSyntax" executed="True" success="True" time="0.000" asserts="1" />
+                        </results>
+                      </test-suite>
+                      <test-suite name="AndTest" executed="True" success="True" time="0.000" asserts="0">
+                        <results>
+                          <test-case name="NUnit.Framework.Syntax.AndTest.SupportedByConstraintBuilder" executed="True" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Framework.Syntax.AndTest.SupportedByInheritedSyntax" executed="True" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Framework.Syntax.AndTest.SupportedByStaticSyntax" executed="True" success="True" time="0.000" asserts="1" />
+                        </results>
+                      </test-suite>
+                      <test-suite name="AndTest_ThreeAndsWithNot" executed="True" success="True" time="0.031" asserts="0">
+                        <results>
+                          <test-case name="NUnit.Framework.Syntax.AndTest_ThreeAndsWithNot.SupportedByConstraintBuilder" executed="True" success="True" time="0.016" asserts="1" />
+                          <test-case name="NUnit.Framework.Syntax.AndTest_ThreeAndsWithNot.SupportedByInheritedSyntax" executed="True" success="True" time="0.016" asserts="1" />
+                          <test-case name="NUnit.Framework.Syntax.AndTest_ThreeAndsWithNot.SupportedByStaticSyntax" executed="True" success="True" time="0.000" asserts="1" />
+                        </results>
+                      </test-suite>
+                      <test-suite name="ArbitraryConstraintMatching" executed="True" success="True" time="0.016" asserts="0">
+                        <results>
+                          <test-case name="NUnit.Framework.Syntax.ArbitraryConstraintMatching.CanMatchCustomConstraint" executed="True" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Framework.Syntax.ArbitraryConstraintMatching.CanMatchCustomConstraintAfterPrefix" executed="True" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Framework.Syntax.ArbitraryConstraintMatching.CanMatchCustomConstraintsUnderAndOperator" executed="True" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Framework.Syntax.ArbitraryConstraintMatching.CanMatchPredicate" executed="True" success="True" time="0.016" asserts="2" />
+                        </results>
+                      </test-suite>
+                      <test-suite name="AssignableFromTest" executed="True" success="True" time="0.000" asserts="0">
+                        <results>
+                          <test-case name="NUnit.Framework.Syntax.AssignableFromTest.SupportedByConstraintBuilder" executed="True" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Framework.Syntax.AssignableFromTest.SupportedByInheritedSyntax" executed="True" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Framework.Syntax.AssignableFromTest.SupportedByStaticSyntax" executed="True" success="True" time="0.000" asserts="1" />
+                        </results>
+                      </test-suite>
+                      <test-suite name="AssignableFromTest_Generic" executed="True" success="True" time="0.000" asserts="0">
+                        <results>
+                          <test-case name="NUnit.Framework.Syntax.AssignableFromTest_Generic.SupportedByConstraintBuilder" executed="True" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Framework.Syntax.AssignableFromTest_Generic.SupportedByInheritedSyntax" executed="True" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Framework.Syntax.AssignableFromTest_Generic.SupportedByStaticSyntax" executed="True" success="True" time="0.000" asserts="1" />
+                        </results>
+                      </test-suite>
+                      <test-suite name="AssignableToTest" executed="True" success="True" time="0.000" asserts="0">
+                        <results>
+                          <test-case name="NUnit.Framework.Syntax.AssignableToTest.SupportedByConstraintBuilder" executed="True" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Framework.Syntax.AssignableToTest.SupportedByInheritedSyntax" executed="True" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Framework.Syntax.AssignableToTest.SupportedByStaticSyntax" executed="True" success="True" time="0.000" asserts="1" />
+                        </results>
+                      </test-suite>
+                      <test-suite name="AssignableToTest_Generic" executed="True" success="True" time="0.016" asserts="0">
+                        <results>
+                          <test-case name="NUnit.Framework.Syntax.AssignableToTest_Generic.SupportedByConstraintBuilder" executed="True" success="True" time="0.016" asserts="1" />
+                          <test-case name="NUnit.Framework.Syntax.AssignableToTest_Generic.SupportedByInheritedSyntax" executed="True" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Framework.Syntax.AssignableToTest_Generic.SupportedByStaticSyntax" executed="True" success="True" time="0.000" asserts="1" />
+                        </results>
+                      </test-suite>
+                      <test-suite name="AtLeastTest" executed="True" success="True" time="0.000" asserts="0">
+                        <results>
+                          <test-case name="NUnit.Framework.Syntax.AtLeastTest.SupportedByConstraintBuilder" executed="True" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Framework.Syntax.AtLeastTest.SupportedByInheritedSyntax" executed="True" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Framework.Syntax.AtLeastTest.SupportedByStaticSyntax" executed="True" success="True" time="0.000" asserts="1" />
+                        </results>
+                      </test-suite>
+                      <test-suite name="AtMostTest" executed="True" success="True" time="0.000" asserts="0">
+                        <results>
+                          <test-case name="NUnit.Framework.Syntax.AtMostTest.SupportedByConstraintBuilder" executed="True" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Framework.Syntax.AtMostTest.SupportedByInheritedSyntax" executed="True" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Framework.Syntax.AtMostTest.SupportedByStaticSyntax" executed="True" success="True" time="0.000" asserts="1" />
+                        </results>
+                      </test-suite>
+                      <test-suite name="AttributeTest" executed="True" success="True" time="0.000" asserts="0">
+                        <results>
+                          <test-case name="NUnit.Framework.Syntax.AttributeTest.SupportedByConstraintBuilder" executed="True" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Framework.Syntax.AttributeTest.SupportedByInheritedSyntax" executed="True" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Framework.Syntax.AttributeTest.SupportedByStaticSyntax" executed="True" success="True" time="0.000" asserts="1" />
+                        </results>
+                      </test-suite>
+                      <test-suite name="AttributeTest_Generic" executed="True" success="True" time="0.016" asserts="0">
+                        <results>
+                          <test-case name="NUnit.Framework.Syntax.AttributeTest_Generic.SupportedByConstraintBuilder" executed="True" success="True" time="0.016" asserts="1" />
+                          <test-case name="NUnit.Framework.Syntax.AttributeTest_Generic.SupportedByInheritedSyntax" executed="True" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Framework.Syntax.AttributeTest_Generic.SupportedByStaticSyntax" executed="True" success="True" time="0.000" asserts="1" />
+                        </results>
+                      </test-suite>
+                      <test-suite name="AttributeTestWithFollowingConstraint" executed="True" success="True" time="0.000" asserts="0">
+                        <results>
+                          <test-case name="NUnit.Framework.Syntax.AttributeTestWithFollowingConstraint.SupportedByConstraintBuilder" executed="True" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Framework.Syntax.AttributeTestWithFollowingConstraint.SupportedByInheritedSyntax" executed="True" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Framework.Syntax.AttributeTestWithFollowingConstraint.SupportedByStaticSyntax" executed="True" success="True" time="0.000" asserts="1" />
+                        </results>
+                      </test-suite>
+                      <test-suite name="BinarySerializableTest" executed="True" success="True" time="0.000" asserts="0">
+                        <results>
+                          <test-case name="NUnit.Framework.Syntax.BinarySerializableTest.SupportedByConstraintBuilder" executed="True" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Framework.Syntax.BinarySerializableTest.SupportedByInheritedSyntax" executed="True" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Framework.Syntax.BinarySerializableTest.SupportedByStaticSyntax" executed="True" success="True" time="0.000" asserts="1" />
+                        </results>
+                      </test-suite>
+                      <test-suite name="CollectionContainsTest" executed="True" success="True" time="0.000" asserts="0">
+                        <results>
+                          <test-case name="NUnit.Framework.Syntax.CollectionContainsTest.SupportedByConstraintBuilder" executed="True" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Framework.Syntax.CollectionContainsTest.SupportedByInheritedSyntax" executed="True" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Framework.Syntax.CollectionContainsTest.SupportedByStaticSyntax" executed="True" success="True" time="0.000" asserts="1" />
+                        </results>
+                      </test-suite>
+                      <test-suite name="CollectionEquivalentTest" executed="True" success="True" time="0.000" asserts="0">
+                        <results>
+                          <test-case name="NUnit.Framework.Syntax.CollectionEquivalentTest.SupportedByConstraintBuilder" executed="True" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Framework.Syntax.CollectionEquivalentTest.SupportedByInheritedSyntax" executed="True" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Framework.Syntax.CollectionEquivalentTest.SupportedByStaticSyntax" executed="True" success="True" time="0.000" asserts="1" />
+                        </results>
+                      </test-suite>
+                      <test-suite name="CollectionOrderedByTest" executed="True" success="True" time="0.000" asserts="0">
+                        <results>
+                          <test-case name="NUnit.Framework.Syntax.CollectionOrderedByTest.SupportedByConstraintBuilder" executed="True" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Framework.Syntax.CollectionOrderedByTest.SupportedByInheritedSyntax" executed="True" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Framework.Syntax.CollectionOrderedByTest.SupportedByStaticSyntax" executed="True" success="True" time="0.000" asserts="1" />
+                        </results>
+                      </test-suite>
+                      <test-suite name="CollectionOrderedByTest_Comparer" executed="True" success="True" time="0.016" asserts="0">
+                        <results>
+                          <test-case name="NUnit.Framework.Syntax.CollectionOrderedByTest_Comparer.SupportedByConstraintBuilder" executed="True" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Framework.Syntax.CollectionOrderedByTest_Comparer.SupportedByInheritedSyntax" executed="True" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Framework.Syntax.CollectionOrderedByTest_Comparer.SupportedByStaticSyntax" executed="True" success="True" time="0.000" asserts="1" />
+                        </results>
+                      </test-suite>
+                      <test-suite name="CollectionOrderedByTest_Comparer_Descending" executed="True" success="True" time="0.000" asserts="0">
+                        <results>
+                          <test-case name="NUnit.Framework.Syntax.CollectionOrderedByTest_Comparer_Descending.SupportedByConstraintBuilder" executed="True" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Framework.Syntax.CollectionOrderedByTest_Comparer_Descending.SupportedByInheritedSyntax" executed="True" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Framework.Syntax.CollectionOrderedByTest_Comparer_Descending.SupportedByStaticSyntax" executed="True" success="True" time="0.000" asserts="1" />
+                        </results>
+                      </test-suite>
+                      <test-suite name="CollectionOrderedByTest_Descending" executed="True" success="True" time="0.000" asserts="0">
+                        <results>
+                          <test-case name="NUnit.Framework.Syntax.CollectionOrderedByTest_Descending.SupportedByConstraintBuilder" executed="True" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Framework.Syntax.CollectionOrderedByTest_Descending.SupportedByInheritedSyntax" executed="True" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Framework.Syntax.CollectionOrderedByTest_Descending.SupportedByStaticSyntax" executed="True" success="True" time="0.000" asserts="1" />
+                        </results>
+                      </test-suite>
+                      <test-suite name="CollectionOrderedTest" executed="True" success="True" time="0.000" asserts="0">
+                        <results>
+                          <test-case name="NUnit.Framework.Syntax.CollectionOrderedTest.SupportedByConstraintBuilder" executed="True" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Framework.Syntax.CollectionOrderedTest.SupportedByInheritedSyntax" executed="True" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Framework.Syntax.CollectionOrderedTest.SupportedByStaticSyntax" executed="True" success="True" time="0.000" asserts="1" />
+                        </results>
+                      </test-suite>
+                      <test-suite name="CollectionOrderedTest_Comparer" executed="True" success="True" time="0.000" asserts="0">
+                        <results>
+                          <test-case name="NUnit.Framework.Syntax.CollectionOrderedTest_Comparer.SupportedByConstraintBuilder" executed="True" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Framework.Syntax.CollectionOrderedTest_Comparer.SupportedByInheritedSyntax" executed="True" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Framework.Syntax.CollectionOrderedTest_Comparer.SupportedByStaticSyntax" executed="True" success="True" time="0.000" asserts="1" />
+                        </results>
+                      </test-suite>
+                      <test-suite name="CollectionOrderedTest_Comparer_Descending" executed="True" success="True" time="0.000" asserts="0">
+                        <results>
+                          <test-case name="NUnit.Framework.Syntax.CollectionOrderedTest_Comparer_Descending.SupportedByConstraintBuilder" executed="True" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Framework.Syntax.CollectionOrderedTest_Comparer_Descending.SupportedByInheritedSyntax" executed="True" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Framework.Syntax.CollectionOrderedTest_Comparer_Descending.SupportedByStaticSyntax" executed="True" success="True" time="0.000" asserts="1" />
+                        </results>
+                      </test-suite>
+                      <test-suite name="CollectionOrderedTest_Descending" executed="True" success="True" time="0.000" asserts="0">
+                        <results>
+                          <test-case name="NUnit.Framework.Syntax.CollectionOrderedTest_Descending.SupportedByConstraintBuilder" executed="True" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Framework.Syntax.CollectionOrderedTest_Descending.SupportedByInheritedSyntax" executed="True" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Framework.Syntax.CollectionOrderedTest_Descending.SupportedByStaticSyntax" executed="True" success="True" time="0.000" asserts="1" />
+                        </results>
+                      </test-suite>
+                      <test-suite name="CollectionSubsetTest" executed="True" success="True" time="0.000" asserts="0">
+                        <results>
+                          <test-case name="NUnit.Framework.Syntax.CollectionSubsetTest.SupportedByConstraintBuilder" executed="True" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Framework.Syntax.CollectionSubsetTest.SupportedByInheritedSyntax" executed="True" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Framework.Syntax.CollectionSubsetTest.SupportedByStaticSyntax" executed="True" success="True" time="0.000" asserts="1" />
+                        </results>
+                      </test-suite>
+                      <test-suite name="CountTest" executed="True" success="True" time="0.000" asserts="0">
+                        <results>
+                          <test-case name="NUnit.Framework.Syntax.CountTest.SupportedByConstraintBuilder" executed="True" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Framework.Syntax.CountTest.SupportedByInheritedSyntax" executed="True" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Framework.Syntax.CountTest.SupportedByStaticSyntax" executed="True" success="True" time="0.000" asserts="1" />
+                        </results>
+                      </test-suite>
+                      <test-suite name="EndsWithTest" executed="True" success="True" time="0.000" asserts="0">
+                        <results>
+                          <test-case name="NUnit.Framework.Syntax.EndsWithTest.SupportedByConstraintBuilder" executed="True" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Framework.Syntax.EndsWithTest.SupportedByInheritedSyntax" executed="True" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Framework.Syntax.EndsWithTest.SupportedByStaticSyntax" executed="True" success="True" time="0.000" asserts="1" />
+                        </results>
+                      </test-suite>
+                      <test-suite name="EndsWithTest_IgnoreCase" executed="True" success="True" time="0.000" asserts="0">
+                        <results>
+                          <test-case name="NUnit.Framework.Syntax.EndsWithTest_IgnoreCase.SupportedByConstraintBuilder" executed="True" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Framework.Syntax.EndsWithTest_IgnoreCase.SupportedByInheritedSyntax" executed="True" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Framework.Syntax.EndsWithTest_IgnoreCase.SupportedByStaticSyntax" executed="True" success="True" time="0.000" asserts="1" />
+                        </results>
+                      </test-suite>
+                      <test-suite name="EqualityTests" executed="True" success="True" time="0.016" asserts="0">
+                        <results>
+                          <test-case name="NUnit.Framework.Syntax.EqualityTests.EqualityTestsUsingDefaultFloatingPointTolerance" executed="True" success="True" time="0.016" asserts="3" />
+                          <test-case name="NUnit.Framework.Syntax.EqualityTests.EqualityTestsWithTolerance" executed="True" success="True" time="0.000" asserts="8" />
+                          <test-case name="NUnit.Framework.Syntax.EqualityTests.EqualityTestsWithTolerance_MixedFloatAndDouble" executed="True" success="True" time="0.000" asserts="6" />
+                          <test-case name="NUnit.Framework.Syntax.EqualityTests.EqualityTestsWithTolerance_MixingTypesGenerally" executed="True" success="True" time="0.000" asserts="7" />
+                          <test-case name="NUnit.Framework.Syntax.EqualityTests.SimpleEqualityTests" executed="True" success="True" time="0.000" asserts="6" />
+                        </results>
+                      </test-suite>
+                      <test-suite name="EqualToTest" executed="True" success="True" time="0.000" asserts="0">
+                        <results>
+                          <test-case name="NUnit.Framework.Syntax.EqualToTest.SupportedByConstraintBuilder" executed="True" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Framework.Syntax.EqualToTest.SupportedByInheritedSyntax" executed="True" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Framework.Syntax.EqualToTest.SupportedByStaticSyntax" executed="True" success="True" time="0.000" asserts="1" />
+                        </results>
+                      </test-suite>
+                      <test-suite name="EqualToTest_IgnoreCase" executed="True" success="True" time="0.000" asserts="0">
+                        <results>
+                          <test-case name="NUnit.Framework.Syntax.EqualToTest_IgnoreCase.SupportedByConstraintBuilder" executed="True" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Framework.Syntax.EqualToTest_IgnoreCase.SupportedByInheritedSyntax" executed="True" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Framework.Syntax.EqualToTest_IgnoreCase.SupportedByStaticSyntax" executed="True" success="True" time="0.000" asserts="1" />
+                        </results>
+                      </test-suite>
+                      <test-suite name="EqualToTest_WithinTolerance" executed="True" success="True" time="0.016" asserts="0">
+                        <results>
+                          <test-case name="NUnit.Framework.Syntax.EqualToTest_WithinTolerance.SupportedByConstraintBuilder" executed="True" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Framework.Syntax.EqualToTest_WithinTolerance.SupportedByInheritedSyntax" executed="True" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Framework.Syntax.EqualToTest_WithinTolerance.SupportedByStaticSyntax" executed="True" success="True" time="0.000" asserts="1" />
+                        </results>
+                      </test-suite>
+                      <test-suite name="ExactTypeTest" executed="True" success="True" time="0.016" asserts="0">
+                        <results>
+                          <test-case name="NUnit.Framework.Syntax.ExactTypeTest.SupportedByConstraintBuilder" executed="True" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Framework.Syntax.ExactTypeTest.SupportedByInheritedSyntax" executed="True" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Framework.Syntax.ExactTypeTest.SupportedByStaticSyntax" executed="True" success="True" time="0.000" asserts="1" />
+                        </results>
+                      </test-suite>
+                      <test-suite name="ExactTypeTest_Generic" executed="True" success="True" time="0.000" asserts="0">
+                        <results>
+                          <test-case name="NUnit.Framework.Syntax.ExactTypeTest_Generic.SupportedByConstraintBuilder" executed="True" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Framework.Syntax.ExactTypeTest_Generic.SupportedByInheritedSyntax" executed="True" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Framework.Syntax.ExactTypeTest_Generic.SupportedByStaticSyntax" executed="True" success="True" time="0.000" asserts="1" />
+                        </results>
+                      </test-suite>
+                      <test-suite name="FalseTest" executed="True" success="True" time="0.000" asserts="0">
+                        <results>
+                          <test-case name="NUnit.Framework.Syntax.FalseTest.SupportedByConstraintBuilder" executed="True" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Framework.Syntax.FalseTest.SupportedByInheritedSyntax" executed="True" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Framework.Syntax.FalseTest.SupportedByStaticSyntax" executed="True" success="True" time="0.000" asserts="1" />
+                        </results>
+                      </test-suite>
+                      <test-suite name="GreaterThanOrEqualTest" executed="True" success="True" time="0.000" asserts="0">
+                        <results>
+                          <test-case name="NUnit.Framework.Syntax.GreaterThanOrEqualTest.SupportedByConstraintBuilder" executed="True" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Framework.Syntax.GreaterThanOrEqualTest.SupportedByInheritedSyntax" executed="True" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Framework.Syntax.GreaterThanOrEqualTest.SupportedByStaticSyntax" executed="True" success="True" time="0.000" asserts="1" />
+                        </results>
+                      </test-suite>
+                      <test-suite name="GreaterThanTest" executed="True" success="True" time="0.000" asserts="0">
+                        <results>
+                          <test-case name="NUnit.Framework.Syntax.GreaterThanTest.SupportedByConstraintBuilder" executed="True" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Framework.Syntax.GreaterThanTest.SupportedByInheritedSyntax" executed="True" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Framework.Syntax.GreaterThanTest.SupportedByStaticSyntax" executed="True" success="True" time="0.000" asserts="1" />
+                        </results>
+                      </test-suite>
+                      <test-suite name="InstanceOfTest" executed="True" success="True" time="0.000" asserts="0">
+                        <results>
+                          <test-case name="NUnit.Framework.Syntax.InstanceOfTest.SupportedByConstraintBuilder" executed="True" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Framework.Syntax.InstanceOfTest.SupportedByInheritedSyntax" executed="True" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Framework.Syntax.InstanceOfTest.SupportedByStaticSyntax" executed="True" success="True" time="0.000" asserts="1" />
+                        </results>
+                      </test-suite>
+                      <test-suite name="InstanceOfTest_Generic" executed="True" success="True" time="0.000" asserts="0">
+                        <results>
+                          <test-case name="NUnit.Framework.Syntax.InstanceOfTest_Generic.SupportedByConstraintBuilder" executed="True" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Framework.Syntax.InstanceOfTest_Generic.SupportedByInheritedSyntax" executed="True" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Framework.Syntax.InstanceOfTest_Generic.SupportedByStaticSyntax" executed="True" success="True" time="0.000" asserts="1" />
+                        </results>
+                      </test-suite>
+                      <test-suite name="InstanceOfTypeTest" executed="True" success="True" time="0.000" asserts="0">
+                        <results>
+                          <test-case name="NUnit.Framework.Syntax.InstanceOfTypeTest.SupportedByConstraintBuilder" executed="True" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Framework.Syntax.InstanceOfTypeTest.SupportedByInheritedSyntax" executed="True" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Framework.Syntax.InstanceOfTypeTest.SupportedByStaticSyntax" executed="True" success="True" time="0.000" asserts="1" />
+                        </results>
+                      </test-suite>
+                      <test-suite name="InstanceOfTypeTest_Generic" executed="True" success="True" time="0.000" asserts="0">
+                        <results>
+                          <test-case name="NUnit.Framework.Syntax.InstanceOfTypeTest_Generic.SupportedByConstraintBuilder" executed="True" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Framework.Syntax.InstanceOfTypeTest_Generic.SupportedByInheritedSyntax" executed="True" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Framework.Syntax.InstanceOfTypeTest_Generic.SupportedByStaticSyntax" executed="True" success="True" time="0.000" asserts="1" />
+                        </results>
+                      </test-suite>
+                      <test-suite name="InvalidCodeTests" executed="True" success="True" time="1.391" asserts="0">
+                        <results>
+                          <test-suite name="CodeShouldNotCompile" executed="True" success="True" time="0.891" asserts="0">
+                            <results>
+                              <test-case name="NUnit.Framework.Syntax.InvalidCodeTests.CodeShouldNotCompile(&quot;Is.Null.All&quot;)" executed="True" success="True" time="0.234" asserts="0" />
+                              <test-case name="NUnit.Framework.Syntax.InvalidCodeTests.CodeShouldNotCompile(&quot;Is.Not.Null.GreaterThan(10))&quot;)" executed="True" success="True" time="0.109" asserts="0" />
+                              <test-case name="NUnit.Framework.Syntax.InvalidCodeTests.CodeShouldNotCompile(&quot;Is.Null.Not&quot;)" executed="True" success="True" time="0.203" asserts="0" />
+                              <test-case name="NUnit.Framework.Syntax.InvalidCodeTests.CodeShouldNotCompile(&quot;Is.And&quot;)" executed="True" success="True" time="0.109" asserts="0" />
+                              <test-case name="NUnit.Framework.Syntax.InvalidCodeTests.CodeShouldNotCompile(&quot;Is.All.And.And&quot;)" executed="True" success="True" time="0.109" asserts="0" />
+                              <test-case name="NUnit.Framework.Syntax.InvalidCodeTests.CodeShouldNotCompile(&quot;Is.Null.And.Throws&quot;)" executed="True" success="True" time="0.109" asserts="0" />
+                            </results>
+                          </test-suite>
+                          <test-suite name="CodeShouldNotCompileAsFinishedConstraint" executed="True" success="True" time="0.500" asserts="0">
+                            <results>
+                              <test-case name="NUnit.Framework.Syntax.InvalidCodeTests.CodeShouldNotCompileAsFinishedConstraint(&quot;Is.Not.All&quot;)" executed="True" success="True" time="0.125" asserts="0" />
+                              <test-case name="NUnit.Framework.Syntax.InvalidCodeTests.CodeShouldNotCompileAsFinishedConstraint(&quot;Is.All&quot;)" executed="True" success="True" time="0.125" asserts="0" />
+                              <test-case name="NUnit.Framework.Syntax.InvalidCodeTests.CodeShouldNotCompileAsFinishedConstraint(&quot;Is.Not&quot;)" executed="True" success="True" time="0.109" asserts="0" />
+                              <test-case name="NUnit.Framework.Syntax.InvalidCodeTests.CodeShouldNotCompileAsFinishedConstraint(&quot;Is.All.Not&quot;)" executed="True" success="True" time="0.141" asserts="0" />
+                            </results>
+                          </test-suite>
+                        </results>
+                      </test-suite>
+                      <test-suite name="LengthTest" executed="True" success="True" time="0.000" asserts="0">
+                        <results>
+                          <test-case name="NUnit.Framework.Syntax.LengthTest.SupportedByConstraintBuilder" executed="True" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Framework.Syntax.LengthTest.SupportedByInheritedSyntax" executed="True" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Framework.Syntax.LengthTest.SupportedByStaticSyntax" executed="True" success="True" time="0.000" asserts="1" />
+                        </results>
+                      </test-suite>
+                      <test-suite name="LessThanOrEqualTest" executed="True" success="True" time="0.000" asserts="0">
+                        <results>
+                          <test-case name="NUnit.Framework.Syntax.LessThanOrEqualTest.SupportedByConstraintBuilder" executed="True" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Framework.Syntax.LessThanOrEqualTest.SupportedByInheritedSyntax" executed="True" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Framework.Syntax.LessThanOrEqualTest.SupportedByStaticSyntax" executed="True" success="True" time="0.000" asserts="1" />
+                        </results>
+                      </test-suite>
+                      <test-suite name="LessThanTest" executed="True" success="True" time="0.016" asserts="0">
+                        <results>
+                          <test-case name="NUnit.Framework.Syntax.LessThanTest.SupportedByConstraintBuilder" executed="True" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Framework.Syntax.LessThanTest.SupportedByInheritedSyntax" executed="True" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Framework.Syntax.LessThanTest.SupportedByStaticSyntax" executed="True" success="True" time="0.000" asserts="1" />
+                        </results>
+                      </test-suite>
+                      <test-suite name="MessageTest" executed="True" success="True" time="0.000" asserts="0">
+                        <results>
+                          <test-case name="NUnit.Framework.Syntax.MessageTest.SupportedByConstraintBuilder" executed="True" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Framework.Syntax.MessageTest.SupportedByInheritedSyntax" executed="True" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Framework.Syntax.MessageTest.SupportedByStaticSyntax" executed="True" success="True" time="0.000" asserts="1" />
+                        </results>
+                      </test-suite>
+                      <test-suite name="MixedOperatorOverrides" executed="True" success="True" time="0.000" asserts="0">
+                        <results>
+                          <test-case name="NUnit.Framework.Syntax.MixedOperatorOverrides.ComplexTests" executed="True" success="True" time="0.000" asserts="3" />
+                        </results>
+                      </test-suite>
+                      <test-suite name="NaNTest" executed="True" success="True" time="0.000" asserts="0">
+                        <results>
+                          <test-case name="NUnit.Framework.Syntax.NaNTest.SupportedByConstraintBuilder" executed="True" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Framework.Syntax.NaNTest.SupportedByInheritedSyntax" executed="True" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Framework.Syntax.NaNTest.SupportedByStaticSyntax" executed="True" success="True" time="0.000" asserts="1" />
+                        </results>
+                      </test-suite>
+                      <test-suite name="NoneTest" executed="True" success="True" time="0.000" asserts="0">
+                        <results>
+                          <test-case name="NUnit.Framework.Syntax.NoneTest.SupportedByConstraintBuilder" executed="True" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Framework.Syntax.NoneTest.SupportedByInheritedSyntax" executed="True" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Framework.Syntax.NoneTest.SupportedByStaticSyntax" executed="True" success="True" time="0.000" asserts="1" />
+                        </results>
+                      </test-suite>
+                      <test-suite name="NotOperatorOverride" executed="True" success="True" time="0.000" asserts="0">
+                        <results>
+                          <test-case name="NUnit.Framework.Syntax.NotOperatorOverride.SupportedByConstraintBuilder" executed="True" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Framework.Syntax.NotOperatorOverride.SupportedByInheritedSyntax" executed="True" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Framework.Syntax.NotOperatorOverride.SupportedByStaticSyntax" executed="True" success="True" time="0.000" asserts="1" />
+                        </results>
+                      </test-suite>
+                      <test-suite name="NotSamePathOrUnderTest_IgnoreCase" executed="True" success="True" time="0.000" asserts="0">
+                        <results>
+                          <test-case name="NUnit.Framework.Syntax.NotSamePathOrUnderTest_IgnoreCase.SupportedByConstraintBuilder" executed="True" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Framework.Syntax.NotSamePathOrUnderTest_IgnoreCase.SupportedByInheritedSyntax" executed="True" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Framework.Syntax.NotSamePathOrUnderTest_IgnoreCase.SupportedByStaticSyntax" executed="True" success="True" time="0.000" asserts="1" />
+                        </results>
+                      </test-suite>
+                      <test-suite name="NotSamePathOrUnderTest_RespectCase" executed="True" success="True" time="0.000" asserts="0">
+                        <results>
+                          <test-case name="NUnit.Framework.Syntax.NotSamePathOrUnderTest_RespectCase.SupportedByConstraintBuilder" executed="True" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Framework.Syntax.NotSamePathOrUnderTest_RespectCase.SupportedByInheritedSyntax" executed="True" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Framework.Syntax.NotSamePathOrUnderTest_RespectCase.SupportedByStaticSyntax" executed="True" success="True" time="0.000" asserts="1" />
+                        </results>
+                      </test-suite>
+                      <test-suite name="NotSamePathTest_IgnoreCase" executed="True" success="True" time="0.016" asserts="0">
+                        <results>
+                          <test-case name="NUnit.Framework.Syntax.NotSamePathTest_IgnoreCase.SupportedByConstraintBuilder" executed="True" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Framework.Syntax.NotSamePathTest_IgnoreCase.SupportedByInheritedSyntax" executed="True" success="True" time="0.016" asserts="1" />
+                          <test-case name="NUnit.Framework.Syntax.NotSamePathTest_IgnoreCase.SupportedByStaticSyntax" executed="True" success="True" time="0.000" asserts="1" />
+                        </results>
+                      </test-suite>
+                      <test-suite name="NotSamePathTest_RespectCase" executed="True" success="True" time="0.000" asserts="0">
+                        <results>
+                          <test-case name="NUnit.Framework.Syntax.NotSamePathTest_RespectCase.SupportedByConstraintBuilder" executed="True" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Framework.Syntax.NotSamePathTest_RespectCase.SupportedByInheritedSyntax" executed="True" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Framework.Syntax.NotSamePathTest_RespectCase.SupportedByStaticSyntax" executed="True" success="True" time="0.000" asserts="1" />
+                        </results>
+                      </test-suite>
+                      <test-suite name="NotTest" executed="True" success="True" time="0.000" asserts="0">
+                        <results>
+                          <test-case name="NUnit.Framework.Syntax.NotTest.SupportedByConstraintBuilder" executed="True" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Framework.Syntax.NotTest.SupportedByInheritedSyntax" executed="True" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Framework.Syntax.NotTest.SupportedByStaticSyntax" executed="True" success="True" time="0.000" asserts="1" />
+                        </results>
+                      </test-suite>
+                      <test-suite name="NotTest_Cascaded" executed="True" success="True" time="0.000" asserts="0">
+                        <results>
+                          <test-case name="NUnit.Framework.Syntax.NotTest_Cascaded.SupportedByConstraintBuilder" executed="True" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Framework.Syntax.NotTest_Cascaded.SupportedByInheritedSyntax" executed="True" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Framework.Syntax.NotTest_Cascaded.SupportedByStaticSyntax" executed="True" success="True" time="0.000" asserts="1" />
+                        </results>
+                      </test-suite>
+                      <test-suite name="NullTest" executed="True" success="True" time="0.000" asserts="0">
+                        <results>
+                          <test-case name="NUnit.Framework.Syntax.NullTest.SupportedByConstraintBuilder" executed="True" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Framework.Syntax.NullTest.SupportedByInheritedSyntax" executed="True" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Framework.Syntax.NullTest.SupportedByStaticSyntax" executed="True" success="True" time="0.000" asserts="1" />
+                        </results>
+                      </test-suite>
+                      <test-suite name="OperatorPrecedenceTests" executed="True" success="True" time="0.000" asserts="0">
+                        <results>
+                          <test-case name="NUnit.Framework.Syntax.OperatorPrecedenceTests.SomeTests" executed="True" success="True" time="0.000" asserts="2" />
+                          <test-case name="NUnit.Framework.Syntax.OperatorPrecedenceTests.WithTests" executed="True" success="True" time="0.000" asserts="6" />
+                        </results>
+                      </test-suite>
+                      <test-suite name="OrOperatorOverride" executed="True" success="True" time="0.000" asserts="0">
+                        <results>
+                          <test-case name="NUnit.Framework.Syntax.OrOperatorOverride.SupportedByConstraintBuilder" executed="True" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Framework.Syntax.OrOperatorOverride.SupportedByInheritedSyntax" executed="True" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Framework.Syntax.OrOperatorOverride.SupportedByStaticSyntax" executed="True" success="True" time="0.000" asserts="1" />
+                        </results>
+                      </test-suite>
+                      <test-suite name="OrTest" executed="True" success="True" time="0.000" asserts="0">
+                        <results>
+                          <test-case name="NUnit.Framework.Syntax.OrTest.SupportedByConstraintBuilder" executed="True" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Framework.Syntax.OrTest.SupportedByInheritedSyntax" executed="True" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Framework.Syntax.OrTest.SupportedByStaticSyntax" executed="True" success="True" time="0.000" asserts="1" />
+                        </results>
+                      </test-suite>
+                      <test-suite name="OrTest_ThreeOrs" executed="True" success="True" time="0.000" asserts="0">
+                        <results>
+                          <test-case name="NUnit.Framework.Syntax.OrTest_ThreeOrs.SupportedByConstraintBuilder" executed="True" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Framework.Syntax.OrTest_ThreeOrs.SupportedByInheritedSyntax" executed="True" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Framework.Syntax.OrTest_ThreeOrs.SupportedByStaticSyntax" executed="True" success="True" time="0.000" asserts="1" />
+                        </results>
+                      </test-suite>
+                      <test-suite name="PropertyExistsTest" executed="True" success="True" time="0.016" asserts="0">
+                        <results>
+                          <test-case name="NUnit.Framework.Syntax.PropertyExistsTest.SupportedByConstraintBuilder" executed="True" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Framework.Syntax.PropertyExistsTest.SupportedByInheritedSyntax" executed="True" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Framework.Syntax.PropertyExistsTest.SupportedByStaticSyntax" executed="True" success="True" time="0.000" asserts="1" />
+                        </results>
+                      </test-suite>
+                      <test-suite name="PropertyExistsTest_AndFollows" executed="True" success="True" time="0.000" asserts="0">
+                        <results>
+                          <test-case name="NUnit.Framework.Syntax.PropertyExistsTest_AndFollows.SupportedByConstraintBuilder" executed="True" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Framework.Syntax.PropertyExistsTest_AndFollows.SupportedByInheritedSyntax" executed="True" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Framework.Syntax.PropertyExistsTest_AndFollows.SupportedByStaticSyntax" executed="True" success="True" time="0.000" asserts="1" />
+                        </results>
+                      </test-suite>
+                      <test-suite name="PropertySyntaxVariations" executed="True" success="True" time="0.000" asserts="0">
+                        <results>
+                          <test-case name="NUnit.Framework.Syntax.PropertySyntaxVariations.ExistenceTest" executed="True" success="True" time="0.000" asserts="2" />
+                          <test-case name="NUnit.Framework.Syntax.PropertySyntaxVariations.SeparateConstraintTest" executed="True" success="True" time="0.000" asserts="2" />
+                        </results>
+                      </test-suite>
+                      <test-suite name="PropertyTest_ConstraintFollows" executed="True" success="True" time="0.000" asserts="0">
+                        <results>
+                          <test-case name="NUnit.Framework.Syntax.PropertyTest_ConstraintFollows.SupportedByConstraintBuilder" executed="True" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Framework.Syntax.PropertyTest_ConstraintFollows.SupportedByInheritedSyntax" executed="True" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Framework.Syntax.PropertyTest_ConstraintFollows.SupportedByStaticSyntax" executed="True" success="True" time="0.000" asserts="1" />
+                        </results>
+                      </test-suite>
+                      <test-suite name="PropertyTest_NotFollows" executed="True" success="True" time="0.000" asserts="0">
+                        <results>
+                          <test-case name="NUnit.Framework.Syntax.PropertyTest_NotFollows.SupportedByConstraintBuilder" executed="True" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Framework.Syntax.PropertyTest_NotFollows.SupportedByInheritedSyntax" executed="True" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Framework.Syntax.PropertyTest_NotFollows.SupportedByStaticSyntax" executed="True" success="True" time="0.000" asserts="1" />
+                        </results>
+                      </test-suite>
+                      <test-suite name="RegexTest" executed="True" success="True" time="0.031" asserts="0">
+                        <results>
+                          <test-case name="NUnit.Framework.Syntax.RegexTest.SupportedByConstraintBuilder" executed="True" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Framework.Syntax.RegexTest.SupportedByInheritedSyntax" executed="True" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Framework.Syntax.RegexTest.SupportedByStaticSyntax" executed="True" success="True" time="0.000" asserts="1" />
+                        </results>
+                      </test-suite>
+                      <test-suite name="RegexTest_IgnoreCase" executed="True" success="True" time="0.000" asserts="0">
+                        <results>
+                          <test-case name="NUnit.Framework.Syntax.RegexTest_IgnoreCase.SupportedByConstraintBuilder" executed="True" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Framework.Syntax.RegexTest_IgnoreCase.SupportedByInheritedSyntax" executed="True" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Framework.Syntax.RegexTest_IgnoreCase.SupportedByStaticSyntax" executed="True" success="True" time="0.000" asserts="1" />
+                        </results>
+                      </test-suite>
+                      <test-suite name="SamePathOrUnderTest" executed="True" success="True" time="0.016" asserts="0">
+                        <results>
+                          <test-case name="NUnit.Framework.Syntax.SamePathOrUnderTest.SupportedByConstraintBuilder" executed="True" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Framework.Syntax.SamePathOrUnderTest.SupportedByInheritedSyntax" executed="True" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Framework.Syntax.SamePathOrUnderTest.SupportedByStaticSyntax" executed="True" success="True" time="0.016" asserts="1" />
+                        </results>
+                      </test-suite>
+                      <test-suite name="SamePathOrUnderTest_IgnoreCase" executed="True" success="True" time="0.000" asserts="0">
+                        <results>
+                          <test-case name="NUnit.Framework.Syntax.SamePathOrUnderTest_IgnoreCase.SupportedByConstraintBuilder" executed="True" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Framework.Syntax.SamePathOrUnderTest_IgnoreCase.SupportedByInheritedSyntax" executed="True" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Framework.Syntax.SamePathOrUnderTest_IgnoreCase.SupportedByStaticSyntax" executed="True" success="True" time="0.000" asserts="1" />
+                        </results>
+                      </test-suite>
+                      <test-suite name="SamePathOrUnderTest_RespectCase" executed="True" success="True" time="0.000" asserts="0">
+                        <results>
+                          <test-case name="NUnit.Framework.Syntax.SamePathOrUnderTest_RespectCase.SupportedByConstraintBuilder" executed="True" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Framework.Syntax.SamePathOrUnderTest_RespectCase.SupportedByInheritedSyntax" executed="True" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Framework.Syntax.SamePathOrUnderTest_RespectCase.SupportedByStaticSyntax" executed="True" success="True" time="0.000" asserts="1" />
+                        </results>
+                      </test-suite>
+                      <test-suite name="SamePathTest" executed="True" success="True" time="0.000" asserts="0">
+                        <results>
+                          <test-case name="NUnit.Framework.Syntax.SamePathTest.SupportedByConstraintBuilder" executed="True" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Framework.Syntax.SamePathTest.SupportedByInheritedSyntax" executed="True" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Framework.Syntax.SamePathTest.SupportedByStaticSyntax" executed="True" success="True" time="0.000" asserts="1" />
+                        </results>
+                      </test-suite>
+                      <test-suite name="SamePathTest_IgnoreCase" executed="True" success="True" time="0.000" asserts="0">
+                        <results>
+                          <test-case name="NUnit.Framework.Syntax.SamePathTest_IgnoreCase.SupportedByConstraintBuilder" executed="True" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Framework.Syntax.SamePathTest_IgnoreCase.SupportedByInheritedSyntax" executed="True" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Framework.Syntax.SamePathTest_IgnoreCase.SupportedByStaticSyntax" executed="True" success="True" time="0.000" asserts="1" />
+                        </results>
+                      </test-suite>
+                      <test-suite name="SamePathTest_RespectCase" executed="True" success="True" time="0.000" asserts="0">
+                        <results>
+                          <test-case name="NUnit.Framework.Syntax.SamePathTest_RespectCase.SupportedByConstraintBuilder" executed="True" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Framework.Syntax.SamePathTest_RespectCase.SupportedByInheritedSyntax" executed="True" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Framework.Syntax.SamePathTest_RespectCase.SupportedByStaticSyntax" executed="True" success="True" time="0.000" asserts="1" />
+                        </results>
+                      </test-suite>
+                      <test-suite name="SomeTest" executed="True" success="True" time="0.000" asserts="0">
+                        <results>
+                          <test-case name="NUnit.Framework.Syntax.SomeTest.SupportedByConstraintBuilder" executed="True" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Framework.Syntax.SomeTest.SupportedByInheritedSyntax" executed="True" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Framework.Syntax.SomeTest.SupportedByStaticSyntax" executed="True" success="True" time="0.000" asserts="1" />
+                        </results>
+                      </test-suite>
+                      <test-suite name="SomeTest_BeforeBinaryOperators" executed="True" success="True" time="0.000" asserts="0">
+                        <results>
+                          <test-case name="NUnit.Framework.Syntax.SomeTest_BeforeBinaryOperators.SupportedByConstraintBuilder" executed="True" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Framework.Syntax.SomeTest_BeforeBinaryOperators.SupportedByInheritedSyntax" executed="True" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Framework.Syntax.SomeTest_BeforeBinaryOperators.SupportedByStaticSyntax" executed="True" success="True" time="0.000" asserts="1" />
+                        </results>
+                      </test-suite>
+                      <test-suite name="SomeTest_NestedSome" executed="True" success="True" time="0.016" asserts="0">
+                        <results>
+                          <test-case name="NUnit.Framework.Syntax.SomeTest_NestedSome.SupportedByConstraintBuilder" executed="True" success="True" time="0.016" asserts="1" />
+                          <test-case name="NUnit.Framework.Syntax.SomeTest_NestedSome.SupportedByInheritedSyntax" executed="True" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Framework.Syntax.SomeTest_NestedSome.SupportedByStaticSyntax" executed="True" success="True" time="0.000" asserts="1" />
+                        </results>
+                      </test-suite>
+                      <test-suite name="SomeTest_UseOfAndSome" executed="True" success="True" time="0.000" asserts="0">
+                        <results>
+                          <test-case name="NUnit.Framework.Syntax.SomeTest_UseOfAndSome.SupportedByConstraintBuilder" executed="True" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Framework.Syntax.SomeTest_UseOfAndSome.SupportedByInheritedSyntax" executed="True" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Framework.Syntax.SomeTest_UseOfAndSome.SupportedByStaticSyntax" executed="True" success="True" time="0.000" asserts="1" />
+                        </results>
+                      </test-suite>
+                      <test-suite name="StartsWithTest" executed="True" success="True" time="0.000" asserts="0">
+                        <results>
+                          <test-case name="NUnit.Framework.Syntax.StartsWithTest.SupportedByConstraintBuilder" executed="True" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Framework.Syntax.StartsWithTest.SupportedByInheritedSyntax" executed="True" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Framework.Syntax.StartsWithTest.SupportedByStaticSyntax" executed="True" success="True" time="0.000" asserts="1" />
+                        </results>
+                      </test-suite>
+                      <test-suite name="StartsWithTest_IgnoreCase" executed="True" success="True" time="0.000" asserts="0">
+                        <results>
+                          <test-case name="NUnit.Framework.Syntax.StartsWithTest_IgnoreCase.SupportedByConstraintBuilder" executed="True" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Framework.Syntax.StartsWithTest_IgnoreCase.SupportedByInheritedSyntax" executed="True" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Framework.Syntax.StartsWithTest_IgnoreCase.SupportedByStaticSyntax" executed="True" success="True" time="0.000" asserts="1" />
+                        </results>
+                      </test-suite>
+                      <test-suite name="SubstringTest" executed="True" success="True" time="0.016" asserts="0">
+                        <results>
+                          <test-case name="NUnit.Framework.Syntax.SubstringTest.SupportedByConstraintBuilder" executed="True" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Framework.Syntax.SubstringTest.SupportedByInheritedSyntax" executed="True" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Framework.Syntax.SubstringTest.SupportedByStaticSyntax" executed="True" success="True" time="0.016" asserts="1" />
+                        </results>
+                      </test-suite>
+                      <test-suite name="SubstringTest_IgnoreCase" executed="True" success="True" time="0.000" asserts="0">
+                        <results>
+                          <test-case name="NUnit.Framework.Syntax.SubstringTest_IgnoreCase.SupportedByConstraintBuilder" executed="True" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Framework.Syntax.SubstringTest_IgnoreCase.SupportedByInheritedSyntax" executed="True" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Framework.Syntax.SubstringTest_IgnoreCase.SupportedByStaticSyntax" executed="True" success="True" time="0.000" asserts="1" />
+                        </results>
+                      </test-suite>
+                      <test-suite name="TextContains" executed="True" success="True" time="0.000" asserts="0">
+                        <results>
+                          <test-case name="NUnit.Framework.Syntax.TextContains.SupportedByConstraintBuilder" executed="True" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Framework.Syntax.TextContains.SupportedByInheritedSyntax" executed="True" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Framework.Syntax.TextContains.SupportedByStaticSyntax" executed="True" success="True" time="0.000" asserts="1" />
+                        </results>
+                      </test-suite>
+                      <test-suite name="TextEndsWithTest" executed="True" success="True" time="0.000" asserts="0">
+                        <results>
+                          <test-case name="NUnit.Framework.Syntax.TextEndsWithTest.SupportedByConstraintBuilder" executed="True" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Framework.Syntax.TextEndsWithTest.SupportedByInheritedSyntax" executed="True" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Framework.Syntax.TextEndsWithTest.SupportedByStaticSyntax" executed="True" success="True" time="0.000" asserts="1" />
+                        </results>
+                      </test-suite>
+                      <test-suite name="TextMatchesTest" executed="True" success="True" time="0.000" asserts="0">
+                        <results>
+                          <test-case name="NUnit.Framework.Syntax.TextMatchesTest.SupportedByConstraintBuilder" executed="True" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Framework.Syntax.TextMatchesTest.SupportedByInheritedSyntax" executed="True" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Framework.Syntax.TextMatchesTest.SupportedByStaticSyntax" executed="True" success="True" time="0.000" asserts="1" />
+                        </results>
+                      </test-suite>
+                      <test-suite name="TextStartsWithTest" executed="True" success="True" time="0.000" asserts="0">
+                        <results>
+                          <test-case name="NUnit.Framework.Syntax.TextStartsWithTest.SupportedByConstraintBuilder" executed="True" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Framework.Syntax.TextStartsWithTest.SupportedByInheritedSyntax" executed="True" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Framework.Syntax.TextStartsWithTest.SupportedByStaticSyntax" executed="True" success="True" time="0.000" asserts="1" />
+                        </results>
+                      </test-suite>
+                      <test-suite name="ThrowsTests" executed="True" success="True" time="0.031" asserts="0">
+                        <results>
+                          <test-case name="NUnit.Framework.Syntax.ThrowsTests.DelegateThrowsException" executed="True" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Framework.Syntax.ThrowsTests.ThrowsArgumentException" executed="True" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Framework.Syntax.ThrowsTests.ThrowsException" executed="True" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Framework.Syntax.ThrowsTests.ThrowsExceptionInstanceOf" executed="True" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Framework.Syntax.ThrowsTests.ThrowsExceptionTypeOf" executed="True" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Framework.Syntax.ThrowsTests.ThrowsExceptionTypeOfAndConstraint" executed="True" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Framework.Syntax.ThrowsTests.ThrowsExceptionWithConstraint" executed="True" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Framework.Syntax.ThrowsTests.ThrowsExceptionWithInnerException" executed="True" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Framework.Syntax.ThrowsTests.ThrowsInnerException" executed="True" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Framework.Syntax.ThrowsTests.ThrowsInstanceOf" executed="True" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Framework.Syntax.ThrowsTests.ThrowsInvalidOperationException" executed="True" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Framework.Syntax.ThrowsTests.ThrowsTargetInvocationExceptionWithInnerException" executed="True" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Framework.Syntax.ThrowsTests.ThrowsTypeOf" executed="True" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Framework.Syntax.ThrowsTests.ThrowsTypeOfAndConstraint" executed="True" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Framework.Syntax.ThrowsTests.ThrowsTypeOfWithConstraint" executed="True" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Framework.Syntax.ThrowsTests.ThrowsTypeOfWithInnerException" executed="True" success="True" time="0.000" asserts="1" />
+                        </results>
+                      </test-suite>
+                      <test-suite name="TrueTest" executed="True" success="True" time="0.000" asserts="0">
+                        <results>
+                          <test-case name="NUnit.Framework.Syntax.TrueTest.SupportedByConstraintBuilder" executed="True" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Framework.Syntax.TrueTest.SupportedByInheritedSyntax" executed="True" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Framework.Syntax.TrueTest.SupportedByStaticSyntax" executed="True" success="True" time="0.000" asserts="1" />
+                        </results>
+                      </test-suite>
+                      <test-suite name="UniqueTest" executed="True" success="True" time="0.000" asserts="0">
+                        <results>
+                          <test-case name="NUnit.Framework.Syntax.UniqueTest.SupportedByConstraintBuilder" executed="True" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Framework.Syntax.UniqueTest.SupportedByInheritedSyntax" executed="True" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Framework.Syntax.UniqueTest.SupportedByStaticSyntax" executed="True" success="True" time="0.000" asserts="1" />
+                        </results>
+                      </test-suite>
+                      <test-suite name="XmlSerializableTest" executed="True" success="True" time="0.000" asserts="0">
+                        <results>
+                          <test-case name="NUnit.Framework.Syntax.XmlSerializableTest.SupportedByConstraintBuilder" executed="True" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Framework.Syntax.XmlSerializableTest.SupportedByInheritedSyntax" executed="True" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Framework.Syntax.XmlSerializableTest.SupportedByStaticSyntax" executed="True" success="True" time="0.000" asserts="1" />
+                        </results>
+                      </test-suite>
+                    </results>
+                  </test-suite>
+                  <test-suite name="Tests" executed="True" success="True" time="2.141" asserts="0">
+                    <results>
+                      <test-suite name="ArrayEqualsFailureMessageFixture" executed="True" success="True" time="0.156" asserts="0">
+                        <results>
+                          <test-case name="NUnit.Framework.Tests.ArrayEqualsFailureMessageFixture.ActualArrayIsLonger" executed="True" success="True" time="0.000" asserts="2" />
+                          <test-case name="NUnit.Framework.Tests.ArrayEqualsFailureMessageFixture.ArrayAndCollection_Failure" executed="True" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Framework.Tests.ArrayEqualsFailureMessageFixture.ArraysDeclaredAsDifferentTypes" executed="True" success="True" time="0.109" asserts="2" />
+                          <test-case name="NUnit.Framework.Tests.ArrayEqualsFailureMessageFixture.ArraysHaveDifferentRanks" executed="True" success="True" time="0.016" asserts="2" />
+                          <test-case name="NUnit.Framework.Tests.ArrayEqualsFailureMessageFixture.ArraysWithDifferentDimensionsAsCollection" executed="True" success="True" time="0.000" asserts="2" />
+                          <test-case name="NUnit.Framework.Tests.ArrayEqualsFailureMessageFixture.ArraysWithDifferentRanksAsCollection" executed="True" success="True" time="0.000" asserts="2" />
+                          <test-case name="NUnit.Framework.Tests.ArrayEqualsFailureMessageFixture.DifferentArrayTypesEqualFails" executed="True" success="True" time="0.000" asserts="2" />
+                          <test-case name="NUnit.Framework.Tests.ArrayEqualsFailureMessageFixture.DoubleDimensionedArrays" executed="True" success="True" time="0.000" asserts="2" />
+                          <test-case name="NUnit.Framework.Tests.ArrayEqualsFailureMessageFixture.ExpectedArrayIsLonger" executed="True" success="True" time="0.000" asserts="2" />
+                          <test-case name="NUnit.Framework.Tests.ArrayEqualsFailureMessageFixture.FailureOnSingleDimensionedArrays" executed="True" success="True" time="0.000" asserts="2" />
+                          <test-case name="NUnit.Framework.Tests.ArrayEqualsFailureMessageFixture.FiveDimensionedArrays" executed="True" success="True" time="0.000" asserts="2" />
+                          <test-case name="NUnit.Framework.Tests.ArrayEqualsFailureMessageFixture.JaggedArrayComparedToSimpleArray" executed="True" success="True" time="0.000" asserts="2" />
+                          <test-case name="NUnit.Framework.Tests.ArrayEqualsFailureMessageFixture.JaggedArrays" executed="True" success="True" time="0.016" asserts="2" />
+                          <test-case name="NUnit.Framework.Tests.ArrayEqualsFailureMessageFixture.SameLengthDifferentContent" executed="True" success="True" time="0.000" asserts="2" />
+                          <test-case name="NUnit.Framework.Tests.ArrayEqualsFailureMessageFixture.TripleDimensionedArrays" executed="True" success="True" time="0.000" asserts="2" />
+                        </results>
+                      </test-suite>
+                      <test-suite name="ArrayEqualsFixture" executed="True" success="True" time="0.016" asserts="0">
+                        <results>
+                          <test-case name="NUnit.Framework.Tests.ArrayEqualsFixture.ArrayAndCollection" executed="True" success="True" time="0.000" asserts="4" />
+                          <test-case name="NUnit.Framework.Tests.ArrayEqualsFixture.ArrayIsEqualToItself" executed="True" success="True" time="0.000" asserts="3" />
+                          <test-case name="NUnit.Framework.Tests.ArrayEqualsFixture.ArrayOfIntAndArrayOfDouble" executed="True" success="True" time="0.000" asserts="4" />
+                          <test-case name="NUnit.Framework.Tests.ArrayEqualsFixture.ArraysDeclaredAsDifferentTypes" executed="True" success="True" time="0.000" asserts="4" />
+                          <test-case name="NUnit.Framework.Tests.ArrayEqualsFixture.ArraysOfArrays" executed="True" success="True" time="0.000" asserts="4" />
+                          <test-case name="NUnit.Framework.Tests.ArrayEqualsFixture.ArraysOfDecimal" executed="True" success="True" time="0.000" asserts="4" />
+                          <test-case name="NUnit.Framework.Tests.ArrayEqualsFixture.ArraysOfDouble" executed="True" success="True" time="0.000" asserts="4" />
+                          <test-case name="NUnit.Framework.Tests.ArrayEqualsFixture.ArraysOfInt" executed="True" success="True" time="0.000" asserts="4" />
+                          <test-case name="NUnit.Framework.Tests.ArrayEqualsFixture.ArraysOfMixedTypes" executed="True" success="True" time="0.000" asserts="4" />
+                          <test-case name="NUnit.Framework.Tests.ArrayEqualsFixture.ArraysOfString" executed="True" success="True" time="0.000" asserts="5" />
+                          <test-case name="NUnit.Framework.Tests.ArrayEqualsFixture.ArraysPassedAsObjects" executed="True" success="True" time="0.000" asserts="4" />
+                          <test-case name="NUnit.Framework.Tests.ArrayEqualsFixture.ArraysWithDifferentDimensionsMatchedAsCollection" executed="True" success="True" time="0.000" asserts="3" />
+                          <test-case name="NUnit.Framework.Tests.ArrayEqualsFixture.ArraysWithDifferentRanksComparedAsCollection" executed="True" success="True" time="0.000" asserts="3" />
+                          <test-case name="NUnit.Framework.Tests.ArrayEqualsFixture.DoubleDimensionedArrays" executed="True" success="True" time="0.000" asserts="4" />
+                          <test-case name="NUnit.Framework.Tests.ArrayEqualsFixture.FiveDimensionedArrays" executed="True" success="True" time="0.000" asserts="2" />
+                          <test-case name="NUnit.Framework.Tests.ArrayEqualsFixture.JaggedArrays" executed="True" success="True" time="0.000" asserts="2" />
+                          <test-case name="NUnit.Framework.Tests.ArrayEqualsFixture.TripleDimensionedArrays" executed="True" success="True" time="0.000" asserts="2" />
+                        </results>
+                      </test-suite>
+                      <test-suite name="ArrayNotEqualFixture" executed="True" success="True" time="0.000" asserts="0">
+                        <results>
+                          <test-case name="NUnit.Framework.Tests.ArrayNotEqualFixture.ArraysDeclaredAsDifferentTypes" executed="True" success="True" time="0.000" asserts="3" />
+                          <test-case name="NUnit.Framework.Tests.ArrayNotEqualFixture.DifferentLengthArrays" executed="True" success="True" time="0.000" asserts="4" />
+                          <test-case name="NUnit.Framework.Tests.ArrayNotEqualFixture.SameLengthDifferentContent" executed="True" success="True" time="0.000" asserts="4" />
+                        </results>
+                      </test-suite>
+                      <test-suite name="AssertThrowsTests" executed="True" success="True" time="0.063" asserts="0">
+                        <results>
+                          <test-case name="NUnit.Framework.Tests.AssertThrowsTests.BaseExceptionThrown" executed="True" success="True" time="0.016" asserts="2" />
+                          <test-case name="NUnit.Framework.Tests.AssertThrowsTests.CanCatchExceptionOfDerivedType" executed="True" success="True" time="0.000" asserts="4" />
+                          <test-case name="NUnit.Framework.Tests.AssertThrowsTests.CanCatchExceptionOfExactType" executed="True" success="True" time="0.000" asserts="4" />
+                          <test-case name="NUnit.Framework.Tests.AssertThrowsTests.CanCatchUnspecifiedException" executed="True" success="True" time="0.000" asserts="4" />
+                          <test-case name="NUnit.Framework.Tests.AssertThrowsTests.CorrectExceptionIsReturnedToMethod" executed="True" success="True" time="0.000" asserts="16" />
+                          <test-case name="NUnit.Framework.Tests.AssertThrowsTests.CorrectExceptionThrown" executed="True" success="True" time="0.000" asserts="5" />
+                          <test-case name="NUnit.Framework.Tests.AssertThrowsTests.DerivedExceptionThrown" executed="True" success="True" time="0.000" asserts="2" />
+                          <test-case name="NUnit.Framework.Tests.AssertThrowsTests.DoesNotThrowFails" executed="True" success="True" time="0.031" asserts="0" />
+                          <test-case name="NUnit.Framework.Tests.AssertThrowsTests.DoesNotThrowSuceeds" executed="True" success="True" time="0.000" asserts="0" />
+                          <test-case name="NUnit.Framework.Tests.AssertThrowsTests.NoExceptionThrown" executed="True" success="True" time="0.000" asserts="2" />
+                          <test-case name="NUnit.Framework.Tests.AssertThrowsTests.UnrelatedExceptionThrown" executed="True" success="True" time="0.000" asserts="2" />
+                        </results>
+                      </test-suite>
+                      <test-suite name="AssumeThatTests" executed="True" success="True" time="0.016" asserts="0">
+                        <results>
+                          <test-case name="NUnit.Framework.Tests.AssumeThatTests.AssumptionPasses_ActualAndConstraint" executed="True" success="True" time="0.000" asserts="0" />
+                          <test-case name="NUnit.Framework.Tests.AssumeThatTests.AssumptionPasses_Boolean" executed="True" success="True" time="0.000" asserts="0" />
+                          <test-case name="NUnit.Framework.Tests.AssumeThatTests.AssumptionPasses_DelegateAndConstraint" executed="True" success="True" time="0.000" asserts="0" />
+                          <test-case name="NUnit.Framework.Tests.AssumeThatTests.AssumptionPasses_ReferenceAndConstraint" executed="True" success="True" time="0.000" asserts="0" />
+                          <test-case name="NUnit.Framework.Tests.AssumeThatTests.FailureThrowsInconclusiveException_ActualAndConstraint" executed="True" success="True" time="0.000" asserts="0" />
+                          <test-case name="NUnit.Framework.Tests.AssumeThatTests.FailureThrowsInconclusiveException_Boolean" executed="True" success="True" time="0.000" asserts="0" />
+                          <test-case name="NUnit.Framework.Tests.AssumeThatTests.FailureThrowsInconclusiveException_DelegateAndConstraint" executed="True" success="True" time="0.000" asserts="0" />
+                          <test-case name="NUnit.Framework.Tests.AssumeThatTests.FailureThrowsInconclusiveException_ReferenceAndConstraint" executed="True" success="True" time="0.000" asserts="0" />
+                        </results>
+                      </test-suite>
+                      <test-suite name="CollectionAssertTest" executed="True" success="True" time="0.109" asserts="0">
+                        <results>
+                          <test-case name="NUnit.Framework.Tests.CollectionAssertTest.AreEqual" executed="True" success="True" time="0.000" asserts="3" />
+                          <test-case name="NUnit.Framework.Tests.CollectionAssertTest.AreEqual_HandlesNull" executed="True" success="True" time="0.000" asserts="2" />
+                          <test-case name="NUnit.Framework.Tests.CollectionAssertTest.AreEqual_UsingIterator" executed="True" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Framework.Tests.CollectionAssertTest.AreEqualFail" executed="True" success="True" time="0.000" asserts="2" />
+                          <test-case name="NUnit.Framework.Tests.CollectionAssertTest.AreEqualFailCount" executed="True" success="True" time="0.000" asserts="2" />
+                          <test-case name="NUnit.Framework.Tests.CollectionAssertTest.AreEquivalentHandlesNull" executed="True" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Framework.Tests.CollectionAssertTest.AreNotEqual" executed="True" success="True" time="0.000" asserts="6" />
+                          <test-case name="NUnit.Framework.Tests.CollectionAssertTest.AreNotEqual_Fails" executed="True" success="True" time="0.000" asserts="2" />
+                          <test-case name="NUnit.Framework.Tests.CollectionAssertTest.AreNotEqual_HandlesNull" executed="True" success="True" time="0.000" asserts="2" />
+                          <test-case name="NUnit.Framework.Tests.CollectionAssertTest.Contains_ICollection" executed="True" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Framework.Tests.CollectionAssertTest.Contains_IList" executed="True" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Framework.Tests.CollectionAssertTest.ContainsFails_EmptyICollection" executed="True" success="True" time="0.000" asserts="2" />
+                          <test-case name="NUnit.Framework.Tests.CollectionAssertTest.ContainsFails_EmptyIList" executed="True" success="True" time="0.016" asserts="2" />
+                          <test-case name="NUnit.Framework.Tests.CollectionAssertTest.ContainsFails_ICollection" executed="True" success="True" time="0.000" asserts="2" />
+                          <test-case name="NUnit.Framework.Tests.CollectionAssertTest.ContainsFails_ILIst" executed="True" success="True" time="0.000" asserts="2" />
+                          <test-case name="NUnit.Framework.Tests.CollectionAssertTest.ContainsNull_ICollection" executed="True" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Framework.Tests.CollectionAssertTest.ContainsNull_IList" executed="True" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Framework.Tests.CollectionAssertTest.DoesNotContain" executed="True" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Framework.Tests.CollectionAssertTest.DoesNotContain_Empty" executed="True" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Framework.Tests.CollectionAssertTest.DoesNotContain_Fails" executed="True" success="True" time="0.000" asserts="2" />
+                          <test-case name="NUnit.Framework.Tests.CollectionAssertTest.EnsureComparerIsUsed" executed="True" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Framework.Tests.CollectionAssertTest.Equivalent" executed="True" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Framework.Tests.CollectionAssertTest.EquivalentFailOne" executed="True" success="True" time="0.000" asserts="2" />
+                          <test-case name="NUnit.Framework.Tests.CollectionAssertTest.EquivalentFailTwo" executed="True" success="True" time="0.000" asserts="2" />
+                          <test-case name="NUnit.Framework.Tests.CollectionAssertTest.IsNotSubsetOf" executed="True" success="True" time="0.000" asserts="2" />
+                          <test-case name="NUnit.Framework.Tests.CollectionAssertTest.IsNotSubsetOf_Fails" executed="True" success="True" time="0.000" asserts="2" />
+                          <test-case name="NUnit.Framework.Tests.CollectionAssertTest.IsNotSubsetOfHandlesNull" executed="True" success="True" time="0.016" asserts="1" />
+                          <test-case name="NUnit.Framework.Tests.CollectionAssertTest.IsOrdered" executed="True" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Framework.Tests.CollectionAssertTest.IsOrdered_Allows_adjacent_equal_values" executed="True" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Framework.Tests.CollectionAssertTest.IsOrdered_ContainedTypesMustBeCompatible" executed="True" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Framework.Tests.CollectionAssertTest.IsOrdered_Fails" executed="True" success="True" time="0.000" asserts="2" />
+                          <test-case name="NUnit.Framework.Tests.CollectionAssertTest.IsOrdered_Handles_custom_comparison" executed="True" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Framework.Tests.CollectionAssertTest.IsOrdered_Handles_custom_comparison2" executed="True" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Framework.Tests.CollectionAssertTest.IsOrdered_Handles_null" executed="True" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Framework.Tests.CollectionAssertTest.IsOrdered_TypesMustImplementIComparable" executed="True" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Framework.Tests.CollectionAssertTest.IsSubsetOf" executed="True" success="True" time="0.000" asserts="2" />
+                          <test-case name="NUnit.Framework.Tests.CollectionAssertTest.IsSubsetOf_Fails" executed="True" success="True" time="0.000" asserts="2" />
+                          <test-case name="NUnit.Framework.Tests.CollectionAssertTest.IsSubsetOfHandlesNull" executed="True" success="True" time="0.000" asserts="2" />
+                          <test-case name="NUnit.Framework.Tests.CollectionAssertTest.ItemsNotNull" executed="True" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Framework.Tests.CollectionAssertTest.ItemsNotNullFailure" executed="True" success="True" time="0.000" asserts="2" />
+                          <test-case name="NUnit.Framework.Tests.CollectionAssertTest.ItemsOfType" executed="True" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Framework.Tests.CollectionAssertTest.ItemsOfTypeFailure" executed="True" success="True" time="0.016" asserts="2" />
+                          <test-case name="NUnit.Framework.Tests.CollectionAssertTest.NotEquivalent" executed="True" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Framework.Tests.CollectionAssertTest.NotEquivalent_Fails" executed="True" success="True" time="0.000" asserts="2" />
+                          <test-case name="NUnit.Framework.Tests.CollectionAssertTest.NotEquivalentHandlesNull" executed="True" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Framework.Tests.CollectionAssertTest.Unique_WithNull" executed="True" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Framework.Tests.CollectionAssertTest.Unique_WithObjects" executed="True" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Framework.Tests.CollectionAssertTest.Unique_WithStrings" executed="True" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Framework.Tests.CollectionAssertTest.UniqueFailure" executed="True" success="True" time="0.000" asserts="2" />
+                          <test-case name="NUnit.Framework.Tests.CollectionAssertTest.UniqueFailure_WithTwoNulls" executed="True" success="True" time="0.000" asserts="1" />
+                        </results>
+                      </test-suite>
+                      <test-suite name="ConditionAssertTests" executed="True" success="True" time="0.047" asserts="0">
+                        <results>
+                          <test-case name="NUnit.Framework.Tests.ConditionAssertTests.IsEmpty" executed="True" success="True" time="0.000" asserts="4" />
+                          <test-case name="NUnit.Framework.Tests.ConditionAssertTests.IsEmptyFailsOnNonEmptyArray" executed="True" success="True" time="0.000" asserts="2" />
+                          <test-case name="NUnit.Framework.Tests.ConditionAssertTests.IsEmptyFailsOnNullString" executed="True" success="True" time="0.000" asserts="2" />
+                          <test-case name="NUnit.Framework.Tests.ConditionAssertTests.IsEmptyFailsOnString" executed="True" success="True" time="0.000" asserts="2" />
+                          <test-case name="NUnit.Framework.Tests.ConditionAssertTests.IsFalse" executed="True" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Framework.Tests.ConditionAssertTests.IsFalseFails" executed="True" success="True" time="0.000" asserts="2" />
+                          <test-case name="NUnit.Framework.Tests.ConditionAssertTests.IsNaN" executed="True" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Framework.Tests.ConditionAssertTests.IsNaNFails" executed="True" success="True" time="0.016" asserts="2" />
+                          <test-case name="NUnit.Framework.Tests.ConditionAssertTests.IsNotEmpty" executed="True" success="True" time="0.000" asserts="4" />
+                          <test-case name="NUnit.Framework.Tests.ConditionAssertTests.IsNotEmptyFailsOnEmptyArray" executed="True" success="True" time="0.000" asserts="2" />
+                          <test-case name="NUnit.Framework.Tests.ConditionAssertTests.IsNotEmptyFailsOnEmptyArrayList" executed="True" success="True" time="0.000" asserts="2" />
+                          <test-case name="NUnit.Framework.Tests.ConditionAssertTests.IsNotEmptyFailsOnEmptyHashTable" executed="True" success="True" time="0.000" asserts="2" />
+                          <test-case name="NUnit.Framework.Tests.ConditionAssertTests.IsNotEmptyFailsOnEmptyString" executed="True" success="True" time="0.000" asserts="2" />
+                          <test-case name="NUnit.Framework.Tests.ConditionAssertTests.IsNotNull" executed="True" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Framework.Tests.ConditionAssertTests.IsNotNullFails" executed="True" success="True" time="0.000" asserts="2" />
+                          <test-case name="NUnit.Framework.Tests.ConditionAssertTests.IsNull" executed="True" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Framework.Tests.ConditionAssertTests.IsNullFails" executed="True" success="True" time="0.000" asserts="2" />
+                          <test-case name="NUnit.Framework.Tests.ConditionAssertTests.IsTrue" executed="True" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Framework.Tests.ConditionAssertTests.IsTrueFails" executed="True" success="True" time="0.000" asserts="2" />
+                        </results>
+                      </test-suite>
+                      <test-suite name="DirectoryAssertTests" executed="True" success="True" time="0.922" asserts="0">
+                        <results>
+                          <test-case name="NUnit.Framework.Tests.DirectoryAssertTests.AreEqualFailsWhenOneDoesNotExist" executed="True" success="True" time="0.031" asserts="1" />
+                          <test-case name="NUnit.Framework.Tests.DirectoryAssertTests.AreEqualFailsWhenOneIsNull" executed="True" success="True" time="0.031" asserts="1" />
+                          <test-case name="NUnit.Framework.Tests.DirectoryAssertTests.AreEqualFailsWithDirectoryInfos" executed="True" success="True" time="0.063" asserts="1" />
+                          <test-case name="NUnit.Framework.Tests.DirectoryAssertTests.AreEqualFailsWithStringPath" executed="True" success="True" time="0.109" asserts="1" />
+                          <test-case name="NUnit.Framework.Tests.DirectoryAssertTests.AreEqualPassesWhenBothAreNull" executed="True" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Framework.Tests.DirectoryAssertTests.AreEqualPassesWithDirectoryInfos" executed="True" success="True" time="0.031" asserts="1" />
+                          <test-case name="NUnit.Framework.Tests.DirectoryAssertTests.AreEqualPassesWithStringPath" executed="True" success="True" time="0.016" asserts="1" />
+                          <test-case name="NUnit.Framework.Tests.DirectoryAssertTests.AreNotEqualFailsWhenBothAreNull" executed="True" success="True" time="0.000" asserts="2" />
+                          <test-case name="NUnit.Framework.Tests.DirectoryAssertTests.AreNotEqualFailsWithDirectoryInfos" executed="True" success="True" time="0.031" asserts="1" />
+                          <test-case name="NUnit.Framework.Tests.DirectoryAssertTests.AreNotEqualFailsWithStringPath" executed="True" success="True" time="0.016" asserts="1" />
+                          <test-case name="NUnit.Framework.Tests.DirectoryAssertTests.AreNotEqualPassesIfOneIsNull" executed="True" success="True" time="0.031" asserts="1" />
+                          <test-case name="NUnit.Framework.Tests.DirectoryAssertTests.AreNotEqualPassesWhenOneDoesNotExist" executed="True" success="True" time="0.016" asserts="1" />
+                          <test-case name="NUnit.Framework.Tests.DirectoryAssertTests.AreNotEqualPassesWithStringPath" executed="True" success="True" time="0.063" asserts="1" />
+                          <test-case name="NUnit.Framework.Tests.DirectoryAssertTests.IsEmptyFailsWithInvalidDirectory" executed="True" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Framework.Tests.DirectoryAssertTests.IsEmptyFailsWithNonEmptyDirectoryUsingDirectoryInfo" executed="True" success="True" time="0.031" asserts="1" />
+                          <test-case name="NUnit.Framework.Tests.DirectoryAssertTests.IsEmptyFailsWithNonEmptyDirectoryUsingStringPath" executed="True" success="True" time="0.031" asserts="1" />
+                          <test-case name="NUnit.Framework.Tests.DirectoryAssertTests.IsEmptyPassesWithEmptyDirectoryUsingDirectoryInfo" executed="True" success="True" time="0.016" asserts="1" />
+                          <test-case name="NUnit.Framework.Tests.DirectoryAssertTests.IsEmptyPassesWithEmptyDirectoryUsingStringPath" executed="True" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Framework.Tests.DirectoryAssertTests.IsEmptyThrowsUsingNull" executed="True" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Framework.Tests.DirectoryAssertTests.IsNotEmptyFailsWithEmptyDirectoryUsingDirectoryInfo" executed="True" success="True" time="0.016" asserts="1" />
+                          <test-case name="NUnit.Framework.Tests.DirectoryAssertTests.IsNotEmptyFailsWithEmptyDirectoryUsingStringPath" executed="True" success="True" time="0.031" asserts="1" />
+                          <test-case name="NUnit.Framework.Tests.DirectoryAssertTests.IsNotEmptyFailsWithInvalidDirectory" executed="True" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Framework.Tests.DirectoryAssertTests.IsNotEmptyPassesWithNonEmptyDirectoryUsingDirectoryInfo" executed="True" success="True" time="0.078" asserts="1" />
+                          <test-case name="NUnit.Framework.Tests.DirectoryAssertTests.IsNotEmptyPassesWithNonEmptyDirectoryUsingStringPath" executed="True" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Framework.Tests.DirectoryAssertTests.IsNotEmptyThrowsUsingNull" executed="True" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Framework.Tests.DirectoryAssertTests.IsNotWithinFailsWithDirectoryInfo" executed="True" success="True" time="0.047" asserts="1" />
+                          <test-case name="NUnit.Framework.Tests.DirectoryAssertTests.IsNotWithinFailsWithStringPath" executed="True" success="True" time="0.031" asserts="1" />
+                          <test-case name="NUnit.Framework.Tests.DirectoryAssertTests.IsNotWithinPassesWhenOutsidePathUsingDirectoryInfo" executed="True" success="True" time="0.031" asserts="1" />
+                          <test-case name="NUnit.Framework.Tests.DirectoryAssertTests.IsNotWithinPassesWhenOutsidePathUsingStringPath" executed="True" success="True" time="0.016" asserts="1" />
+                          <test-case name="NUnit.Framework.Tests.DirectoryAssertTests.IsNotWithinThrowsWhenBothAreNull" executed="True" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Framework.Tests.DirectoryAssertTests.IsWithinFailsWhenOutsidePathUsingDirectoryInfo" executed="True" success="True" time="0.047" asserts="1" />
+                          <test-case name="NUnit.Framework.Tests.DirectoryAssertTests.IsWithinFailsWhenOutsidePathUsingStringPath" executed="True" success="True" time="0.016" asserts="1" />
+                          <test-case name="NUnit.Framework.Tests.DirectoryAssertTests.IsWithinPassesWithDirectoryInfo" executed="True" success="True" time="0.016" asserts="1" />
+                          <test-case name="NUnit.Framework.Tests.DirectoryAssertTests.IsWithinPassesWithStringPath" executed="True" success="True" time="0.031" asserts="1" />
+                          <test-case name="NUnit.Framework.Tests.DirectoryAssertTests.IsWithinThrowsWhenBothAreNull" executed="True" success="True" time="0.000" asserts="1" />
+                        </results>
+                      </test-suite>
+                      <test-suite name="EqualsFixture" executed="True" success="True" time="0.078" asserts="0">
+                        <results>
+                          <test-case name="NUnit.Framework.Tests.EqualsFixture.Bug575936Int32Int64Comparison" executed="True" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Framework.Tests.EqualsFixture.Byte" executed="True" success="True" time="0.000" asserts="2" />
+                          <test-case name="NUnit.Framework.Tests.EqualsFixture.DateTimeEqual" executed="True" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Framework.Tests.EqualsFixture.DateTimeNotEqual" executed="True" success="True" time="0.000" asserts="2" />
+                          <test-case name="NUnit.Framework.Tests.EqualsFixture.Decimal" executed="True" success="True" time="0.000" asserts="6" />
+                          <test-case name="NUnit.Framework.Tests.EqualsFixture.DoubleNotEqualMessageDisplaysAllDigits" executed="True" success="True" time="0.000" asserts="2" />
+                          <test-case name="NUnit.Framework.Tests.EqualsFixture.DoubleNotEqualMessageDisplaysDefaultTolerance" executed="True" success="True" time="0.000" asserts="2" />
+                          <test-case name="NUnit.Framework.Tests.EqualsFixture.DoubleNotEqualMessageDisplaysTolerance" executed="True" success="True" time="0.016" asserts="2" />
+                          <test-case name="NUnit.Framework.Tests.EqualsFixture.DoubleNotEqualWithNanDoesNotDisplayDefaultTolerance" executed="True" success="True" time="0.000" asserts="2" />
+                          <test-case name="NUnit.Framework.Tests.EqualsFixture.EnumsEqual" executed="True" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Framework.Tests.EqualsFixture.EnumsNotEqual" executed="True" success="True" time="0.000" asserts="2" />
+                          <test-case name="NUnit.Framework.Tests.EqualsFixture.Equals" executed="True" success="True" time="0.000" asserts="2" />
+                          <test-case name="NUnit.Framework.Tests.EqualsFixture.EqualsFail" executed="True" success="True" time="0.000" asserts="2" />
+                          <test-case name="NUnit.Framework.Tests.EqualsFixture.EqualsNaNFails" executed="True" success="True" time="0.016" asserts="2" />
+                          <test-case name="NUnit.Framework.Tests.EqualsFixture.EqualsNull" executed="True" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Framework.Tests.EqualsFixture.EqualsSameTypes" executed="True" success="True" time="0.000" asserts="31" />
+                          <test-case name="NUnit.Framework.Tests.EqualsFixture.EqualsThrowsException" executed="True" success="True" time="0.000" asserts="0" />
+                          <test-case name="NUnit.Framework.Tests.EqualsFixture.Float" executed="True" success="True" time="0.000" asserts="2" />
+                          <test-case name="NUnit.Framework.Tests.EqualsFixture.FloatNotEqualMessageDisplaysAllDigits" executed="True" success="True" time="0.000" asserts="2" />
+                          <test-case name="NUnit.Framework.Tests.EqualsFixture.FloatNotEqualMessageDisplaysTolerance" executed="True" success="True" time="0.000" asserts="2" />
+                          <test-case name="NUnit.Framework.Tests.EqualsFixture.Int" executed="True" success="True" time="0.000" asserts="2" />
+                          <test-case name="NUnit.Framework.Tests.EqualsFixture.IntegerEquals" executed="True" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Framework.Tests.EqualsFixture.IntegerLongComparison" executed="True" success="True" time="0.000" asserts="2" />
+                          <test-case name="NUnit.Framework.Tests.EqualsFixture.NanEqualsFails" executed="True" success="True" time="0.000" asserts="2" />
+                          <test-case name="NUnit.Framework.Tests.EqualsFixture.NanEqualsNaNSucceeds" executed="True" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Framework.Tests.EqualsFixture.NegInfinityEqualsInfinity" executed="True" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Framework.Tests.EqualsFixture.PosInfinityEqualsInfinity" executed="True" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Framework.Tests.EqualsFixture.PosInfinityNotEquals" executed="True" success="True" time="0.000" asserts="2" />
+                          <test-case name="NUnit.Framework.Tests.EqualsFixture.PosInfinityNotEqualsNegInfinity" executed="True" success="True" time="0.000" asserts="2" />
+                          <test-case name="NUnit.Framework.Tests.EqualsFixture.ReferenceEqualsThrowsException" executed="True" success="True" time="0.000" asserts="0" />
+                          <test-case name="NUnit.Framework.Tests.EqualsFixture.Short" executed="True" success="True" time="0.000" asserts="2" />
+                          <test-case name="NUnit.Framework.Tests.EqualsFixture.SinglePosInfinityNotEqualsNegInfinity" executed="True" success="True" time="0.016" asserts="2" />
+                          <test-case name="NUnit.Framework.Tests.EqualsFixture.String" executed="True" success="True" time="0.000" asserts="2" />
+                          <test-case name="NUnit.Framework.Tests.EqualsFixture.UInt" executed="True" success="True" time="0.000" asserts="2" />
+                        </results>
+                      </test-suite>
+                      <test-suite name="FileAssertTests" executed="True" success="True" time="0.266" asserts="0">
+                        <results>
+                          <test-case name="NUnit.Framework.Tests.FileAssertTests.AreEqualFailsWhenOneIsNull" executed="True" success="True" time="0.016" asserts="2" />
+                          <test-case name="NUnit.Framework.Tests.FileAssertTests.AreEqualFailsWithFileInfos" executed="True" success="True" time="0.016" asserts="2" />
+                          <test-case name="NUnit.Framework.Tests.FileAssertTests.AreEqualFailsWithFiles" executed="True" success="True" time="0.016" asserts="2" />
+                          <test-case name="NUnit.Framework.Tests.FileAssertTests.AreEqualFailsWithStreams" executed="True" success="True" time="0.016" asserts="2" />
+                          <test-case name="NUnit.Framework.Tests.FileAssertTests.AreEqualFailsWithTextFilesAfterReadingBothFiles" executed="True" success="True" time="0.016" asserts="2" />
+                          <test-case name="NUnit.Framework.Tests.FileAssertTests.AreEqualPassesUsingSameFileTwice" executed="True" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Framework.Tests.FileAssertTests.AreEqualPassesWhenBothAreNull" executed="True" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Framework.Tests.FileAssertTests.AreEqualPassesWithEqualStreams" executed="True" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Framework.Tests.FileAssertTests.AreEqualPassesWithFileInfos" executed="True" success="True" time="0.016" asserts="2" />
+                          <test-case name="NUnit.Framework.Tests.FileAssertTests.AreEqualPassesWithFiles" executed="True" success="True" time="0.016" asserts="1" />
+                          <test-case name="NUnit.Framework.Tests.FileAssertTests.AreEqualPassesWithSameStream" executed="True" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Framework.Tests.FileAssertTests.AreEqualPassesWithTextFiles" executed="True" success="True" time="0.016" asserts="1" />
+                          <test-case name="NUnit.Framework.Tests.FileAssertTests.AreNotEqualFailsWhenBothAreNull" executed="True" success="True" time="0.000" asserts="2" />
+                          <test-case name="NUnit.Framework.Tests.FileAssertTests.AreNotEqualFailsWithFileInfos" executed="True" success="True" time="0.016" asserts="2" />
+                          <test-case name="NUnit.Framework.Tests.FileAssertTests.AreNotEqualFailsWithFiles" executed="True" success="True" time="0.000" asserts="2" />
+                          <test-case name="NUnit.Framework.Tests.FileAssertTests.AreNotEqualFailsWithStreams" executed="True" success="True" time="0.016" asserts="2" />
+                          <test-case name="NUnit.Framework.Tests.FileAssertTests.AreNotEqualIteratesOverTheEntireFile" executed="True" success="True" time="0.016" asserts="1" />
+                          <test-case name="NUnit.Framework.Tests.FileAssertTests.AreNotEqualIteratesOverTheEntireFileAndFails" executed="True" success="True" time="0.016" asserts="2" />
+                          <test-case name="NUnit.Framework.Tests.FileAssertTests.AreNotEqualPassesIfOneIsNull" executed="True" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Framework.Tests.FileAssertTests.AreNotEqualPassesWithFileInfos" executed="True" success="True" time="0.016" asserts="1" />
+                          <test-case name="NUnit.Framework.Tests.FileAssertTests.AreNotEqualPassesWithFiles" executed="True" success="True" time="0.016" asserts="1" />
+                          <test-case name="NUnit.Framework.Tests.FileAssertTests.AreNotEqualPassesWithStreams" executed="True" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Framework.Tests.FileAssertTests.NonReadableStreamGivesException" executed="True" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Framework.Tests.FileAssertTests.NonSeekableStreamGivesException" executed="True" success="True" time="0.016" asserts="1" />
+                        </results>
+                      </test-suite>
+                      <test-suite name="GreaterEqualFixture" executed="True" success="True" time="0.094" asserts="0">
+                        <results>
+                          <test-case name="NUnit.Framework.Tests.GreaterEqualFixture.FailureMessage" executed="True" success="True" time="0.000" asserts="3" />
+                          <test-case name="NUnit.Framework.Tests.GreaterEqualFixture.GreaterOrEqual_Decimal" executed="True" success="True" time="0.000" asserts="2" />
+                          <test-case name="NUnit.Framework.Tests.GreaterEqualFixture.GreaterOrEqual_Double" executed="True" success="True" time="0.000" asserts="2" />
+                          <test-case name="NUnit.Framework.Tests.GreaterEqualFixture.GreaterOrEqual_Float" executed="True" success="True" time="0.000" asserts="2" />
+                          <test-case name="NUnit.Framework.Tests.GreaterEqualFixture.GreaterOrEqual_Int32" executed="True" success="True" time="0.000" asserts="2" />
+                          <test-case name="NUnit.Framework.Tests.GreaterEqualFixture.GreaterOrEqual_Long" executed="True" success="True" time="0.000" asserts="2" />
+                          <test-case name="NUnit.Framework.Tests.GreaterEqualFixture.GreaterOrEqual_UInt32" executed="True" success="True" time="0.000" asserts="2" />
+                          <test-case name="NUnit.Framework.Tests.GreaterEqualFixture.GreaterOrEqual_ULong" executed="True" success="True" time="0.000" asserts="2" />
+                          <test-case name="NUnit.Framework.Tests.GreaterEqualFixture.MixedTypes" executed="True" success="True" time="0.000" asserts="42" />
+                          <test-case name="NUnit.Framework.Tests.GreaterEqualFixture.NotGreaterEqualIComparable" executed="True" success="True" time="0.000" asserts="2" />
+                          <test-case name="NUnit.Framework.Tests.GreaterEqualFixture.NotGreaterOrEqual" executed="True" success="True" time="0.000" asserts="2" />
+                        </results>
+                      </test-suite>
+                      <test-suite name="GreaterFixture" executed="True" success="True" time="0.016" asserts="0">
+                        <results>
+                          <test-case name="NUnit.Framework.Tests.GreaterFixture.FailureMessage" executed="True" success="True" time="0.000" asserts="2" />
+                          <test-case name="NUnit.Framework.Tests.GreaterFixture.Greater" executed="True" success="True" time="0.000" asserts="7" />
+                          <test-case name="NUnit.Framework.Tests.GreaterFixture.MixedTypes" executed="True" success="True" time="0.016" asserts="42" />
+                          <test-case name="NUnit.Framework.Tests.GreaterFixture.NotGreater" executed="True" success="True" time="0.000" asserts="2" />
+                          <test-case name="NUnit.Framework.Tests.GreaterFixture.NotGreaterIComparable" executed="True" success="True" time="0.000" asserts="2" />
+                          <test-case name="NUnit.Framework.Tests.GreaterFixture.NotGreaterWhenEqual" executed="True" success="True" time="0.000" asserts="2" />
+                        </results>
+                      </test-suite>
+                      <test-suite name="LessEqualFixture" executed="True" success="True" time="0.031" asserts="0">
+                        <results>
+                          <test-case name="NUnit.Framework.Tests.LessEqualFixture.FailureMessage" executed="True" success="True" time="0.016" asserts="2" />
+                          <test-case name="NUnit.Framework.Tests.LessEqualFixture.LessOrEqual" executed="True" success="True" time="0.000" asserts="42" />
+                          <test-case name="NUnit.Framework.Tests.LessEqualFixture.MixedTypes" executed="True" success="True" time="0.000" asserts="42" />
+                          <test-case name="NUnit.Framework.Tests.LessEqualFixture.NotLessEqualIComparable" executed="True" success="True" time="0.016" asserts="2" />
+                          <test-case name="NUnit.Framework.Tests.LessEqualFixture.NotLessOrEqual" executed="True" success="True" time="0.000" asserts="2" />
+                        </results>
+                      </test-suite>
+                      <test-suite name="LessFixture" executed="True" success="True" time="0.016" asserts="0">
+                        <results>
+                          <test-case name="NUnit.Framework.Tests.LessFixture.FailureMessage" executed="True" success="True" time="0.000" asserts="3" />
+                          <test-case name="NUnit.Framework.Tests.LessFixture.Less" executed="True" success="True" time="0.000" asserts="18" />
+                          <test-case name="NUnit.Framework.Tests.LessFixture.MixedTypes" executed="True" success="True" time="0.016" asserts="42" />
+                          <test-case name="NUnit.Framework.Tests.LessFixture.NotLess" executed="True" success="True" time="0.000" asserts="2" />
+                          <test-case name="NUnit.Framework.Tests.LessFixture.NotLessIComparable" executed="True" success="True" time="0.000" asserts="2" />
+                          <test-case name="NUnit.Framework.Tests.LessFixture.NotLessWhenEqual" executed="True" success="True" time="0.000" asserts="2" />
+                        </results>
+                      </test-suite>
+                      <test-suite name="ListContentsTests" executed="True" success="True" time="0.016" asserts="0">
+                        <results>
+                          <test-case name="NUnit.Framework.Tests.ListContentsTests.ArrayFails" executed="True" success="True" time="0.000" asserts="2" />
+                          <test-case name="NUnit.Framework.Tests.ListContentsTests.ArrayListFails" executed="True" success="True" time="0.000" asserts="2" />
+                          <test-case name="NUnit.Framework.Tests.ListContentsTests.ArrayListSucceeds" executed="True" success="True" time="0.000" asserts="3" />
+                          <test-case name="NUnit.Framework.Tests.ListContentsTests.ArraySucceeds" executed="True" success="True" time="0.000" asserts="3" />
+                          <test-case name="NUnit.Framework.Tests.ListContentsTests.DifferentTypesMayBeEqual" executed="True" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Framework.Tests.ListContentsTests.EmptyArrayFails" executed="True" success="True" time="0.000" asserts="2" />
+                          <test-case name="NUnit.Framework.Tests.ListContentsTests.NullArrayIsError" executed="True" success="True" time="0.000" asserts="1" />
+                        </results>
+                      </test-suite>
+                      <test-suite name="NotEqualFixture" executed="True" success="True" time="0.016" asserts="0">
+                        <results>
+                          <test-case name="NUnit.Framework.Tests.NotEqualFixture.ArraysNotEqual" executed="True" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Framework.Tests.NotEqualFixture.ArraysNotEqualFails" executed="True" success="True" time="0.000" asserts="2" />
+                          <test-case name="NUnit.Framework.Tests.NotEqualFixture.NotEqual" executed="True" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Framework.Tests.NotEqualFixture.NotEqualFails" executed="True" success="True" time="0.000" asserts="2" />
+                          <test-case name="NUnit.Framework.Tests.NotEqualFixture.NotEqualSameTypes" executed="True" success="True" time="0.000" asserts="21" />
+                          <test-case name="NUnit.Framework.Tests.NotEqualFixture.NullEqualsNull" executed="True" success="True" time="0.000" asserts="2" />
+                          <test-case name="NUnit.Framework.Tests.NotEqualFixture.NullNotEqualToNonNull" executed="True" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Framework.Tests.NotEqualFixture.UInt" executed="True" success="True" time="0.000" asserts="1" />
+                        </results>
+                      </test-suite>
+                      <test-suite name="NotSameFixture" executed="True" success="True" time="0.000" asserts="0">
+                        <results>
+                          <test-case name="NUnit.Framework.Tests.NotSameFixture.NotSame" executed="True" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Framework.Tests.NotSameFixture.NotSameFails" executed="True" success="True" time="0.000" asserts="2" />
+                        </results>
+                      </test-suite>
+                      <test-suite name="NullableTypesTests" executed="True" success="True" time="0.016" asserts="0">
+                        <categories>
+                          <category name="Generics" />
+                        </categories>
+                        <results>
+                          <test-case name="NUnit.Framework.Tests.NullableTypesTests.CanCompareNullableDecimals" executed="True" success="True" time="0.000" asserts="12" />
+                          <test-case name="NUnit.Framework.Tests.NullableTypesTests.CanCompareNullableDoubles" executed="True" success="True" time="0.000" asserts="12" />
+                          <test-case name="NUnit.Framework.Tests.NullableTypesTests.CanCompareNullableEnums" executed="True" success="True" time="0.000" asserts="3" />
+                          <test-case name="NUnit.Framework.Tests.NullableTypesTests.CanCompareNullableInts" executed="True" success="True" time="0.000" asserts="12" />
+                          <test-case name="NUnit.Framework.Tests.NullableTypesTests.CanCompareNullableMixedNumerics" executed="True" success="True" time="0.016" asserts="54" />
+                          <test-case name="NUnit.Framework.Tests.NullableTypesTests.CanCompareNullableStructs" executed="True" success="True" time="0.000" asserts="4" />
+                          <test-case name="NUnit.Framework.Tests.NullableTypesTests.CanCompareWithTolerance" executed="True" success="True" time="0.000" asserts="4" />
+                          <test-case name="NUnit.Framework.Tests.NullableTypesTests.CanTestForNaN" executed="True" success="True" time="0.000" asserts="2" />
+                          <test-case name="NUnit.Framework.Tests.NullableTypesTests.CanTestForNull" executed="True" success="True" time="0.000" asserts="4" />
+                        </results>
+                      </test-suite>
+                      <test-suite name="RandomizerTests" executed="True" success="True" time="0.000" asserts="0">
+                        <results>
+                          <test-case name="NUnit.Framework.Tests.RandomizerTests.RandomDoublesAreUnique" executed="True" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Framework.Tests.RandomizerTests.RandomIntsAreUnique" executed="True" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Framework.Tests.RandomizerTests.RandomizersWithDifferentSeedsReturnDifferentValues" executed="True" success="True" time="0.000" asserts="10" />
+                          <test-case name="NUnit.Framework.Tests.RandomizerTests.RandomizersWithSameSeedsReturnSameValues" executed="True" success="True" time="0.000" asserts="10" />
+                          <test-case name="NUnit.Framework.Tests.RandomizerTests.RandomSeedsAreUnique" executed="True" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Framework.Tests.RandomizerTests.ReturnsDifferentRandomizersForDifferentMethods" executed="True" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Framework.Tests.RandomizerTests.ReturnsSameRandomizerForDifferentParametersOfSameMethod" executed="True" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Framework.Tests.RandomizerTests.ReturnsSameRandomizerForSameMethod" executed="True" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Framework.Tests.RandomizerTests.ReturnsSameRandomizerForSameParameter" executed="True" success="True" time="0.000" asserts="1" />
+                        </results>
+                      </test-suite>
+                      <test-suite name="RangeTests" executed="True" success="True" time="0.016" asserts="0">
+                        <results>
+                          <test-case name="NUnit.Framework.Tests.RangeTests.InRangeFails" executed="True" success="True" time="0.000" asserts="2" />
+                          <test-case name="NUnit.Framework.Tests.RangeTests.InRangeSucceeds" executed="True" success="True" time="0.000" asserts="3" />
+                          <test-case name="NUnit.Framework.Tests.RangeTests.NotInRangeFails" executed="True" success="True" time="0.016" asserts="2" />
+                          <test-case name="NUnit.Framework.Tests.RangeTests.NotInRangeSucceeds" executed="True" success="True" time="0.000" asserts="2" />
+                        </results>
+                      </test-suite>
+                      <test-suite name="SameFixture" executed="True" success="True" time="0.016" asserts="0">
+                        <results>
+                          <test-case name="NUnit.Framework.Tests.SameFixture.Same" executed="True" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Framework.Tests.SameFixture.SameFails" executed="True" success="True" time="0.000" asserts="2" />
+                          <test-case name="NUnit.Framework.Tests.SameFixture.SameValueTypes" executed="True" success="True" time="0.000" asserts="2" />
+                        </results>
+                      </test-suite>
+                      <test-suite name="StringAssertTests" executed="True" success="True" time="0.031" asserts="0">
+                        <results>
+                          <test-case name="NUnit.Framework.Tests.StringAssertTests.CaseInsensitiveCompare" executed="True" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Framework.Tests.StringAssertTests.CaseInsensitiveCompareFails" executed="True" success="True" time="0.000" asserts="2" />
+                          <test-case name="NUnit.Framework.Tests.StringAssertTests.Contains" executed="True" success="True" time="0.000" asserts="3" />
+                          <test-case name="NUnit.Framework.Tests.StringAssertTests.ContainsFails" executed="True" success="True" time="0.000" asserts="2" />
+                          <test-case name="NUnit.Framework.Tests.StringAssertTests.DifferentEncodingsOfSameStringAreNotEqual" executed="True" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Framework.Tests.StringAssertTests.DoesNotContain" executed="True" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Framework.Tests.StringAssertTests.DoesNotContainFails" executed="True" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Framework.Tests.StringAssertTests.DoesNotEndWith" executed="True" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Framework.Tests.StringAssertTests.DoesNotEndWithFails" executed="True" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Framework.Tests.StringAssertTests.DoesNotStartWith" executed="True" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Framework.Tests.StringAssertTests.DoesNotStartWithFails" executed="True" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Framework.Tests.StringAssertTests.EndsWith" executed="True" success="True" time="0.000" asserts="2" />
+                          <test-case name="NUnit.Framework.Tests.StringAssertTests.EndsWithFails" executed="True" success="True" time="0.016" asserts="2" />
+                          <test-case name="NUnit.Framework.Tests.StringAssertTests.IsMatch" executed="True" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Framework.Tests.StringAssertTests.IsMatchFails" executed="True" success="True" time="0.000" asserts="2" />
+                          <test-case name="NUnit.Framework.Tests.StringAssertTests.StartsWith" executed="True" success="True" time="0.000" asserts="2" />
+                          <test-case name="NUnit.Framework.Tests.StringAssertTests.StartsWithFails" executed="True" success="True" time="0.000" asserts="2" />
+                        </results>
+                      </test-suite>
+                      <test-suite name="TestFixtureAttributeTests" executed="True" success="True" time="0.000" asserts="0">
+                        <results>
+                          <test-case name="NUnit.Framework.Tests.TestFixtureAttributeTests.ConstructWithCombinedArgs" executed="True" success="True" time="0.000" asserts="2">
+                            <categories>
+                              <category name="Generics" />
+                            </categories>
+                          </test-case>
+                          <test-case name="NUnit.Framework.Tests.TestFixtureAttributeTests.ConstructWithFixtureArgs" executed="True" success="True" time="0.000" asserts="2" />
+                          <test-case name="NUnit.Framework.Tests.TestFixtureAttributeTests.ConstructWithFixtureArgsAndSetTypeArgs" executed="True" success="True" time="0.000" asserts="2">
+                            <categories>
+                              <category name="Generics" />
+                            </categories>
+                          </test-case>
+                          <test-case name="NUnit.Framework.Tests.TestFixtureAttributeTests.ConstructWithJustTypeArgs" executed="True" success="True" time="0.000" asserts="2">
+                            <categories>
+                              <category name="Generics" />
+                            </categories>
+                          </test-case>
+                          <test-case name="NUnit.Framework.Tests.TestFixtureAttributeTests.ConstructWithNoArgumentsAndSetTypeArgs" executed="True" success="True" time="0.000" asserts="2">
+                            <categories>
+                              <category name="Generics" />
+                            </categories>
+                          </test-case>
+                          <test-case name="NUnit.Framework.Tests.TestFixtureAttributeTests.ConstructWithoutArguments" executed="True" success="True" time="0.000" asserts="2" />
+                        </results>
+                      </test-suite>
+                      <test-suite name="TextMessageWriterTests" executed="True" success="True" time="0.000" asserts="0">
+                        <results>
+                          <test-case name="NUnit.Framework.Tests.TextMessageWriterTests.ConnectorIsWrittenWithSurroundingSpaces" executed="True" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Framework.Tests.TextMessageWriterTests.DateTimeTest" executed="True" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Framework.Tests.TextMessageWriterTests.DecimalIsWrittenToTwentyNineDigits" executed="True" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Framework.Tests.TextMessageWriterTests.DecimalIsWrittenWithTrailingM" executed="True" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Framework.Tests.TextMessageWriterTests.DisplayStringDifferences" executed="True" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Framework.Tests.TextMessageWriterTests.DisplayStringDifferences_NoClipping" executed="True" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Framework.Tests.TextMessageWriterTests.DoubleIsWrittenToSeventeenDigits" executed="True" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Framework.Tests.TextMessageWriterTests.DoubleIsWrittenWithTrailingD" executed="True" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Framework.Tests.TextMessageWriterTests.FloatIsWrittenToNineDigits" executed="True" success="True" time="0.000" asserts="2" />
+                          <test-case name="NUnit.Framework.Tests.TextMessageWriterTests.FloatIsWrittenWithTrailingF" executed="True" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Framework.Tests.TextMessageWriterTests.IntegerIsWrittenAsIs" executed="True" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Framework.Tests.TextMessageWriterTests.PredicateIsWrittenWithTrailingSpace" executed="True" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Framework.Tests.TextMessageWriterTests.StringIsWrittenWithQuotes" executed="True" success="True" time="0.000" asserts="1" />
+                        </results>
+                      </test-suite>
+                      <test-suite name="TypeAssertTests" executed="True" success="True" time="0.047" asserts="0">
+                        <results>
+                          <test-case name="NUnit.Framework.Tests.TypeAssertTests.ExactType" executed="True" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Framework.Tests.TypeAssertTests.ExactTypeFails" executed="True" success="True" time="0.000" asserts="2" />
+                          <test-case name="NUnit.Framework.Tests.TypeAssertTests.IsAssignableFrom" executed="True" success="True" time="0.000" asserts="3" />
+                          <test-case name="NUnit.Framework.Tests.TypeAssertTests.IsAssignableFromFails" executed="True" success="True" time="0.000" asserts="2" />
+                          <test-case name="NUnit.Framework.Tests.TypeAssertTests.IsInstanceOf" executed="True" success="True" time="0.000" asserts="3" />
+                          <test-case name="NUnit.Framework.Tests.TypeAssertTests.IsInstanceOfFails" executed="True" success="True" time="0.000" asserts="2" />
+                          <test-case name="NUnit.Framework.Tests.TypeAssertTests.IsNotAssignableFrom" executed="True" success="True" time="0.000" asserts="3" />
+                          <test-case name="NUnit.Framework.Tests.TypeAssertTests.IsNotAssignableFromFails" executed="True" success="True" time="0.047" asserts="2" />
+                          <test-case name="NUnit.Framework.Tests.TypeAssertTests.IsNotInstanceOf" executed="True" success="True" time="0.000" asserts="3" />
+                          <test-case name="NUnit.Framework.Tests.TypeAssertTests.IsNotInstanceOfFails" executed="True" success="True" time="0.000" asserts="2" />
+                        </results>
+                      </test-suite>
+                      <test-suite name="ValuesAttributeTests" executed="True" success="True" time="0.000" asserts="0">
+                        <results>
+                          <test-case name="NUnit.Framework.Tests.ValuesAttributeTests.RangeAttributeWithDoubleRangeAndStep" executed="True" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Framework.Tests.ValuesAttributeTests.RangeAttributeWithFloatRangeAndStep" executed="True" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Framework.Tests.ValuesAttributeTests.RangeAttributeWithIntRange" executed="True" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Framework.Tests.ValuesAttributeTests.RangeAttributeWithIntRangeAndStep" executed="True" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Framework.Tests.ValuesAttributeTests.RangeAttributeWithLongRangeAndStep" executed="True" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Framework.Tests.ValuesAttributeTests.ValuesAttributeProvidesSpecifiedValues" executed="True" success="True" time="0.000" asserts="1" />
+                        </results>
+                      </test-suite>
+                    </results>
+                  </test-suite>
+                </results>
+              </test-suite>
+            </results>
+          </test-suite>
+        </results>
+      </test-suite>
+      <test-suite name="C:\Program Files\NUnit 2.5.2\bin\net-2.0\tests/nunit.core.tests.dll" executed="True" success="True" time="15.563" asserts="0">
+        <results>
+          <test-suite name="NUnit" executed="True" success="True" time="15.469" asserts="0">
+            <results>
+              <test-suite name="Core" executed="True" success="True" time="15.219" asserts="0">
+                <results>
+                  <test-suite name="Tests" executed="True" success="True" time="15.172" asserts="0">
+                    <results>
+                      <test-suite name="AssemblyReaderTests" executed="True" success="True" time="1.156" asserts="0">
+                        <results>
+                          <test-case name="NUnit.Core.Tests.AssemblyReaderTests.CreateFromAssembly" executed="True" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Core.Tests.AssemblyReaderTests.CreateFromPath" executed="True" success="True" time="0.094" asserts="1" />
+                          <test-case name="NUnit.Core.Tests.AssemblyReaderTests.ImageRuntimeVersion" executed="True" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Core.Tests.AssemblyReaderTests.IsDotNetFile" executed="True" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Core.Tests.AssemblyReaderTests.IsValidPeFile" executed="True" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Core.Tests.AssemblyReaderTests.IsValidPeFile_Fails" executed="True" success="True" time="0.000" asserts="1" />
+                        </results>
+                      </test-suite>
+                      <test-suite name="AssemblyResolverTests" executed="True" success="True" time="0.188" asserts="0">
+                        <results>
+                          <test-case name="NUnit.Core.Tests.AssemblyResolverTests.AddFile" executed="True" success="True" time="0.156" asserts="0" />
+                        </results>
+                      </test-suite>
+                      <test-suite name="AssemblyTests" executed="True" success="True" time="0.391" asserts="0">
+                        <results>
+                          <test-case name="NUnit.Core.Tests.AssemblyTests.AppSettingsLoaded" executed="True" success="True" time="0.000" asserts="3" />
+                          <test-case name="NUnit.Core.Tests.AssemblyTests.LoadAssembly" executed="True" success="True" time="0.266" asserts="2" />
+                          <test-case name="NUnit.Core.Tests.AssemblyTests.LoadAssemblyNotFound" executed="True" success="True" time="0.000" asserts="0" />
+                          <test-case name="NUnit.Core.Tests.AssemblyTests.LoadAssemblyWithoutTestFixtures" executed="True" success="True" time="0.078" asserts="4" />
+                          <test-case name="NUnit.Core.Tests.AssemblyTests.LoadTestFixtureFromAssembly" executed="True" success="True" time="0.016" asserts="1" />
+                          <test-case name="NUnit.Core.Tests.AssemblyTests.NUnitTraceIsEnabled" executed="True" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Core.Tests.AssemblyTests.RunSetsCurrentDirectory" executed="True" success="True" time="0.000" asserts="1" />
+                        </results>
+                      </test-suite>
+                      <test-suite name="AssemblyVersionFixture" executed="True" success="True" time="0.016" asserts="0">
+                        <results>
+                          <test-case name="NUnit.Core.Tests.AssemblyVersionFixture.Version" executed="True" success="True" time="0.016" asserts="1" />
+                        </results>
+                      </test-suite>
+                      <test-suite name="AssertInconclusiveFixture" executed="True" success="True" time="0.000" asserts="0">
+                        <results>
+                          <test-case name="NUnit.Core.Tests.AssertInconclusiveFixture.AssertInconclusiveThrowsException" executed="True" success="True" time="0.000" asserts="2" />
+                        </results>
+                      </test-suite>
+                      <test-suite name="AssertPassFixture" executed="True" success="True" time="0.016" asserts="0">
+                        <results>
+                          <test-case name="NUnit.Core.Tests.AssertPassFixture.AssertPassReturnsSuccess" executed="True" success="True" time="0.016" asserts="0" />
+                          <test-case name="NUnit.Core.Tests.AssertPassFixture.SubsequentFailureIsIrrelevant" executed="True" success="True" time="0.000" asserts="0" />
+                        </results>
+                      </test-suite>
+                      <test-suite name="AttributeInheritance" executed="True" success="True" time="0.016" asserts="0">
+                        <results>
+                          <test-case name="NUnit.Core.Tests.AttributeInheritance.InheritedFixtureAttributeIsRecognized" executed="True" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Core.Tests.AttributeInheritance.InheritedTestAttributeIsRecognized" executed="True" success="True" time="0.016" asserts="1" />
+                        </results>
+                      </test-suite>
+                      <test-suite name="CallContextTests" executed="True" success="True" time="0.016" asserts="0">
+                        <results>
+                          <test-case name="NUnit.Core.Tests.CallContextTests.GenericPrincipalTest" executed="True" success="True" time="0.000" asserts="0" />
+                          <test-case name="NUnit.Core.Tests.CallContextTests.ILogicalThreadAffinativeTest" executed="True" success="True" time="0.000" asserts="0" />
+                          <test-case name="NUnit.Core.Tests.CallContextTests.ILogicalThreadAffinativeTestConsole" executed="True" success="True" time="0.000" asserts="0" />
+                          <test-case name="NUnit.Core.Tests.CallContextTests.SetCustomPrincipalOnThread" executed="True" success="True" time="0.000" asserts="0" />
+                          <test-case name="NUnit.Core.Tests.CallContextTests.SetGenericPrincipalOnThread" executed="True" success="True" time="0.000" asserts="0" />
+                          <test-case name="NUnit.Core.Tests.CallContextTests.UseCustomIdentity" executed="True" success="True" time="0.000" asserts="0" />
+                        </results>
+                      </test-suite>
+                      <test-suite name="CategoryAttributeTests" executed="True" success="True" time="0.016" asserts="0">
+                        <results>
+                          <test-case name="NUnit.Core.Tests.CategoryAttributeTests.CanDeriveFromCategoryAttribute" executed="True" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Core.Tests.CategoryAttributeTests.CategoryOnFixture" executed="True" success="True" time="0.016" asserts="1" />
+                          <test-case name="NUnit.Core.Tests.CategoryAttributeTests.CategoryOnTestCase" executed="True" success="True" time="0.000" asserts="1" />
+                        </results>
+                      </test-suite>
+                      <test-suite name="CombinatorialTests" executed="True" success="True" time="0.000" asserts="0">
+                        <results>
+                          <test-suite name="RandomArgsAreIndependent" executed="True" success="True" time="0.000" asserts="0">
+                            <results>
+                              <test-case name="NUnit.Core.Tests.CombinatorialTests.RandomArgsAreIndependent(0.55076334837394d,0.857465667583731d)" executed="True" success="True" time="0.000" asserts="1" />
+                            </results>
+                          </test-suite>
+                          <test-suite name="RandomTest" executed="True" success="True" time="0.000" asserts="0">
+                            <results>
+                              <test-case name="NUnit.Core.Tests.CombinatorialTests.RandomTest(98,0.182266548360822d)" executed="True" success="True" time="0.000" asserts="2" />
+                              <test-case name="NUnit.Core.Tests.CombinatorialTests.RandomTest(168,0.443459582255902d)" executed="True" success="True" time="0.000" asserts="2" />
+                              <test-case name="NUnit.Core.Tests.CombinatorialTests.RandomTest(193,0.634647673291456d)" executed="True" success="True" time="0.000" asserts="2" />
+                              <test-case name="NUnit.Core.Tests.CombinatorialTests.RandomTest(48,0.670450251861685d)" executed="True" success="True" time="0.000" asserts="2" />
+                              <test-case name="NUnit.Core.Tests.CombinatorialTests.RandomTest(88,0.35110911603603d)" executed="True" success="True" time="0.000" asserts="2" />
+                            </results>
+                          </test-suite>
+                          <test-suite name="RangeTest" executed="True" success="True" time="0.000" asserts="0">
+                            <results>
+                              <test-case name="NUnit.Core.Tests.CombinatorialTests.RangeTest(0.2d,10)" executed="True" success="True" time="0.000" asserts="0" />
+                              <test-case name="NUnit.Core.Tests.CombinatorialTests.RangeTest(0.2d,15)" executed="True" success="True" time="0.000" asserts="0" />
+                              <test-case name="NUnit.Core.Tests.CombinatorialTests.RangeTest(0.2d,20)" executed="True" success="True" time="0.000" asserts="0" />
+                              <test-case name="NUnit.Core.Tests.CombinatorialTests.RangeTest(0.4d,10)" executed="True" success="True" time="0.000" asserts="0" />
+                              <test-case name="NUnit.Core.Tests.CombinatorialTests.RangeTest(0.4d,15)" executed="True" success="True" time="0.000" asserts="0" />
+                              <test-case name="NUnit.Core.Tests.CombinatorialTests.RangeTest(0.4d,20)" executed="True" success="True" time="0.000" asserts="0" />
+                              <test-case name="NUnit.Core.Tests.CombinatorialTests.RangeTest(0.6d,10)" executed="True" success="True" time="0.000" asserts="0" />
+                              <test-case name="NUnit.Core.Tests.CombinatorialTests.RangeTest(0.6d,15)" executed="True" success="True" time="0.000" asserts="0" />
+                              <test-case name="NUnit.Core.Tests.CombinatorialTests.RangeTest(0.6d,20)" executed="True" success="True" time="0.000" asserts="0" />
+                            </results>
+                          </test-suite>
+                          <test-suite name="SingleArgument" executed="True" success="True" time="0.000" asserts="0">
+                            <results>
+                              <test-case name="NUnit.Core.Tests.CombinatorialTests.SingleArgument(1.3d)" executed="True" success="True" time="0.000" asserts="1" />
+                              <test-case name="NUnit.Core.Tests.CombinatorialTests.SingleArgument(1.7d)" executed="True" success="True" time="0.000" asserts="1" />
+                              <test-case name="NUnit.Core.Tests.CombinatorialTests.SingleArgument(1.5d)" executed="True" success="True" time="0.000" asserts="1" />
+                            </results>
+                          </test-suite>
+                          <test-suite name="ThreeArguments_Combinatorial" executed="True" success="True" time="0.000" asserts="0">
+                            <results>
+                              <test-case name="NUnit.Core.Tests.CombinatorialTests.ThreeArguments_Combinatorial(1,10,&quot;Charlie&quot;)" executed="True" success="True" time="0.000" asserts="2" />
+                              <test-case name="NUnit.Core.Tests.CombinatorialTests.ThreeArguments_Combinatorial(1,10,&quot;Joe&quot;)" executed="True" success="True" time="0.000" asserts="2" />
+                              <test-case name="NUnit.Core.Tests.CombinatorialTests.ThreeArguments_Combinatorial(1,10,&quot;Frank&quot;)" executed="True" success="True" time="0.000" asserts="2" />
+                              <test-case name="NUnit.Core.Tests.CombinatorialTests.ThreeArguments_Combinatorial(1,20,&quot;Charlie&quot;)" executed="True" success="True" time="0.000" asserts="2" />
+                              <test-case name="NUnit.Core.Tests.CombinatorialTests.ThreeArguments_Combinatorial(1,20,&quot;Joe&quot;)" executed="True" success="True" time="0.000" asserts="2" />
+                              <test-case name="NUnit.Core.Tests.CombinatorialTests.ThreeArguments_Combinatorial(1,20,&quot;Frank&quot;)" executed="True" success="True" time="0.000" asserts="2" />
+                              <test-case name="NUnit.Core.Tests.CombinatorialTests.ThreeArguments_Combinatorial(2,10,&quot;Charlie&quot;)" executed="True" success="True" time="0.000" asserts="2" />
+                              <test-case name="NUnit.Core.Tests.CombinatorialTests.ThreeArguments_Combinatorial(2,10,&quot;Joe&quot;)" executed="True" success="True" time="0.000" asserts="2" />
+                              <test-case name="NUnit.Core.Tests.CombinatorialTests.ThreeArguments_Combinatorial(2,10,&quot;Frank&quot;)" executed="True" success="True" time="0.000" asserts="2" />
+                              <test-case name="NUnit.Core.Tests.CombinatorialTests.ThreeArguments_Combinatorial(2,20,&quot;Charlie&quot;)" executed="True" success="True" time="0.000" asserts="2" />
+                              <test-case name="NUnit.Core.Tests.CombinatorialTests.ThreeArguments_Combinatorial(2,20,&quot;Joe&quot;)" executed="True" success="True" time="0.000" asserts="2" />
+                              <test-case name="NUnit.Core.Tests.CombinatorialTests.ThreeArguments_Combinatorial(2,20,&quot;Frank&quot;)" executed="True" success="True" time="0.000" asserts="2" />
+                              <test-case name="NUnit.Core.Tests.CombinatorialTests.ThreeArguments_Combinatorial(3,10,&quot;Charlie&quot;)" executed="True" success="True" time="0.000" asserts="2" />
+                              <test-case name="NUnit.Core.Tests.CombinatorialTests.ThreeArguments_Combinatorial(3,10,&quot;Joe&quot;)" executed="True" success="True" time="0.000" asserts="2" />
+                              <test-case name="NUnit.Core.Tests.CombinatorialTests.ThreeArguments_Combinatorial(3,10,&quot;Frank&quot;)" executed="True" success="True" time="0.000" asserts="2" />
+                              <test-case name="NUnit.Core.Tests.CombinatorialTests.ThreeArguments_Combinatorial(3,20,&quot;Charlie&quot;)" executed="True" success="True" time="0.000" asserts="2" />
+                              <test-case name="NUnit.Core.Tests.CombinatorialTests.ThreeArguments_Combinatorial(3,20,&quot;Joe&quot;)" executed="True" success="True" time="0.000" asserts="2" />
+                              <test-case name="NUnit.Core.Tests.CombinatorialTests.ThreeArguments_Combinatorial(3,20,&quot;Frank&quot;)" executed="True" success="True" time="0.000" asserts="2" />
+                            </results>
+                          </test-suite>
+                          <test-suite name="ThreeArguments_Sequential" executed="True" success="True" time="0.000" asserts="0">
+                            <results>
+                              <test-case name="NUnit.Core.Tests.CombinatorialTests.ThreeArguments_Sequential(1,10,&quot;Charlie&quot;)" executed="True" success="True" time="0.000" asserts="2" />
+                              <test-case name="NUnit.Core.Tests.CombinatorialTests.ThreeArguments_Sequential(2,20,&quot;Joe&quot;)" executed="True" success="True" time="0.000" asserts="2" />
+                              <test-case name="NUnit.Core.Tests.CombinatorialTests.ThreeArguments_Sequential(3,null,&quot;Frank&quot;)" executed="True" success="True" time="0.000" asserts="2" />
+                            </results>
+                          </test-suite>
+                          <test-suite name="TwoArguments_Combinatorial" executed="True" success="True" time="0.000" asserts="0">
+                            <results>
+                              <test-case name="NUnit.Core.Tests.CombinatorialTests.TwoArguments_Combinatorial(1,10)" executed="True" success="True" time="0.000" asserts="1" />
+                              <test-case name="NUnit.Core.Tests.CombinatorialTests.TwoArguments_Combinatorial(1,20)" executed="True" success="True" time="0.000" asserts="1" />
+                              <test-case name="NUnit.Core.Tests.CombinatorialTests.TwoArguments_Combinatorial(2,10)" executed="True" success="True" time="0.000" asserts="1" />
+                              <test-case name="NUnit.Core.Tests.CombinatorialTests.TwoArguments_Combinatorial(2,20)" executed="True" success="True" time="0.000" asserts="1" />
+                              <test-case name="NUnit.Core.Tests.CombinatorialTests.TwoArguments_Combinatorial(3,10)" executed="True" success="True" time="0.000" asserts="1" />
+                              <test-case name="NUnit.Core.Tests.CombinatorialTests.TwoArguments_Combinatorial(3,20)" executed="True" success="True" time="0.000" asserts="1" />
+                            </results>
+                          </test-suite>
+                          <test-suite name="TwoArguments_Sequential" executed="True" success="True" time="0.000" asserts="0">
+                            <results>
+                              <test-case name="NUnit.Core.Tests.CombinatorialTests.TwoArguments_Sequential(1,10)" executed="True" success="True" time="0.000" asserts="1" />
+                              <test-case name="NUnit.Core.Tests.CombinatorialTests.TwoArguments_Sequential(2,20)" executed="True" success="True" time="0.000" asserts="1" />
+                              <test-case name="NUnit.Core.Tests.CombinatorialTests.TwoArguments_Sequential(3,null)" executed="True" success="True" time="0.000" asserts="1" />
+                            </results>
+                          </test-suite>
+                        </results>
+                      </test-suite>
+                      <test-suite name="CoreExtensionsTests" executed="True" success="True" time="0.016" asserts="0">
+                        <results>
+                          <test-case name="NUnit.Core.Tests.CoreExtensionsTests.CanAddDecorator" executed="True" success="True" time="0.016" asserts="2" />
+                          <test-case name="NUnit.Core.Tests.CoreExtensionsTests.CanAddEventListener" executed="True" success="True" time="0.000" asserts="4" />
+                          <test-case name="NUnit.Core.Tests.CoreExtensionsTests.CanAddSuiteBuilder" executed="True" success="True" time="0.000" asserts="4" />
+                          <test-case name="NUnit.Core.Tests.CoreExtensionsTests.CanAddTestCaseBuilder" executed="True" success="True" time="0.000" asserts="4" />
+                          <test-case name="NUnit.Core.Tests.CoreExtensionsTests.CanAddTestCaseBuilder2" executed="True" success="True" time="0.000" asserts="4" />
+                          <test-case name="NUnit.Core.Tests.CoreExtensionsTests.DecoratorsRunInOrderOfPriorities" executed="True" success="True" time="0.000" asserts="2" />
+                          <test-case name="NUnit.Core.Tests.CoreExtensionsTests.HasEventListenerExtensionPoint" executed="True" success="True" time="0.000" asserts="3" />
+                          <test-case name="NUnit.Core.Tests.CoreExtensionsTests.HasSuiteBuildersExtensionPoint" executed="True" success="True" time="0.000" asserts="3" />
+                          <test-case name="NUnit.Core.Tests.CoreExtensionsTests.HasTestCaseBuildersExtensionPoint" executed="True" success="True" time="0.000" asserts="3" />
+                          <test-case name="NUnit.Core.Tests.CoreExtensionsTests.HasTestDecoratorsExtensionPoint" executed="True" success="True" time="0.000" asserts="3" />
+                          <test-case name="NUnit.Core.Tests.CoreExtensionsTests.HasTestFrameworkRegistry" executed="True" success="True" time="0.000" asserts="3" />
+                        </results>
+                      </test-suite>
+                      <test-suite name="CultureSettingAndDetectionTests" executed="True" success="True" time="0.156" asserts="0">
+                        <results>
+                          <test-case name="NUnit.Core.Tests.CultureSettingAndDetectionTests.CanMatchAttributeWithExclude" executed="True" success="True" time="0.000" asserts="2" />
+                          <test-case name="NUnit.Core.Tests.CultureSettingAndDetectionTests.CanMatchAttributeWithInclude" executed="True" success="True" time="0.109" asserts="2" />
+                          <test-case name="NUnit.Core.Tests.CultureSettingAndDetectionTests.CanMatchAttributeWithIncludeAndExclude" executed="True" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Core.Tests.CultureSettingAndDetectionTests.CanMatchStrings" executed="True" success="True" time="0.000" asserts="5" />
+                          <test-case name="NUnit.Core.Tests.CultureSettingAndDetectionTests.LoadWithFrenchCanadianCulture" executed="True" success="True" time="0.000" asserts="5" />
+                          <test-case name="NUnit.Core.Tests.CultureSettingAndDetectionTests.LoadWithFrenchCulture" executed="True" success="True" time="0.016" asserts="5" />
+                          <test-case name="NUnit.Core.Tests.CultureSettingAndDetectionTests.LoadWithRussianCulture" executed="True" success="True" time="0.016" asserts="5" />
+                          <test-case name="NUnit.Core.Tests.CultureSettingAndDetectionTests.SettingInvalidCultureGivesError" executed="True" success="True" time="0.000" asserts="3" />
+                        </results>
+                      </test-suite>
+                      <test-suite name="CultureSettingAndDetectionTests+NestedFixture" executed="True" success="True" time="0.000" asserts="0">
+                        <results>
+                          <test-case name="NUnit.Core.Tests.CultureSettingAndDetectionTests+NestedFixture.CanSetCultureOnFixture" executed="True" success="True" time="0.000" asserts="1" />
+                        </results>
+                      </test-suite>
+                      <test-suite name="DirectorySwapperTests" executed="True" success="True" time="0.000" asserts="0">
+                        <results>
+                          <test-case name="NUnit.Core.Tests.DirectorySwapperTests.ChangeAndRestore" executed="True" success="True" time="0.000" asserts="3" />
+                          <test-case name="NUnit.Core.Tests.DirectorySwapperTests.SwapAndRestore" executed="True" success="True" time="0.000" asserts="2" />
+                        </results>
+                      </test-suite>
+                      <test-suite name="EventQueueTests" executed="True" success="True" time="0.016" asserts="0">
+                        <results>
+                          <test-case name="NUnit.Core.Tests.EventQueueTests.PumpAutoStopsOnRunFinished" executed="True" success="True" time="0.000" asserts="3" />
+                          <test-case name="NUnit.Core.Tests.EventQueueTests.PumpEvents" executed="True" success="True" time="0.016" asserts="9" />
+                          <test-case name="NUnit.Core.Tests.EventQueueTests.PumpEventsWithAutoStop" executed="True" success="True" time="0.000" asserts="2" />
+                          <test-case name="NUnit.Core.Tests.EventQueueTests.QueueEvents" executed="True" success="True" time="0.000" asserts="6" />
+                          <test-case name="NUnit.Core.Tests.EventQueueTests.SendEvents" executed="True" success="True" time="0.000" asserts="6" />
+                          <test-case name="NUnit.Core.Tests.EventQueueTests.StartAndStopPumpOnEmptyQueue" executed="True" success="True" time="0.000" asserts="2" />
+                        </results>
+                      </test-suite>
+                      <test-suite name="EventTestFixture" description="Tests that proper events are generated when running  test" executed="True" success="True" time="0.266" asserts="0">
+                        <results>
+                          <test-case name="NUnit.Core.Tests.EventTestFixture.CheckEventListening" executed="True" success="True" time="0.266" asserts="4" />
+                        </results>
+                      </test-suite>
+                      <test-suite name="ExpectExceptionTest" executed="True" success="True" time="0.203" asserts="0">
+                        <results>
+                          <test-case name="NUnit.Core.Tests.ExpectExceptionTest.AssertFailBeforeException" executed="True" success="True" time="0.016" asserts="2" />
+                          <test-case name="NUnit.Core.Tests.ExpectExceptionTest.CanExpectUnspecifiedException" executed="True" success="True" time="0.000" asserts="0" />
+                          <test-case name="NUnit.Core.Tests.ExpectExceptionTest.ExceptionHandlerIsCalledWhenExceptionMatches" executed="True" success="True" time="0.000" asserts="2" />
+                          <test-case name="NUnit.Core.Tests.ExpectExceptionTest.ExceptionHandlerIsCalledWhenExceptionMatches_AlternateHandler" executed="True" success="True" time="0.000" asserts="2" />
+                          <test-case name="NUnit.Core.Tests.ExpectExceptionTest.ExceptionHandlerIsNotCalledWhenExceptionDoesNotMatch" executed="True" success="True" time="0.000" asserts="2" />
+                          <test-case name="NUnit.Core.Tests.ExpectExceptionTest.ExceptionHandlerIsNotCalledWhenExceptionDoesNotMatch_AlternateHandler" executed="True" success="True" time="0.016" asserts="2" />
+                          <test-case name="NUnit.Core.Tests.ExpectExceptionTest.MethodThrowsArgumentOutOfRange" executed="True" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Core.Tests.ExpectExceptionTest.MethodThrowsException" executed="True" success="True" time="0.016" asserts="1" />
+                          <test-case name="NUnit.Core.Tests.ExpectExceptionTest.MethodThrowsRightExceptionMessage" executed="True" success="True" time="0.016" asserts="1" />
+                          <test-case name="NUnit.Core.Tests.ExpectExceptionTest.MethodThrowsWrongExceptionMessage" executed="True" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Core.Tests.ExpectExceptionTest.SetUpThrowsSameException" executed="True" success="True" time="0.016" asserts="1" />
+                          <test-case name="NUnit.Core.Tests.ExpectExceptionTest.TearDownThrowsSameException" executed="True" success="True" time="0.016" asserts="1" />
+                          <test-case name="NUnit.Core.Tests.ExpectExceptionTest.TestExceptionNameNotThrown" executed="True" success="True" time="0.000" asserts="2" />
+                          <test-case name="NUnit.Core.Tests.ExpectExceptionTest.TestExceptionNameNotThrownWithUserMessage" executed="True" success="True" time="0.000" asserts="2" />
+                          <test-case name="NUnit.Core.Tests.ExpectExceptionTest.TestExceptionTypeNotThrown" executed="True" success="True" time="0.000" asserts="2" />
+                          <test-case name="NUnit.Core.Tests.ExpectExceptionTest.TestExceptionTypeNotThrownWithUserMessage" executed="True" success="True" time="0.000" asserts="2" />
+                          <test-case name="NUnit.Core.Tests.ExpectExceptionTest.TestFailsWhenBaseExceptionIsThrown" executed="True" success="True" time="0.016" asserts="2" />
+                          <test-case name="NUnit.Core.Tests.ExpectExceptionTest.TestFailsWhenDerivedExceptionIsThrown" executed="True" success="True" time="0.000" asserts="2" />
+                          <test-case name="NUnit.Core.Tests.ExpectExceptionTest.TestIsNotRunnableWhenAlternateHandlerIsNotFound" executed="True" success="True" time="0.000" asserts="2" />
+                          <test-case name="NUnit.Core.Tests.ExpectExceptionTest.TestMismatchedExceptionMessage" executed="True" success="True" time="0.000" asserts="2" />
+                          <test-case name="NUnit.Core.Tests.ExpectExceptionTest.TestMismatchedExceptionMessageWithUserMessage" executed="True" success="True" time="0.000" asserts="2" />
+                          <test-case name="NUnit.Core.Tests.ExpectExceptionTest.TestMismatchedExceptionName" executed="True" success="True" time="0.016" asserts="2" />
+                          <test-case name="NUnit.Core.Tests.ExpectExceptionTest.TestMismatchedExceptionNameWithUserMessage" executed="True" success="True" time="0.000" asserts="2" />
+                          <test-case name="NUnit.Core.Tests.ExpectExceptionTest.TestMismatchedExceptionType" executed="True" success="True" time="0.000" asserts="2" />
+                          <test-case name="NUnit.Core.Tests.ExpectExceptionTest.TestMismatchedExceptionTypeAsNamedParameter" executed="True" success="True" time="0.000" asserts="2" />
+                          <test-case name="NUnit.Core.Tests.ExpectExceptionTest.TestMismatchedExceptionTypeWithUserMessage" executed="True" success="True" time="0.000" asserts="2" />
+                          <test-case name="NUnit.Core.Tests.ExpectExceptionTest.TestSucceedsWhenSpecifiedExceptionNameAndContainsMatch" executed="True" success="True" time="0.000" asserts="0" />
+                          <test-case name="NUnit.Core.Tests.ExpectExceptionTest.TestSucceedsWhenSpecifiedExceptionNameAndRegexMatch" executed="True" success="True" time="0.000" asserts="0" />
+                          <test-case name="NUnit.Core.Tests.ExpectExceptionTest.TestSucceedsWithSpecifiedExceptionName" executed="True" success="True" time="0.000" asserts="0" />
+                          <test-case name="NUnit.Core.Tests.ExpectExceptionTest.TestSucceedsWithSpecifiedExceptionNameAndExactMatch" executed="True" success="True" time="0.000" asserts="0" />
+                          <test-case name="NUnit.Core.Tests.ExpectExceptionTest.TestSucceedsWithSpecifiedExceptionNameAndMessage_NewFormat" executed="True" success="True" time="0.000" asserts="0" />
+                          <test-case name="NUnit.Core.Tests.ExpectExceptionTest.TestSucceedsWithSpecifiedExceptionNameAsNamedParameter" executed="True" success="True" time="0.000" asserts="0" />
+                          <test-case name="NUnit.Core.Tests.ExpectExceptionTest.TestSucceedsWithSpecifiedExceptionType" executed="True" success="True" time="0.000" asserts="0" />
+                          <test-case name="NUnit.Core.Tests.ExpectExceptionTest.TestSucceedsWithSpecifiedExceptionTypeAndContainsMatch" executed="True" success="True" time="0.000" asserts="0" />
+                          <test-case name="NUnit.Core.Tests.ExpectExceptionTest.TestSucceedsWithSpecifiedExceptionTypeAndExactMatch" executed="True" success="True" time="0.000" asserts="0" />
+                          <test-case name="NUnit.Core.Tests.ExpectExceptionTest.TestSucceedsWithSpecifiedExceptionTypeAndMessage" executed="True" success="True" time="0.000" asserts="0" />
+                          <test-case name="NUnit.Core.Tests.ExpectExceptionTest.TestSucceedsWithSpecifiedExceptionTypeAndRegexMatch" executed="True" success="True" time="0.000" asserts="0" />
+                          <test-case name="NUnit.Core.Tests.ExpectExceptionTest.TestSucceedsWithSpecifiedExceptionTypeAndStartsWithMatch" executed="True" success="True" time="0.016" asserts="0" />
+                          <test-case name="NUnit.Core.Tests.ExpectExceptionTest.TestSucceedsWithSpecifiedExceptionTypeAsNamedParameter" executed="True" success="True" time="0.000" asserts="0" />
+                          <test-case name="NUnit.Core.Tests.ExpectExceptionTest.TestUnspecifiedExceptionNotThrown" executed="True" success="True" time="0.000" asserts="2" />
+                          <test-case name="NUnit.Core.Tests.ExpectExceptionTest.TestUnspecifiedExceptionNotThrownWithUserMessage" executed="True" success="True" time="0.000" asserts="2" />
+                          <test-case name="NUnit.Core.Tests.ExpectExceptionTest.ThrowingMyAppException" executed="True" success="True" time="0.000" asserts="0" />
+                          <test-case name="NUnit.Core.Tests.ExpectExceptionTest.ThrowingMyAppExceptionWithMessage" executed="True" success="True" time="0.000" asserts="0" />
+                          <test-case name="NUnit.Core.Tests.ExpectExceptionTest.ThrowNUnitException" executed="True" success="True" time="0.000" asserts="0" />
+                        </results>
+                      </test-suite>
+                      <test-suite name="FailFixture" executed="True" success="True" time="0.016" asserts="0">
+                        <results>
+                          <test-case name="NUnit.Core.Tests.FailFixture.BadStackTraceIsHandled" executed="True" success="True" time="0.000" asserts="3" />
+                          <test-case name="NUnit.Core.Tests.FailFixture.CustomExceptionIsHandled" executed="True" success="True" time="0.000" asserts="2" />
+                          <test-case name="NUnit.Core.Tests.FailFixture.FailInheritsFromSystemException" executed="True" success="True" time="0.000" asserts="0" />
+                          <test-case name="NUnit.Core.Tests.FailFixture.FailRecordsInnerException" executed="True" success="True" time="0.016" asserts="2" />
+                          <test-case name="NUnit.Core.Tests.FailFixture.FailThrowsAssertionException" executed="True" success="True" time="0.000" asserts="0" />
+                          <test-case name="NUnit.Core.Tests.FailFixture.VerifyFailWorks" executed="True" success="True" time="0.000" asserts="2" />
+                        </results>
+                      </test-suite>
+                      <test-suite name="FixtureSetupTearDownTest" executed="True" success="True" time="0.203" asserts="0">
+                        <results>
+                          <test-case name="NUnit.Core.Tests.FixtureSetupTearDownTest.BaseSetUpCalledFirstAndTearDownCalledLast" executed="True" success="True" time="0.016" asserts="6" />
+                          <test-case name="NUnit.Core.Tests.FixtureSetupTearDownTest.CheckInheritedSetUpAndTearDownAreCalled" executed="True" success="True" time="0.016" asserts="2" />
+                          <test-case name="NUnit.Core.Tests.FixtureSetupTearDownTest.DisposeCalledWhenFixtureImplementsIDisposable" executed="True" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Core.Tests.FixtureSetupTearDownTest.FixtureWithNoTestsShouldNotCallFixtureSetUpOrTearDown" executed="True" success="True" time="0.016" asserts="2" />
+                          <test-case name="NUnit.Core.Tests.FixtureSetupTearDownTest.HandleErrorInFixtureSetup" executed="True" success="True" time="0.016" asserts="11" />
+                          <test-case name="NUnit.Core.Tests.FixtureSetupTearDownTest.HandleErrorInFixtureTearDown" executed="True" success="True" time="0.016" asserts="9" />
+                          <test-case name="NUnit.Core.Tests.FixtureSetupTearDownTest.HandleExceptionInFixtureConstructor" executed="True" success="True" time="0.000" asserts="9" />
+                          <test-case name="NUnit.Core.Tests.FixtureSetupTearDownTest.HandleIgnoreInFixtureSetup" executed="True" success="True" time="0.016" asserts="7" />
+                          <test-case name="NUnit.Core.Tests.FixtureSetupTearDownTest.HandleSetUpAndTearDownWithTestInName" executed="True" success="True" time="0.016" asserts="2" />
+                          <test-case name="NUnit.Core.Tests.FixtureSetupTearDownTest.IgnoredFixtureShouldNotCallFixtureSetUpOrTearDown" executed="True" success="True" time="0.000" asserts="2" />
+                          <test-case name="NUnit.Core.Tests.FixtureSetupTearDownTest.MakeSureSetUpAndTearDownAreCalled" executed="True" success="True" time="0.016" asserts="2" />
+                          <test-case name="NUnit.Core.Tests.FixtureSetupTearDownTest.MakeSureSetUpAndTearDownAreCalledOnExplicitFixture" executed="True" success="True" time="0.000" asserts="2" />
+                          <test-case name="NUnit.Core.Tests.FixtureSetupTearDownTest.OverriddenSetUpAndTearDownAreNotCalled" executed="True" success="True" time="0.016" asserts="4" />
+                          <test-case name="NUnit.Core.Tests.FixtureSetupTearDownTest.RerunFixtureAfterSetUpFixed" executed="True" success="True" time="0.016" asserts="4" />
+                          <test-case name="NUnit.Core.Tests.FixtureSetupTearDownTest.RerunFixtureAfterTearDownFixed" executed="True" success="True" time="0.016" asserts="4" />
+                          <test-case name="NUnit.Core.Tests.FixtureSetupTearDownTest.RunningSingleMethodCallsSetUpAndTearDown" executed="True" success="True" time="0.016" asserts="2" />
+                        </results>
+                      </test-suite>
+                      <test-suite name="Generic" executed="True" success="True" time="0.031" asserts="0">
+                        <results>
+                          <test-suite name="DeduceTypeArgsFromArgs&lt;T1,T2&gt;" executed="True" success="True" time="0.016" asserts="0">
+                            <results>
+                              <test-suite name="DeduceTypeArgsFromArgs&lt;Double,Int32&gt;(100.0d,42)" executed="True" success="True" time="0.016" asserts="0">
+                                <categories>
+                                  <category name="Generics" />
+                                </categories>
+                                <results>
+                                  <test-suite name="TestMyArgTypes" executed="True" success="True" time="0.016" asserts="0">
+                                    <results>
+                                      <test-case name="NUnit.Core.Tests.Generic.DeduceTypeArgsFromArgs`2[[System.Double, mscorlib, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089],[System.Int32, mscorlib, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089]].TestMyArgTypes(5,7)" executed="True" success="True" time="0.000" asserts="2" />
+                                    </results>
+                                  </test-suite>
+                                </results>
+                              </test-suite>
+                              <test-suite name="DeduceTypeArgsFromArgs&lt;Int32,Double&gt;(42,100.0d)" executed="True" success="True" time="0.000" asserts="0">
+                                <categories>
+                                  <category name="Generics" />
+                                </categories>
+                                <results>
+                                  <test-suite name="TestMyArgTypes" executed="True" success="True" time="0.000" asserts="0">
+                                    <results>
+                                      <test-case name="NUnit.Core.Tests.Generic.DeduceTypeArgsFromArgs`2[[System.Int32, mscorlib, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089],[System.Double, mscorlib, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089]].TestMyArgTypes(5,7)" executed="True" success="True" time="0.000" asserts="2" />
+                                    </results>
+                                  </test-suite>
+                                </results>
+                              </test-suite>
+                            </results>
+                          </test-suite>
+                          <test-suite name="SimpleGenericFixture&lt;TList&gt;" executed="True" success="True" time="0.016" asserts="0">
+                            <results>
+                              <test-suite name="SimpleGenericFixture&lt;ArrayList&gt;" executed="True" success="True" time="0.016" asserts="0">
+                                <categories>
+                                  <category name="Generics" />
+                                </categories>
+                                <results>
+                                  <test-case name="NUnit.Core.Tests.Generic.SimpleGenericFixture`1[[System.Collections.ArrayList, mscorlib, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089]].TestCollectionCount" executed="True" success="True" time="0.016" asserts="1" />
+                                </results>
+                              </test-suite>
+                              <test-suite name="SimpleGenericFixture&lt;List&lt;Int32&gt;&gt;" executed="True" success="True" time="0.000" asserts="0">
+                                <categories>
+                                  <category name="Generics" />
+                                </categories>
+                                <results>
+                                  <test-case name="NUnit.Core.Tests.Generic.SimpleGenericFixture`1[[System.Collections.Generic.List`1[[System.Int32, mscorlib, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089]], mscorlib, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089]].TestCollectionCount" executed="True" success="True" time="0.000" asserts="1" />
+                                </results>
+                              </test-suite>
+                            </results>
+                          </test-suite>
+                          <test-suite name="SimpleGenericMethods" executed="True" success="True" time="0.000" asserts="0">
+                            <categories>
+                              <category name="Generics" />
+                            </categories>
+                            <results>
+                              <test-suite name="GenericTestMethodWithOneTypeParameter" executed="True" success="True" time="0.000" asserts="0">
+                                <results>
+                                  <test-case name="NUnit.Core.Tests.Generic.SimpleGenericMethods.GenericTestMethodWithOneTypeParameter&lt;Double&gt;(5.0d,2.0d,&quot;ABC&quot;)" executed="True" success="True" time="0.000" asserts="3" />
+                                  <test-case name="NUnit.Core.Tests.Generic.SimpleGenericMethods.GenericTestMethodWithOneTypeParameter&lt;Double&gt;(5.0d,2.0d,&quot;ABC&quot;)" executed="True" success="True" time="0.000" asserts="3" />
+                                  <test-case name="NUnit.Core.Tests.Generic.SimpleGenericMethods.GenericTestMethodWithOneTypeParameter&lt;Double&gt;(5.0d,2.0d,&quot;ABC&quot;)" executed="True" success="True" time="0.000" asserts="3" />
+                                  <test-case name="NUnit.Core.Tests.Generic.SimpleGenericMethods.GenericTestMethodWithOneTypeParameter&lt;Int32&gt;(5,2,&quot;ABC&quot;)" executed="True" success="True" time="0.000" asserts="3" />
+                                </results>
+                              </test-suite>
+                              <test-suite name="GenericTestMethodWithTwoTypeParameters" executed="True" success="True" time="0.000" asserts="0">
+                                <results>
+                                  <test-case name="NUnit.Core.Tests.Generic.SimpleGenericMethods.GenericTestMethodWithTwoTypeParameters&lt;Int32,Double&gt;(5,2.0d,&quot;ABC&quot;)" executed="True" success="True" time="0.000" asserts="3" />
+                                  <test-case name="NUnit.Core.Tests.Generic.SimpleGenericMethods.GenericTestMethodWithTwoTypeParameters&lt;Int32,Int32&gt;(5,2,&quot;ABC&quot;)" executed="True" success="True" time="0.000" asserts="3" />
+                                  <test-case name="NUnit.Core.Tests.Generic.SimpleGenericMethods.GenericTestMethodWithTwoTypeParameters&lt;Double,Double&gt;(5.0d,2.0d,&quot;ABC&quot;)" executed="True" success="True" time="0.000" asserts="3" />
+                                  <test-case name="NUnit.Core.Tests.Generic.SimpleGenericMethods.GenericTestMethodWithTwoTypeParameters&lt;Double,Int64&gt;(5.0d,2L,&quot;ABC&quot;)" executed="True" success="True" time="0.000" asserts="3" />
+                                </results>
+                              </test-suite>
+                              <test-suite name="GenericTestMethodWithTwoTypeParameters_Reversed" executed="True" success="True" time="0.000" asserts="0">
+                                <results>
+                                  <test-case name="NUnit.Core.Tests.Generic.SimpleGenericMethods.GenericTestMethodWithTwoTypeParameters_Reversed&lt;Int32,Int32&gt;(5,2,&quot;ABC&quot;)" executed="True" success="True" time="0.000" asserts="3" />
+                                  <test-case name="NUnit.Core.Tests.Generic.SimpleGenericMethods.GenericTestMethodWithTwoTypeParameters_Reversed&lt;Int64,Double&gt;(5.0d,2L,&quot;ABC&quot;)" executed="True" success="True" time="0.000" asserts="3" />
+                                  <test-case name="NUnit.Core.Tests.Generic.SimpleGenericMethods.GenericTestMethodWithTwoTypeParameters_Reversed&lt;Double,Double&gt;(5.0d,2.0d,&quot;ABC&quot;)" executed="True" success="True" time="0.000" asserts="3" />
+                                  <test-case name="NUnit.Core.Tests.Generic.SimpleGenericMethods.GenericTestMethodWithTwoTypeParameters_Reversed&lt;Double,Int32&gt;(5,2.0d,&quot;ABC&quot;)" executed="True" success="True" time="0.000" asserts="3" />
+                                </results>
+                              </test-suite>
+                            </results>
+                          </test-suite>
+                          <test-suite name="TypeParameterUsedWithTestMethod&lt;T&gt;" executed="True" success="True" time="0.000" asserts="0">
+                            <results>
+                              <test-suite name="TypeParameterUsedWithTestMethod&lt;Double&gt;" executed="True" success="True" time="0.000" asserts="0">
+                                <categories>
+                                  <category name="Generics" />
+                                </categories>
+                                <results>
+                                  <test-suite name="TestMyArgType" executed="True" success="True" time="0.000" asserts="0">
+                                    <results>
+                                      <test-case name="NUnit.Core.Tests.Generic.TypeParameterUsedWithTestMethod`1[[System.Double, mscorlib, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089]].TestMyArgType(1.23d)" executed="True" success="True" time="0.000" asserts="1" />
+                                      <test-case name="NUnit.Core.Tests.Generic.TypeParameterUsedWithTestMethod`1[[System.Double, mscorlib, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089]].TestMyArgType(5)" executed="True" success="True" time="0.000" asserts="1" />
+                                    </results>
+                                  </test-suite>
+                                </results>
+                              </test-suite>
+                            </results>
+                          </test-suite>
+                        </results>
+                      </test-suite>
+                      <test-suite name="IgnoreFixture" executed="True" success="True" time="0.094" asserts="0">
+                        <results>
+                          <test-case name="NUnit.Core.Tests.IgnoreFixture.IgnoreTakesPrecedenceOverExpectedException" executed="True" success="True" time="0.016" asserts="2" />
+                          <test-case name="NUnit.Core.Tests.IgnoreFixture.IgnoreThrowsIgnoreException" executed="True" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Core.Tests.IgnoreFixture.IgnoreWithUserMessage" executed="True" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Core.Tests.IgnoreFixture.IgnoreWithUserMessage_ArrayOfArgs" executed="True" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Core.Tests.IgnoreFixture.IgnoreWithUserMessage_OneArg" executed="True" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Core.Tests.IgnoreFixture.IgnoreWithUserMessage_ThreeArgs" executed="True" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Core.Tests.IgnoreFixture.IgnoreWorksForTestCase" executed="True" success="True" time="0.047" asserts="2" />
+                          <test-case name="NUnit.Core.Tests.IgnoreFixture.IgnoreWorksForTestSuite" executed="True" success="True" time="0.000" asserts="3" />
+                          <test-case name="NUnit.Core.Tests.IgnoreFixture.IgnoreWorksFromSetUp" executed="True" success="True" time="0.016" asserts="3" />
+                        </results>
+                      </test-suite>
+                      <test-suite name="LegacySuiteTests" executed="True" success="True" time="0.172" asserts="0">
+                        <results>
+                          <test-case name="NUnit.Core.Tests.LegacySuiteTests.SetUpAndTearDownAreCalled" executed="True" success="True" time="0.016" asserts="3" />
+                          <test-case name="NUnit.Core.Tests.LegacySuiteTests.SuitePropertyWithInvalidType" executed="True" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Core.Tests.LegacySuiteTests.SuiteReturningFixtures" executed="True" success="True" time="0.094" asserts="3" />
+                          <test-case name="NUnit.Core.Tests.LegacySuiteTests.SuiteReturningTestSuite" executed="True" success="True" time="0.016" asserts="3" />
+                          <test-case name="NUnit.Core.Tests.LegacySuiteTests.SuiteReturningTypes" executed="True" success="True" time="0.031" asserts="3" />
+                        </results>
+                      </test-suite>
+                      <test-suite name="MaxTimeTests" executed="True" success="True" time="0.109" asserts="0">
+                        <results>
+                          <test-case name="NUnit.Core.Tests.MaxTimeTests.ErrorReport" executed="True" success="True" time="0.000" asserts="0">
+                            <properties>
+                              <property name="MaxTime" value="1000" />
+                            </properties>
+                          </test-case>
+                          <test-case name="NUnit.Core.Tests.MaxTimeTests.ErrorReportHasPriorityOverMaxTime" executed="True" success="True" time="0.047" asserts="3" />
+                          <test-case name="NUnit.Core.Tests.MaxTimeTests.FailureReport" executed="True" success="True" time="0.000" asserts="0">
+                            <properties>
+                              <property name="MaxTime" value="1000" />
+                            </properties>
+                          </test-case>
+                          <test-case name="NUnit.Core.Tests.MaxTimeTests.FailureReportHasPriorityOverMaxTime" executed="True" success="True" time="0.031" asserts="3" />
+                          <test-case name="NUnit.Core.Tests.MaxTimeTests.MaxTimeExceeded" executed="True" success="True" time="0.031" asserts="2" />
+                          <test-case name="NUnit.Core.Tests.MaxTimeTests.MaxTimeNotExceeded" executed="True" success="True" time="0.000" asserts="0">
+                            <properties>
+                              <property name="MaxTime" value="1000" />
+                            </properties>
+                          </test-case>
+                        </results>
+                      </test-suite>
+                      <test-suite name="NameFilterTest" executed="True" success="True" time="0.063" asserts="0">
+                        <results>
+                          <test-case name="NUnit.Core.Tests.NameFilterTest.ExplicitTestCaseDoesNotMatchWhenNotSelectedDirectly" executed="True" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Core.Tests.NameFilterTest.ExplicitTestCaseMatchesWhenSelectedDirectly" executed="True" success="True" time="0.016" asserts="2" />
+                          <test-case name="NUnit.Core.Tests.NameFilterTest.ExplicitTestSuiteDoesNotMatchWhenNotSelectedDirectly" executed="True" success="True" time="0.000" asserts="2" />
+                          <test-case name="NUnit.Core.Tests.NameFilterTest.ExplicitTestSuiteMatchesWhenSelectedDirectly" executed="True" success="True" time="0.016" asserts="3" />
+                          <test-case name="NUnit.Core.Tests.NameFilterTest.HighLevelSuite" executed="True" success="True" time="0.000" asserts="3" />
+                          <test-case name="NUnit.Core.Tests.NameFilterTest.MultipleNameMatch" executed="True" success="True" time="0.016" asserts="3" />
+                          <test-case name="NUnit.Core.Tests.NameFilterTest.SingleNameMatch" executed="True" success="True" time="0.000" asserts="4" />
+                          <test-case name="NUnit.Core.Tests.NameFilterTest.SuiteNameMatch" executed="True" success="True" time="0.000" asserts="3" />
+                          <test-case name="NUnit.Core.Tests.NameFilterTest.TestDoesNotMatch" executed="True" success="True" time="0.016" asserts="2" />
+                        </results>
+                      </test-suite>
+                      <test-suite name="NamespaceAssemblyTests" executed="True" success="True" time="0.219" asserts="0">
+                        <results>
+                          <test-case name="NUnit.Core.Tests.NamespaceAssemblyTests.Hierarchy" executed="True" success="True" time="0.078" asserts="16" />
+                          <test-case name="NUnit.Core.Tests.NamespaceAssemblyTests.LoadTestFixtureFromAssembly" executed="True" success="True" time="0.031" asserts="1" />
+                          <test-case name="NUnit.Core.Tests.NamespaceAssemblyTests.NoNamespaceInAssembly" executed="True" success="True" time="0.047" asserts="5" />
+                          <test-case name="NUnit.Core.Tests.NamespaceAssemblyTests.TestRoot" executed="True" success="True" time="0.063" asserts="1" />
+                        </results>
+                      </test-suite>
+                      <test-suite name="PairwiseTest" executed="True" success="True" time="0.016" asserts="0">
+                        <results>
+                          <test-suite name="Test" executed="True" success="True" time="0.016" asserts="0">
+                            <results>
+                              <test-case name="NUnit.Core.Tests.PairwiseTest.Test 2x4" executed="True" success="True" time="0.000" asserts="2" />
+                              <test-case name="NUnit.Core.Tests.PairwiseTest.Test 2x2x2" executed="True" success="True" time="0.000" asserts="2" />
+                              <test-case name="NUnit.Core.Tests.PairwiseTest.Test 3x2x2" executed="True" success="True" time="0.000" asserts="2" />
+                              <test-case name="NUnit.Core.Tests.PairwiseTest.Test 3x2x2x2" executed="True" success="True" time="0.000" asserts="2" />
+                              <test-case name="NUnit.Core.Tests.PairwiseTest.Test 3x2x2x2x2" executed="True" success="True" time="0.000" asserts="2" />
+                              <test-case name="NUnit.Core.Tests.PairwiseTest.Test 3x2x2x2x2x2" executed="True" success="True" time="0.016" asserts="2" />
+                              <test-case name="NUnit.Core.Tests.PairwiseTest.Test 3x3x3" executed="True" success="True" time="0.000" asserts="2" />
+                              <test-case name="NUnit.Core.Tests.PairwiseTest.Test 4x4x4" executed="True" success="True" time="0.000" asserts="2" />
+                              <test-case name="NUnit.Core.Tests.PairwiseTest.Test 5x5x5" executed="True" success="True" time="0.000" asserts="2" />
+                            </results>
+                          </test-suite>
+                        </results>
+                      </test-suite>
+                      <test-suite name="PairwiseTest+LiveTest" executed="True" success="True" time="0.000" asserts="1">
+                        <results>
+                          <test-suite name="Test" executed="True" success="True" time="0.000" asserts="0">
+                            <results>
+                              <test-case name="NUnit.Core.Tests.PairwiseTest+LiveTest.Test(&quot;a&quot;,&quot;-&quot;,&quot;x&quot;)" executed="True" success="True" time="0.000" asserts="0" />
+                              <test-case name="NUnit.Core.Tests.PairwiseTest+LiveTest.Test(&quot;b&quot;,&quot;+&quot;,&quot;y&quot;)" executed="True" success="True" time="0.000" asserts="0" />
+                              <test-case name="NUnit.Core.Tests.PairwiseTest+LiveTest.Test(&quot;c&quot;,&quot;+&quot;,&quot;x&quot;)" executed="True" success="True" time="0.000" asserts="0" />
+                              <test-case name="NUnit.Core.Tests.PairwiseTest+LiveTest.Test(&quot;b&quot;,&quot;-&quot;,&quot;x&quot;)" executed="True" success="True" time="0.000" asserts="0" />
+                              <test-case name="NUnit.Core.Tests.PairwiseTest+LiveTest.Test(&quot;a&quot;,&quot;-&quot;,&quot;y&quot;)" executed="True" success="True" time="0.000" asserts="0" />
+                              <test-case name="NUnit.Core.Tests.PairwiseTest+LiveTest.Test(&quot;c&quot;,&quot;-&quot;,&quot;y&quot;)" executed="True" success="True" time="0.000" asserts="0" />
+                              <test-case name="NUnit.Core.Tests.PairwiseTest+LiveTest.Test(&quot;a&quot;,&quot;+&quot;,&quot;x&quot;)" executed="True" success="True" time="0.000" asserts="0" />
+                            </results>
+                          </test-suite>
+                        </results>
+                      </test-suite>
+                      <test-suite name="ParameterizedTestFixture" executed="True" success="True" time="0.000" asserts="0">
+                        <results>
+                          <test-suite name="ParameterizedTestFixture(&quot;hello&quot;,&quot;hello&quot;,&quot;goodbye&quot;)" executed="True" success="True" time="0.000" asserts="0">
+                            <results>
+                              <test-case name="NUnit.Core.Tests.ParameterizedTestFixture.TestEquality" executed="True" success="True" time="0.000" asserts="2" />
+                              <test-case name="NUnit.Core.Tests.ParameterizedTestFixture.TestInequality" executed="True" success="True" time="0.000" asserts="2" />
+                            </results>
+                          </test-suite>
+                          <test-suite name="ParameterizedTestFixture(&quot;zip&quot;,&quot;zip&quot;)" executed="True" success="True" time="0.000" asserts="0">
+                            <results>
+                              <test-case name="NUnit.Core.Tests.ParameterizedTestFixture.TestEquality" executed="True" success="True" time="0.000" asserts="2" />
+                              <test-case name="NUnit.Core.Tests.ParameterizedTestFixture.TestInequality" executed="True" success="True" time="0.000" asserts="1" />
+                            </results>
+                          </test-suite>
+                          <test-suite name="ParameterizedTestFixture(42,42,99)" executed="True" success="True" time="0.000" asserts="0">
+                            <results>
+                              <test-case name="NUnit.Core.Tests.ParameterizedTestFixture.TestEquality" executed="True" success="True" time="0.000" asserts="2" />
+                              <test-case name="NUnit.Core.Tests.ParameterizedTestFixture.TestInequality" executed="True" success="True" time="0.000" asserts="2" />
+                            </results>
+                          </test-suite>
+                        </results>
+                      </test-suite>
+                      <test-suite name="ParameterizedTestFixtureWithDataSources" executed="True" success="True" time="0.063" asserts="0">
+                        <results>
+                          <test-suite name="ParameterizedTestFixtureWithDataSources(42)" executed="True" success="True" time="0.016" asserts="0">
+                            <results>
+                              <test-suite name="CanAccessTestCaseSource" executed="True" success="True" time="0.016" asserts="0">
+                                <results>
+                                  <test-case name="NUnit.Core.Tests.ParameterizedTestFixtureWithDataSources.CanAccessTestCaseSource(6,7)" executed="True" success="True" time="0.000" asserts="1" />
+                                  <test-case name="NUnit.Core.Tests.ParameterizedTestFixtureWithDataSources.CanAccessTestCaseSource(3,14)" executed="True" success="True" time="0.000" asserts="1" />
+                                </results>
+                              </test-suite>
+                              <test-suite name="CanAccessValueSource" executed="True" success="True" time="0.000" asserts="0">
+                                <results>
+                                  <test-case name="NUnit.Core.Tests.ParameterizedTestFixtureWithDataSources.CanAccessValueSource(1)" executed="True" success="True" time="0.000" asserts="1" />
+                                  <test-case name="NUnit.Core.Tests.ParameterizedTestFixtureWithDataSources.CanAccessValueSource(2)" executed="True" success="True" time="0.000" asserts="1" />
+                                  <test-case name="NUnit.Core.Tests.ParameterizedTestFixtureWithDataSources.CanAccessValueSource(3)" executed="True" success="True" time="0.000" asserts="1" />
+                                </results>
+                              </test-suite>
+                              <test-suite name="CanGenerateDataFromParameter" executed="True" success="True" time="0.000" asserts="0">
+                                <results>
+                                  <test-case name="NUnit.Core.Tests.ParameterizedTestFixtureWithDataSources.CanGenerateDataFromParameter(1,42)" executed="True" success="True" time="0.000" asserts="1" />
+                                  <test-case name="NUnit.Core.Tests.ParameterizedTestFixtureWithDataSources.CanGenerateDataFromParameter(2,21)" executed="True" success="True" time="0.000" asserts="1" />
+                                  <test-case name="NUnit.Core.Tests.ParameterizedTestFixtureWithDataSources.CanGenerateDataFromParameter(3,14)" executed="True" success="True" time="0.000" asserts="1" />
+                                  <test-case name="NUnit.Core.Tests.ParameterizedTestFixtureWithDataSources.CanGenerateDataFromParameter(6,7)" executed="True" success="True" time="0.000" asserts="1" />
+                                  <test-case name="NUnit.Core.Tests.ParameterizedTestFixtureWithDataSources.CanGenerateDataFromParameter(7,6)" executed="True" success="True" time="0.000" asserts="1" />
+                                  <test-case name="NUnit.Core.Tests.ParameterizedTestFixtureWithDataSources.CanGenerateDataFromParameter(14,3)" executed="True" success="True" time="0.000" asserts="1" />
+                                  <test-case name="NUnit.Core.Tests.ParameterizedTestFixtureWithDataSources.CanGenerateDataFromParameter(21,2)" executed="True" success="True" time="0.000" asserts="1" />
+                                  <test-case name="NUnit.Core.Tests.ParameterizedTestFixtureWithDataSources.CanGenerateDataFromParameter(42,1)" executed="True" success="True" time="0.000" asserts="1" />
+                                </results>
+                              </test-suite>
+                            </results>
+                          </test-suite>
+                        </results>
+                      </test-suite>
+                      <test-suite name="PlatformDetectionTests" executed="True" success="True" time="0.016" asserts="0">
+                        <results>
+                          <test-case name="NUnit.Core.Tests.PlatformDetectionTests.ArrayOfPlatforms" executed="True" success="True" time="0.000" asserts="2" />
+                          <test-case name="NUnit.Core.Tests.PlatformDetectionTests.DetectExactVersion" executed="True" success="True" time="0.000" asserts="4" />
+                          <test-case name="NUnit.Core.Tests.PlatformDetectionTests.DetectMono10" executed="True" success="True" time="0.000" asserts="8" />
+                          <test-case name="NUnit.Core.Tests.PlatformDetectionTests.DetectMono20" executed="True" success="True" time="0.000" asserts="8" />
+                          <test-case name="NUnit.Core.Tests.PlatformDetectionTests.DetectNet10" executed="True" success="True" time="0.000" asserts="8" />
+                          <test-case name="NUnit.Core.Tests.PlatformDetectionTests.DetectNet11" executed="True" success="True" time="0.000" asserts="8" />
+                          <test-case name="NUnit.Core.Tests.PlatformDetectionTests.DetectNet20" executed="True" success="True" time="0.000" asserts="8" />
+                          <test-case name="NUnit.Core.Tests.PlatformDetectionTests.DetectNetCF" executed="True" success="True" time="0.000" asserts="9" />
+                          <test-case name="NUnit.Core.Tests.PlatformDetectionTests.DetectNT3" executed="True" success="True" time="0.000" asserts="16" />
+                          <test-case name="NUnit.Core.Tests.PlatformDetectionTests.DetectNT4" executed="True" success="True" time="0.000" asserts="16" />
+                          <test-case name="NUnit.Core.Tests.PlatformDetectionTests.DetectSSCLI" executed="True" success="True" time="0.000" asserts="8" />
+                          <test-case name="NUnit.Core.Tests.PlatformDetectionTests.DetectUnixUnderMicrosoftDotNet" executed="True" success="True" time="0.000" asserts="18" />
+                          <test-case name="NUnit.Core.Tests.PlatformDetectionTests.DetectUnixUnderMono" executed="False">
+                            <reason>
+                              <message><![CDATA[Not supported on Net]]></message>
+                            </reason>
+                          </test-case>
+                          <test-case name="NUnit.Core.Tests.PlatformDetectionTests.DetectVista" executed="True" success="True" time="0.000" asserts="15" />
+                          <test-case name="NUnit.Core.Tests.PlatformDetectionTests.DetectWin2003Server" executed="True" success="True" time="0.000" asserts="15" />
+                          <test-case name="NUnit.Core.Tests.PlatformDetectionTests.DetectWin2008Server" executed="True" success="True" time="0.000" asserts="15" />
+                          <test-case name="NUnit.Core.Tests.PlatformDetectionTests.DetectWin2K" executed="True" success="True" time="0.000" asserts="15" />
+                          <test-case name="NUnit.Core.Tests.PlatformDetectionTests.DetectWin95" executed="True" success="True" time="0.000" asserts="16" />
+                          <test-case name="NUnit.Core.Tests.PlatformDetectionTests.DetectWin98" executed="True" success="True" time="0.000" asserts="16" />
+                          <test-case name="NUnit.Core.Tests.PlatformDetectionTests.DetectWinCE" executed="True" success="True" time="0.000" asserts="17" />
+                          <test-case name="NUnit.Core.Tests.PlatformDetectionTests.DetectWinMe" executed="True" success="True" time="0.000" asserts="16" />
+                          <test-case name="NUnit.Core.Tests.PlatformDetectionTests.DetectWinXP" executed="True" success="True" time="0.000" asserts="15" />
+                          <test-case name="NUnit.Core.Tests.PlatformDetectionTests.PlatformAttribute_Exclude" executed="True" success="True" time="0.000" asserts="3" />
+                          <test-case name="NUnit.Core.Tests.PlatformDetectionTests.PlatformAttribute_Include" executed="True" success="True" time="0.016" asserts="3" />
+                          <test-case name="NUnit.Core.Tests.PlatformDetectionTests.PlatformAttribute_IncludeAndExclude" executed="True" success="True" time="0.000" asserts="7" />
+                          <test-case name="NUnit.Core.Tests.PlatformDetectionTests.PlatformAttribute_InvalidPlatform" executed="True" success="True" time="0.000" asserts="2" />
+                        </results>
+                      </test-suite>
+                      <test-suite name="PropertyAttributeTests" executed="True" success="True" time="0.031" asserts="0">
+                        <results>
+                          <test-case name="NUnit.Core.Tests.PropertyAttributeTests.CanDeriveFromPropertyAttribute" executed="True" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Core.Tests.PropertyAttributeTests.PropertiesWithNumericValues" executed="True" success="True" time="0.016" asserts="2" />
+                          <test-case name="NUnit.Core.Tests.PropertyAttributeTests.PropertyWithStringValue" executed="True" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Core.Tests.PropertyAttributeTests.PropertyWorksOnFixtures" executed="True" success="True" time="0.016" asserts="1" />
+                        </results>
+                      </test-suite>
+                      <test-suite name="ReflectTests" executed="True" success="True" time="0.000" asserts="0">
+                        <results>
+                          <test-case name="NUnit.Core.Tests.ReflectTests.CanDetectAttributes" executed="True" success="True" time="0.000" asserts="3" />
+                          <test-case name="NUnit.Core.Tests.ReflectTests.CanDetectInheritedAttributes" executed="True" success="True" time="0.000" asserts="3" />
+                          <test-case name="NUnit.Core.Tests.ReflectTests.Construct" executed="True" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Core.Tests.ReflectTests.GetAttribute" executed="True" success="True" time="0.000" asserts="3" />
+                          <test-case name="NUnit.Core.Tests.ReflectTests.GetAttributes" executed="True" success="True" time="0.000" asserts="4" />
+                          <test-case name="NUnit.Core.Tests.ReflectTests.GetConstructor" executed="True" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Core.Tests.ReflectTests.GetInheritedAttribute" executed="True" success="True" time="0.000" asserts="3" />
+                          <test-case name="NUnit.Core.Tests.ReflectTests.GetInheritedAttributes" executed="True" success="True" time="0.000" asserts="4" />
+                          <test-case name="NUnit.Core.Tests.ReflectTests.GetMethodsWithAttribute" executed="True" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Core.Tests.ReflectTests.GetNamedMethod" executed="True" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Core.Tests.ReflectTests.GetNamedMethodWithArgs" executed="True" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Core.Tests.ReflectTests.GetNamedProperty" executed="True" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Core.Tests.ReflectTests.GetPropertyValue" executed="True" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Core.Tests.ReflectTests.GetPropertyWithAttribute" executed="True" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Core.Tests.ReflectTests.HasInterface" executed="True" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Core.Tests.ReflectTests.InheritsFrom" executed="True" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Core.Tests.ReflectTests.InvokeMethod" executed="True" success="True" time="0.000" asserts="1" />
+                        </results>
+                      </test-suite>
+                      <test-suite name="RemoteRunnerTests" executed="True" success="True" time="1.281" asserts="1">
+                        <results>
+                          <test-case name="NUnit.Core.Tests.RemoteRunnerTests.CheckRunnerID" executed="True" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Core.Tests.RemoteRunnerTests.CountTestCases" executed="True" success="True" time="0.188" asserts="1" />
+                          <test-case name="NUnit.Core.Tests.RemoteRunnerTests.CountTestCasesAcrossMultipleAssemblies" executed="True" success="True" time="0.156" asserts="1" />
+                          <test-case name="NUnit.Core.Tests.RemoteRunnerTests.LoadAssembly" executed="True" success="True" time="0.078" asserts="1" />
+                          <test-case name="NUnit.Core.Tests.RemoteRunnerTests.LoadAssemblyWithFixture" executed="True" success="True" time="0.063" asserts="1" />
+                          <test-case name="NUnit.Core.Tests.RemoteRunnerTests.LoadAssemblyWithoutNamespaces" executed="True" success="True" time="0.078" asserts="4" />
+                          <test-case name="NUnit.Core.Tests.RemoteRunnerTests.LoadAssemblyWithSuite" executed="True" success="True" time="0.047" asserts="1" />
+                          <test-case name="NUnit.Core.Tests.RemoteRunnerTests.LoadMultipleAssemblies" executed="True" success="True" time="0.109" asserts="1" />
+                          <test-case name="NUnit.Core.Tests.RemoteRunnerTests.LoadMultipleAssembliesWithFixture" executed="True" success="True" time="0.078" asserts="1" />
+                          <test-case name="NUnit.Core.Tests.RemoteRunnerTests.LoadMultipleAssembliesWithSuite" executed="True" success="True" time="0.094" asserts="1" />
+                          <test-case name="NUnit.Core.Tests.RemoteRunnerTests.RunAssembly" executed="True" success="True" time="0.109" asserts="1" />
+                          <test-case name="NUnit.Core.Tests.RemoteRunnerTests.RunAssemblyUsingBeginAndEndRun" executed="True" success="True" time="0.078" asserts="2" />
+                          <test-case name="NUnit.Core.Tests.RemoteRunnerTests.RunMultipleAssemblies" executed="True" success="True" time="0.094" asserts="1" />
+                          <test-case name="NUnit.Core.Tests.RemoteRunnerTests.RunMultipleAssembliesUsingBeginAndEndRun" executed="True" success="True" time="0.094" asserts="2" />
+                        </results>
+                      </test-suite>
+                      <test-suite name="RepeatedTestFixture" executed="True" success="True" time="0.063" asserts="0">
+                        <results>
+                          <test-case name="NUnit.Core.Tests.RepeatedTestFixture.CategoryWorksWithRepeatedTest" executed="True" success="True" time="0.016" asserts="3" />
+                          <test-case name="NUnit.Core.Tests.RepeatedTestFixture.IgnoreWorksWithRepeatedTest" executed="True" success="True" time="0.000" asserts="3" />
+                          <test-case name="NUnit.Core.Tests.RepeatedTestFixture.RepeatFailOnFirst" executed="True" success="True" time="0.016" asserts="4" />
+                          <test-case name="NUnit.Core.Tests.RepeatedTestFixture.RepeatFailOnThird" executed="True" success="True" time="0.016" asserts="4" />
+                          <test-case name="NUnit.Core.Tests.RepeatedTestFixture.RepeatSuccess" executed="True" success="True" time="0.016" asserts="6" />
+                        </results>
+                      </test-suite>
+                      <test-suite name="RuntimeFrameworkTests" executed="True" success="True" time="0.016" asserts="0">
+                        <results>
+                          <test-case name="NUnit.Core.Tests.RuntimeFrameworkTests.CanGetCurrentFramework" executed="True" success="True" time="0.000" asserts="2" />
+                          <test-case name="NUnit.Core.Tests.RuntimeFrameworkTests.CanListAvailableFrameworks" executed="True" success="True" time="0.016" asserts="2" />
+                          <test-case name="NUnit.Core.Tests.RuntimeFrameworkTests.CurrentFrameworkMustBeAvailable" executed="True" success="True" time="0.000" asserts="1" />
+                        </results>
+                      </test-suite>
+                      <test-suite name="SerializationBug" executed="True" success="True" time="0.000" asserts="0">
+                        <results>
+                          <test-case name="NUnit.Core.Tests.SerializationBug.SaveAndLoad" executed="True" success="True" time="0.000" asserts="3" />
+                        </results>
+                      </test-suite>
+                      <test-suite name="SetCultureAttributeTests" executed="True" success="True" time="0.016" asserts="0">
+                        <results>
+                          <test-case name="NUnit.Core.Tests.SetCultureAttributeTests.SetBothCulturesToFrench" executed="True" success="True" time="0.000" asserts="2" />
+                          <test-case name="NUnit.Core.Tests.SetCultureAttributeTests.SetBothCulturesToFrenchCanadian" executed="True" success="True" time="0.000" asserts="2" />
+                          <test-case name="NUnit.Core.Tests.SetCultureAttributeTests.SetBothCulturesToRussian" executed="True" success="True" time="0.000" asserts="2" />
+                          <test-case name="NUnit.Core.Tests.SetCultureAttributeTests.SetMixedCulturesToFrenchAndUIFrenchCanadian" executed="True" success="True" time="0.000" asserts="2" />
+                          <test-case name="NUnit.Core.Tests.SetCultureAttributeTests.SetMixedCulturesToRussianAndUIEnglishUS" executed="True" success="True" time="0.000" asserts="2" />
+                          <test-case name="NUnit.Core.Tests.SetCultureAttributeTests.SetUICultureOnlyToFrench" executed="True" success="True" time="0.000" asserts="2" />
+                          <test-case name="NUnit.Core.Tests.SetCultureAttributeTests.SetUICultureOnlyToFrenchCanadian" executed="True" success="True" time="0.000" asserts="2" />
+                          <test-case name="NUnit.Core.Tests.SetCultureAttributeTests.SetUICultureOnlyToRussian" executed="True" success="True" time="0.000" asserts="2" />
+                        </results>
+                      </test-suite>
+                      <test-suite name="SetCultureAttributeTests+NestedBehavior" executed="True" success="True" time="0.000" asserts="0">
+                        <results>
+                          <test-case name="NUnit.Core.Tests.SetCultureAttributeTests+NestedBehavior.InheritedRussian" executed="True" success="True" time="0.000" asserts="2" />
+                          <test-case name="NUnit.Core.Tests.SetCultureAttributeTests+NestedBehavior.InheritedRussianWithUIFrench" executed="True" success="True" time="0.000" asserts="2" />
+                        </results>
+                      </test-suite>
+                      <test-suite name="SetUpFixtureTests" executed="True" success="True" time="2.719" asserts="0">
+                        <results>
+                          <test-case name="NUnit.Core.Tests.SetUpFixtureTests.AssemblySetUpFixtureReplacesAssemblyNodeInTree" executed="True" success="True" time="1.172" asserts="4" />
+                          <test-case name="NUnit.Core.Tests.SetUpFixtureTests.AssemblySetupFixtureWrapsExecutionOfTest" executed="True" success="True" time="1.125" asserts="5" />
+                          <test-case name="NUnit.Core.Tests.SetUpFixtureTests.NamespaceSetUpFixtureReplacesNamespaceNodeInTree" executed="True" success="True" time="0.078" asserts="14" />
+                          <test-case name="NUnit.Core.Tests.SetUpFixtureTests.NamespaceSetUpFixtureWrapsExecutionOfSingleTest" executed="True" success="True" time="0.047" asserts="8" />
+                          <test-case name="NUnit.Core.Tests.SetUpFixtureTests.NamespaceSetUpFixtureWrapsExecutionOfTwoTests" executed="True" success="True" time="0.047" asserts="13" />
+                          <test-case name="NUnit.Core.Tests.SetUpFixtureTests.NamespaceSetUpFixtureWrapsNestedNamespaceSetUpFixture" executed="True" success="True" time="0.078" asserts="15" />
+                          <test-case name="NUnit.Core.Tests.SetUpFixtureTests.NamespaceSetUpMethodsMayBeStatic" executed="True" success="True" time="0.078" asserts="8" />
+                          <test-case name="NUnit.Core.Tests.SetUpFixtureTests.WithTwoSetUpFixtuesOnlyOneIsUsed" executed="True" success="True" time="0.078" asserts="8" />
+                        </results>
+                      </test-suite>
+                      <test-suite name="SetUpTest" executed="True" success="True" time="0.078" asserts="0">
+                        <results>
+                          <test-case name="NUnit.Core.Tests.SetUpTest.BaseSetUpIsCalledFirstTearDownLast" executed="True" success="True" time="0.016" asserts="6" />
+                          <test-case name="NUnit.Core.Tests.SetUpTest.CheckInheritedSetUpAndTearDownAreCalled" executed="True" success="True" time="0.000" asserts="2" />
+                          <test-case name="NUnit.Core.Tests.SetUpTest.CheckOverriddenSetUpAndTearDownAreNotCalled" executed="True" success="True" time="0.016" asserts="4" />
+                          <test-case name="NUnit.Core.Tests.SetUpTest.MakeSureSetUpAndTearDownAreCalled" executed="True" success="True" time="0.000" asserts="2" />
+                          <test-case name="NUnit.Core.Tests.SetUpTest.MultipleSetUpAndTearDownMethodsAreCalled" executed="True" success="True" time="0.016" asserts="5" />
+                          <test-case name="NUnit.Core.Tests.SetUpTest.SetUpAndTearDownCounter" executed="True" success="True" time="0.000" asserts="2" />
+                          <test-case name="NUnit.Core.Tests.SetUpTest.SetupRecordsOriginalExceptionThownByTestCase" executed="True" success="True" time="0.031" asserts="3" />
+                          <test-case name="NUnit.Core.Tests.SetUpTest.TearDownRecordsOriginalExceptionThownByTestCase" executed="True" success="True" time="0.000" asserts="4" />
+                        </results>
+                      </test-suite>
+                      <test-suite name="SimpleNameFilterTests" executed="True" success="True" time="0.078" asserts="0">
+                        <results>
+                          <test-case name="NUnit.Core.Tests.SimpleNameFilterTests.ExplicitTestCaseDoesNotMatchWhenNotSelectedDirectly" executed="True" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Core.Tests.SimpleNameFilterTests.ExplicitTestCaseMatchesWhenSelectedDirectly" executed="True" success="True" time="0.016" asserts="2" />
+                          <test-case name="NUnit.Core.Tests.SimpleNameFilterTests.ExplicitTestSuiteDoesNotMatchWhenNotSelectedDirectly" executed="True" success="True" time="0.000" asserts="2" />
+                          <test-case name="NUnit.Core.Tests.SimpleNameFilterTests.ExplicitTestSuiteMatchesWhenSelectedDirectly" executed="True" success="True" time="0.016" asserts="3" />
+                          <test-case name="NUnit.Core.Tests.SimpleNameFilterTests.HighLevelSuite" executed="True" success="True" time="0.000" asserts="3" />
+                          <test-case name="NUnit.Core.Tests.SimpleNameFilterTests.MultipleNameMatch" executed="True" success="True" time="0.016" asserts="3" />
+                          <test-case name="NUnit.Core.Tests.SimpleNameFilterTests.SingleNameMatch" executed="True" success="True" time="0.000" asserts="4" />
+                          <test-case name="NUnit.Core.Tests.SimpleNameFilterTests.SuiteNameMatch" executed="True" success="True" time="0.031" asserts="3" />
+                          <test-case name="NUnit.Core.Tests.SimpleNameFilterTests.TestDoesNotMatch" executed="True" success="True" time="0.000" asserts="2" />
+                        </results>
+                      </test-suite>
+                      <test-suite name="SimpleTestRunnerTests" executed="True" success="True" time="1.156" asserts="1">
+                        <results>
+                          <test-case name="NUnit.Core.Tests.SimpleTestRunnerTests.CheckRunnerID" executed="True" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Core.Tests.SimpleTestRunnerTests.CountTestCases" executed="True" success="True" time="0.078" asserts="1" />
+                          <test-case name="NUnit.Core.Tests.SimpleTestRunnerTests.CountTestCasesAcrossMultipleAssemblies" executed="True" success="True" time="0.141" asserts="1" />
+                          <test-case name="NUnit.Core.Tests.SimpleTestRunnerTests.LoadAssembly" executed="True" success="True" time="0.078" asserts="1" />
+                          <test-case name="NUnit.Core.Tests.SimpleTestRunnerTests.LoadAssemblyWithFixture" executed="True" success="True" time="0.047" asserts="1" />
+                          <test-case name="NUnit.Core.Tests.SimpleTestRunnerTests.LoadAssemblyWithoutNamespaces" executed="True" success="True" time="0.063" asserts="4" />
+                          <test-case name="NUnit.Core.Tests.SimpleTestRunnerTests.LoadAssemblyWithSuite" executed="True" success="True" time="0.047" asserts="1" />
+                          <test-case name="NUnit.Core.Tests.SimpleTestRunnerTests.LoadMultipleAssemblies" executed="True" success="True" time="0.109" asserts="1" />
+                          <test-case name="NUnit.Core.Tests.SimpleTestRunnerTests.LoadMultipleAssembliesWithFixture" executed="True" success="True" time="0.047" asserts="1" />
+                          <test-case name="NUnit.Core.Tests.SimpleTestRunnerTests.LoadMultipleAssembliesWithSuite" executed="True" success="True" time="0.109" asserts="1" />
+                          <test-case name="NUnit.Core.Tests.SimpleTestRunnerTests.RunAssembly" executed="True" success="True" time="0.063" asserts="1" />
+                          <test-case name="NUnit.Core.Tests.SimpleTestRunnerTests.RunAssemblyUsingBeginAndEndRun" executed="True" success="True" time="0.094" asserts="2" />
+                          <test-case name="NUnit.Core.Tests.SimpleTestRunnerTests.RunMultipleAssemblies" executed="True" success="True" time="0.125" asserts="1" />
+                          <test-case name="NUnit.Core.Tests.SimpleTestRunnerTests.RunMultipleAssembliesUsingBeginAndEndRun" executed="True" success="True" time="0.125" asserts="2" />
+                        </results>
+                      </test-suite>
+                      <test-suite name="StackOverflowTestFixture" executed="False">
+                        <reason>
+                          <message><![CDATA[Cannot handle StackOverflowException in managed code]]></message>
+                        </reason>
+                        <results>
+                          <test-case name="NUnit.Core.Tests.StackOverflowTestFixture.SimpleOverflow" executed="False">
+                            <reason>
+                              <message><![CDATA[Cannot handle StackOverflowException in managed code]]></message>
+                            </reason>
+                          </test-case>
+                        </results>
+                      </test-suite>
+                      <test-suite name="SuiteBuilderTests" executed="True" success="True" time="1.109" asserts="0">
+                        <results>
+                          <test-case name="NUnit.Core.Tests.SuiteBuilderTests.DiscoverSuite" executed="True" success="True" time="0.047" asserts="1" />
+                          <test-case name="NUnit.Core.Tests.SuiteBuilderTests.FileNotFound" executed="True" success="True" time="0.016" asserts="0" />
+                          <test-case name="NUnit.Core.Tests.SuiteBuilderTests.FixtureNotFound" executed="True" success="True" time="0.031" asserts="1" />
+                          <test-case name="NUnit.Core.Tests.SuiteBuilderTests.InvalidAssembly" executed="True" success="True" time="0.016" asserts="0" />
+                          <test-case name="NUnit.Core.Tests.SuiteBuilderTests.LoadAssembly" executed="True" success="True" time="0.328" asserts="3" />
+                          <test-case name="NUnit.Core.Tests.SuiteBuilderTests.LoadAssemblyWithoutNamespaces" executed="True" success="True" time="0.266" asserts="3" />
+                          <test-case name="NUnit.Core.Tests.SuiteBuilderTests.LoadFixture" executed="True" success="True" time="0.031" asserts="1" />
+                          <test-case name="NUnit.Core.Tests.SuiteBuilderTests.LoadNamespaceAsSuite" executed="True" success="True" time="0.297" asserts="3" />
+                          <test-case name="NUnit.Core.Tests.SuiteBuilderTests.LoadSuite" executed="True" success="True" time="0.031" asserts="2" />
+                          <test-case name="NUnit.Core.Tests.SuiteBuilderTests.WrongReturnTypeSuite" executed="True" success="True" time="0.016" asserts="1" />
+                        </results>
+                      </test-suite>
+                      <test-suite name="SuiteBuilderTests_Multiple" executed="True" success="True" time="0.453" asserts="0">
+                        <results>
+                          <test-case name="NUnit.Core.Tests.SuiteBuilderTests_Multiple.BuildSuite" executed="True" success="True" time="0.109" asserts="1" />
+                          <test-case name="NUnit.Core.Tests.SuiteBuilderTests_Multiple.LoadFixture" executed="True" success="True" time="0.125" asserts="2" />
+                          <test-case name="NUnit.Core.Tests.SuiteBuilderTests_Multiple.RootNode" executed="True" success="True" time="0.094" asserts="1" />
+                          <test-case name="NUnit.Core.Tests.SuiteBuilderTests_Multiple.TestCaseCount" executed="True" success="True" time="0.109" asserts="1" />
+                        </results>
+                      </test-suite>
+                      <test-suite name="TestAssemblyBuilderTests" executed="True" success="True" time="0.188" asserts="0">
+                        <results>
+                          <test-case name="NUnit.Core.Tests.TestAssemblyBuilderTests.CanLoadAssemblyAtRelativeDirectoryLocation" executed="True" success="True" time="0.094" asserts="1" />
+                          <test-case name="NUnit.Core.Tests.TestAssemblyBuilderTests.CanLoadAssemblyInCurrentDirectory" executed="True" success="True" time="0.094" asserts="1" />
+                        </results>
+                      </test-suite>
+                      <test-suite name="TestAttributeFixture" executed="True" success="True" time="0.047" asserts="0">
+                        <results>
+                          <test-case name="NUnit.Core.Tests.TestAttributeFixture.Description" executed="True" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Core.Tests.TestAttributeFixture.DescriptionInResult" executed="True" success="True" time="0.016" asserts="2" />
+                          <test-case name="NUnit.Core.Tests.TestAttributeFixture.FixtureDescription" executed="True" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Core.Tests.TestAttributeFixture.FixtureDescriptionInResult" executed="True" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Core.Tests.TestAttributeFixture.NoDescription" executed="True" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Core.Tests.TestAttributeFixture.ReflectionTest" executed="True" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Core.Tests.TestAttributeFixture.SeparateDescriptionAttribute" executed="True" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Core.Tests.TestAttributeFixture.SeparateDescriptionInResult" executed="True" success="True" time="0.016" asserts="1" />
+                        </results>
+                      </test-suite>
+                      <test-suite name="TestCaseAttributeTests" executed="True" success="True" time="0.078" asserts="0">
+                        <results>
+                          <test-suite name="ArgumentsAreCoalescedInObjectArray" executed="True" success="True" time="0.000" asserts="0">
+                            <results>
+                              <test-case name="NUnit.Core.Tests.TestCaseAttributeTests.ArgumentsAreCoalescedInObjectArray(System.Object[])" executed="True" success="True" time="0.000" asserts="2" />
+                            </results>
+                          </test-suite>
+                          <test-suite name="ArgumentsOfDifferentTypeAreCoalescedInObjectArray" executed="True" success="True" time="0.000" asserts="0">
+                            <results>
+                              <test-case name="NUnit.Core.Tests.TestCaseAttributeTests.ArgumentsOfDifferentTypeAreCoalescedInObjectArray(System.Object[])" executed="True" success="True" time="0.000" asserts="2" />
+                            </results>
+                          </test-suite>
+                          <test-suite name="CanConvertDoubleToDecimal" executed="True" success="True" time="0.000" asserts="0">
+                            <results>
+                              <test-case name="NUnit.Core.Tests.TestCaseAttributeTests.CanConvertDoubleToDecimal(2.2m,3.3m)" executed="True" success="True" time="0.000" asserts="1" />
+                            </results>
+                          </test-suite>
+                          <test-suite name="CanConvertIntToDouble" executed="True" success="True" time="0.000" asserts="0">
+                            <results>
+                              <test-case name="NUnit.Core.Tests.TestCaseAttributeTests.CanConvertIntToDouble(2,2)" executed="True" success="True" time="0.000" asserts="1" />
+                            </results>
+                          </test-suite>
+                          <test-suite name="CanConvertStringToDateTime" executed="True" success="True" time="0.000" asserts="0">
+                            <results>
+                              <test-case name="NUnit.Core.Tests.TestCaseAttributeTests.CanConvertStringToDateTime(10/12/1942 00:00:00)" executed="True" success="True" time="0.000" asserts="1" />
+                            </results>
+                          </test-suite>
+                          <test-suite name="CanConvertStringToDecimal" executed="True" success="True" time="0.000" asserts="0">
+                            <results>
+                              <test-case name="NUnit.Core.Tests.TestCaseAttributeTests.CanConvertStringToDecimal(2.2m,3.3m)" executed="True" success="True" time="0.000" asserts="1" />
+                            </results>
+                          </test-suite>
+                          <test-case name="NUnit.Core.Tests.TestCaseAttributeTests.CanIgnoreIndividualTestCase" executed="True" success="True" time="0.000" asserts="3" />
+                          <test-suite name="CanPassArrayAsArgument" executed="True" success="True" time="0.000" asserts="0">
+                            <results>
+                              <test-case name="NUnit.Core.Tests.TestCaseAttributeTests.CanPassArrayAsArgument(System.Object[])" executed="True" success="True" time="0.000" asserts="2" />
+                            </results>
+                          </test-suite>
+                          <test-suite name="CanPassNullAsFirstArgument" executed="True" success="True" time="0.000" asserts="0">
+                            <results>
+                              <test-case name="NUnit.Core.Tests.TestCaseAttributeTests.CanPassNullAsFirstArgument(null)" executed="True" success="True" time="0.000" asserts="1" />
+                            </results>
+                          </test-suite>
+                          <test-suite name="CanPassObjectArrayAsFirstArgument" executed="True" success="True" time="0.000" asserts="0">
+                            <results>
+                              <test-case name="NUnit.Core.Tests.TestCaseAttributeTests.CanPassObjectArrayAsFirstArgument(System.Object[])" executed="True" success="True" time="0.000" asserts="0" />
+                              <test-case name="NUnit.Core.Tests.TestCaseAttributeTests.CanPassObjectArrayAsFirstArgument(System.Object[])" executed="True" success="True" time="0.000" asserts="0" />
+                            </results>
+                          </test-suite>
+                          <test-case name="NUnit.Core.Tests.TestCaseAttributeTests.CanSpecifyDescription" executed="True" success="True" time="0.000" asserts="1" />
+                          <test-suite name="CanSpecifyExceptionMessage" executed="True" success="True" time="0.000" asserts="0">
+                            <results>
+                              <test-case name="NUnit.Core.Tests.TestCaseAttributeTests.CanSpecifyExceptionMessage(42)" executed="True" success="True" time="0.000" asserts="0" />
+                            </results>
+                          </test-suite>
+                          <test-suite name="CanSpecifyExceptionMessageAndMatchType" executed="True" success="True" time="0.031" asserts="0">
+                            <results>
+                              <test-case name="NUnit.Core.Tests.TestCaseAttributeTests.CanSpecifyExceptionMessageAndMatchType(42)" executed="True" success="True" time="0.031" asserts="0" />
+                            </results>
+                          </test-suite>
+                          <test-case name="NUnit.Core.Tests.TestCaseAttributeTests.CanSpecifyExpectedException" executed="True" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Core.Tests.TestCaseAttributeTests.CanSpecifyExpectedException_NoneThrown" executed="True" success="True" time="0.000" asserts="2" />
+                          <test-case name="NUnit.Core.Tests.TestCaseAttributeTests.CanSpecifyExpectedException_WrongException" executed="True" success="True" time="0.000" asserts="2" />
+                          <test-case name="NUnit.Core.Tests.TestCaseAttributeTests.CanSpecifyExpectedException_WrongMessage" executed="True" success="True" time="0.000" asserts="2" />
+                          <test-case name="NUnit.Core.Tests.TestCaseAttributeTests.CanSpecifyTestName" executed="True" success="True" time="0.016" asserts="2" />
+                          <test-case name="NUnit.Core.Tests.TestCaseAttributeTests.ConversionOverflowGivesError" executed="True" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Core.Tests.TestCaseAttributeTests.IgnoreTakesPrecedenceOverExpectedException" executed="True" success="True" time="0.000" asserts="2" />
+                          <test-suite name="IntegerDivisionWithResultCheckedByNUnit" executed="True" success="True" time="0.016" asserts="0">
+                            <results>
+                              <test-case name="NUnit.Core.Tests.TestCaseAttributeTests.IntegerDivisionWithResultCheckedByNUnit(12,4)" executed="True" success="True" time="0.000" asserts="1" />
+                              <test-case name="NUnit.Core.Tests.TestCaseAttributeTests.IntegerDivisionWithResultCheckedByNUnit(12,3)" executed="True" success="True" time="0.000" asserts="1" />
+                              <test-case name="NUnit.Core.Tests.TestCaseAttributeTests.IntegerDivisionWithResultCheckedByNUnit(12,2)" executed="True" success="True" time="0.000" asserts="1" />
+                              <test-case name="NUnit.Core.Tests.TestCaseAttributeTests.DivisionByZeroThrowsException" executed="True" success="True" time="0.000" asserts="0" />
+                              <test-case name="NUnit.Core.Tests.TestCaseAttributeTests.IntegerDivisionWithResultCheckedByNUnit(12,0)" executed="True" success="True" time="0.000" asserts="0" />
+                            </results>
+                          </test-suite>
+                          <test-suite name="IntegerDivisionWithResultPassedToTest" executed="True" success="True" time="0.000" asserts="0">
+                            <results>
+                              <test-case name="NUnit.Core.Tests.TestCaseAttributeTests.IntegerDivisionWithResultPassedToTest(12,0,0)" executed="True" success="True" time="0.000" asserts="0" />
+                              <test-case name="NUnit.Core.Tests.TestCaseAttributeTests.IntegerDivisionWithResultPassedToTest(12,4,3)" executed="True" success="True" time="0.000" asserts="1" />
+                              <test-case name="NUnit.Core.Tests.TestCaseAttributeTests.IntegerDivisionWithResultPassedToTest(12,2,6)" executed="True" success="True" time="0.000" asserts="1" />
+                              <test-case name="NUnit.Core.Tests.TestCaseAttributeTests.IntegerDivisionWithResultPassedToTest(12,0,0)" executed="True" success="True" time="0.000" asserts="0" />
+                              <test-case name="NUnit.Core.Tests.TestCaseAttributeTests.IntegerDivisionWithResultPassedToTest(12,3,4)" executed="True" success="True" time="0.000" asserts="1" />
+                            </results>
+                          </test-suite>
+                        </results>
+                      </test-suite>
+                      <test-suite name="TestCaseResultFixture" executed="True" success="True" time="0.000" asserts="0">
+                        <results>
+                          <test-case name="NUnit.Core.Tests.TestCaseResultFixture.TestCaseDefault" executed="True" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Core.Tests.TestCaseResultFixture.TestCaseFailure" executed="True" success="True" time="0.000" asserts="4" />
+                          <test-case name="NUnit.Core.Tests.TestCaseResultFixture.TestCaseNotRun" executed="True" success="True" time="0.000" asserts="2" />
+                          <test-case name="NUnit.Core.Tests.TestCaseResultFixture.TestCaseSuccess" executed="True" success="True" time="0.000" asserts="1" />
+                        </results>
+                      </test-suite>
+                      <test-suite name="TestCaseSourceTests" executed="True" success="True" time="0.078" asserts="0">
+                        <results>
+                          <test-case name="NUnit.Core.Tests.TestCaseSourceTests.CanIgnoreIndividualTestCases" executed="True" success="True" time="0.000" asserts="3" />
+                          <test-case name="NUnit.Core.Tests.TestCaseSourceTests.CanSpecifyExpectedException" executed="True" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Core.Tests.TestCaseSourceTests.CanSpecifyExpectedException_NoneThrown" executed="True" success="True" time="0.000" asserts="2" />
+                          <test-case name="NUnit.Core.Tests.TestCaseSourceTests.CanSpecifyExpectedException_WrongException" executed="True" success="True" time="0.031" asserts="2" />
+                          <test-case name="NUnit.Core.Tests.TestCaseSourceTests.HandlesExceptionInTestCaseSource" executed="True" success="True" time="0.000" asserts="3" />
+                          <test-case name="NUnit.Core.Tests.TestCaseSourceTests.IgnoreTakesPrecedenceOverExpectedException" executed="True" success="True" time="0.000" asserts="2" />
+                          <test-suite name="MethodTakingTwoStringArrays" executed="True" success="True" time="0.000" asserts="0">
+                            <results>
+                              <test-case name="NUnit.Core.Tests.TestCaseSourceTests.MethodTakingTwoStringArrays(System.String[],System.String[])" executed="True" success="True" time="0.000" asserts="2" />
+                            </results>
+                          </test-suite>
+                          <test-suite name="SourceCanBeInstanceField" executed="True" success="True" time="0.000" asserts="0">
+                            <results>
+                              <test-case name="NUnit.Core.Tests.TestCaseSourceTests.SourceCanBeInstanceField(&quot;InstanceField&quot;)" executed="True" success="True" time="0.000" asserts="1" />
+                            </results>
+                          </test-suite>
+                          <test-suite name="SourceCanBeInstanceMethod" executed="True" success="True" time="0.000" asserts="0">
+                            <results>
+                              <test-case name="NUnit.Core.Tests.TestCaseSourceTests.SourceCanBeInstanceMethod(&quot;InstanceMethod&quot;)" executed="True" success="True" time="0.000" asserts="1" />
+                            </results>
+                          </test-suite>
+                          <test-suite name="SourceCanBeInstanceProperty" executed="True" success="True" time="0.000" asserts="0">
+                            <results>
+                              <test-case name="NUnit.Core.Tests.TestCaseSourceTests.SourceCanBeInstanceProperty(&quot;InstanceProperty&quot;)" executed="True" success="True" time="0.000" asserts="1" />
+                            </results>
+                          </test-suite>
+                          <test-suite name="SourceCanBeStaticField" executed="True" success="True" time="0.000" asserts="0">
+                            <results>
+                              <test-case name="NUnit.Core.Tests.TestCaseSourceTests.SourceCanBeStaticField(&quot;StaticField&quot;)" executed="True" success="True" time="0.000" asserts="1" />
+                            </results>
+                          </test-suite>
+                          <test-suite name="SourceCanBeStaticMethod" executed="True" success="True" time="0.000" asserts="0">
+                            <results>
+                              <test-case name="NUnit.Core.Tests.TestCaseSourceTests.SourceCanBeStaticMethod(&quot;StaticMethod&quot;)" executed="True" success="True" time="0.000" asserts="1" />
+                            </results>
+                          </test-suite>
+                          <test-suite name="SourceCanBeStaticProperty" executed="True" success="True" time="0.000" asserts="0">
+                            <results>
+                              <test-case name="NUnit.Core.Tests.TestCaseSourceTests.SourceCanBeStaticProperty(&quot;StaticProperty&quot;)" executed="True" success="True" time="0.000" asserts="1" />
+                            </results>
+                          </test-suite>
+                          <test-suite name="SourceIsInvokedWithCorrectCurrentDirectory" executed="True" success="True" time="0.000" asserts="0">
+                            <results>
+                              <test-case name="NUnit.Core.Tests.TestCaseSourceTests.SourceIsInvokedWithCorrectCurrentDirectory(True)" executed="True" success="True" time="0.000" asserts="1" />
+                            </results>
+                          </test-suite>
+                          <test-suite name="SourceMayBeInAnotherClass" executed="True" success="True" time="0.000" asserts="0">
+                            <results>
+                              <test-case name="NUnit.Core.Tests.TestCaseSourceTests.ThisOneShouldThrow" description="Demonstrates use of ExpectedException" executed="True" success="True" time="0.000" asserts="0">
+                                <categories>
+                                  <category name="Junk" />
+                                </categories>
+                                <properties>
+                                  <property name="MyProp" value="zip" />
+                                </properties>
+                              </test-case>
+                              <test-case name="NUnit.Core.Tests.TestCaseSourceTests.SourceMayBeInAnotherClass(100,20,5)" executed="True" success="True" time="0.000" asserts="1" />
+                              <test-case name="NUnit.Core.Tests.TestCaseSourceTests.SourceMayBeInAnotherClass(100,4,25)" executed="True" success="True" time="0.000" asserts="1" />
+                            </results>
+                          </test-suite>
+                          <test-suite name="SourceMayBeInAnotherClassWithReturn" executed="True" success="True" time="0.000" asserts="0">
+                            <results>
+                              <test-case name="NUnit.Core.Tests.TestCaseSourceTests.TC1" executed="True" success="True" time="0.000" asserts="1" />
+                              <test-case name="NUnit.Core.Tests.TestCaseSourceTests.TC2" executed="True" success="True" time="0.000" asserts="1" />
+                              <test-case name="NUnit.Core.Tests.TestCaseSourceTests.TC3" executed="True" success="True" time="0.000" asserts="1" />
+                            </results>
+                          </test-suite>
+                          <test-suite name="SourceMayReturnArgumentsAsIntArray" executed="True" success="True" time="0.000" asserts="0">
+                            <results>
+                              <test-case name="NUnit.Core.Tests.TestCaseSourceTests.SourceMayReturnArgumentsAsIntArray(12,3,4)" executed="True" success="True" time="0.000" asserts="1" />
+                              <test-case name="NUnit.Core.Tests.TestCaseSourceTests.SourceMayReturnArgumentsAsIntArray(12,4,3)" executed="True" success="True" time="0.000" asserts="1" />
+                              <test-case name="NUnit.Core.Tests.TestCaseSourceTests.SourceMayReturnArgumentsAsIntArray(12,6,2)" executed="True" success="True" time="0.000" asserts="1" />
+                            </results>
+                          </test-suite>
+                          <test-suite name="SourceMayReturnArgumentsAsObjectArray" executed="True" success="True" time="0.000" asserts="0">
+                            <results>
+                              <test-case name="NUnit.Core.Tests.TestCaseSourceTests.SourceMayReturnArgumentsAsObjectArray(12,3,4)" executed="True" success="True" time="0.000" asserts="1" />
+                              <test-case name="NUnit.Core.Tests.TestCaseSourceTests.SourceMayReturnArgumentsAsObjectArray(12,4,3)" executed="True" success="True" time="0.000" asserts="1" />
+                              <test-case name="NUnit.Core.Tests.TestCaseSourceTests.SourceMayReturnArgumentsAsObjectArray(12,6,2)" executed="True" success="True" time="0.000" asserts="1" />
+                            </results>
+                          </test-suite>
+                          <test-suite name="SourceMayReturnArgumentsAsParamSet" executed="True" success="True" time="0.000" asserts="0">
+                            <results>
+                              <test-case name="NUnit.Core.Tests.TestCaseSourceTests.SourceMayReturnArgumentsAsParamSet(24,3)" executed="True" success="True" time="0.000" asserts="1" />
+                              <test-case name="NUnit.Core.Tests.TestCaseSourceTests.SourceMayReturnArgumentsAsParamSet(24,2)" executed="True" success="True" time="0.000" asserts="1" />
+                            </results>
+                          </test-suite>
+                          <test-suite name="SourceMayReturnSinglePrimitiveArgumentAlone" executed="True" success="True" time="0.000" asserts="0">
+                            <results>
+                              <test-case name="NUnit.Core.Tests.TestCaseSourceTests.SourceMayReturnSinglePrimitiveArgumentAlone(2)" executed="True" success="True" time="0.000" asserts="1" />
+                              <test-case name="NUnit.Core.Tests.TestCaseSourceTests.SourceMayReturnSinglePrimitiveArgumentAlone(4)" executed="True" success="True" time="0.000" asserts="1" />
+                              <test-case name="NUnit.Core.Tests.TestCaseSourceTests.SourceMayReturnSinglePrimitiveArgumentAlone(6)" executed="True" success="True" time="0.000" asserts="1" />
+                              <test-case name="NUnit.Core.Tests.TestCaseSourceTests.SourceMayReturnSinglePrimitiveArgumentAlone(8)" executed="True" success="True" time="0.000" asserts="1" />
+                            </results>
+                          </test-suite>
+                          <test-suite name="TestAttributeIsOptional" executed="True" success="True" time="0.000" asserts="0">
+                            <results>
+                              <test-case name="NUnit.Core.Tests.TestCaseSourceTests.TestAttributeIsOptional(12,3,4)" executed="True" success="True" time="0.000" asserts="1" />
+                              <test-case name="NUnit.Core.Tests.TestCaseSourceTests.TestAttributeIsOptional(12,4,3)" executed="True" success="True" time="0.000" asserts="1" />
+                              <test-case name="NUnit.Core.Tests.TestCaseSourceTests.TestAttributeIsOptional(12,6,2)" executed="True" success="True" time="0.000" asserts="1" />
+                            </results>
+                          </test-suite>
+                          <test-suite name="TestMayUseMultipleSourceAttributes" executed="True" success="True" time="0.000" asserts="0">
+                            <results>
+                              <test-case name="NUnit.Core.Tests.TestCaseSourceTests.TestMayUseMultipleSourceAttributes(12,0,0)" executed="True" success="True" time="0.000" asserts="0" />
+                              <test-case name="NUnit.Core.Tests.TestCaseSourceTests.TestMayUseMultipleSourceAttributes(12,1,12)" executed="True" success="True" time="0.000" asserts="1" />
+                              <test-case name="NUnit.Core.Tests.TestCaseSourceTests.TestMayUseMultipleSourceAttributes(12,2,6)" executed="True" success="True" time="0.000" asserts="1" />
+                              <test-case name="NUnit.Core.Tests.TestCaseSourceTests.TestMayUseMultipleSourceAttributes(12,3,4)" executed="True" success="True" time="0.000" asserts="1" />
+                              <test-case name="NUnit.Core.Tests.TestCaseSourceTests.TestMayUseMultipleSourceAttributes(12,4,3)" executed="True" success="True" time="0.000" asserts="1" />
+                              <test-case name="NUnit.Core.Tests.TestCaseSourceTests.TestMayUseMultipleSourceAttributes(12,6,2)" executed="True" success="True" time="0.000" asserts="1" />
+                            </results>
+                          </test-suite>
+                          <test-suite name="TestWithFourArguments" executed="True" success="True" time="0.000" asserts="0">
+                            <results>
+                              <test-case name="NUnit.Core.Tests.TestCaseSourceTests.TestWithFourArguments(12,3,4,0)" executed="True" success="True" time="0.000" asserts="2" />
+                              <test-case name="NUnit.Core.Tests.TestCaseSourceTests.TestWithFourArguments(12,4,3,0)" executed="True" success="True" time="0.000" asserts="2" />
+                              <test-case name="NUnit.Core.Tests.TestCaseSourceTests.TestWithFourArguments(12,5,2,2)" executed="True" success="True" time="0.000" asserts="2" />
+                            </results>
+                          </test-suite>
+                        </results>
+                      </test-suite>
+                      <test-suite name="TestCaseTest" executed="True" success="True" time="0.000" asserts="0">
+                        <results>
+                          <test-case name="NUnit.Core.Tests.TestCaseTest.CreateIgnoredTestCase" executed="True" success="True" time="0.000" asserts="3" />
+                          <test-case name="NUnit.Core.Tests.TestCaseTest.LoadMethodCategories" executed="True" success="True" time="0.000" asserts="3" />
+                          <test-case name="NUnit.Core.Tests.TestCaseTest.RunIgnoredTestCase" executed="True" success="True" time="0.000" asserts="3" />
+                        </results>
+                      </test-suite>
+                      <test-suite name="TestConsole" executed="True" success="True" time="0.000" asserts="0">
+                        <results>
+                          <test-case name="NUnit.Core.Tests.TestConsole.ConsoleWrite" executed="True" success="True" time="0.000" asserts="0" />
+                          <test-case name="NUnit.Core.Tests.TestConsole.ConsoleWriteLine" executed="True" success="True" time="0.000" asserts="0" />
+                        </results>
+                      </test-suite>
+                      <test-suite name="TestContextTests" executed="True" success="True" time="0.016" asserts="0">
+                        <results>
+                          <test-case name="NUnit.Core.Tests.TestContextTests.SetAndRestoreCurrentCulture" executed="True" success="True" time="0.000" asserts="5" />
+                          <test-case name="NUnit.Core.Tests.TestContextTests.SetAndRestoreCurrentDirectory" executed="True" success="True" time="0.000" asserts="5" />
+                          <test-case name="NUnit.Core.Tests.TestContextTests.SetAndRestoreCurrentUICulture" executed="True" success="True" time="0.000" asserts="5" />
+                        </results>
+                      </test-suite>
+                      <test-suite name="TestDelegateFixture" executed="True" success="True" time="0.000" asserts="0">
+                        <results>
+                          <test-case name="NUnit.Core.Tests.TestDelegateFixture.DelegateTest" executed="True" success="True" time="0.000" asserts="1" />
+                        </results>
+                      </test-suite>
+                      <test-suite name="TestFixtureBuilderTests" executed="True" success="True" time="0.031" asserts="0">
+                        <results>
+                          <test-case name="NUnit.Core.Tests.TestFixtureBuilderTests.GoodSignature" executed="True" success="True" time="0.016" asserts="2" />
+                          <test-case name="NUnit.Core.Tests.TestFixtureBuilderTests.LoadCategories" executed="True" success="True" time="0.016" asserts="2" />
+                        </results>
+                      </test-suite>
+                      <test-suite name="TestFixtureExtension" executed="True" success="True" time="0.234" asserts="0">
+                        <results>
+                          <test-case name="NUnit.Core.Tests.TestFixtureExtension.CheckMultipleSetUp" executed="True" success="True" time="0.063" asserts="1" />
+                          <test-case name="NUnit.Core.Tests.TestFixtureExtension.DerivedTest" executed="True" success="True" time="0.063" asserts="1" />
+                          <test-case name="NUnit.Core.Tests.TestFixtureExtension.InheritSetup" executed="True" success="True" time="0.047" asserts="1" />
+                          <test-case name="NUnit.Core.Tests.TestFixtureExtension.InheritTearDown" executed="True" success="True" time="0.063" asserts="1" />
+                        </results>
+                      </test-suite>
+                      <test-suite name="TestFixtureTests" executed="True" success="True" time="0.438" asserts="0">
+                        <results>
+                          <test-case name="NUnit.Core.Tests.TestFixtureTests.CannotRunAbstractDerivedFixture" executed="True" success="True" time="0.016" asserts="2" />
+                          <test-case name="NUnit.Core.Tests.TestFixtureTests.CannotRunAbstractFixture" executed="True" success="True" time="0.000" asserts="2" />
+                          <test-case name="NUnit.Core.Tests.TestFixtureTests.CannotRunBadConstructor" executed="True" success="True" time="0.000" asserts="2" />
+                          <test-case name="NUnit.Core.Tests.TestFixtureTests.CannotRunConstructorWithArgsNotSupplied" executed="True" success="True" time="0.016" asserts="2" />
+                          <test-case name="NUnit.Core.Tests.TestFixtureTests.CannotRunFixtureSetupWithParameters" executed="True" success="True" time="0.016" asserts="2" />
+                          <test-case name="NUnit.Core.Tests.TestFixtureTests.CannotRunFixtureSetupWithReturnValue" executed="True" success="True" time="0.000" asserts="2" />
+                          <test-case name="NUnit.Core.Tests.TestFixtureTests.CannotRunFixtureTearDownWithParameters" executed="True" success="True" time="0.016" asserts="2" />
+                          <test-case name="NUnit.Core.Tests.TestFixtureTests.CannotRunFixtureTearDownWithReturnValue" executed="True" success="True" time="0.016" asserts="2" />
+                          <test-case name="NUnit.Core.Tests.TestFixtureTests.CannotRunIgnoredFixture" executed="True" success="True" time="0.016" asserts="2" />
+                          <test-case name="NUnit.Core.Tests.TestFixtureTests.CannotRunPrivateFixtureSetUp" executed="True" success="True" time="0.000" asserts="2" />
+                          <test-case name="NUnit.Core.Tests.TestFixtureTests.CannotRunPrivateFixtureTearDown" executed="True" success="True" time="0.016" asserts="2" />
+                          <test-case name="NUnit.Core.Tests.TestFixtureTests.CannotRunPrivateSetUp" executed="True" success="True" time="0.016" asserts="2" />
+                          <test-case name="NUnit.Core.Tests.TestFixtureTests.CannotRunPrivateTearDown" executed="True" success="True" time="0.000" asserts="2" />
+                          <test-case name="NUnit.Core.Tests.TestFixtureTests.CannotRunSetupWithParameters" executed="True" success="True" time="0.000" asserts="2" />
+                          <test-case name="NUnit.Core.Tests.TestFixtureTests.CannotRunSetupWithReturnValue" executed="True" success="True" time="0.016" asserts="2" />
+                          <test-case name="NUnit.Core.Tests.TestFixtureTests.CannotRunTearDownWithParameters" executed="True" success="True" time="0.000" asserts="2" />
+                          <test-case name="NUnit.Core.Tests.TestFixtureTests.CannotRunTearDownWithReturnValue" executed="True" success="True" time="0.000" asserts="2" />
+                          <test-case name="NUnit.Core.Tests.TestFixtureTests.CanRunConstructorWithArgsSupplied" executed="True" success="True" time="0.016" asserts="1" />
+                          <test-case name="NUnit.Core.Tests.TestFixtureTests.CanRunMultipleSetUp" executed="True" success="True" time="0.016" asserts="1" />
+                          <test-case name="NUnit.Core.Tests.TestFixtureTests.CanRunMultipleTearDown" executed="True" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Core.Tests.TestFixtureTests.CanRunMultipleTestFixtureSetUp" executed="True" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Core.Tests.TestFixtureTests.CanRunMultipleTestFixtureTearDown" executed="True" success="True" time="0.016" asserts="1" />
+                          <test-case name="NUnit.Core.Tests.TestFixtureTests.CanRunProtectedFixtureSetUp" executed="True" success="True" time="0.016" asserts="1" />
+                          <test-case name="NUnit.Core.Tests.TestFixtureTests.CanRunProtectedFixtureTearDown" executed="True" success="True" time="0.016" asserts="1" />
+                          <test-case name="NUnit.Core.Tests.TestFixtureTests.CanRunProtectedSetUp" executed="True" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Core.Tests.TestFixtureTests.CanRunProtectedTearDown" executed="True" success="True" time="0.016" asserts="1" />
+                          <test-case name="NUnit.Core.Tests.TestFixtureTests.CanRunStaticFixture" executed="True" success="True" time="0.016" asserts="1" />
+                          <test-case name="NUnit.Core.Tests.TestFixtureTests.CanRunStaticFixtureSetUp" executed="True" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Core.Tests.TestFixtureTests.CanRunStaticFixtureTearDown" executed="True" success="True" time="0.031" asserts="1" />
+                          <test-case name="NUnit.Core.Tests.TestFixtureTests.CanRunStaticSetUp" executed="True" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Core.Tests.TestFixtureTests.CanRunStaticTearDown" executed="True" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Core.Tests.TestFixtureTests.ConstructFromDoublyNestedType" executed="True" success="True" time="0.016" asserts="2" />
+                          <test-case name="NUnit.Core.Tests.TestFixtureTests.ConstructFromNestedType" executed="True" success="True" time="0.016" asserts="2" />
+                          <test-case name="NUnit.Core.Tests.TestFixtureTests.ConstructFromStaticTypeWithoutTestFixtureAttribute" executed="True" success="True" time="0.016" asserts="2" />
+                          <test-case name="NUnit.Core.Tests.TestFixtureTests.ConstructFromType" executed="True" success="True" time="0.000" asserts="2" />
+                          <test-case name="NUnit.Core.Tests.TestFixtureTests.ConstructFromTypeWithoutNamespace" executed="True" success="True" time="0.016" asserts="2" />
+                          <test-case name="NUnit.Core.Tests.TestFixtureTests.ConstructFromTypeWithoutTestFixtureAttribute" executed="True" success="True" time="0.000" asserts="2" />
+                        </results>
+                      </test-suite>
+                      <test-suite name="TestFrameworkTests" executed="True" success="True" time="0.016" asserts="0">
+                        <results>
+                          <test-case name="NUnit.Core.Tests.TestFrameworkTests.NUnitFrameworkIsKnownAndReferenced" executed="True" success="True" time="0.000" asserts="0" />
+                        </results>
+                      </test-suite>
+                      <test-suite name="TestIDTests" executed="True" success="True" time="0.000" asserts="0">
+                        <results>
+                          <test-case name="NUnit.Core.Tests.TestIDTests.ClonedTestIDsAreEqual" executed="True" success="True" time="0.000" asserts="3" />
+                          <test-case name="NUnit.Core.Tests.TestIDTests.DifferentTestIDsAreNotEqual" executed="True" success="True" time="0.000" asserts="3" />
+                          <test-case name="NUnit.Core.Tests.TestIDTests.DifferentTestIDsDisplayDifferentStrings" executed="True" success="True" time="0.000" asserts="1" />
+                        </results>
+                      </test-suite>
+                      <test-suite name="TestInfoTests" executed="True" success="True" time="0.016" asserts="0">
+                        <results>
+                          <test-case name="NUnit.Core.Tests.TestInfoTests.ConstructFromFixture" executed="True" success="True" time="0.000" asserts="8" />
+                          <test-case name="NUnit.Core.Tests.TestInfoTests.ConstructFromSuite" executed="True" success="True" time="0.016" asserts="7" />
+                          <test-case name="NUnit.Core.Tests.TestInfoTests.ConstructFromTestCase" executed="True" success="True" time="0.000" asserts="7" />
+                        </results>
+                      </test-suite>
+                      <test-suite name="TestMethodSignatureTests" executed="True" success="True" time="0.250" asserts="0">
+                        <results>
+                          <test-case name="NUnit.Core.Tests.TestMethodSignatureTests.InstanceTestMethodIsRunnable" executed="True" success="True" time="0.016" asserts="1" />
+                          <test-case name="NUnit.Core.Tests.TestMethodSignatureTests.PrivateTestMethodIsNotRunnable" executed="True" success="True" time="0.016" asserts="2" />
+                          <test-case name="NUnit.Core.Tests.TestMethodSignatureTests.ProtectedTestMethodIsNotRunnable" executed="True" success="True" time="0.016" asserts="2" />
+                          <test-case name="NUnit.Core.Tests.TestMethodSignatureTests.RunningTestsThroughFixtureGivesCorrectResults" executed="True" success="True" time="0.000" asserts="6" />
+                          <test-case name="NUnit.Core.Tests.TestMethodSignatureTests.StaticTestMethodIsRunnable" executed="True" success="True" time="0.031" asserts="1" />
+                          <test-case name="NUnit.Core.Tests.TestMethodSignatureTests.StaticTestMethodWithArgumentsNotProvidedIsNotRunnable" executed="True" success="True" time="0.016" asserts="2" />
+                          <test-case name="NUnit.Core.Tests.TestMethodSignatureTests.StaticTestMethodWithArgumentsProvidedIsRunnable" executed="True" success="True" time="0.016" asserts="1" />
+                          <test-case name="NUnit.Core.Tests.TestMethodSignatureTests.StaticTestMethodWithWrongArgumentTypesProvidedGivesError" executed="True" success="True" time="0.016" asserts="1" />
+                          <test-case name="NUnit.Core.Tests.TestMethodSignatureTests.StaticTestMethodWithWrongNumberOfArgumentsProvidedIsNotRunnable" executed="True" success="True" time="0.016" asserts="2" />
+                          <test-case name="NUnit.Core.Tests.TestMethodSignatureTests.TestMethodWithArgumentsNotProvidedIsNotRunnable" executed="True" success="True" time="0.000" asserts="2" />
+                          <test-case name="NUnit.Core.Tests.TestMethodSignatureTests.TestMethodWithArgumentsProvidedIsRunnable" executed="True" success="True" time="0.016" asserts="1" />
+                          <test-case name="NUnit.Core.Tests.TestMethodSignatureTests.TestMethodWithConvertibleArgumentsIsRunnable" executed="True" success="True" time="0.016" asserts="1" />
+                          <test-case name="NUnit.Core.Tests.TestMethodSignatureTests.TestMethodWithMultipleTestCasesExecutesMultipleTimes" executed="True" success="True" time="0.016" asserts="2" />
+                          <test-case name="NUnit.Core.Tests.TestMethodSignatureTests.TestMethodWithMultipleTestCasesUsesCorrectNames" executed="True" success="True" time="0.016" asserts="7" />
+                          <test-case name="NUnit.Core.Tests.TestMethodSignatureTests.TestMethodWithNonConvertibleArgumentsGivesError" executed="True" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Core.Tests.TestMethodSignatureTests.TestMethodWithoutParametersWithArgumentsProvidedIsNotRunnable" executed="True" success="True" time="0.000" asserts="2" />
+                          <test-case name="NUnit.Core.Tests.TestMethodSignatureTests.TestMethodWithReturnTypeIsNotRunnable" executed="True" success="True" time="0.016" asserts="2" />
+                          <test-case name="NUnit.Core.Tests.TestMethodSignatureTests.TestMethodWithWrongArgumentTypesProvidedGivesError" executed="True" success="True" time="0.016" asserts="1" />
+                          <test-case name="NUnit.Core.Tests.TestMethodSignatureTests.TestMethodWithWrongNumberOfArgumentsProvidedIsNotRunnable" executed="True" success="True" time="0.000" asserts="2" />
+                        </results>
+                      </test-suite>
+                      <test-suite name="TestNameTests" executed="True" success="True" time="0.016" asserts="0">
+                        <results>
+                          <test-case name="NUnit.Core.Tests.TestNameTests.CanCompareStrongTestNames" executed="True" success="True" time="0.000" asserts="9" />
+                          <test-case name="NUnit.Core.Tests.TestNameTests.CanCompareWeakAndStrongTestNames" executed="True" success="True" time="0.000" asserts="3" />
+                          <test-case name="NUnit.Core.Tests.TestNameTests.CanCompareWeakTestNames" executed="True" success="True" time="0.000" asserts="6" />
+                          <test-case name="NUnit.Core.Tests.TestNameTests.CanDisplayUniqueNames" executed="True" success="True" time="0.016" asserts="2" />
+                          <test-case name="NUnit.Core.Tests.TestNameTests.CanParseSimpleTestNames" executed="True" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Core.Tests.TestNameTests.CanParseStrongTestNames" executed="True" success="True" time="0.000" asserts="2" />
+                          <test-case name="NUnit.Core.Tests.TestNameTests.CanParseWeakTestNames" executed="True" success="True" time="0.000" asserts="2" />
+                          <test-case name="NUnit.Core.Tests.TestNameTests.ClonedTestNamesAreEqual" executed="True" success="True" time="0.000" asserts="6" />
+                          <test-case name="NUnit.Core.Tests.TestNameTests.TestNamesWithDifferentRunnerIDsAreNotEqual" executed="True" success="True" time="0.000" asserts="7" />
+                        </results>
+                      </test-suite>
+                      <test-suite name="TestNodeTests" executed="True" success="True" time="0.031" asserts="0">
+                        <results>
+                          <test-case name="NUnit.Core.Tests.TestNodeTests.ConstructFromMultipleTests" executed="True" success="True" time="0.016" asserts="8" />
+                          <test-case name="NUnit.Core.Tests.TestNodeTests.ConstructFromSuite" executed="True" success="True" time="0.016" asserts="3" />
+                          <test-case name="NUnit.Core.Tests.TestNodeTests.ConstructFromTestCase" executed="True" success="True" time="0.000" asserts="1" />
+                        </results>
+                      </test-suite>
+                      <test-suite name="TestRunnerThreadTests" executed="True" success="True" time="0.016" asserts="0">
+                        <results>
+                          <test-case name="NUnit.Core.Tests.TestRunnerThreadTests.RunMultipleTests" executed="True" success="True" time="0.016" asserts="2" />
+                          <test-case name="NUnit.Core.Tests.TestRunnerThreadTests.RunNamedTest" executed="True" success="True" time="0.000" asserts="2" />
+                          <test-case name="NUnit.Core.Tests.TestRunnerThreadTests.RunTestSuite" executed="True" success="True" time="0.000" asserts="2" />
+                        </results>
+                      </test-suite>
+                      <test-suite name="TestSuiteTest" executed="True" success="True" time="0.469" asserts="0">
+                        <results>
+                          <test-case name="NUnit.Core.Tests.TestSuiteTest.CanSortUsingExternalComparer" executed="True" success="True" time="0.016" asserts="1" />
+                          <test-case name="NUnit.Core.Tests.TestSuiteTest.CountTestCasesFilteredByName" executed="True" success="True" time="0.016" asserts="4" />
+                          <test-case name="NUnit.Core.Tests.TestSuiteTest.DefaultSortIsByName" executed="True" success="True" time="0.016" asserts="1" />
+                          <test-case name="NUnit.Core.Tests.TestSuiteTest.ExcludingCategoryDoesNotRunExplicitTestCases" executed="True" success="True" time="0.016" asserts="1" />
+                          <test-case name="NUnit.Core.Tests.TestSuiteTest.ExcludingCategoryDoesNotRunExplicitTestFixtures" executed="True" success="True" time="0.109" asserts="1" />
+                          <test-case name="NUnit.Core.Tests.TestSuiteTest.InheritedTestCount" executed="True" success="True" time="0.031" asserts="1" />
+                          <test-case name="NUnit.Core.Tests.TestSuiteTest.RunExplicitTestByCategory" executed="True" success="True" time="0.016" asserts="1" />
+                          <test-case name="NUnit.Core.Tests.TestSuiteTest.RunExplicitTestByName" executed="True" success="True" time="0.016" asserts="1" />
+                          <test-case name="NUnit.Core.Tests.TestSuiteTest.RunExplicitTestDirectly" executed="True" success="True" time="0.016" asserts="1" />
+                          <test-case name="NUnit.Core.Tests.TestSuiteTest.RunNoTestSuite" executed="True" success="True" time="0.016" asserts="3" />
+                          <test-case name="NUnit.Core.Tests.TestSuiteTest.RunSingleTest" executed="True" success="True" time="0.031" asserts="1" />
+                          <test-case name="NUnit.Core.Tests.TestSuiteTest.RunSuiteByCategory" executed="True" success="True" time="0.016" asserts="1" />
+                          <test-case name="NUnit.Core.Tests.TestSuiteTest.RunSuiteByName" executed="True" success="True" time="0.016" asserts="2" />
+                          <test-case name="NUnit.Core.Tests.TestSuiteTest.RunTestByCategory" executed="True" success="True" time="0.016" asserts="1" />
+                          <test-case name="NUnit.Core.Tests.TestSuiteTest.RunTestByName" executed="True" success="True" time="0.016" asserts="2" />
+                          <test-case name="NUnit.Core.Tests.TestSuiteTest.RunTestExcludingCategory" executed="True" success="True" time="0.031" asserts="1" />
+                          <test-case name="NUnit.Core.Tests.TestSuiteTest.RunTestsInFixture" executed="True" success="True" time="0.031" asserts="6" />
+                          <test-case name="NUnit.Core.Tests.TestSuiteTest.SuiteRunInitialized" executed="True" success="True" time="0.016" asserts="1" />
+                          <test-case name="NUnit.Core.Tests.TestSuiteTest.SuiteWithNoTests" executed="True" success="True" time="0.016" asserts="3" />
+                        </results>
+                      </test-suite>
+                      <test-suite name="TheoryTests" executed="True" success="True" time="0.016" asserts="0">
+                        <results>
+                          <test-suite name="ArrayWithDatapointsAttributeIsUsed" executed="True" success="True" time="0.016" asserts="0">
+                            <results>
+                              <test-case name="NUnit.Core.Tests.TheoryTests.ArrayWithDatapointsAttributeIsUsed(&quot;xyz1&quot;)" executed="True" success="True" time="0.000" asserts="1" />
+                              <test-case name="NUnit.Core.Tests.TheoryTests.ArrayWithDatapointsAttributeIsUsed(&quot;xyz2&quot;)" executed="True" success="True" time="0.000" asserts="1" />
+                              <test-case name="NUnit.Core.Tests.TheoryTests.ArrayWithDatapointsAttributeIsUsed(&quot;xyz3&quot;)" executed="True" success="True" time="0.000" asserts="1" />
+                            </results>
+                          </test-suite>
+                          <test-case name="NUnit.Core.Tests.TheoryTests.SimpleTestIgnoresDataPoints" executed="True" success="True" time="0.000" asserts="1" />
+                          <test-suite name="SquareRootWithAllBadValues" executed="True" success="False" time="0.000" asserts="0">
+                            <results>
+                              <test-case name="NUnit.Core.Tests.TheoryTests.SquareRootWithAllBadValues(-12.0d)" executed="True" success="False" time="0.000" asserts="0" />
+                              <test-case name="NUnit.Core.Tests.TheoryTests.SquareRootWithAllBadValues(-4.0d)" executed="True" success="False" time="0.000" asserts="0" />
+                              <test-case name="NUnit.Core.Tests.TheoryTests.SquareRootWithAllBadValues(-9.0d)" executed="True" success="False" time="0.000" asserts="0" />
+                            </results>
+                          </test-suite>
+                          <test-suite name="SquareRootWithAllGoodValues" executed="True" success="True" time="0.000" asserts="0">
+                            <results>
+                              <test-case name="NUnit.Core.Tests.TheoryTests.SquareRootWithAllGoodValues(12.0d)" executed="True" success="True" time="0.000" asserts="2" />
+                              <test-case name="NUnit.Core.Tests.TheoryTests.SquareRootWithAllGoodValues(4.0d)" executed="True" success="True" time="0.000" asserts="2" />
+                              <test-case name="NUnit.Core.Tests.TheoryTests.SquareRootWithAllGoodValues(9.0d)" executed="True" success="True" time="0.000" asserts="2" />
+                            </results>
+                          </test-suite>
+                          <test-suite name="SquareRootWithOneBadValue" executed="True" success="True" time="0.000" asserts="0">
+                            <results>
+                              <test-case name="NUnit.Core.Tests.TheoryTests.SquareRootWithOneBadValue(12.0d)" executed="True" success="True" time="0.000" asserts="2" />
+                              <test-case name="NUnit.Core.Tests.TheoryTests.SquareRootWithOneBadValue(-4.0d)" executed="True" success="False" time="0.000" asserts="0" />
+                              <test-case name="NUnit.Core.Tests.TheoryTests.SquareRootWithOneBadValue(9.0d)" executed="True" success="True" time="0.000" asserts="2" />
+                            </results>
+                          </test-suite>
+                          <test-case name="NUnit.Core.Tests.TheoryTests.TheoryWithDatapointsIsRunnable" executed="True" success="True" time="0.000" asserts="2" />
+                          <test-case name="NUnit.Core.Tests.TheoryTests.TheoryWithNoArgumentsIsTreatedAsTest" executed="True" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Core.Tests.TheoryTests.TheoryWithNoDatapointsIsNotRunnable" executed="True" success="True" time="0.000" asserts="2" />
+                        </results>
+                      </test-suite>
+                      <test-suite name="TheoryTests+SqrtTests" executed="True" success="True" time="0.000" asserts="0">
+                        <results>
+                          <test-suite name="SqrtTimesItselfGivesOriginal" executed="True" success="True" time="0.000" asserts="0">
+                            <results>
+                              <test-case name="NUnit.Core.Tests.TheoryTests+SqrtTests.SqrtTimesItselfGivesOriginal(0.0d)" executed="True" success="True" time="0.000" asserts="2" />
+                              <test-case name="NUnit.Core.Tests.TheoryTests+SqrtTests.SqrtTimesItselfGivesOriginal(1.0d)" executed="True" success="True" time="0.000" asserts="2" />
+                              <test-case name="NUnit.Core.Tests.TheoryTests+SqrtTests.SqrtTimesItselfGivesOriginal(-1.0d)" executed="True" success="False" time="0.000" asserts="0" />
+                              <test-case name="NUnit.Core.Tests.TheoryTests+SqrtTests.SqrtTimesItselfGivesOriginal(double.MaxValue)" executed="True" success="False" time="0.000" asserts="0" />
+                              <test-case name="NUnit.Core.Tests.TheoryTests+SqrtTests.SqrtTimesItselfGivesOriginal(double.PositiveInfinity)" executed="True" success="False" time="0.000" asserts="0" />
+                            </results>
+                          </test-suite>
+                        </results>
+                      </test-suite>
+                      <test-suite name="ThreadedTestRunnerTests" executed="True" success="True" time="1.031" asserts="1">
+                        <results>
+                          <test-case name="NUnit.Core.Tests.ThreadedTestRunnerTests.CheckRunnerID" executed="True" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Core.Tests.ThreadedTestRunnerTests.CountTestCases" executed="True" success="True" time="0.078" asserts="1" />
+                          <test-case name="NUnit.Core.Tests.ThreadedTestRunnerTests.CountTestCasesAcrossMultipleAssemblies" executed="True" success="True" time="0.109" asserts="1" />
+                          <test-case name="NUnit.Core.Tests.ThreadedTestRunnerTests.LoadAssembly" executed="True" success="True" time="0.078" asserts="1" />
+                          <test-case name="NUnit.Core.Tests.ThreadedTestRunnerTests.LoadAssemblyWithFixture" executed="True" success="True" time="0.031" asserts="1" />
+                          <test-case name="NUnit.Core.Tests.ThreadedTestRunnerTests.LoadAssemblyWithoutNamespaces" executed="True" success="True" time="0.078" asserts="4" />
+                          <test-case name="NUnit.Core.Tests.ThreadedTestRunnerTests.LoadAssemblyWithSuite" executed="True" success="True" time="0.031" asserts="1" />
+                          <test-case name="NUnit.Core.Tests.ThreadedTestRunnerTests.LoadMultipleAssemblies" executed="True" success="True" time="0.109" asserts="1" />
+                          <test-case name="NUnit.Core.Tests.ThreadedTestRunnerTests.LoadMultipleAssembliesWithFixture" executed="True" success="True" time="0.063" asserts="1" />
+                          <test-case name="NUnit.Core.Tests.ThreadedTestRunnerTests.LoadMultipleAssembliesWithSuite" executed="True" success="True" time="0.078" asserts="1" />
+                          <test-case name="NUnit.Core.Tests.ThreadedTestRunnerTests.RunAssembly" executed="True" success="True" time="0.063" asserts="1" />
+                          <test-case name="NUnit.Core.Tests.ThreadedTestRunnerTests.RunAssemblyUsingBeginAndEndRun" executed="True" success="True" time="0.063" asserts="2" />
+                          <test-case name="NUnit.Core.Tests.ThreadedTestRunnerTests.RunMultipleAssemblies" executed="True" success="True" time="0.109" asserts="1" />
+                          <test-case name="NUnit.Core.Tests.ThreadedTestRunnerTests.RunMultipleAssembliesUsingBeginAndEndRun" executed="True" success="True" time="0.125" asserts="2" />
+                        </results>
+                      </test-suite>
+                      <test-suite name="ThreadingTests" executed="True" success="True" time="0.375" asserts="0">
+                        <results>
+                          <test-case name="NUnit.Core.Tests.ThreadingTests.TestWithInfiniteLoopTimesOut" executed="True" success="True" time="0.172" asserts="2" />
+                          <test-case name="NUnit.Core.Tests.ThreadingTests.TestWithMTAThreadRunsInMTA" executed="True" success="True" time="0.000" asserts="2">
+                            <properties>
+                              <property name="APARTMENT_STATE" value="MTA" />
+                            </properties>
+                          </test-case>
+                          <test-case name="NUnit.Core.Tests.ThreadingTests.TestWithRequiresMTARunsInMTA" executed="True" success="True" time="0.000" asserts="2">
+                            <properties>
+                              <property name="APARTMENT_STATE" value="MTA" />
+                            </properties>
+                          </test-case>
+                          <test-case name="NUnit.Core.Tests.ThreadingTests.TestWithRequiresSTARunsInSTA" executed="True" success="True" time="0.000" asserts="1">
+                            <properties>
+                              <property name="APARTMENT_STATE" value="STA" />
+                            </properties>
+                          </test-case>
+                          <test-case name="NUnit.Core.Tests.ThreadingTests.TestWithRequiresThreadRunsInSeparateThread" executed="True" success="True" time="0.000" asserts="1">
+                            <properties>
+                              <property name="RequiresThread" value="True" />
+                            </properties>
+                          </test-case>
+                          <test-case name="NUnit.Core.Tests.ThreadingTests.TestWithRequiresThreadRunsSetUpAndTestOnSameThread" executed="True" success="True" time="0.000" asserts="1">
+                            <properties>
+                              <property name="RequiresThread" value="True" />
+                            </properties>
+                          </test-case>
+                          <test-case name="NUnit.Core.Tests.ThreadingTests.TestWithRequiresThreadWithMTAArgRunsOnSeparateThreadInMTA" executed="True" success="True" time="0.000" asserts="2">
+                            <properties>
+                              <property name="RequiresThread" value="True" />
+                              <property name="APARTMENT_STATE" value="MTA" />
+                            </properties>
+                          </test-case>
+                          <test-case name="NUnit.Core.Tests.ThreadingTests.TestWithRequiresThreadWithSTAArgRunsOnSeparateThreadInSTA" executed="True" success="True" time="0.000" asserts="2">
+                            <properties>
+                              <property name="RequiresThread" value="True" />
+                              <property name="APARTMENT_STATE" value="STA" />
+                            </properties>
+                          </test-case>
+                          <test-case name="NUnit.Core.Tests.ThreadingTests.TestWithSTAThreadRunsInSTA" executed="True" success="True" time="0.000" asserts="1">
+                            <properties>
+                              <property name="APARTMENT_STATE" value="STA" />
+                            </properties>
+                          </test-case>
+                          <test-case name="NUnit.Core.Tests.ThreadingTests.TestWithTimeoutRunsOnSeparateThread" executed="True" success="True" time="0.000" asserts="1">
+                            <properties>
+                              <property name="Timeout" value="50" />
+                            </properties>
+                          </test-case>
+                          <test-case name="NUnit.Core.Tests.ThreadingTests.TestWithTimeoutRunsSetUpAndTestOnSameThread" executed="True" success="True" time="0.000" asserts="1">
+                            <properties>
+                              <property name="Timeout" value="50" />
+                            </properties>
+                          </test-case>
+                          <test-case name="NUnit.Core.Tests.ThreadingTests.TimeoutCanBeSetOnTestFixture" executed="True" success="True" time="0.188" asserts="3" />
+                        </results>
+                      </test-suite>
+                      <test-suite name="ThreadingTests+FixtureRequiresMTA" executed="True" success="True" time="0.000" asserts="0">
+                        <properties>
+                          <property name="APARTMENT_STATE" value="MTA" />
+                        </properties>
+                        <results>
+                          <test-case name="NUnit.Core.Tests.ThreadingTests+FixtureRequiresMTA.RequiresMTACanBeSetOnTestFixture" executed="True" success="True" time="0.000" asserts="1" />
+                        </results>
+                      </test-suite>
+                      <test-suite name="ThreadingTests+FixtureRequiresSTA" executed="True" success="True" time="0.000" asserts="0">
+                        <properties>
+                          <property name="APARTMENT_STATE" value="STA" />
+                        </properties>
+                        <results>
+                          <test-case name="NUnit.Core.Tests.ThreadingTests+FixtureRequiresSTA.RequiresSTACanBeSetOnTestFixture" executed="True" success="True" time="0.000" asserts="1" />
+                        </results>
+                      </test-suite>
+                      <test-suite name="ThreadingTests+FixtureRequiresThread" executed="True" success="True" time="0.000" asserts="0">
+                        <properties>
+                          <property name="RequiresThread" value="True" />
+                        </properties>
+                        <results>
+                          <test-case name="NUnit.Core.Tests.ThreadingTests+FixtureRequiresThread.RequiresThreadCanBeSetOnTestFixture" executed="True" success="True" time="0.000" asserts="1" />
+                        </results>
+                      </test-suite>
+                      <test-suite name="ValueSourceTests" executed="True" success="True" time="0.016" asserts="0">
+                        <results>
+                          <test-suite name="MultipleArguments" executed="True" success="True" time="0.000" asserts="0">
+                            <results>
+                              <test-case name="NUnit.Core.Tests.ValueSourceTests.MultipleArguments(12,3,4)" executed="True" success="True" time="0.000" asserts="1" />
+                              <test-case name="NUnit.Core.Tests.ValueSourceTests.MultipleArguments(12,4,3)" executed="True" success="True" time="0.000" asserts="1" />
+                              <test-case name="NUnit.Core.Tests.ValueSourceTests.MultipleArguments(12,6,2)" executed="True" success="True" time="0.000" asserts="1" />
+                            </results>
+                          </test-suite>
+                          <test-suite name="ValueSourceCanBeInstanceField" executed="True" success="True" time="0.000" asserts="0">
+                            <results>
+                              <test-case name="NUnit.Core.Tests.ValueSourceTests.ValueSourceCanBeInstanceField(&quot;InstanceField&quot;)" executed="True" success="True" time="0.000" asserts="1" />
+                            </results>
+                          </test-suite>
+                          <test-suite name="ValueSourceCanBeInstanceMethod" executed="True" success="True" time="0.000" asserts="0">
+                            <results>
+                              <test-case name="NUnit.Core.Tests.ValueSourceTests.ValueSourceCanBeInstanceMethod(&quot;InstanceMethod&quot;)" executed="True" success="True" time="0.000" asserts="1" />
+                            </results>
+                          </test-suite>
+                          <test-suite name="ValueSourceCanBeInstanceProperty" executed="True" success="True" time="0.000" asserts="0">
+                            <results>
+                              <test-case name="NUnit.Core.Tests.ValueSourceTests.ValueSourceCanBeInstanceProperty(&quot;InstanceProperty&quot;)" executed="True" success="True" time="0.000" asserts="1" />
+                            </results>
+                          </test-suite>
+                          <test-suite name="ValueSourceCanBeStaticField" executed="True" success="True" time="0.000" asserts="0">
+                            <results>
+                              <test-case name="NUnit.Core.Tests.ValueSourceTests.ValueSourceCanBeStaticField(&quot;StaticField&quot;)" executed="True" success="True" time="0.000" asserts="1" />
+                            </results>
+                          </test-suite>
+                          <test-suite name="ValueSourceCanBeStaticMethod" executed="True" success="True" time="0.000" asserts="0">
+                            <results>
+                              <test-case name="NUnit.Core.Tests.ValueSourceTests.ValueSourceCanBeStaticMethod(&quot;StaticMethod&quot;)" executed="True" success="True" time="0.000" asserts="1" />
+                            </results>
+                          </test-suite>
+                          <test-suite name="ValueSourceCanBeStaticProperty" executed="True" success="True" time="0.000" asserts="0">
+                            <results>
+                              <test-case name="NUnit.Core.Tests.ValueSourceTests.ValueSourceCanBeStaticProperty(&quot;StaticProperty&quot;)" executed="True" success="True" time="0.000" asserts="1" />
+                            </results>
+                          </test-suite>
+                          <test-suite name="ValueSourceIsInvokedWithCorrectCurrentDirectory" executed="True" success="True" time="0.000" asserts="0">
+                            <results>
+                              <test-case name="NUnit.Core.Tests.ValueSourceTests.ValueSourceIsInvokedWithCorrectCurrentDirectory(True)" executed="True" success="True" time="0.000" asserts="1" />
+                            </results>
+                          </test-suite>
+                          <test-suite name="ValueSourceMayBeInAnotherClass" executed="True" success="False" time="0.000" asserts="0" />
+                        </results>
+                      </test-suite>
+                      <test-suite name="XmlTest" executed="True" success="True" time="1.109" asserts="0">
+                        <results>
+                          <test-case name="NUnit.Core.Tests.XmlTest.removeTime" executed="True" success="True" time="0.031" asserts="1" />
+                          <test-case name="NUnit.Core.Tests.XmlTest.TestSchemaValidatorFrenchCulture" executed="True" success="True" time="0.547" asserts="1" />
+                          <test-case name="NUnit.Core.Tests.XmlTest.TestSchemaValidatorInvariantCulture" executed="True" success="True" time="0.125" asserts="1" />
+                          <test-case name="NUnit.Core.Tests.XmlTest.TestSchemaValidatorUnitedStatesCulture" executed="True" success="True" time="0.125" asserts="1" />
+                          <test-case name="NUnit.Core.Tests.XmlTest.TestStream" executed="True" success="True" time="0.219" asserts="1" />
+                        </results>
+                      </test-suite>
+                    </results>
+                  </test-suite>
+                </results>
+              </test-suite>
+            </results>
+          </test-suite>
+        </results>
+      </test-suite>
+      <test-suite name="C:\Program Files\NUnit 2.5.2\bin\net-2.0\tests/nunit.util.tests.dll" executed="True" success="True" time="98.609" asserts="0">
+        <results>
+          <test-suite name="NUnit" executed="True" success="True" time="98.609" asserts="0">
+            <results>
+              <test-suite name="Util" executed="True" success="True" time="98.609" asserts="0">
+                <results>
+                  <test-suite name="Tests" executed="True" success="True" time="98.594" asserts="0">
+                    <results>
+                      <test-suite name="AssemblyListTests" executed="True" success="True" time="0.031" asserts="0">
+                        <results>
+                          <test-case name="NUnit.Util.Tests.AssemblyListTests.AddFiresChangedEvent" executed="True" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Util.Tests.AssemblyListTests.CanAddAssemblies" executed="True" success="True" time="0.000" asserts="3" />
+                          <test-case name="NUnit.Util.Tests.AssemblyListTests.CanRemoveAssemblies" executed="True" success="True" time="0.000" asserts="3" />
+                          <test-case name="NUnit.Util.Tests.AssemblyListTests.EmptyList" executed="True" success="True" time="0.031" asserts="1" />
+                          <test-case name="NUnit.Util.Tests.AssemblyListTests.MustAddAbsolutePath" executed="True" success="True" time="0.000" asserts="0" />
+                          <test-case name="NUnit.Util.Tests.AssemblyListTests.RemoveAtFiresChangedEvent" executed="True" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Util.Tests.AssemblyListTests.RemoveFiresChangedEvent" executed="True" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Util.Tests.AssemblyListTests.SettingFullPathFiresChangedEvent" executed="True" success="True" time="0.000" asserts="1" />
+                        </results>
+                      </test-suite>
+                      <test-suite name="CategoryManagerTest" executed="True" success="True" time="0.172" asserts="0">
+                        <results>
+                          <test-case name="NUnit.Util.Tests.CategoryManagerTest.CanAddAllAvailableCategoriesInTestTree" executed="True" success="True" time="0.094" asserts="1" />
+                          <test-case name="NUnit.Util.Tests.CategoryManagerTest.CanAddStrings" executed="True" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Util.Tests.CategoryManagerTest.CanAddStringsWithoutDuplicating" executed="True" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Util.Tests.CategoryManagerTest.CanAddTestCategories" executed="True" success="True" time="0.078" asserts="1" />
+                          <test-case name="NUnit.Util.Tests.CategoryManagerTest.CanClearEntries" executed="True" success="True" time="0.000" asserts="1" />
+                        </results>
+                      </test-suite>
+                      <test-suite name="CategoryParseTests" executed="True" success="True" time="0.031" asserts="0">
+                        <results>
+                          <test-case name="NUnit.Util.Tests.CategoryParseTests.CanParseCompoundCategory" executed="True" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Util.Tests.CategoryParseTests.CanParseExcludedCategories" executed="True" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Util.Tests.CategoryParseTests.CanParseMultipleAlternatives" executed="True" success="True" time="0.000" asserts="4" />
+                          <test-case name="NUnit.Util.Tests.CategoryParseTests.CanParseMultipleCategoriesWithAnd" executed="True" success="True" time="0.000" asserts="4" />
+                          <test-case name="NUnit.Util.Tests.CategoryParseTests.CanParseSimpleCategory" executed="True" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Util.Tests.CategoryParseTests.EmptyStringReturnsEmptyFilter" executed="True" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Util.Tests.CategoryParseTests.OrAndMinusCombined" executed="True" success="True" time="0.000" asserts="5" />
+                          <test-case name="NUnit.Util.Tests.CategoryParseTests.PlusAndMinusCombined" executed="True" success="True" time="0.000" asserts="6" />
+                          <test-case name="NUnit.Util.Tests.CategoryParseTests.PrecedenceTest" executed="True" success="True" time="0.016" asserts="4" />
+                          <test-case name="NUnit.Util.Tests.CategoryParseTests.PrecedenceTestWithParentheses" executed="True" success="True" time="0.000" asserts="5" />
+                        </results>
+                      </test-suite>
+                      <test-suite name="EventDispatcherTests" executed="True" success="True" time="0.016" asserts="0">
+                        <results>
+                          <test-case name="NUnit.Util.Tests.EventDispatcherTests.ProjectLoaded" executed="True" success="True" time="0.000" asserts="3" />
+                          <test-case name="NUnit.Util.Tests.EventDispatcherTests.ProjectLoadFailed" executed="True" success="True" time="0.000" asserts="4" />
+                          <test-case name="NUnit.Util.Tests.EventDispatcherTests.ProjectLoading" executed="True" success="True" time="0.000" asserts="3" />
+                          <test-case name="NUnit.Util.Tests.EventDispatcherTests.ProjectUnloaded" executed="True" success="True" time="0.000" asserts="3" />
+                          <test-case name="NUnit.Util.Tests.EventDispatcherTests.ProjectUnloadFailed" executed="True" success="True" time="0.000" asserts="4" />
+                          <test-case name="NUnit.Util.Tests.EventDispatcherTests.ProjectUnloading" executed="True" success="True" time="0.000" asserts="3" />
+                          <test-case name="NUnit.Util.Tests.EventDispatcherTests.RunFailed" executed="True" success="True" time="0.000" asserts="3" />
+                          <test-case name="NUnit.Util.Tests.EventDispatcherTests.RunFinished" executed="True" success="True" time="0.000" asserts="3" />
+                          <test-case name="NUnit.Util.Tests.EventDispatcherTests.RunStarting" executed="True" success="True" time="0.000" asserts="4" />
+                          <test-case name="NUnit.Util.Tests.EventDispatcherTests.SuiteFinished" executed="True" success="True" time="0.000" asserts="3" />
+                          <test-case name="NUnit.Util.Tests.EventDispatcherTests.SuiteStarting" executed="True" success="True" time="0.000" asserts="3" />
+                          <test-case name="NUnit.Util.Tests.EventDispatcherTests.TestFinished" executed="True" success="True" time="0.000" asserts="3" />
+                          <test-case name="NUnit.Util.Tests.EventDispatcherTests.TestLoaded" executed="True" success="True" time="0.000" asserts="4" />
+                          <test-case name="NUnit.Util.Tests.EventDispatcherTests.TestLoadFailed" executed="True" success="True" time="0.000" asserts="4" />
+                          <test-case name="NUnit.Util.Tests.EventDispatcherTests.TestLoading" executed="True" success="True" time="0.000" asserts="3" />
+                          <test-case name="NUnit.Util.Tests.EventDispatcherTests.TestReloaded" executed="True" success="True" time="0.000" asserts="4" />
+                          <test-case name="NUnit.Util.Tests.EventDispatcherTests.TestReloadFailed" executed="True" success="True" time="0.000" asserts="4" />
+                          <test-case name="NUnit.Util.Tests.EventDispatcherTests.TestReloading" executed="True" success="True" time="0.000" asserts="3" />
+                          <test-case name="NUnit.Util.Tests.EventDispatcherTests.TestStarting" executed="True" success="True" time="0.000" asserts="3" />
+                          <test-case name="NUnit.Util.Tests.EventDispatcherTests.TestUnloaded" executed="True" success="True" time="0.000" asserts="3" />
+                          <test-case name="NUnit.Util.Tests.EventDispatcherTests.TestUnloadFailed" executed="True" success="True" time="0.000" asserts="4" />
+                          <test-case name="NUnit.Util.Tests.EventDispatcherTests.TestUnloading" executed="True" success="True" time="0.000" asserts="3" />
+                        </results>
+                      </test-suite>
+                      <test-suite name="FileWatcherTest" executed="True" success="True" time="0.969" asserts="0">
+                        <results>
+                          <test-case name="NUnit.Util.Tests.FileWatcherTest.ChangingAttributesDoesNotTriggerWatcher" executed="True" success="True" time="0.250" asserts="1" />
+                          <test-case name="NUnit.Util.Tests.FileWatcherTest.ChangingFileTriggersWatcher" executed="True" success="True" time="0.219" asserts="2" />
+                          <test-case name="NUnit.Util.Tests.FileWatcherTest.CopyingFileDoesNotTriggerWatcher" executed="True" success="True" time="0.203" asserts="1" />
+                          <test-case name="NUnit.Util.Tests.FileWatcherTest.MultipleCloselySpacedChangesTriggerWatcherOnlyOnce" executed="True" success="True" time="0.297" asserts="2" />
+                        </results>
+                      </test-suite>
+                      <test-suite name="MemorySettingsStorageTests" executed="True" success="True" time="0.000" asserts="0">
+                        <results>
+                          <test-case name="NUnit.Util.Tests.MemorySettingsStorageTests.MakeStorage" executed="True" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Util.Tests.MemorySettingsStorageTests.MakeSubStorages" executed="True" success="True" time="0.000" asserts="2" />
+                          <test-case name="NUnit.Util.Tests.MemorySettingsStorageTests.RemoveSettings" executed="True" success="True" time="0.000" asserts="3" />
+                          <test-case name="NUnit.Util.Tests.MemorySettingsStorageTests.SaveAndLoadSettings" executed="True" success="True" time="0.000" asserts="4" />
+                          <test-case name="NUnit.Util.Tests.MemorySettingsStorageTests.SubstorageSettings" executed="True" success="True" time="0.000" asserts="5" />
+                          <test-case name="NUnit.Util.Tests.MemorySettingsStorageTests.TypeSafeSettings" executed="True" success="True" time="0.000" asserts="3" />
+                        </results>
+                      </test-suite>
+                      <test-suite name="NUnitProjectLoad" executed="True" success="True" time="0.172" asserts="0">
+                        <results>
+                          <test-case name="NUnit.Util.Tests.NUnitProjectLoad.FromAssembly" executed="True" success="True" time="0.016" asserts="5" />
+                          <test-case name="NUnit.Util.Tests.NUnitProjectLoad.LoadEmptyConfigs" executed="True" success="True" time="0.094" asserts="3" />
+                          <test-case name="NUnit.Util.Tests.NUnitProjectLoad.LoadEmptyProject" executed="True" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Util.Tests.NUnitProjectLoad.LoadNormalProject" executed="True" success="True" time="0.000" asserts="7" />
+                          <test-case name="NUnit.Util.Tests.NUnitProjectLoad.LoadProjectWithManualBinPath" executed="True" success="True" time="0.000" asserts="2" />
+                          <test-case name="NUnit.Util.Tests.NUnitProjectLoad.SaveClearsAssemblyWrapper" executed="True" success="True" time="0.031" asserts="1" />
+                        </results>
+                      </test-suite>
+                      <test-suite name="NUnitProjectSave" executed="True" success="True" time="0.031" asserts="0">
+                        <results>
+                          <test-case name="NUnit.Util.Tests.NUnitProjectSave.SaveEmptyConfigs" executed="True" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Util.Tests.NUnitProjectSave.SaveEmptyProject" executed="True" success="True" time="0.016" asserts="1" />
+                          <test-case name="NUnit.Util.Tests.NUnitProjectSave.SaveNormalProject" executed="True" success="True" time="0.016" asserts="1" />
+                        </results>
+                      </test-suite>
+                      <test-suite name="NUnitProjectTests" executed="True" success="True" time="0.172" asserts="0">
+                        <results>
+                          <test-case name="NUnit.Util.Tests.NUnitProjectTests.AddConfigMakesProjectDirty" executed="True" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Util.Tests.NUnitProjectTests.CanAddAssemblies" executed="True" success="True" time="0.000" asserts="3" />
+                          <test-case name="NUnit.Util.Tests.NUnitProjectTests.CanAddConfigs" executed="True" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Util.Tests.NUnitProjectTests.CanSetActiveConfig" executed="True" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Util.Tests.NUnitProjectTests.CanSetAppBase" executed="True" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Util.Tests.NUnitProjectTests.ConfigurationFileFromAssemblies" executed="True" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Util.Tests.NUnitProjectTests.ConfigurationFileFromAssembly" executed="True" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Util.Tests.NUnitProjectTests.DefaultActiveConfig" executed="True" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Util.Tests.NUnitProjectTests.DefaultApplicationBase" executed="True" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Util.Tests.NUnitProjectTests.DefaultConfigurationFile" executed="True" success="True" time="0.016" asserts="2" />
+                          <test-case name="NUnit.Util.Tests.NUnitProjectTests.DefaultProjectName" executed="True" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Util.Tests.NUnitProjectTests.IsProjectFile" executed="True" success="True" time="0.000" asserts="2" />
+                          <test-case name="NUnit.Util.Tests.NUnitProjectTests.LoadMakesProjectNotDirty" executed="True" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Util.Tests.NUnitProjectTests.NewProjectDefaultPath" executed="True" success="True" time="0.000" asserts="3" />
+                          <test-case name="NUnit.Util.Tests.NUnitProjectTests.NewProjectIsEmpty" executed="True" success="True" time="0.000" asserts="2" />
+                          <test-case name="NUnit.Util.Tests.NUnitProjectTests.NewProjectIsNotDirty" executed="True" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Util.Tests.NUnitProjectTests.NewProjectNotLoadable" executed="True" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Util.Tests.NUnitProjectTests.RemoveActiveConfig" executed="True" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Util.Tests.NUnitProjectTests.RemoveConfigMakesProjectDirty" executed="True" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Util.Tests.NUnitProjectTests.RenameActiveConfig" executed="True" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Util.Tests.NUnitProjectTests.RenameConfigMakesProjectDirty" executed="True" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Util.Tests.NUnitProjectTests.SaveAndLoadConfigsWithAssemblies" executed="True" success="True" time="0.000" asserts="8" />
+                          <test-case name="NUnit.Util.Tests.NUnitProjectTests.SaveAndLoadEmptyConfigs" executed="True" success="True" time="0.016" asserts="4" />
+                          <test-case name="NUnit.Util.Tests.NUnitProjectTests.SaveAndLoadEmptyProject" executed="True" success="True" time="0.000" asserts="2" />
+                          <test-case name="NUnit.Util.Tests.NUnitProjectTests.SaveMakesProjectNotDirty" executed="True" success="True" time="0.016" asserts="1" />
+                          <test-case name="NUnit.Util.Tests.NUnitProjectTests.SaveSetsProjectPath" executed="True" success="True" time="0.000" asserts="2" />
+                          <test-case name="NUnit.Util.Tests.NUnitProjectTests.SettingActiveConfigMakesProjectDirty" executed="True" success="True" time="0.000" asserts="1" />
+                        </results>
+                      </test-suite>
+                      <test-suite name="NUnitRegistryTests" executed="True" success="True" time="0.000" asserts="0">
+                        <results>
+                          <test-case name="NUnit.Util.Tests.NUnitRegistryTests.CurrentUser" executed="True" success="True" time="0.000" asserts="2" />
+                          <test-case name="NUnit.Util.Tests.NUnitRegistryTests.CurrentUserTestMode" executed="True" success="True" time="0.000" asserts="2" />
+                          <test-case name="NUnit.Util.Tests.NUnitRegistryTests.LocalMachine" executed="True" success="True" time="0.000" asserts="2" />
+                          <test-case name="NUnit.Util.Tests.NUnitRegistryTests.LocalMachineTestMode" executed="True" success="True" time="0.000" asserts="2" />
+                          <test-case name="NUnit.Util.Tests.NUnitRegistryTests.TestClearRoutines" executed="True" success="True" time="0.000" asserts="2" />
+                        </results>
+                      </test-suite>
+                      <test-suite name="PathUtilTests" executed="True" success="True" time="0.000" asserts="0">
+                        <results>
+                          <test-case name="NUnit.Util.Tests.PathUtilTests.CheckDefaults" executed="True" success="True" time="0.000" asserts="2" />
+                        </results>
+                      </test-suite>
+                      <test-suite name="PathUtilTests_Unix" executed="True" success="True" time="0.016" asserts="0">
+                        <results>
+                          <test-case name="NUnit.Util.Tests.PathUtilTests_Unix.Canonicalize" executed="True" success="True" time="0.000" asserts="5" />
+                          <test-case name="NUnit.Util.Tests.PathUtilTests_Unix.IsAssemblyFileType" executed="True" success="True" time="0.000" asserts="3" />
+                          <test-case name="NUnit.Util.Tests.PathUtilTests_Unix.PathFromUri" executed="True" success="True" time="0.000" asserts="2" />
+                          <test-case name="NUnit.Util.Tests.PathUtilTests_Unix.RelativePath" executed="True" success="True" time="0.000" asserts="5" />
+                          <test-case name="NUnit.Util.Tests.PathUtilTests_Unix.SamePath" executed="True" success="True" time="0.016" asserts="4" />
+                          <test-case name="NUnit.Util.Tests.PathUtilTests_Unix.SamePathOrUnder" executed="True" success="True" time="0.000" asserts="7" />
+                        </results>
+                      </test-suite>
+                      <test-suite name="PathUtilTests_Windows" executed="True" success="True" time="0.000" asserts="0">
+                        <results>
+                          <test-case name="NUnit.Util.Tests.PathUtilTests_Windows.Canonicalize" executed="True" success="True" time="0.000" asserts="5" />
+                          <test-case name="NUnit.Util.Tests.PathUtilTests_Windows.IsAssemblyFileType" executed="True" success="True" time="0.000" asserts="3" />
+                          <test-case name="NUnit.Util.Tests.PathUtilTests_Windows.PathFromUri" executed="True" success="True" time="0.000" asserts="2" />
+                          <test-case name="NUnit.Util.Tests.PathUtilTests_Windows.RelativePath" executed="True" success="True" time="0.000" asserts="4" />
+                          <test-case name="NUnit.Util.Tests.PathUtilTests_Windows.SamePath" executed="True" success="True" time="0.000" asserts="4" />
+                          <test-case name="NUnit.Util.Tests.PathUtilTests_Windows.SamePathOrUnder" executed="True" success="True" time="0.000" asserts="9" />
+                        </results>
+                      </test-suite>
+                      <test-suite name="ProcessRunnerTests" executed="True" success="True" time="23.031" asserts="1">
+                        <properties>
+                          <property name="Timeout" value="10000" />
+                        </properties>
+                        <results>
+                          <test-case name="NUnit.Util.Tests.ProcessRunnerTests.CheckRunnerID" executed="True" success="True" time="0.047" asserts="1" />
+                          <test-case name="NUnit.Util.Tests.ProcessRunnerTests.CountTestCases" executed="True" success="True" time="1.719" asserts="1" />
+                          <test-case name="NUnit.Util.Tests.ProcessRunnerTests.CountTestCasesAcrossMultipleAssemblies" executed="True" success="True" time="1.781" asserts="1" />
+                          <test-case name="NUnit.Util.Tests.ProcessRunnerTests.LoadAssembly" executed="True" success="True" time="1.328" asserts="1" />
+                          <test-case name="NUnit.Util.Tests.ProcessRunnerTests.LoadAssemblyWithFixture" executed="True" success="True" time="1.547" asserts="1" />
+                          <test-case name="NUnit.Util.Tests.ProcessRunnerTests.LoadAssemblyWithoutNamespaces" executed="True" success="True" time="1.609" asserts="4" />
+                          <test-case name="NUnit.Util.Tests.ProcessRunnerTests.LoadAssemblyWithSuite" executed="True" success="True" time="1.453" asserts="1" />
+                          <test-case name="NUnit.Util.Tests.ProcessRunnerTests.LoadMultipleAssemblies" executed="True" success="True" time="1.672" asserts="1" />
+                          <test-case name="NUnit.Util.Tests.ProcessRunnerTests.LoadMultipleAssembliesWithFixture" executed="True" success="True" time="1.719" asserts="1" />
+                          <test-case name="NUnit.Util.Tests.ProcessRunnerTests.LoadMultipleAssembliesWithSuite" executed="True" success="True" time="1.578" asserts="1" />
+                          <test-case name="NUnit.Util.Tests.ProcessRunnerTests.RunAssembly" executed="True" success="True" time="2.047" asserts="1" />
+                          <test-case name="NUnit.Util.Tests.ProcessRunnerTests.RunAssemblyUsingBeginAndEndRun" executed="True" success="True" time="2.516" asserts="2" />
+                          <test-case name="NUnit.Util.Tests.ProcessRunnerTests.RunMultipleAssemblies" executed="True" success="True" time="2.000" asserts="1" />
+                          <test-case name="NUnit.Util.Tests.ProcessRunnerTests.RunMultipleAssembliesUsingBeginAndEndRun" executed="True" success="True" time="1.922" asserts="2" />
+                        </results>
+                      </test-suite>
+                      <test-suite name="ProjectConfigTests" executed="True" success="True" time="0.016" asserts="0">
+                        <results>
+                          <test-case name="NUnit.Util.Tests.ProjectConfigTests.AbsoluteBasePath" executed="True" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Util.Tests.ProjectConfigTests.AbsoluteConfigurationFile" executed="True" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Util.Tests.ProjectConfigTests.AddingConfigMarksProjectDirty" executed="True" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Util.Tests.ProjectConfigTests.AddingInitialConfigRequiresReload" executed="True" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Util.Tests.ProjectConfigTests.AddingSubsequentConfigDoesNotRequireReload" executed="True" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Util.Tests.ProjectConfigTests.AddToActiveConfigMarksProjectDirty" executed="True" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Util.Tests.ProjectConfigTests.AddToActiveConfigRequiresReload" executed="True" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Util.Tests.ProjectConfigTests.AddToInactiveConfigDoesNotRequireReload" executed="True" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Util.Tests.ProjectConfigTests.AddToInactiveConfigMarksProjectDirty" executed="True" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Util.Tests.ProjectConfigTests.CanAddAssemblies" executed="True" success="True" time="0.000" asserts="3" />
+                          <test-case name="NUnit.Util.Tests.ProjectConfigTests.DefaultConfigurationFile" executed="True" success="True" time="0.000" asserts="2" />
+                          <test-case name="NUnit.Util.Tests.ProjectConfigTests.EmptyConfig" executed="True" success="True" time="0.000" asserts="2" />
+                          <test-case name="NUnit.Util.Tests.ProjectConfigTests.ManualPrivateBinPath" executed="True" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Util.Tests.ProjectConfigTests.NoBasePathSet" executed="True" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Util.Tests.ProjectConfigTests.NoPrivateBinPath" executed="True" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Util.Tests.ProjectConfigTests.RelativeBasePath" executed="True" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Util.Tests.ProjectConfigTests.RelativeConfigurationFile" executed="True" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Util.Tests.ProjectConfigTests.RemoveActiveConfigMarksProjectDirty" executed="True" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Util.Tests.ProjectConfigTests.RemoveActiveConfigRequiresReload" executed="True" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Util.Tests.ProjectConfigTests.RemoveInactiveConfigDoesNotRequireReload" executed="True" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Util.Tests.ProjectConfigTests.RemoveInactiveConfigMarksProjectDirty" executed="True" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Util.Tests.ProjectConfigTests.RenameActiveConfigMarksProjectDirty" executed="True" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Util.Tests.ProjectConfigTests.RenameActiveConfigRequiresReload" executed="True" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Util.Tests.ProjectConfigTests.RenameInactiveConfigDoesNotRequireReload" executed="True" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Util.Tests.ProjectConfigTests.RenameInctiveConfigMarksProjectDirty" executed="True" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Util.Tests.ProjectConfigTests.SettingActiveConfigApplicationBaseMarksProjectDirty" executed="True" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Util.Tests.ProjectConfigTests.SettingActiveConfigApplicationBaseRequiresReload" executed="True" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Util.Tests.ProjectConfigTests.SettingActiveConfigBinPathTypeMarksProjectDirty" executed="True" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Util.Tests.ProjectConfigTests.SettingActiveConfigBinPathTypeRequiresReload" executed="True" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Util.Tests.ProjectConfigTests.SettingActiveConfigConfigurationFileMarksProjectDirty" executed="True" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Util.Tests.ProjectConfigTests.SettingActiveConfigConfigurationFileRequiresReload" executed="True" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Util.Tests.ProjectConfigTests.SettingActiveConfigPrivateBinPathMarksProjectDirty" executed="True" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Util.Tests.ProjectConfigTests.SettingActiveConfigPrivateBinPathRequiresReload" executed="True" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Util.Tests.ProjectConfigTests.SettingInactiveConfigApplicationBaseDoesNotRequireReload" executed="True" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Util.Tests.ProjectConfigTests.SettingInactiveConfigApplicationBaseMarksProjectDirty" executed="True" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Util.Tests.ProjectConfigTests.SettingInactiveConfigBinPathTypeDoesNotRequireReload" executed="True" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Util.Tests.ProjectConfigTests.SettingInactiveConfigBinPathTypeMarksProjectDirty" executed="True" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Util.Tests.ProjectConfigTests.SettingInactiveConfigConfigurationFileDoesNotRequireReload" executed="True" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Util.Tests.ProjectConfigTests.SettingInactiveConfigConfigurationFileMarksProjectDirty" executed="True" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Util.Tests.ProjectConfigTests.SettingInactiveConfigPrivateBinPathDoesNotRequireReload" executed="True" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Util.Tests.ProjectConfigTests.SettingInactiveConfigPrivateBinPathMarksProjectDirty" executed="True" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Util.Tests.ProjectConfigTests.ToArray" executed="True" success="True" time="0.000" asserts="2" />
+                        </results>
+                      </test-suite>
+                      <test-suite name="RecentFileEntryTests" executed="True" success="True" time="0.000" asserts="0">
+                        <results>
+                          <test-case name="NUnit.Util.Tests.RecentFileEntryTests.CanCreateFromFileNameAndVersion" executed="True" success="True" time="0.000" asserts="2" />
+                          <test-case name="NUnit.Util.Tests.RecentFileEntryTests.CanCreateFromSimpleFileName" executed="True" success="True" time="0.000" asserts="2" />
+                          <test-case name="NUnit.Util.Tests.RecentFileEntryTests.CanParseFileNamePlusVersionString" executed="True" success="True" time="0.000" asserts="2" />
+                          <test-case name="NUnit.Util.Tests.RecentFileEntryTests.CanParseFileNameWithCommaPlusVersionString" executed="True" success="True" time="0.000" asserts="2" />
+                          <test-case name="NUnit.Util.Tests.RecentFileEntryTests.CanParseSimpleFileName" executed="True" success="True" time="0.000" asserts="2" />
+                          <test-case name="NUnit.Util.Tests.RecentFileEntryTests.CanParseSimpleFileNameWithComma" executed="True" success="True" time="0.000" asserts="2" />
+                          <test-case name="NUnit.Util.Tests.RecentFileEntryTests.EntryCanDisplayItself" executed="True" success="True" time="0.000" asserts="1" />
+                        </results>
+                      </test-suite>
+                      <test-suite name="RecentFilesTests" executed="True" success="True" time="0.000" asserts="0">
+                        <results>
+                          <test-case name="NUnit.Util.Tests.RecentFilesTests.AddMaxItems" executed="True" success="True" time="0.000" asserts="7" />
+                          <test-case name="NUnit.Util.Tests.RecentFilesTests.AddSingleItem" executed="True" success="True" time="0.000" asserts="3" />
+                          <test-case name="NUnit.Util.Tests.RecentFilesTests.AddTooManyItems" executed="True" success="True" time="0.000" asserts="7" />
+                          <test-case name="NUnit.Util.Tests.RecentFilesTests.CountAtMax" executed="True" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Util.Tests.RecentFilesTests.CountAtMin" executed="True" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Util.Tests.RecentFilesTests.CountDefault" executed="True" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Util.Tests.RecentFilesTests.CountOverMax" executed="True" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Util.Tests.RecentFilesTests.CountUnderMin" executed="True" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Util.Tests.RecentFilesTests.EmptyList" executed="True" success="True" time="0.000" asserts="3" />
+                          <test-case name="NUnit.Util.Tests.RecentFilesTests.IncreaseSize" executed="True" success="True" time="0.000" asserts="12" />
+                          <test-case name="NUnit.Util.Tests.RecentFilesTests.IncreaseSizeAfterAdd" executed="True" success="True" time="0.000" asserts="8" />
+                          <test-case name="NUnit.Util.Tests.RecentFilesTests.ReduceSize" executed="True" success="True" time="0.000" asserts="5" />
+                          <test-case name="NUnit.Util.Tests.RecentFilesTests.ReduceSizeAfterAdd" executed="True" success="True" time="0.000" asserts="4" />
+                          <test-case name="NUnit.Util.Tests.RecentFilesTests.RemoveFirstProject" executed="True" success="True" time="0.000" asserts="3" />
+                          <test-case name="NUnit.Util.Tests.RecentFilesTests.RemoveLastProject" executed="True" success="True" time="0.000" asserts="5" />
+                          <test-case name="NUnit.Util.Tests.RecentFilesTests.RemoveMultipleProjects" executed="True" success="True" time="0.000" asserts="3" />
+                          <test-case name="NUnit.Util.Tests.RecentFilesTests.RemoveOneProject" executed="True" success="True" time="0.000" asserts="4" />
+                          <test-case name="NUnit.Util.Tests.RecentFilesTests.ReorderLastProject" executed="True" success="True" time="0.000" asserts="6" />
+                          <test-case name="NUnit.Util.Tests.RecentFilesTests.ReorderMultipleProjects" executed="True" success="True" time="0.000" asserts="6" />
+                          <test-case name="NUnit.Util.Tests.RecentFilesTests.ReorderSameProject" executed="True" success="True" time="0.000" asserts="6" />
+                          <test-case name="NUnit.Util.Tests.RecentFilesTests.ReorderSingleProject" executed="True" success="True" time="0.000" asserts="6" />
+                          <test-case name="NUnit.Util.Tests.RecentFilesTests.ReorderWithListNotFull" executed="True" success="True" time="0.000" asserts="4" />
+                        </results>
+                      </test-suite>
+                      <test-suite name="RegistrySettingsStorageTests" executed="True" success="True" time="0.016" asserts="0">
+                        <results>
+                          <test-case name="NUnit.Util.Tests.RegistrySettingsStorageTests.MakeSubStorages" executed="True" success="True" time="0.000" asserts="4" />
+                          <test-case name="NUnit.Util.Tests.RegistrySettingsStorageTests.RemoveSettings" executed="True" success="True" time="0.016" asserts="3" />
+                          <test-case name="NUnit.Util.Tests.RegistrySettingsStorageTests.SaveAndLoadSettings" executed="True" success="True" time="0.000" asserts="6" />
+                          <test-case name="NUnit.Util.Tests.RegistrySettingsStorageTests.StorageHasCorrectKey" executed="True" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Util.Tests.RegistrySettingsStorageTests.SubstorageSettings" executed="True" success="True" time="0.000" asserts="5" />
+                          <test-case name="NUnit.Util.Tests.RegistrySettingsStorageTests.TypeSafeSettings" executed="True" success="True" time="0.000" asserts="3" />
+                        </results>
+                      </test-suite>
+                      <test-suite name="RemoteTestAgentTests" executed="True" success="True" time="0.000" asserts="0">
+                        <results>
+                          <test-case name="NUnit.Util.Tests.RemoteTestAgentTests.AgentReturnsProcessId" executed="True" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Util.Tests.RemoteTestAgentTests.CanLocateAgentExecutable" executed="True" success="True" time="0.000" asserts="1" />
+                        </results>
+                      </test-suite>
+                      <test-suite name="RemoteTestResultTest" executed="True" success="True" time="2.250" asserts="0">
+                        <results>
+                          <test-case name="NUnit.Util.Tests.RemoteTestResultTest.ResultStillValidAfterDomainUnload" executed="True" success="True" time="2.250" asserts="3" />
+                        </results>
+                      </test-suite>
+                      <test-suite name="ServerUtilityTests" executed="True" success="True" time="0.047" asserts="0">
+                        <results>
+                          <test-case name="NUnit.Util.Tests.ServerUtilityTests.CanGetTcpChannelOnSpecifiedPort" executed="True" success="True" time="0.031" asserts="5" />
+                          <test-case name="NUnit.Util.Tests.ServerUtilityTests.CanGetTcpChannelOnUnpecifiedPort" executed="True" success="True" time="0.016" asserts="4" />
+                        </results>
+                      </test-suite>
+                      <test-suite name="SettingsGroupTests" executed="True" success="True" time="0.031" asserts="0">
+                        <results>
+                          <test-case name="NUnit.Util.Tests.SettingsGroupTests.BadSetting" executed="True" success="True" time="0.016" asserts="1" />
+                          <test-case name="NUnit.Util.Tests.SettingsGroupTests.DefaultSettings" executed="True" success="True" time="0.000" asserts="7" />
+                          <test-case name="NUnit.Util.Tests.SettingsGroupTests.SubGroupSettings" executed="True" success="True" time="0.000" asserts="7" />
+                          <test-case name="NUnit.Util.Tests.SettingsGroupTests.TopLevelSettings" executed="True" success="True" time="0.000" asserts="5" />
+                          <test-case name="NUnit.Util.Tests.SettingsGroupTests.TypeSafeSettings" executed="True" success="True" time="0.000" asserts="3" />
+                        </results>
+                      </test-suite>
+                      <test-suite name="SummaryResultFixture" executed="True" success="True" time="0.031" asserts="0">
+                        <results>
+                          <test-case name="NUnit.Util.Tests.SummaryResultFixture.SummaryMatchesResult" executed="True" success="True" time="0.031" asserts="9" />
+                        </results>
+                      </test-suite>
+                      <test-suite name="TestAgencyTests" executed="True" success="True" time="1.234" asserts="0">
+                        <results>
+                          <test-case name="NUnit.Util.Tests.TestAgencyTests.CanConnectToAgency" executed="True" success="True" time="0.031" asserts="2" />
+                          <test-case name="NUnit.Util.Tests.TestAgencyTests.CanLaunchAndConnectToAgent" executed="True" success="True" time="1.188" asserts="1" />
+                        </results>
+                      </test-suite>
+                      <test-suite name="TestDomainFixture" executed="True" success="True" time="2.703" asserts="0">
+                        <results>
+                          <test-case name="NUnit.Util.Tests.TestDomainFixture.AppDomainIsSetUpCorrectly" executed="True" success="True" time="0.016" asserts="8" />
+                          <test-case name="NUnit.Util.Tests.TestDomainFixture.AssemblyIsLoadedCorrectly" executed="True" success="True" time="0.000" asserts="2" />
+                          <test-case name="NUnit.Util.Tests.TestDomainFixture.CanRunMockAssemblyTests" executed="True" success="True" time="0.563" asserts="5" />
+                        </results>
+                      </test-suite>
+                      <test-suite name="TestDomainRunnerTests" executed="True" success="True" time="34.500" asserts="1">
+                        <results>
+                          <test-case name="NUnit.Util.Tests.TestDomainRunnerTests.CheckRunnerID" executed="True" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Util.Tests.TestDomainRunnerTests.CountTestCases" executed="True" success="True" time="2.844" asserts="1" />
+                          <test-case name="NUnit.Util.Tests.TestDomainRunnerTests.CountTestCasesAcrossMultipleAssemblies" executed="True" success="True" time="2.391" asserts="1" />
+                          <test-case name="NUnit.Util.Tests.TestDomainRunnerTests.LoadAssembly" executed="True" success="True" time="2.438" asserts="1" />
+                          <test-case name="NUnit.Util.Tests.TestDomainRunnerTests.LoadAssemblyWithFixture" executed="True" success="True" time="2.656" asserts="1" />
+                          <test-case name="NUnit.Util.Tests.TestDomainRunnerTests.LoadAssemblyWithoutNamespaces" executed="True" success="True" time="2.141" asserts="4" />
+                          <test-case name="NUnit.Util.Tests.TestDomainRunnerTests.LoadAssemblyWithSuite" executed="True" success="True" time="2.047" asserts="1" />
+                          <test-case name="NUnit.Util.Tests.TestDomainRunnerTests.LoadMultipleAssemblies" executed="True" success="True" time="2.531" asserts="1" />
+                          <test-case name="NUnit.Util.Tests.TestDomainRunnerTests.LoadMultipleAssembliesWithFixture" executed="True" success="True" time="2.234" asserts="1" />
+                          <test-case name="NUnit.Util.Tests.TestDomainRunnerTests.LoadMultipleAssembliesWithSuite" executed="True" success="True" time="2.391" asserts="1" />
+                          <test-case name="NUnit.Util.Tests.TestDomainRunnerTests.RunAssembly" executed="True" success="True" time="3.047" asserts="1" />
+                          <test-case name="NUnit.Util.Tests.TestDomainRunnerTests.RunAssemblyUsingBeginAndEndRun" executed="True" success="True" time="3.094" asserts="2" />
+                          <test-case name="NUnit.Util.Tests.TestDomainRunnerTests.RunMultipleAssemblies" executed="True" success="True" time="2.984" asserts="1" />
+                          <test-case name="NUnit.Util.Tests.TestDomainRunnerTests.RunMultipleAssembliesUsingBeginAndEndRun" executed="True" success="True" time="3.578" asserts="2" />
+                        </results>
+                      </test-suite>
+                      <test-suite name="TestDomainTests" executed="True" success="True" time="15.828" asserts="0">
+                        <results>
+                          <test-case name="NUnit.Util.Tests.TestDomainTests.BasePathOverrideIsHonored" executed="True" success="True" time="2.656" asserts="1" />
+                          <test-case name="NUnit.Util.Tests.TestDomainTests.BinPathOverrideIsHonored" executed="True" success="True" time="2.406" asserts="1" />
+                          <test-case name="NUnit.Util.Tests.TestDomainTests.ConfigFileOverrideIsHonored" executed="True" success="True" time="2.297" asserts="1" />
+                          <test-case name="NUnit.Util.Tests.TestDomainTests.FileNotFound" executed="True" success="True" time="1.641" asserts="0" />
+                          <test-case name="NUnit.Util.Tests.TestDomainTests.InvalidTestFixture" executed="True" success="True" time="2.234" asserts="1" />
+                          <test-case name="NUnit.Util.Tests.TestDomainTests.SpecificTestFixture" executed="True" success="True" time="2.906" asserts="4" />
+                          <test-case name="NUnit.Util.Tests.TestDomainTests.TurnOffShadowCopy" executed="True" success="True" time="1.656" asserts="1" />
+                        </results>
+                      </test-suite>
+                      <test-suite name="TestDomainTests_Multiple" executed="True" success="True" time="3.000" asserts="0">
+                        <results>
+                          <test-case name="NUnit.Util.Tests.TestDomainTests_Multiple.AssemblyNodes" executed="True" success="True" time="0.000" asserts="2" />
+                          <test-case name="NUnit.Util.Tests.TestDomainTests_Multiple.BuildSuite" executed="True" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Util.Tests.TestDomainTests_Multiple.RootNode" executed="True" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Util.Tests.TestDomainTests_Multiple.RunMultipleAssemblies" executed="True" success="True" time="0.500" asserts="1" />
+                          <test-case name="NUnit.Util.Tests.TestDomainTests_Multiple.TestCaseCount" executed="True" success="True" time="0.000" asserts="1" />
+                        </results>
+                      </test-suite>
+                      <test-suite name="TestDomainTests_MultipleFixture" executed="True" success="True" time="2.359" asserts="0">
+                        <results>
+                          <test-case name="NUnit.Util.Tests.TestDomainTests_MultipleFixture.LoadFixture" executed="True" success="True" time="2.344" asserts="1" />
+                        </results>
+                      </test-suite>
+                      <test-suite name="TestLoaderAssemblyTests" executed="True" success="True" time="10.547" asserts="0">
+                        <results>
+                          <test-case name="NUnit.Util.Tests.TestLoaderAssemblyTests.AssemblyWithNoTests" executed="True" success="True" time="2.375" asserts="4" />
+                          <test-case name="NUnit.Util.Tests.TestLoaderAssemblyTests.FileNotFound" executed="True" success="True" time="0.000" asserts="5" />
+                          <test-case name="NUnit.Util.Tests.TestLoaderAssemblyTests.LoadProject" executed="True" success="True" time="0.016" asserts="5" />
+                          <test-case name="NUnit.Util.Tests.TestLoaderAssemblyTests.LoadTest" executed="True" success="True" time="2.266" asserts="6" />
+                          <test-case name="NUnit.Util.Tests.TestLoaderAssemblyTests.RunTest" executed="True" success="True" time="3.531" asserts="9" />
+                          <test-case name="NUnit.Util.Tests.TestLoaderAssemblyTests.UnloadProject" executed="True" success="True" time="0.000" asserts="5" />
+                          <test-case name="NUnit.Util.Tests.TestLoaderAssemblyTests.UnloadTest" executed="True" success="True" time="2.266" asserts="3" />
+                        </results>
+                      </test-suite>
+                      <test-suite name="VisualStudioConverterTests" executed="True" success="True" time="0.625" asserts="0">
+                        <results>
+                          <test-case name="NUnit.Util.Tests.VisualStudioConverterTests.FromCppProject" executed="True" success="True" time="0.234" asserts="5" />
+                          <test-case name="NUnit.Util.Tests.VisualStudioConverterTests.FromCSharpProject" executed="True" success="True" time="0.016" asserts="5" />
+                          <test-case name="NUnit.Util.Tests.VisualStudioConverterTests.FromJsharpProject" executed="True" success="True" time="0.000" asserts="5" />
+                          <test-case name="NUnit.Util.Tests.VisualStudioConverterTests.FromMakefileProject" executed="True" success="True" time="0.000" asserts="3" />
+                          <test-case name="NUnit.Util.Tests.VisualStudioConverterTests.FromProjectWithHebrewFileIncluded" executed="True" success="True" time="0.031" asserts="5" />
+                          <test-case name="NUnit.Util.Tests.VisualStudioConverterTests.FromVBProject" executed="True" success="True" time="0.016" asserts="5" />
+                          <test-case name="NUnit.Util.Tests.VisualStudioConverterTests.FromVSSolution2003" executed="True" success="True" time="0.078" asserts="7" />
+                          <test-case name="NUnit.Util.Tests.VisualStudioConverterTests.FromVSSolution2005" executed="True" success="True" time="0.094" asserts="7" />
+                          <test-case name="NUnit.Util.Tests.VisualStudioConverterTests.FromWebApplication" executed="True" success="True" time="0.031" asserts="3" />
+                          <test-case name="NUnit.Util.Tests.VisualStudioConverterTests.WithUnmanagedCpp" executed="True" success="True" time="0.078" asserts="5" />
+                        </results>
+                      </test-suite>
+                      <test-suite name="VSProjectTests" executed="True" success="True" time="0.234" asserts="0">
+                        <results>
+                          <test-case name="NUnit.Util.Tests.VSProjectTests.FileNotFoundError" executed="True" success="True" time="0.000" asserts="0" />
+                          <test-case name="NUnit.Util.Tests.VSProjectTests.GenerateCorrectExtensionsFromVCProjectVS2005" executed="True" success="True" time="0.016" asserts="4" />
+                          <test-case name="NUnit.Util.Tests.VSProjectTests.InvalidProjectFormat" executed="True" success="True" time="0.016" asserts="0" />
+                          <test-case name="NUnit.Util.Tests.VSProjectTests.InvalidXmlFormat" executed="True" success="True" time="0.016" asserts="0" />
+                          <test-case name="NUnit.Util.Tests.VSProjectTests.LoadCppProject" executed="True" success="True" time="0.000" asserts="3" />
+                          <test-case name="NUnit.Util.Tests.VSProjectTests.LoadCppProjectVS2005" executed="True" success="True" time="0.016" asserts="3" />
+                          <test-case name="NUnit.Util.Tests.VSProjectTests.LoadCppProjectWithMacros" executed="True" success="True" time="0.016" asserts="4" />
+                          <test-case name="NUnit.Util.Tests.VSProjectTests.LoadCsharpProject" executed="True" success="True" time="0.016" asserts="3" />
+                          <test-case name="NUnit.Util.Tests.VSProjectTests.LoadCsharpProjectVS2005" executed="True" success="True" time="0.000" asserts="3" />
+                          <test-case name="NUnit.Util.Tests.VSProjectTests.LoadInvalidFileType" executed="True" success="True" time="0.016" asserts="0" />
+                          <test-case name="NUnit.Util.Tests.VSProjectTests.LoadJsharpProject" executed="True" success="True" time="0.000" asserts="3" />
+                          <test-case name="NUnit.Util.Tests.VSProjectTests.LoadJsharpProjectVS2005" executed="True" success="True" time="0.000" asserts="3" />
+                          <test-case name="NUnit.Util.Tests.VSProjectTests.LoadProjectWithHebrewFileIncluded" executed="True" success="True" time="0.016" asserts="3" />
+                          <test-case name="NUnit.Util.Tests.VSProjectTests.LoadVbProject" executed="True" success="True" time="0.016" asserts="3" />
+                          <test-case name="NUnit.Util.Tests.VSProjectTests.LoadVbProjectVS2005" executed="True" success="True" time="0.016" asserts="3" />
+                          <test-case name="NUnit.Util.Tests.VSProjectTests.MissingAttributes" executed="True" success="True" time="0.016" asserts="0" />
+                          <test-case name="NUnit.Util.Tests.VSProjectTests.NoConfigurations" executed="True" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Util.Tests.VSProjectTests.NotWebProject" executed="True" success="True" time="0.000" asserts="2" />
+                          <test-case name="NUnit.Util.Tests.VSProjectTests.ProjectExtensions" executed="True" success="True" time="0.000" asserts="4" />
+                          <test-case name="NUnit.Util.Tests.VSProjectTests.SolutionExtension" executed="True" success="True" time="0.000" asserts="2" />
+                        </results>
+                      </test-suite>
+                      <test-suite name="XmlResultWriterTest" executed="True" success="True" time="0.266" asserts="0">
+                        <results>
+                          <test-case name="NUnit.Util.Tests.XmlResultWriterTest.HasMultipleCategories" executed="True" success="True" time="0.016" asserts="2" />
+                          <test-case name="NUnit.Util.Tests.XmlResultWriterTest.HasMultipleProperties" executed="True" success="True" time="0.016" asserts="2" />
+                          <test-case name="NUnit.Util.Tests.XmlResultWriterTest.HasSingleCategory" executed="True" success="True" time="0.000" asserts="3" />
+                          <test-case name="NUnit.Util.Tests.XmlResultWriterTest.HasSingleProperty" executed="True" success="True" time="0.000" asserts="3" />
+                          <test-case name="NUnit.Util.Tests.XmlResultWriterTest.SuiteResultHasCategories" executed="True" success="True" time="0.000" asserts="3" />
+                          <test-case name="NUnit.Util.Tests.XmlResultWriterTest.TestHasCultureInfo" executed="True" success="True" time="0.000" asserts="5" />
+                          <test-case name="NUnit.Util.Tests.XmlResultWriterTest.TestHasEnvironmentInfo" executed="True" success="True" time="0.000" asserts="9" />
+                        </results>
+                      </test-suite>
+                    </results>
+                  </test-suite>
+                </results>
+              </test-suite>
+            </results>
+          </test-suite>
+        </results>
+      </test-suite>
+      <test-suite name="C:\Program Files\NUnit 2.5.2\bin\net-2.0\tests/nunit.mocks.tests.dll" executed="True" success="True" time="0.781" asserts="0">
+        <results>
+          <test-suite name="NUnit" executed="True" success="True" time="0.781" asserts="0">
+            <results>
+              <test-suite name="Mocks" executed="True" success="True" time="0.781" asserts="0">
+                <results>
+                  <test-suite name="Tests" executed="True" success="True" time="0.781" asserts="0">
+                    <results>
+                      <test-suite name="DynamicMockTests" executed="True" success="True" time="0.609" asserts="0">
+                        <results>
+                          <test-case name="NUnit.Mocks.Tests.DynamicMockTests.CallMethod" executed="True" success="True" time="0.000" asserts="0" />
+                          <test-case name="NUnit.Mocks.Tests.DynamicMockTests.CallMethodWithArgs" executed="True" success="True" time="0.000" asserts="0" />
+                          <test-case name="NUnit.Mocks.Tests.DynamicMockTests.CreateMockForMBRClass" executed="True" success="True" time="0.000" asserts="13" />
+                          <test-case name="NUnit.Mocks.Tests.DynamicMockTests.CreateMockForNonMBRClassFails" executed="True" success="True" time="0.000" asserts="0" />
+                          <test-case name="NUnit.Mocks.Tests.DynamicMockTests.DefaultReturnValues" executed="True" success="True" time="0.000" asserts="5" />
+                          <test-case name="NUnit.Mocks.Tests.DynamicMockTests.ExpectedMethod" executed="True" success="True" time="0.000" asserts="2" />
+                          <test-case name="NUnit.Mocks.Tests.DynamicMockTests.ExpectedMethodNotCalled" executed="True" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Mocks.Tests.DynamicMockTests.MethodWithReturnValue" executed="True" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Mocks.Tests.DynamicMockTests.MockHasDefaultName" executed="True" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Mocks.Tests.DynamicMockTests.MockHasNonDefaultName" executed="True" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Mocks.Tests.DynamicMockTests.OverrideMethodOnDynamicMock" executed="True" success="True" time="0.156" asserts="1" />
+                          <test-case name="NUnit.Mocks.Tests.DynamicMockTests.RefParameter" executed="True" success="True" time="0.000" asserts="2" />
+                          <test-case name="NUnit.Mocks.Tests.DynamicMockTests.WrongReturnType" executed="True" success="True" time="0.000" asserts="0" />
+                        </results>
+                      </test-suite>
+                      <test-suite name="MockTests" executed="True" success="True" time="0.156" asserts="0">
+                        <results>
+                          <test-case name="NUnit.Mocks.Tests.MockTests.CallMultipleMethodsInDifferentOrder" executed="True" success="True" time="0.000" asserts="6" />
+                          <test-case name="NUnit.Mocks.Tests.MockTests.CallMultipleMethodsSomeWithoutExpectations" executed="True" success="True" time="0.000" asserts="5" />
+                          <test-case name="NUnit.Mocks.Tests.MockTests.ChangeExpectAndReturnToFixedReturn" executed="True" success="True" time="0.000" asserts="8" />
+                          <test-case name="NUnit.Mocks.Tests.MockTests.ChangeFixedReturnToExpectAndReturn" executed="True" success="True" time="0.000" asserts="9" />
+                          <test-case name="NUnit.Mocks.Tests.MockTests.ConstraintArgumentSucceeds" executed="True" success="True" time="0.000" asserts="3" />
+                          <test-case name="NUnit.Mocks.Tests.MockTests.ConstraintArgumentThatFails" executed="True" success="True" time="0.000" asserts="3" />
+                          <test-case name="NUnit.Mocks.Tests.MockTests.ExpectAndReturn" executed="True" success="True" time="0.000" asserts="4" />
+                          <test-case name="NUnit.Mocks.Tests.MockTests.ExpectAndReturnNull" executed="True" success="True" time="0.000" asserts="4" />
+                          <test-case name="NUnit.Mocks.Tests.MockTests.ExpectAndReturnWithArgument" executed="True" success="True" time="0.000" asserts="5" />
+                          <test-case name="NUnit.Mocks.Tests.MockTests.ExpectAndReturnWithWrongArgument" executed="True" success="True" time="0.000" asserts="3" />
+                          <test-case name="NUnit.Mocks.Tests.MockTests.ExpectAndThrowException" executed="True" success="True" time="0.031" asserts="2" />
+                          <test-case name="NUnit.Mocks.Tests.MockTests.ExpectNoCallFails" executed="True" success="True" time="0.000" asserts="0" />
+                          <test-case name="NUnit.Mocks.Tests.MockTests.ExpectNoCallSucceeds" executed="True" success="True" time="0.000" asserts="0" />
+                          <test-case name="NUnit.Mocks.Tests.MockTests.FailWithParametersSpecified" executed="True" success="True" time="0.000" asserts="2" />
+                          <test-case name="NUnit.Mocks.Tests.MockTests.IgnoreArguments" executed="True" success="True" time="0.000" asserts="2" />
+                          <test-case name="NUnit.Mocks.Tests.MockTests.MethodNotCalled" executed="True" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Mocks.Tests.MockTests.MockHasName" executed="True" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Mocks.Tests.MockTests.MultipleCallsToSameMethod" executed="True" success="True" time="0.000" asserts="4" />
+                          <test-case name="NUnit.Mocks.Tests.MockTests.MultipleExpectAndReturn" executed="True" success="True" time="0.000" asserts="10" />
+                          <test-case name="NUnit.Mocks.Tests.MockTests.MultipleExpectations" executed="True" success="True" time="0.000" asserts="12" />
+                          <test-case name="NUnit.Mocks.Tests.MockTests.NotEnoughCalls" executed="True" success="True" time="0.031" asserts="3" />
+                          <test-case name="NUnit.Mocks.Tests.MockTests.OneExpectation" executed="True" success="True" time="0.000" asserts="2" />
+                          <test-case name="NUnit.Mocks.Tests.MockTests.RequireArguments" executed="True" success="True" time="0.000" asserts="2" />
+                          <test-case name="NUnit.Mocks.Tests.MockTests.SetReturnValue" executed="True" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Mocks.Tests.MockTests.SetReturnValueMultipleTimesOnMultipleMethods" executed="True" success="True" time="0.000" asserts="7" />
+                          <test-case name="NUnit.Mocks.Tests.MockTests.SetReturnValueRepeatedCalls" executed="True" success="True" time="0.000" asserts="3" />
+                          <test-case name="NUnit.Mocks.Tests.MockTests.SetReturnValueWithoutCalling" executed="True" success="True" time="0.000" asserts="0" />
+                          <test-case name="NUnit.Mocks.Tests.MockTests.StrictDefaultsToFalse" executed="True" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Mocks.Tests.MockTests.StrictMode" executed="True" success="True" time="0.016" asserts="2" />
+                          <test-case name="NUnit.Mocks.Tests.MockTests.StrictMode_ExceptionsCaught" executed="True" success="True" time="0.016" asserts="4" />
+                          <test-case name="NUnit.Mocks.Tests.MockTests.TooManyCalls" executed="True" success="True" time="0.000" asserts="3" />
+                          <test-case name="NUnit.Mocks.Tests.MockTests.UnexpectedCallsIgnored" executed="True" success="True" time="0.000" asserts="0" />
+                          <test-case name="NUnit.Mocks.Tests.MockTests.VerifyNewMock" executed="True" success="True" time="0.000" asserts="0" />
+                        </results>
+                      </test-suite>
+                    </results>
+                  </test-suite>
+                </results>
+              </test-suite>
+            </results>
+          </test-suite>
+        </results>
+      </test-suite>
+      <test-suite name="C:\Program Files\NUnit 2.5.2\bin\net-2.0\tests/nunit-console.tests.dll" executed="True" success="True" time="34.328" asserts="0">
+        <results>
+          <test-suite name="NUnit" executed="True" success="True" time="34.313" asserts="0">
+            <results>
+              <test-suite name="ConsoleRunner" executed="True" success="True" time="34.297" asserts="0">
+                <results>
+                  <test-suite name="Tests" executed="True" success="True" time="34.297" asserts="0">
+                    <results>
+                      <test-suite name="CommandLineTests" executed="True" success="True" time="0.297" asserts="0">
+                        <results>
+                          <test-case name="NUnit.ConsoleRunner.Tests.CommandLineTests.AllowForwardSlashDefaultsCorrectly" executed="True" success="True" time="0.188" asserts="1" />
+                          <test-case name="NUnit.ConsoleRunner.Tests.CommandLineTests.AssemblyAloneIsValid" executed="True" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.ConsoleRunner.Tests.CommandLineTests.AssemblyName" executed="True" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.ConsoleRunner.Tests.CommandLineTests.FileNameWithoutXmlParameterLooksLikeParameter" executed="True" success="True" time="0.000" asserts="2" />
+                          <test-case name="NUnit.ConsoleRunner.Tests.CommandLineTests.FixtureNamePlusAssemblyIsValid" executed="True" success="True" time="0.000" asserts="3" />
+                          <test-case name="NUnit.ConsoleRunner.Tests.CommandLineTests.HelpTextUsesCorrectDelimiterForPlatform" executed="True" success="True" time="0.016" asserts="2" />
+                          <test-case name="NUnit.ConsoleRunner.Tests.CommandLineTests.InvalidCommandLineParms" executed="True" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.ConsoleRunner.Tests.CommandLineTests.InvalidOption" executed="True" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.ConsoleRunner.Tests.CommandLineTests.NoFixtureNameProvided" executed="True" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.ConsoleRunner.Tests.CommandLineTests.NoParametersCount" executed="True" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.ConsoleRunner.Tests.CommandLineTests.OptionsAreRecognized" executed="True" success="True" time="0.047" asserts="98" />
+                          <test-case name="NUnit.ConsoleRunner.Tests.CommandLineTests.XmlParameter" executed="True" success="True" time="0.000" asserts="3" />
+                          <test-case name="NUnit.ConsoleRunner.Tests.CommandLineTests.XmlParameterWithFullPath" executed="True" success="True" time="0.000" asserts="3" />
+                          <test-case name="NUnit.ConsoleRunner.Tests.CommandLineTests.XmlParameterWithFullPathUsingEqualSign" executed="True" success="True" time="0.000" asserts="3" />
+                          <test-case name="NUnit.ConsoleRunner.Tests.CommandLineTests.XmlParameterWithoutFileNameIsInvalid" executed="True" success="True" time="0.000" asserts="1" />
+                        </results>
+                      </test-suite>
+                      <test-suite name="CommandLineTests_MultipleAssemblies" executed="True" success="True" time="0.000" asserts="0">
+                        <results>
+                          <test-case name="NUnit.ConsoleRunner.Tests.CommandLineTests_MultipleAssemblies.CheckParameters" executed="True" success="True" time="0.000" asserts="2" />
+                          <test-case name="NUnit.ConsoleRunner.Tests.CommandLineTests_MultipleAssemblies.FixtureParameters" executed="True" success="True" time="0.000" asserts="3" />
+                          <test-case name="NUnit.ConsoleRunner.Tests.CommandLineTests_MultipleAssemblies.FixtureValidate" executed="True" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.ConsoleRunner.Tests.CommandLineTests_MultipleAssemblies.MultipleAssemblyValidate" executed="True" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.ConsoleRunner.Tests.CommandLineTests_MultipleAssemblies.ParameterCount" executed="True" success="True" time="0.000" asserts="1" />
+                        </results>
+                      </test-suite>
+                      <test-suite name="ConsoleRunnerTest" executed="True" success="True" time="34.000" asserts="0">
+                        <results>
+                          <test-case name="NUnit.ConsoleRunner.Tests.ConsoleRunnerTest.AssemblyNotFound" executed="True" success="True" time="1.766" asserts="1" />
+                          <test-case name="NUnit.ConsoleRunner.Tests.ConsoleRunnerTest.Bug1073539Test" executed="True" success="True" time="2.859" asserts="1" />
+                          <test-case name="NUnit.ConsoleRunner.Tests.ConsoleRunnerTest.Bug1311644Test" executed="True" success="True" time="2.797" asserts="1" />
+                          <test-case name="NUnit.ConsoleRunner.Tests.ConsoleRunnerTest.CanRunWithMultipleTestDomains" executed="True" success="True" time="5.703" asserts="2" />
+                          <test-case name="NUnit.ConsoleRunner.Tests.ConsoleRunnerTest.CanRunWithMultipleTestDomains_NoThread" executed="True" success="True" time="3.875" asserts="2" />
+                          <test-case name="NUnit.ConsoleRunner.Tests.ConsoleRunnerTest.CanRunWithoutTestDomain" executed="True" success="True" time="1.406" asserts="2" />
+                          <test-case name="NUnit.ConsoleRunner.Tests.ConsoleRunnerTest.CanRunWithoutTestDomain_NoThread" executed="True" success="True" time="1.391" asserts="2" />
+                          <test-case name="NUnit.ConsoleRunner.Tests.ConsoleRunnerTest.CanRunWithSingleTestDomain" executed="True" success="True" time="1.281" asserts="2" />
+                          <test-case name="NUnit.ConsoleRunner.Tests.ConsoleRunnerTest.CanRunWithSingleTestDomain_NoThread" executed="True" success="True" time="1.297" asserts="2" />
+                          <test-case name="NUnit.ConsoleRunner.Tests.ConsoleRunnerTest.FailureFixture" executed="True" success="True" time="1.266" asserts="1" />
+                          <test-case name="NUnit.ConsoleRunner.Tests.ConsoleRunnerTest.InvalidFixture" executed="True" success="True" time="0.891" asserts="1" />
+                          <test-case name="NUnit.ConsoleRunner.Tests.ConsoleRunnerTest.MultiFailureFixture" executed="True" success="True" time="1.250" asserts="1" />
+                          <test-case name="NUnit.ConsoleRunner.Tests.ConsoleRunnerTest.OneOfTwoAssembliesNotFound" executed="True" success="True" time="2.313" asserts="1" />
+                          <test-case name="NUnit.ConsoleRunner.Tests.ConsoleRunnerTest.SuccessFixture" executed="True" success="True" time="1.734" asserts="1" />
+                          <test-case name="NUnit.ConsoleRunner.Tests.ConsoleRunnerTest.XmlResult" executed="True" success="True" time="1.953" asserts="2" />
+                          <test-case name="NUnit.ConsoleRunner.Tests.ConsoleRunnerTest.XmlToConsole" executed="True" success="True" time="2.156" asserts="2" />
+                        </results>
+                      </test-suite>
+                    </results>
+                  </test-suite>
+                </results>
+              </test-suite>
+            </results>
+          </test-suite>
+        </results>
+      </test-suite>
+      <test-suite name="C:\Program Files\NUnit 2.5.2\bin\net-2.0\tests/nunit.uiexception.tests.dll" executed="True" success="True" time="1.859" asserts="0">
+        <results>
+          <test-suite name="NUnit" executed="True" success="True" time="1.859" asserts="0">
+            <results>
+              <test-suite name="UiException" executed="True" success="True" time="1.813" asserts="0">
+                <results>
+                  <test-suite name="Tests" executed="True" success="True" time="1.766" asserts="0">
+                    <results>
+                      <test-suite name="CodeFormatters" executed="True" success="True" time="0.406" asserts="0">
+                        <results>
+                          <test-suite name="TestCodeFormatterCollection" executed="True" success="True" time="0.031" asserts="0">
+                            <results>
+                              <test-case name="NUnit.UiException.Tests.CodeFormatters.TestCodeFormatterCollection.Clear" executed="True" success="True" time="0.000" asserts="1" />
+                              <test-case name="NUnit.UiException.Tests.CodeFormatters.TestCodeFormatterCollection.ContainsFormatterFromExtension" executed="True" success="True" time="0.000" asserts="1" />
+                              <test-case name="NUnit.UiException.Tests.CodeFormatters.TestCodeFormatterCollection.Indexer_Can_Throw_UnknownExtensionException" executed="True" success="True" time="0.016" asserts="0" />
+                              <test-case name="NUnit.UiException.Tests.CodeFormatters.TestCodeFormatterCollection.ItemIndexer_Can_Throw_NullExtensionException" executed="True" success="True" time="0.000" asserts="0" />
+                              <test-case name="NUnit.UiException.Tests.CodeFormatters.TestCodeFormatterCollection.Register_Can_Throw_NullExtensionException" executed="True" success="True" time="0.000" asserts="0" />
+                              <test-case name="NUnit.UiException.Tests.CodeFormatters.TestCodeFormatterCollection.Register_Can_Throw_NullFormatterException" executed="True" success="True" time="0.000" asserts="0" />
+                              <test-case name="NUnit.UiException.Tests.CodeFormatters.TestCodeFormatterCollection.Register_Check_Extension_Case" executed="True" success="True" time="0.000" asserts="0" />
+                              <test-case name="NUnit.UiException.Tests.CodeFormatters.TestCodeFormatterCollection.Register_Check_Extension_Is_Not_Empty" executed="True" success="True" time="0.000" asserts="0" />
+                              <test-case name="NUnit.UiException.Tests.CodeFormatters.TestCodeFormatterCollection.Register_Check_Extension_Not_Contain_Dot_Character" executed="True" success="True" time="0.000" asserts="0" />
+                              <test-case name="NUnit.UiException.Tests.CodeFormatters.TestCodeFormatterCollection.Register_Check_Multiple_Extension_Definition" executed="True" success="True" time="0.000" asserts="0" />
+                              <test-case name="NUnit.UiException.Tests.CodeFormatters.TestCodeFormatterCollection.Remove" executed="True" success="True" time="0.000" asserts="4" />
+                              <test-case name="NUnit.UiException.Tests.CodeFormatters.TestCodeFormatterCollection.Remove_Is_Not_Case_Sensitive" executed="True" success="True" time="0.000" asserts="1" />
+                              <test-case name="NUnit.UiException.Tests.CodeFormatters.TestCodeFormatterCollection.StringIndexer_Can_Throw_NullExtensionException" executed="True" success="True" time="0.000" asserts="0" />
+                              <test-case name="NUnit.UiException.Tests.CodeFormatters.TestCodeFormatterCollection.Test_Default" executed="True" success="True" time="0.000" asserts="10" />
+                            </results>
+                          </test-suite>
+                          <test-suite name="TestCSharpCodeFormatter" executed="True" success="True" time="0.047" asserts="0">
+                            <results>
+                              <test-case name="NUnit.UiException.Tests.CodeFormatters.TestCSharpCodeFormatter.Format_Can_Throw_CSharpNullException" executed="True" success="True" time="0.000" asserts="0" />
+                              <test-case name="NUnit.UiException.Tests.CodeFormatters.TestCSharpCodeFormatter.Test_Conserve_Intermediary_Spaces" executed="True" success="True" time="0.031" asserts="9" />
+                              <test-case name="NUnit.UiException.Tests.CodeFormatters.TestCSharpCodeFormatter.Test_Default" executed="True" success="True" time="0.000" asserts="4" />
+                              <test-case name="NUnit.UiException.Tests.CodeFormatters.TestCSharpCodeFormatter.Test_Format" executed="True" success="True" time="0.016" asserts="1" />
+                              <test-case name="NUnit.UiException.Tests.CodeFormatters.TestCSharpCodeFormatter.Test_Format_2" executed="True" success="True" time="0.000" asserts="1" />
+                              <test-case name="NUnit.UiException.Tests.CodeFormatters.TestCSharpCodeFormatter.Test_Format_3" executed="True" success="True" time="0.000" asserts="2" />
+                              <test-case name="NUnit.UiException.Tests.CodeFormatters.TestCSharpCodeFormatter.Test_PreProcess" executed="True" success="True" time="0.000" asserts="3" />
+                            </results>
+                          </test-suite>
+                          <test-suite name="TestFormattedCode" executed="True" success="True" time="0.047" asserts="0">
+                            <results>
+                              <test-case name="NUnit.UiException.Tests.CodeFormatters.TestFormattedCode.CheckData_Can_Throw_NullDataException" executed="True" success="True" time="0.000" asserts="0" />
+                              <test-case name="NUnit.UiException.Tests.CodeFormatters.TestFormattedCode.CheckData_IndexArray_And_TagArray_Count_Must_Match" executed="True" success="True" time="0.016" asserts="0" />
+                              <test-case name="NUnit.UiException.Tests.CodeFormatters.TestFormattedCode.CheckData_LineArray_Values_Must_Always_Grow_Up" executed="True" success="True" time="0.000" asserts="0" />
+                              <test-case name="NUnit.UiException.Tests.CodeFormatters.TestFormattedCode.CheckData_LineArray_Values_Must_Be_In_IndexArray_Count" executed="True" success="True" time="0.000" asserts="0" />
+                              <test-case name="NUnit.UiException.Tests.CodeFormatters.TestFormattedCode.Empty" executed="True" success="True" time="0.000" asserts="2" />
+                              <test-case name="NUnit.UiException.Tests.CodeFormatters.TestFormattedCode.Test_ComplexCollection" executed="True" success="True" time="0.000" asserts="22" />
+                              <test-case name="NUnit.UiException.Tests.CodeFormatters.TestFormattedCode.Test_Equals" executed="True" success="True" time="0.000" asserts="10" />
+                              <test-case name="NUnit.UiException.Tests.CodeFormatters.TestFormattedCode.Test_MaxLength" executed="True" success="True" time="0.000" asserts="3" />
+                              <test-case name="NUnit.UiException.Tests.CodeFormatters.TestFormattedCode.Test_SimpleCollection" executed="True" success="True" time="0.000" asserts="17" />
+                            </results>
+                          </test-suite>
+                          <test-suite name="TestGeneralCodeFormatter" executed="True" success="True" time="0.094" asserts="0">
+                            <results>
+                              <test-case name="NUnit.UiException.Tests.CodeFormatters.TestGeneralCodeFormatter.All_Formatters_Have_Unique_Language_Value" executed="True" success="True" time="0.016" asserts="2" />
+                              <test-case name="NUnit.UiException.Tests.CodeFormatters.TestGeneralCodeFormatter.All_Formatters_Should_Have_Overwrite_Behavior" executed="True" success="True" time="0.000" asserts="2" />
+                              <test-case name="NUnit.UiException.Tests.CodeFormatters.TestGeneralCodeFormatter.All_Formatters_Should_PreProcess_Tab_Character" executed="True" success="True" time="0.000" asserts="2" />
+                              <test-case name="NUnit.UiException.Tests.CodeFormatters.TestGeneralCodeFormatter.Any_Formatter_Should_Format_Any_Text" executed="True" success="True" time="0.031" asserts="6" />
+                              <test-case name="NUnit.UiException.Tests.CodeFormatters.TestGeneralCodeFormatter.DefaultFormatter" executed="True" success="True" time="0.000" asserts="1" />
+                              <test-case name="NUnit.UiException.Tests.CodeFormatters.TestGeneralCodeFormatter.DefaultFormatter_Can_Throw_FormatterNullException" executed="True" success="True" time="0.000" asserts="0" />
+                              <test-case name="NUnit.UiException.Tests.CodeFormatters.TestGeneralCodeFormatter.Format" executed="True" success="True" time="0.000" asserts="2" />
+                              <test-case name="NUnit.UiException.Tests.CodeFormatters.TestGeneralCodeFormatter.Format_Can_Throw_CodeNullException" executed="True" success="True" time="0.000" asserts="0" />
+                              <test-case name="NUnit.UiException.Tests.CodeFormatters.TestGeneralCodeFormatter.Format_Can_Throw_LanguageNameNullException" executed="True" success="True" time="0.000" asserts="0" />
+                              <test-case name="NUnit.UiException.Tests.CodeFormatters.TestGeneralCodeFormatter.Format_Pick_Best_Formatter" executed="True" success="True" time="0.016" asserts="2" />
+                              <test-case name="NUnit.UiException.Tests.CodeFormatters.TestGeneralCodeFormatter.FormatFromExtension_Can_Throw_CodeNullException" executed="True" success="True" time="0.000" asserts="0" />
+                              <test-case name="NUnit.UiException.Tests.CodeFormatters.TestGeneralCodeFormatter.FormatFromExtension_Can_Throw_ExtensionNullException" executed="True" success="True" time="0.000" asserts="0" />
+                              <test-case name="NUnit.UiException.Tests.CodeFormatters.TestGeneralCodeFormatter.GetFormatterFromExtension_Can_Throw_ExtensionNullException" executed="True" success="True" time="0.000" asserts="0" />
+                              <test-case name="NUnit.UiException.Tests.CodeFormatters.TestGeneralCodeFormatter.GetFormatterFromLanguage_Can_Throw_LanguageNullException" executed="True" success="True" time="0.000" asserts="0" />
+                              <test-case name="NUnit.UiException.Tests.CodeFormatters.TestGeneralCodeFormatter.GetFormatterFroms" executed="True" success="True" time="0.000" asserts="4" />
+                              <test-case name="NUnit.UiException.Tests.CodeFormatters.TestGeneralCodeFormatter.LanguageFromExtension" executed="True" success="True" time="0.000" asserts="3" />
+                              <test-case name="NUnit.UiException.Tests.CodeFormatters.TestGeneralCodeFormatter.Test_Default" executed="True" success="True" time="0.000" asserts="3" />
+                            </results>
+                          </test-suite>
+                          <test-suite name="TestLexer" executed="True" success="True" time="0.016" asserts="0">
+                            <results>
+                              <test-case name="NUnit.UiException.Tests.CodeFormatters.TestLexer.Test_Default" executed="True" success="True" time="0.000" asserts="3" />
+                              <test-case name="NUnit.UiException.Tests.CodeFormatters.TestLexer.Test_Dot_Character" executed="True" success="True" time="0.000" asserts="5" />
+                              <test-case name="NUnit.UiException.Tests.CodeFormatters.TestLexer.Test_SetText_Throws_NullArgumentException" executed="True" success="True" time="0.000" asserts="0" />
+                              <test-case name="NUnit.UiException.Tests.CodeFormatters.TestLexer.Test_Split_ColonCharacter" executed="True" success="True" time="0.000" asserts="20" />
+                              <test-case name="NUnit.UiException.Tests.CodeFormatters.TestLexer.Test_Split_CommentC" executed="True" success="True" time="0.000" asserts="10" />
+                              <test-case name="NUnit.UiException.Tests.CodeFormatters.TestLexer.Test_Split_CommentCpp" executed="True" success="True" time="0.000" asserts="5" />
+                              <test-case name="NUnit.UiException.Tests.CodeFormatters.TestLexer.Test_Split_DoubleQuote" executed="True" success="True" time="0.000" asserts="19" />
+                              <test-case name="NUnit.UiException.Tests.CodeFormatters.TestLexer.Test_Split_Equals" executed="True" success="True" time="0.000" asserts="5" />
+                              <test-case name="NUnit.UiException.Tests.CodeFormatters.TestLexer.Test_Split_New_Line" executed="True" success="True" time="0.000" asserts="5" />
+                              <test-case name="NUnit.UiException.Tests.CodeFormatters.TestLexer.Test_Split_NumberSign" executed="True" success="True" time="0.000" asserts="5" />
+                              <test-case name="NUnit.UiException.Tests.CodeFormatters.TestLexer.Test_Split_SingleQuote" executed="True" success="True" time="0.000" asserts="5" />
+                              <test-case name="NUnit.UiException.Tests.CodeFormatters.TestLexer.Test_Split_WhiteSpaces" executed="True" success="True" time="0.016" asserts="35" />
+                              <test-case name="NUnit.UiException.Tests.CodeFormatters.TestLexer.Test_Split_Words" executed="True" success="True" time="0.000" asserts="10" />
+                            </results>
+                          </test-suite>
+                          <test-suite name="TestPlainTextCodeFormatter" executed="True" success="True" time="0.000" asserts="0">
+                            <results>
+                              <test-case name="NUnit.UiException.Tests.CodeFormatters.TestPlainTextCodeFormatter.Format_Can_Throw_CodeNullException" executed="True" success="True" time="0.000" asserts="0" />
+                              <test-case name="NUnit.UiException.Tests.CodeFormatters.TestPlainTextCodeFormatter.Format_HelloWorld" executed="True" success="True" time="0.000" asserts="1" />
+                              <test-case name="NUnit.UiException.Tests.CodeFormatters.TestPlainTextCodeFormatter.Format_Lines" executed="True" success="True" time="0.000" asserts="1" />
+                              <test-case name="NUnit.UiException.Tests.CodeFormatters.TestPlainTextCodeFormatter.Test_Language" executed="True" success="True" time="0.000" asserts="1" />
+                              <test-case name="NUnit.UiException.Tests.CodeFormatters.TestPlainTextCodeFormatter.Test_PreProcess" executed="True" success="True" time="0.000" asserts="3" />
+                            </results>
+                          </test-suite>
+                          <test-suite name="TestToken" executed="True" success="True" time="0.016" asserts="0">
+                            <results>
+                              <test-case name="NUnit.UiException.Tests.CodeFormatters.TestToken.Test_Equals" executed="True" success="True" time="0.000" asserts="6" />
+                            </results>
+                          </test-suite>
+                          <test-suite name="TestTokenClassifier" executed="True" success="True" time="0.031" asserts="0">
+                            <results>
+                              <test-case name="NUnit.UiException.Tests.CodeFormatters.TestTokenClassifier.test_AcceptToken" executed="True" success="True" time="0.000" asserts="60" />
+                              <test-case name="NUnit.UiException.Tests.CodeFormatters.TestTokenClassifier.Test_Classification_Cases" executed="True" success="True" time="0.000" asserts="32" />
+                              <test-case name="NUnit.UiException.Tests.CodeFormatters.TestTokenClassifier.Test_Classify" executed="True" success="True" time="0.016" asserts="60" />
+                              <test-case name="NUnit.UiException.Tests.CodeFormatters.TestTokenClassifier.Test_Classify_As_Keyword" executed="True" success="True" time="0.000" asserts="81" />
+                              <test-case name="NUnit.UiException.Tests.CodeFormatters.TestTokenClassifier.Test_Classify_Can_Throw_ArgumentNullException" executed="True" success="True" time="0.000" asserts="0" />
+                              <test-case name="NUnit.UiException.Tests.CodeFormatters.TestTokenClassifier.Test_Classify_Throw_NullArgException" executed="True" success="True" time="0.000" asserts="0" />
+                              <test-case name="NUnit.UiException.Tests.CodeFormatters.TestTokenClassifier.Test_Escaping_sequence" executed="True" success="True" time="0.016" asserts="61" />
+                              <test-case name="NUnit.UiException.Tests.CodeFormatters.TestTokenClassifier.Test_NewState" executed="True" success="True" time="0.000" asserts="40" />
+                              <test-case name="NUnit.UiException.Tests.CodeFormatters.TestTokenClassifier.Test_Reset" executed="True" success="True" time="0.000" asserts="1" />
+                            </results>
+                          </test-suite>
+                          <test-suite name="TestTokenDictionary" executed="True" success="True" time="0.031" asserts="0">
+                            <results>
+                              <test-case name="NUnit.UiException.Tests.CodeFormatters.TestTokenDictionary.Add_can_throw_AlreadyDefinedException" executed="True" success="True" time="0.000" asserts="2" />
+                              <test-case name="NUnit.UiException.Tests.CodeFormatters.TestTokenDictionary.Add_can_throw_EmptySequenceException" executed="True" success="True" time="0.000" asserts="2" />
+                              <test-case name="NUnit.UiException.Tests.CodeFormatters.TestTokenDictionary.Add_can_throw_InvalidSortException" executed="True" success="True" time="0.000" asserts="2" />
+                              <test-case name="NUnit.UiException.Tests.CodeFormatters.TestTokenDictionary.Add_can_throw_NullValueException" executed="True" success="True" time="0.000" asserts="2" />
+                              <test-case name="NUnit.UiException.Tests.CodeFormatters.TestTokenDictionary.add_token" executed="True" success="True" time="0.000" asserts="3" />
+                              <test-case name="NUnit.UiException.Tests.CodeFormatters.TestTokenDictionary.PopulateTokenStartingWith" executed="True" success="True" time="0.000" asserts="14" />
+                              <test-case name="NUnit.UiException.Tests.CodeFormatters.TestTokenDictionary.PopulateTokenStartingWith_can_throw_NullOutputException" executed="True" success="True" time="0.000" asserts="2" />
+                              <test-case name="NUnit.UiException.Tests.CodeFormatters.TestTokenDictionary.PopulateTokenStartingWith_can_throw_NullStarterException" executed="True" success="True" time="0.000" asserts="2" />
+                              <test-case name="NUnit.UiException.Tests.CodeFormatters.TestTokenDictionary.test_default" executed="True" success="True" time="0.000" asserts="3" />
+                              <test-case name="NUnit.UiException.Tests.CodeFormatters.TestTokenDictionary.TryMatch_can_throw_NullPredictionException" executed="True" success="True" time="0.000" asserts="2" />
+                              <test-case name="NUnit.UiException.Tests.CodeFormatters.TestTokenDictionary.TryMatch_can_throw_NullTextException" executed="True" success="True" time="0.000" asserts="2" />
+                              <test-case name="NUnit.UiException.Tests.CodeFormatters.TestTokenDictionary.TryMatch_no_prediction" executed="True" success="True" time="0.000" asserts="146" />
+                              <test-case name="NUnit.UiException.Tests.CodeFormatters.TestTokenDictionary.TryMatch_prediction" executed="True" success="True" time="0.000" asserts="19" />
+                            </results>
+                          </test-suite>
+                        </results>
+                      </test-suite>
+                      <test-suite name="Controls" executed="True" success="True" time="1.156" asserts="0">
+                        <results>
+                          <test-suite name="TestCodeBox" executed="True" success="True" time="0.266" asserts="0">
+                            <results>
+                              <test-case name="NUnit.UiException.Tests.Controls.TestCodeBox.Can_Disable_ShowCurrentLine" executed="True" success="True" time="0.203" asserts="3" />
+                              <test-case name="NUnit.UiException.Tests.Controls.TestCodeBox.Can_Set_Back_And_Fore_Colors" executed="True" success="True" time="0.016" asserts="2" />
+                              <test-case name="NUnit.UiException.Tests.Controls.TestCodeBox.Changing_Font_Causes_Reformatting" executed="True" success="True" time="0.000" asserts="24" />
+                              <test-case name="NUnit.UiException.Tests.Controls.TestCodeBox.Changing_Language_Causes_Reformatting" executed="True" success="True" time="0.016" asserts="34" />
+                              <test-case name="NUnit.UiException.Tests.Controls.TestCodeBox.CurrentLine" executed="True" success="True" time="0.000" asserts="30" />
+                              <test-case name="NUnit.UiException.Tests.Controls.TestCodeBox.DefaultState" executed="True" success="True" time="0.000" asserts="12" />
+                              <test-case name="NUnit.UiException.Tests.Controls.TestCodeBox.Format_Text_With_Language" executed="True" success="True" time="0.016" asserts="25" />
+                              <test-case name="NUnit.UiException.Tests.Controls.TestCodeBox.OnPaint" executed="True" success="True" time="0.000" asserts="19" />
+                            </results>
+                          </test-suite>
+                          <test-suite name="TestCodeRenderingContext" executed="True" success="True" time="0.016" asserts="0">
+                            <results>
+                              <test-case name="NUnit.UiException.Tests.Controls.TestCodeRenderingContext.Can_Change_Colors" executed="True" success="True" time="0.016" asserts="43" />
+                              <test-case name="NUnit.UiException.Tests.Controls.TestCodeRenderingContext.DefaultState" executed="True" success="True" time="0.000" asserts="39" />
+                            </results>
+                          </test-suite>
+                          <test-suite name="TestDefaultCodeRenderer" executed="True" success="True" time="0.031" asserts="0">
+                            <results>
+                              <test-case name="NUnit.UiException.Tests.Controls.TestDefaultCodeRenderer.DrawToGraphics_Can_Raise_ArgumentNullException" executed="True" success="True" time="0.016" asserts="2" />
+                              <test-case name="NUnit.UiException.Tests.Controls.TestDefaultCodeRenderer.GetDocumentSize" executed="True" success="True" time="0.000" asserts="4" />
+                              <test-case name="NUnit.UiException.Tests.Controls.TestDefaultCodeRenderer.GetDocumentSize_Can_Raise_ArgumentNullException" executed="True" success="True" time="0.000" asserts="3" />
+                              <test-case name="NUnit.UiException.Tests.Controls.TestDefaultCodeRenderer.LineIndexToYCoordinate" executed="True" success="True" time="0.000" asserts="4" />
+                              <test-case name="NUnit.UiException.Tests.Controls.TestDefaultCodeRenderer.LineIndexToYCoordinate_Can_Raise_ArgumentNullException" executed="True" success="True" time="0.016" asserts="2" />
+                              <test-case name="NUnit.UiException.Tests.Controls.TestDefaultCodeRenderer.ViewportLines" executed="True" success="True" time="0.000" asserts="32" />
+                            </results>
+                          </test-suite>
+                          <test-suite name="TestDefaultErrorListRenderer" executed="True" success="True" time="0.250" asserts="0">
+                            <results>
+                              <test-case name="NUnit.UiException.Tests.Controls.TestDefaultErrorListRenderer.DefaultState" executed="True" success="True" time="0.016" asserts="3" />
+                              <test-case name="NUnit.UiException.Tests.Controls.TestDefaultErrorListRenderer.DrawToGraphics_Can_Throw_ArgumentNullException" executed="True" success="True" time="0.000" asserts="2" />
+                              <test-case name="NUnit.UiException.Tests.Controls.TestDefaultErrorListRenderer.GetDocumentSize" executed="True" success="True" time="0.016" asserts="5" />
+                              <test-case name="NUnit.UiException.Tests.Controls.TestDefaultErrorListRenderer.IsDirty" executed="True" success="True" time="0.203" asserts="7" />
+                              <test-case name="NUnit.UiException.Tests.Controls.TestDefaultErrorListRenderer.ItemAt" executed="True" success="True" time="0.000" asserts="7" />
+                              <test-case name="NUnit.UiException.Tests.Controls.TestDefaultErrorListRenderer.MeasureItem" executed="True" success="True" time="0.000" asserts="6" />
+                            </results>
+                          </test-suite>
+                          <test-suite name="TestErrorBrowser" executed="True" success="True" time="0.219" asserts="0">
+                            <results>
+                              <test-case name="NUnit.UiException.Tests.Controls.TestErrorBrowser.Can_Raise_ErrorSourceChanged" executed="True" success="True" time="0.141" asserts="3" />
+                              <test-case name="NUnit.UiException.Tests.Controls.TestErrorBrowser.Cannot_Register_Null_Display" executed="True" success="True" time="0.016" asserts="0" />
+                              <test-case name="NUnit.UiException.Tests.Controls.TestErrorBrowser.DefaultState" executed="True" success="True" time="0.000" asserts="10" />
+                              <test-case name="NUnit.UiException.Tests.Controls.TestErrorBrowser.ErrorDisplay_Plugins_life_cycle_events" executed="True" success="True" time="0.047" asserts="55" />
+                              <test-case name="NUnit.UiException.Tests.Controls.TestErrorBrowser.LayoutPanel_Auto_Resizes_When_Parent_Sizes_Change" executed="True" success="True" time="0.000" asserts="4" />
+                            </results>
+                          </test-suite>
+                          <test-suite name="TestErrorList" executed="True" success="True" time="0.047" asserts="0">
+                            <results>
+                              <test-case name="NUnit.UiException.Tests.Controls.TestErrorList.AutoSelectFirstItem" executed="True" success="True" time="0.000" asserts="4" />
+                              <test-case name="NUnit.UiException.Tests.Controls.TestErrorList.CanReportInvalidItems" executed="True" success="True" time="0.000" asserts="3" />
+                              <test-case name="NUnit.UiException.Tests.Controls.TestErrorList.Click_Can_Select_Item" executed="True" success="True" time="0.000" asserts="23" />
+                              <test-case name="NUnit.UiException.Tests.Controls.TestErrorList.CurrentSelection" executed="True" success="True" time="0.000" asserts="10" />
+                              <test-case name="NUnit.UiException.Tests.Controls.TestErrorList.DefaultState" executed="True" success="True" time="0.000" asserts="7" />
+                              <test-case name="NUnit.UiException.Tests.Controls.TestErrorList.DrawItem" executed="True" success="True" time="0.016" asserts="39" />
+                              <test-case name="NUnit.UiException.Tests.Controls.TestErrorList.Invoking_DrawToGraphics" executed="True" success="True" time="0.000" asserts="22" />
+                              <test-case name="NUnit.UiException.Tests.Controls.TestErrorList.ListOrderPolicy" executed="True" success="True" time="0.000" asserts="22" />
+                              <test-case name="NUnit.UiException.Tests.Controls.TestErrorList.Populate_StackTraceSource" executed="True" success="True" time="0.000" asserts="11" />
+                            </results>
+                          </test-suite>
+                          <test-suite name="TestErrorPanelLayout" executed="True" success="True" time="0.016" asserts="0">
+                            <results>
+                              <test-case name="NUnit.UiException.Tests.Controls.TestErrorPanelLayout.Can_Layout_Child_Controls_When_Size_Changed" executed="True" success="True" time="0.000" asserts="16" />
+                              <test-case name="NUnit.UiException.Tests.Controls.TestErrorPanelLayout.DefaultState" executed="True" success="True" time="0.000" asserts="13" />
+                              <test-case name="NUnit.UiException.Tests.Controls.TestErrorPanelLayout.Setting_Content" executed="True" success="True" time="0.000" asserts="21" />
+                              <test-case name="NUnit.UiException.Tests.Controls.TestErrorPanelLayout.Setting_Toolbar" executed="True" success="True" time="0.000" asserts="14" />
+                            </results>
+                          </test-suite>
+                          <test-suite name="TestErrorToolbar" executed="True" success="True" time="0.109" asserts="0">
+                            <results>
+                              <test-case name="NUnit.UiException.Tests.Controls.TestErrorToolbar.Cannot_Register_Null_Display" executed="True" success="True" time="0.000" asserts="2" />
+                              <test-case name="NUnit.UiException.Tests.Controls.TestErrorToolbar.Cannot_Select_UnRegistered_Display" executed="True" success="True" time="0.016" asserts="0" />
+                              <test-case name="NUnit.UiException.Tests.Controls.TestErrorToolbar.DefaultState" executed="True" success="True" time="0.000" asserts="8" />
+                              <test-case name="NUnit.UiException.Tests.Controls.TestErrorToolbar.NewStripButton" executed="True" success="True" time="0.000" asserts="1" />
+                              <test-case name="NUnit.UiException.Tests.Controls.TestErrorToolbar.PluginItem_Click_Raises_SelectedRenderedChanged" executed="True" success="True" time="0.031" asserts="4" />
+                              <test-case name="NUnit.UiException.Tests.Controls.TestErrorToolbar.Registering_displays_adds_ToolStripItem" executed="True" success="True" time="0.047" asserts="30" />
+                              <test-case name="NUnit.UiException.Tests.Controls.TestErrorToolbar.SelectedDisplay" executed="True" success="True" time="0.000" asserts="9" />
+                              <test-case name="NUnit.UiException.Tests.Controls.TestErrorToolbar.Set_Or_Unset_Check_Flag_On_Selection" executed="True" success="True" time="0.000" asserts="6" />
+                            </results>
+                          </test-suite>
+                          <test-suite name="TestSourceCodeDisplay" executed="True" success="True" time="0.063" asserts="0">
+                            <results>
+                              <test-case name="NUnit.UiException.Tests.Controls.TestSourceCodeDisplay.CanReportFileException" executed="True" success="True" time="0.016" asserts="2" />
+                              <test-case name="NUnit.UiException.Tests.Controls.TestSourceCodeDisplay.DefaultState" executed="True" success="True" time="0.000" asserts="15" />
+                              <test-case name="NUnit.UiException.Tests.Controls.TestSourceCodeDisplay.ListOrderPolicy" executed="True" success="True" time="0.000" asserts="14" />
+                              <test-case name="NUnit.UiException.Tests.Controls.TestSourceCodeDisplay.SelectedItemChanged" executed="True" success="True" time="0.000" asserts="26" />
+                              <test-case name="NUnit.UiException.Tests.Controls.TestSourceCodeDisplay.SplitOrientation" executed="True" success="True" time="0.016" asserts="4" />
+                              <test-case name="NUnit.UiException.Tests.Controls.TestSourceCodeDisplay.SplitterDistance" executed="True" success="True" time="0.016" asserts="2" />
+                            </results>
+                          </test-suite>
+                          <test-suite name="TestSplitterBox" executed="True" success="True" time="0.047" asserts="0">
+                            <results>
+                              <test-case name="NUnit.UiException.Tests.Controls.TestSplitterBox.CanChangeDefaultControl1" executed="True" success="True" time="0.000" asserts="48" />
+                              <test-case name="NUnit.UiException.Tests.Controls.TestSplitterBox.CanChangeDefaultControl2" executed="True" success="True" time="0.000" asserts="48" />
+                              <test-case name="NUnit.UiException.Tests.Controls.TestSplitterBox.ChangingSizeInvokeDoLayout" executed="True" success="True" time="0.000" asserts="28" />
+                              <test-case name="NUnit.UiException.Tests.Controls.TestSplitterBox.CollapseControl" executed="True" success="True" time="0.000" asserts="82" />
+                              <test-case name="NUnit.UiException.Tests.Controls.TestSplitterBox.DefaultState" executed="True" success="True" time="0.000" asserts="51" />
+                              <test-case name="NUnit.UiException.Tests.Controls.TestSplitterBox.MouseActions" executed="True" success="True" time="0.000" asserts="6" />
+                              <test-case name="NUnit.UiException.Tests.Controls.TestSplitterBox.OrientationAffectsLayout" executed="True" success="True" time="0.000" asserts="25" />
+                              <test-case name="NUnit.UiException.Tests.Controls.TestSplitterBox.PointToSplit" executed="True" success="True" time="0.000" asserts="75" />
+                              <test-case name="NUnit.UiException.Tests.Controls.TestSplitterBox.SplitterDistance" executed="True" success="True" time="0.000" asserts="81" />
+                            </results>
+                          </test-suite>
+                          <test-suite name="TestStackTraceDisplay" executed="True" success="True" time="0.063" asserts="0">
+                            <results>
+                              <test-case name="NUnit.UiException.Tests.Controls.TestStackTraceDisplay.CopyToClipBoard" executed="True" success="True" time="0.047" asserts="4">
+                                <properties>
+                                  <property name="APARTMENT_STATE" value="STA" />
+                                </properties>
+                              </test-case>
+                              <test-case name="NUnit.UiException.Tests.Controls.TestStackTraceDisplay.DefaultState" executed="True" success="True" time="0.000" asserts="10" />
+                              <test-case name="NUnit.UiException.Tests.Controls.TestStackTraceDisplay.FeedingDisplayWithGarbageDoesNotMakeItCrash" executed="True" success="True" time="0.000" asserts="1" />
+                              <test-case name="NUnit.UiException.Tests.Controls.TestStackTraceDisplay.OnStackTraceChanged" executed="True" success="True" time="0.000" asserts="3" />
+                            </results>
+                          </test-suite>
+                        </results>
+                      </test-suite>
+                      <test-suite name="StackTraceAnalyzers" executed="True" success="True" time="0.063" asserts="0">
+                        <results>
+                          <test-suite name="TestFunctionParser" executed="True" success="True" time="0.000" asserts="0">
+                            <results>
+                              <test-case name="NUnit.UiException.Tests.StackTraceAnalyzers.TestFunctionParser.Test_Ability_To_Parse_Regular_Function_Values" executed="True" success="True" time="0.000" asserts="8" />
+                              <test-case name="NUnit.UiException.Tests.StackTraceAnalyzers.TestFunctionParser.Test_Fail_To_Parse_Odd_Function_Values" executed="True" success="True" time="0.000" asserts="5" />
+                              <test-case name="NUnit.UiException.Tests.StackTraceAnalyzers.TestFunctionParser.Test_IErrorParser_Can_Throw_ArgsNullException" executed="True" success="True" time="0.000" asserts="10" />
+                              <test-case name="NUnit.UiException.Tests.StackTraceAnalyzers.TestFunctionParser.Test_IErrorParser_Can_Throw_ParserNullException" executed="True" success="True" time="0.000" asserts="10" />
+                            </results>
+                          </test-suite>
+                          <test-suite name="TestIErrorParser" executed="True" success="True" time="0.000" asserts="0">
+                            <results>
+                              <test-case name="NUnit.UiException.Tests.StackTraceAnalyzers.TestIErrorParser.Test_IErrorParser_Can_Throw_ArgsNullException" executed="True" success="True" time="0.000" asserts="10" />
+                              <test-case name="NUnit.UiException.Tests.StackTraceAnalyzers.TestIErrorParser.Test_IErrorParser_Can_Throw_ParserNullException" executed="True" success="True" time="0.000" asserts="10" />
+                            </results>
+                          </test-suite>
+                          <test-suite name="TestLineNumberParser" executed="True" success="True" time="0.000" asserts="0">
+                            <results>
+                              <test-case name="NUnit.UiException.Tests.StackTraceAnalyzers.TestLineNumberParser.Test_Ability_To_Parse_Regular_Line_Number_Values" executed="True" success="True" time="0.000" asserts="10" />
+                              <test-case name="NUnit.UiException.Tests.StackTraceAnalyzers.TestLineNumberParser.Test_Ability_To_Reject_Odd_Line_Number_Values" executed="True" success="True" time="0.000" asserts="5" />
+                              <test-case name="NUnit.UiException.Tests.StackTraceAnalyzers.TestLineNumberParser.Test_IErrorParser_Can_Throw_ArgsNullException" executed="True" success="True" time="0.000" asserts="10" />
+                              <test-case name="NUnit.UiException.Tests.StackTraceAnalyzers.TestLineNumberParser.Test_IErrorParser_Can_Throw_ParserNullException" executed="True" success="True" time="0.000" asserts="10" />
+                            </results>
+                          </test-suite>
+                          <test-suite name="TestPathParser" executed="True" success="True" time="0.000" asserts="0">
+                            <results>
+                              <test-case name="NUnit.UiException.Tests.StackTraceAnalyzers.TestPathParser.Test_Ability_To_Handle_Unix_Path_Like_Values" executed="True" success="True" time="0.000" asserts="4" />
+                              <test-case name="NUnit.UiException.Tests.StackTraceAnalyzers.TestPathParser.Test_Ability_To_Handle_Windows_Path_Like_Values" executed="True" success="True" time="0.000" asserts="4" />
+                              <test-case name="NUnit.UiException.Tests.StackTraceAnalyzers.TestPathParser.Test_IErrorParser_Can_Throw_ArgsNullException" executed="True" success="True" time="0.000" asserts="12" />
+                              <test-case name="NUnit.UiException.Tests.StackTraceAnalyzers.TestPathParser.Test_IErrorParser_Can_Throw_ParserNullException" executed="True" success="True" time="0.000" asserts="12" />
+                            </results>
+                          </test-suite>
+                          <test-suite name="TestUnixPathParser" executed="True" success="True" time="0.000" asserts="0">
+                            <results>
+                              <test-case name="NUnit.UiException.Tests.StackTraceAnalyzers.TestUnixPathParser.Test_Ability_To_Parse_Regular_Unix_Like_Path_Values" executed="True" success="True" time="0.000" asserts="21" />
+                              <test-case name="NUnit.UiException.Tests.StackTraceAnalyzers.TestUnixPathParser.Test_IErrorParser_Can_Throw_ArgsNullException" executed="True" success="True" time="0.000" asserts="11" />
+                              <test-case name="NUnit.UiException.Tests.StackTraceAnalyzers.TestUnixPathParser.Test_IErrorParser_Can_Throw_ParserNullException" executed="True" success="True" time="0.000" asserts="11" />
+                              <test-case name="NUnit.UiException.Tests.StackTraceAnalyzers.TestUnixPathParser.Test_Inability_To_Parse_Non_Unix_Like_Path_Values" executed="True" success="True" time="0.000" asserts="6" />
+                            </results>
+                          </test-suite>
+                          <test-suite name="TestWindowsPathParser" executed="True" success="True" time="0.000" asserts="0">
+                            <results>
+                              <test-case name="NUnit.UiException.Tests.StackTraceAnalyzers.TestWindowsPathParser.Test_Ability_To_Parse_Regular_Windows_Path" executed="True" success="True" time="0.000" asserts="21" />
+                              <test-case name="NUnit.UiException.Tests.StackTraceAnalyzers.TestWindowsPathParser.Test_IErrorParser_Can_Throw_ArgsNullException" executed="True" success="True" time="0.000" asserts="11" />
+                              <test-case name="NUnit.UiException.Tests.StackTraceAnalyzers.TestWindowsPathParser.Test_IErrorParser_Can_Throw_ParserNullException" executed="True" success="True" time="0.000" asserts="11" />
+                              <test-case name="NUnit.UiException.Tests.StackTraceAnalyzers.TestWindowsPathParser.Test_Inability_To_Parse_Non_Windows_Like_Path_Values" executed="True" success="True" time="0.000" asserts="6" />
+                            </results>
+                          </test-suite>
+                        </results>
+                      </test-suite>
+                      <test-suite name="TestDefaultTextManager" executed="True" success="True" time="0.000" asserts="0">
+                        <results>
+                          <test-case name="NUnit.UiException.Tests.TestDefaultTextManager.Test_CodeBlockCollection" executed="True" success="True" time="0.000" asserts="15" />
+                          <test-case name="NUnit.UiException.Tests.TestDefaultTextManager.Test_Default" executed="True" success="True" time="0.000" asserts="3" />
+                          <test-case name="NUnit.UiException.Tests.TestDefaultTextManager.Test_MaxLength" executed="True" success="True" time="0.000" asserts="3" />
+                        </results>
+                      </test-suite>
+                      <test-suite name="TestErrorItem" executed="True" success="True" time="0.047" asserts="0">
+                        <results>
+                          <test-case name="NUnit.UiException.Tests.TestErrorItem.Can_Set_Properties" executed="True" success="True" time="0.000" asserts="10" />
+                          <test-case name="NUnit.UiException.Tests.TestErrorItem.Ctor_2" executed="True" success="True" time="0.000" asserts="10" />
+                          <test-case name="NUnit.UiException.Tests.TestErrorItem.Ctor_Throws_NullPathException" executed="True" success="True" time="0.031" asserts="0" />
+                          <test-case name="NUnit.UiException.Tests.TestErrorItem.Ctor_With_Line_0" executed="True" success="True" time="0.000" asserts="0" />
+                          <test-case name="NUnit.UiException.Tests.TestErrorItem.ReadFile" executed="True" success="True" time="0.000" asserts="2" />
+                          <test-case name="NUnit.UiException.Tests.TestErrorItem.ReadFile_Throws_FileNotExistException" executed="True" success="True" time="0.000" asserts="0" />
+                          <test-case name="NUnit.UiException.Tests.TestErrorItem.Test_Equals" executed="True" success="True" time="0.000" asserts="8" />
+                          <test-case name="NUnit.UiException.Tests.TestErrorItem.Test_FileExtension" executed="True" success="True" time="0.000" asserts="5" />
+                          <test-case name="NUnit.UiException.Tests.TestErrorItem.Test_MethodName" executed="True" success="True" time="0.000" asserts="15" />
+                        </results>
+                      </test-suite>
+                      <test-suite name="TestErrorItemCollection" executed="True" success="True" time="0.031" asserts="0">
+                        <results>
+                          <test-case name="NUnit.UiException.Tests.TestErrorItemCollection.Test_Add_Throws_NullItemException" executed="True" success="True" time="0.016" asserts="0" />
+                          <test-case name="NUnit.UiException.Tests.TestErrorItemCollection.Test_Clear" executed="True" success="True" time="0.000" asserts="2" />
+                          <test-case name="NUnit.UiException.Tests.TestErrorItemCollection.Test_Contains" executed="True" success="True" time="0.016" asserts="3" />
+                          <test-case name="NUnit.UiException.Tests.TestErrorItemCollection.Test_TraceItems" executed="True" success="True" time="0.000" asserts="7" />
+                        </results>
+                      </test-suite>
+                      <test-suite name="TestPaintLineLocation" executed="True" success="True" time="0.016" asserts="0">
+                        <results>
+                          <test-case name="NUnit.UiException.Tests.TestPaintLineLocation.Test_Equals" executed="True" success="True" time="0.000" asserts="8" />
+                          <test-case name="NUnit.UiException.Tests.TestPaintLineLocation.Test_PaintLineLocation" executed="True" success="True" time="0.000" asserts="3" />
+                          <test-case name="NUnit.UiException.Tests.TestPaintLineLocation.Test_SetText_Throws_NullTextException" executed="True" success="True" time="0.000" asserts="0" />
+                        </results>
+                      </test-suite>
+                      <test-suite name="TestStackTraceParser" executed="True" success="True" time="0.016" asserts="0">
+                        <results>
+                          <test-case name="NUnit.UiException.Tests.TestStackTraceParser.Test_Ability_To_Handle_Different_Path_System_Syntaxes" executed="True" success="True" time="0.000" asserts="3" />
+                          <test-case name="NUnit.UiException.Tests.TestStackTraceParser.Test_Ability_To_Handle_Files_With_Unknown_Extension" executed="True" success="True" time="0.000" asserts="2" />
+                          <test-case name="NUnit.UiException.Tests.TestStackTraceParser.Test_Analysis_Does_Not_Depend_Upon_File_Extension" executed="True" success="True" time="0.000" asserts="2" />
+                          <test-case name="NUnit.UiException.Tests.TestStackTraceParser.Test_Default" executed="True" success="True" time="0.000" asserts="2" />
+                          <test-case name="NUnit.UiException.Tests.TestStackTraceParser.Test_English_Stack" executed="True" success="True" time="0.000" asserts="2" />
+                          <test-case name="NUnit.UiException.Tests.TestStackTraceParser.Test_Missing_Line_Number" executed="True" success="True" time="0.000" asserts="2" />
+                          <test-case name="NUnit.UiException.Tests.TestStackTraceParser.Test_Parse" executed="True" success="True" time="0.000" asserts="3" />
+                          <test-case name="NUnit.UiException.Tests.TestStackTraceParser.Test_Parse_MultipleExtension" executed="True" success="True" time="0.000" asserts="6" />
+                          <test-case name="NUnit.UiException.Tests.TestStackTraceParser.Test_Parse_Null" executed="True" success="True" time="0.000" asserts="0" />
+                          <test-case name="NUnit.UiException.Tests.TestStackTraceParser.Test_Parse_With_Real_Life_Samples" executed="True" success="True" time="0.000" asserts="5" />
+                          <test-case name="NUnit.UiException.Tests.TestStackTraceParser.Test_Trace_When_Missing_File" executed="True" success="True" time="0.000" asserts="5" />
+                        </results>
+                      </test-suite>
+                    </results>
+                  </test-suite>
+                </results>
+              </test-suite>
+            </results>
+          </test-suite>
+        </results>
+      </test-suite>
+      <test-suite name="C:\Program Files\NUnit 2.5.2\bin\net-2.0\tests/nunit.uikit.tests.dll" executed="True" success="True" time="9.125" asserts="0">
+        <results>
+          <test-suite name="NUnit" executed="True" success="True" time="9.094" asserts="0">
+            <results>
+              <test-suite name="UiKit" executed="True" success="True" time="9.078" asserts="0">
+                <results>
+                  <test-suite name="Tests" executed="True" success="True" time="9.047" asserts="0">
+                    <results>
+                      <test-suite name="AddConfigurationDialogTests" executed="True" success="True" time="0.594" asserts="0">
+                        <results>
+                          <test-case name="NUnit.UiKit.Tests.AddConfigurationDialogTests.CheckComboBox" executed="True" success="True" time="0.297" asserts="5" />
+                          <test-case name="NUnit.UiKit.Tests.AddConfigurationDialogTests.CheckForControls" executed="True" success="True" time="0.000" asserts="0" />
+                          <test-case name="NUnit.UiKit.Tests.AddConfigurationDialogTests.CheckTextBox" executed="True" success="True" time="0.016" asserts="1" />
+                          <test-case name="NUnit.UiKit.Tests.AddConfigurationDialogTests.TestComplexEntry" executed="True" success="True" time="0.219" asserts="2" />
+                          <test-case name="NUnit.UiKit.Tests.AddConfigurationDialogTests.TestSimpleEntry" executed="True" success="True" time="0.031" asserts="2" />
+                        </results>
+                      </test-suite>
+                      <test-suite name="ErrorDisplayTests" executed="True" success="True" time="0.078" asserts="0">
+                        <results>
+                          <test-case name="NUnit.UiKit.Tests.ErrorDisplayTests.ControlsArePositionedCorrectly" executed="True" success="True" time="0.000" asserts="0" />
+                          <test-case name="NUnit.UiKit.Tests.ErrorDisplayTests.ControlsExist" executed="True" success="True" time="0.000" asserts="0" />
+                        </results>
+                      </test-suite>
+                      <test-suite name="LongRunningOperationDisplayTests" executed="True" success="True" time="0.063" asserts="0">
+                        <results>
+                          <test-case name="NUnit.UiKit.Tests.LongRunningOperationDisplayTests.CreateDisplay" executed="True" success="True" time="0.047" asserts="2" />
+                        </results>
+                      </test-suite>
+                      <test-suite name="ProgressBarTests" executed="True" success="True" time="0.203" asserts="0">
+                        <results>
+                          <test-case name="NUnit.UiKit.Tests.ProgressBarTests.TestProgressDisplay" executed="True" success="True" time="0.203" asserts="5" />
+                        </results>
+                      </test-suite>
+                      <test-suite name="RecentFileMenuHandlerTests" executed="True" success="True" time="0.031" asserts="0">
+                        <results>
+                          <test-case name="NUnit.UiKit.Tests.RecentFileMenuHandlerTests.DisableOnLoadWhenEmpty" executed="True" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.UiKit.Tests.RecentFileMenuHandlerTests.EnableOnLoadWhenNotEmpty" executed="True" success="True" time="0.016" asserts="1" />
+                          <test-case name="NUnit.UiKit.Tests.RecentFileMenuHandlerTests.LoadMenuItems" executed="True" success="True" time="0.000" asserts="2" />
+                        </results>
+                      </test-suite>
+                      <test-suite name="SimpleTextDisplayTests" executed="True" success="True" time="0.547" asserts="0">
+                        <results>
+                          <test-case name="NUnit.UiKit.Tests.SimpleTextDisplayTests.AppendText_AfterCreation" executed="True" success="True" time="0.031" asserts="7" />
+                          <test-case name="NUnit.UiKit.Tests.SimpleTextDisplayTests.AppendText_BeforeAndAfterCreation" executed="True" success="True" time="0.000" asserts="2" />
+                          <test-case name="NUnit.UiKit.Tests.SimpleTextDisplayTests.AppendText_BeforeCreation" executed="True" success="True" time="0.000" asserts="2" />
+                          <test-case name="NUnit.UiKit.Tests.SimpleTextDisplayTests.ClearText_AfterCreation" executed="True" success="True" time="0.000" asserts="2" />
+                          <test-case name="NUnit.UiKit.Tests.SimpleTextDisplayTests.ClearText_BeforeCreation" executed="True" success="True" time="0.000" asserts="2" />
+                          <test-case name="NUnit.UiKit.Tests.SimpleTextDisplayTests.SetText_AfterCreation" executed="True" success="True" time="0.000" asserts="2" />
+                          <test-case name="NUnit.UiKit.Tests.SimpleTextDisplayTests.SetText_BeforeCreation" executed="True" success="True" time="0.000" asserts="4" />
+                          <test-case name="NUnit.UiKit.Tests.SimpleTextDisplayTests.StressTest" executed="True" success="True" time="0.500" asserts="2" />
+                        </results>
+                      </test-suite>
+                      <test-suite name="StatusBarTests" executed="True" success="True" time="0.875" asserts="0">
+                        <results>
+                          <test-case name="NUnit.UiKit.Tests.StatusBarTests.TestConstruction" executed="True" success="True" time="0.281" asserts="5" />
+                          <test-case name="NUnit.UiKit.Tests.StatusBarTests.TestFinalDisplay" executed="True" success="True" time="0.234" asserts="5" />
+                          <test-case name="NUnit.UiKit.Tests.StatusBarTests.TestInitialization" executed="True" success="True" time="0.156" asserts="10" />
+                          <test-case name="NUnit.UiKit.Tests.StatusBarTests.TestProgressDisplay" executed="True" success="True" time="0.188" asserts="5" />
+                        </results>
+                      </test-suite>
+                      <test-suite name="TestSuiteTreeNodeTests" executed="True" success="True" time="0.250" asserts="0">
+                        <results>
+                          <test-case name="NUnit.UiKit.Tests.TestSuiteTreeNodeTests.ClearNestedResults" executed="True" success="True" time="0.063" asserts="8" />
+                          <test-case name="NUnit.UiKit.Tests.TestSuiteTreeNodeTests.ClearResult" executed="True" success="True" time="0.016" asserts="5" />
+                          <test-case name="NUnit.UiKit.Tests.TestSuiteTreeNodeTests.ConstructFromTestInfo" executed="True" success="True" time="0.016" asserts="6" />
+                          <test-case name="NUnit.UiKit.Tests.TestSuiteTreeNodeTests.ResultNotSet" executed="True" success="True" time="0.016" asserts="2" />
+                          <test-case name="NUnit.UiKit.Tests.TestSuiteTreeNodeTests.SetResult_Failure" executed="True" success="True" time="0.016" asserts="3" />
+                          <test-case name="NUnit.UiKit.Tests.TestSuiteTreeNodeTests.SetResult_Ignore" executed="True" success="True" time="0.016" asserts="4" />
+                          <test-case name="NUnit.UiKit.Tests.TestSuiteTreeNodeTests.SetResult_Inconclusive" executed="True" success="True" time="0.031" asserts="4" />
+                          <test-case name="NUnit.UiKit.Tests.TestSuiteTreeNodeTests.SetResult_Skipped" executed="True" success="True" time="0.016" asserts="3" />
+                          <test-case name="NUnit.UiKit.Tests.TestSuiteTreeNodeTests.SetResult_Success" executed="True" success="True" time="0.016" asserts="3" />
+                        </results>
+                      </test-suite>
+                      <test-suite name="TestSuiteTreeViewReloadTests" executed="True" success="True" time="3.594" asserts="0">
+                        <results>
+                          <test-case name="NUnit.UiKit.Tests.TestSuiteTreeViewReloadTests.CanReloadAfterChangingOrder" executed="True" success="True" time="0.797" asserts="103" />
+                          <test-case name="NUnit.UiKit.Tests.TestSuiteTreeViewReloadTests.CanReloadAfterDeletingBranch" executed="True" success="True" time="0.313" asserts="65" />
+                          <test-case name="NUnit.UiKit.Tests.TestSuiteTreeViewReloadTests.CanReloadAfterDeletingOneTestCase" executed="True" success="True" time="0.250" asserts="100" />
+                          <test-case name="NUnit.UiKit.Tests.TestSuiteTreeViewReloadTests.CanReloadAfterDeletingThreeTestCases" executed="True" success="True" time="0.250" asserts="94" />
+                          <test-case name="NUnit.UiKit.Tests.TestSuiteTreeViewReloadTests.CanReloadAfterInsertingTestCase" executed="True" success="True" time="0.234" asserts="106" />
+                          <test-case name="NUnit.UiKit.Tests.TestSuiteTreeViewReloadTests.CanReloadAfterInsertingTestFixture" executed="True" success="True" time="0.266" asserts="107" />
+                          <test-case name="NUnit.UiKit.Tests.TestSuiteTreeViewReloadTests.CanReloadAfterMultipleChanges" executed="True" success="True" time="0.234" asserts="104" />
+                          <test-case name="NUnit.UiKit.Tests.TestSuiteTreeViewReloadTests.CanReloadAfterTurningOffAutoNamespaces" executed="True" success="True" time="0.453" asserts="84" />
+                          <test-case name="NUnit.UiKit.Tests.TestSuiteTreeViewReloadTests.CanReloadWithoutChange" executed="True" success="True" time="0.281" asserts="102" />
+                          <test-case name="NUnit.UiKit.Tests.TestSuiteTreeViewReloadTests.ReloadTreeWithWrongTest" executed="True" success="True" time="0.234" asserts="0" />
+                          <test-case name="NUnit.UiKit.Tests.TestSuiteTreeViewReloadTests.VerifyCheckTreeWorks" executed="True" success="True" time="0.234" asserts="102" />
+                        </results>
+                      </test-suite>
+                      <test-suite name="TestSuiteTreeViewTests" executed="True" success="True" time="1.250" asserts="0">
+                        <results>
+                          <test-case name="NUnit.UiKit.Tests.TestSuiteTreeViewTests.BuildFromResult" executed="True" success="True" time="0.266" asserts="15" />
+                          <test-case name="NUnit.UiKit.Tests.TestSuiteTreeViewTests.BuildTreeView" executed="True" success="True" time="0.234" asserts="5" />
+                          <test-case name="NUnit.UiKit.Tests.TestSuiteTreeViewTests.ClearTree" executed="True" success="True" time="0.234" asserts="1" />
+                          <test-case name="NUnit.UiKit.Tests.TestSuiteTreeViewTests.ProcessChecks" executed="True" success="True" time="0.266" asserts="7" />
+                          <test-case name="NUnit.UiKit.Tests.TestSuiteTreeViewTests.SetTestResult" executed="True" success="True" time="0.234" asserts="3" />
+                        </results>
+                      </test-suite>
+                      <test-suite name="VisualStateTests" executed="True" success="True" time="1.531" asserts="0">
+                        <results>
+                          <test-case name="NUnit.UiKit.Tests.VisualStateTests.SaveAndRestoreVisualState" executed="True" success="True" time="1.516" asserts="5" />
+                        </results>
+                      </test-suite>
+                    </results>
+                  </test-suite>
+                </results>
+              </test-suite>
+            </results>
+          </test-suite>
+        </results>
+      </test-suite>
+      <test-suite name="C:\Program Files\NUnit 2.5.2\bin\net-2.0\tests/nunit-gui.tests.dll" executed="True" success="True" time="1.156" asserts="0">
+        <results>
+          <test-suite name="NUnit" executed="True" success="True" time="1.156" asserts="0">
+            <results>
+              <test-suite name="Gui" executed="True" success="True" time="1.156" asserts="0">
+                <results>
+                  <test-suite name="Tests" executed="True" success="True" time="1.156" asserts="0">
+                    <results>
+                      <test-suite name="CommandLineTests" executed="True" success="True" time="0.125" asserts="0">
+                        <results>
+                          <test-case name="NUnit.Gui.Tests.CommandLineTests.AssemblyName" executed="True" success="True" time="0.094" asserts="1" />
+                          <test-case name="NUnit.Gui.Tests.CommandLineTests.Help" executed="True" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Gui.Tests.CommandLineTests.HelpTextUsesCorrectDelimiterForPlatform" executed="True" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Gui.Tests.CommandLineTests.InvalidArgs" executed="True" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Gui.Tests.CommandLineTests.InvalidCommandLineParms" executed="True" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Gui.Tests.CommandLineTests.NoNameValuePairs" executed="True" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Gui.Tests.CommandLineTests.NoParametersCount" executed="True" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Gui.Tests.CommandLineTests.ShortHelp" executed="True" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Gui.Tests.CommandLineTests.ValidateSuccessful" executed="True" success="True" time="0.000" asserts="1" />
+                        </results>
+                      </test-suite>
+                      <test-suite name="ExceptionDetailsFormTests" executed="True" success="True" time="0.188" asserts="0">
+                        <results>
+                          <test-case name="NUnit.Gui.Tests.ExceptionDetailsFormTests.ControlsArePositionedCorrectly" executed="True" success="True" time="0.000" asserts="0" />
+                          <test-case name="NUnit.Gui.Tests.ExceptionDetailsFormTests.ControlsExist" executed="True" success="True" time="0.000" asserts="0" />
+                          <test-case name="NUnit.Gui.Tests.ExceptionDetailsFormTests.MessageDisplaysCorrectly" executed="True" success="True" time="0.078" asserts="1" />
+                        </results>
+                      </test-suite>
+                      <test-suite name="ProjectEditorTests" executed="True" success="True" time="0.828" asserts="0">
+                        <results>
+                          <test-case name="NUnit.Gui.Tests.ProjectEditorTests.CheckControls" executed="True" success="True" time="0.547" asserts="0" />
+                          <test-case name="NUnit.Gui.Tests.ProjectEditorTests.InitialFieldValues" executed="True" success="True" time="0.156" asserts="2" />
+                          <test-case name="NUnit.Gui.Tests.ProjectEditorTests.SetProjectBase" executed="True" success="True" time="0.109" asserts="1" />
+                        </results>
+                      </test-suite>
+                    </results>
+                  </test-suite>
+                </results>
+              </test-suite>
+            </results>
+          </test-suite>
+        </results>
+      </test-suite>
+      <test-suite name="C:\Program Files\NUnit 2.5.2\bin\net-2.0\tests/nunit.fixtures.tests.dll" executed="True" success="True" time="1.375" asserts="0">
+        <results>
+          <test-suite name="NUnit" executed="True" success="True" time="1.359" asserts="0">
+            <results>
+              <test-suite name="Fixtures" executed="True" success="True" time="1.359" asserts="0">
+                <results>
+                  <test-suite name="Tests" executed="True" success="True" time="1.359" asserts="0">
+                    <results>
+                      <test-suite name="CompilationTests" executed="True" success="True" time="1.328" asserts="0">
+                        <results>
+                          <test-case name="NUnit.Fixtures.Tests.CompilationTests.CheckDefaultSettings" executed="True" success="True" time="0.141" asserts="5" />
+                          <test-case name="NUnit.Fixtures.Tests.CompilationTests.CompileToFile" executed="True" success="True" time="0.484" asserts="3" />
+                          <test-case name="NUnit.Fixtures.Tests.CompilationTests.CompilingBadCodeGivesAnError" executed="True" success="True" time="0.219" asserts="1" />
+                          <test-case name="NUnit.Fixtures.Tests.CompilationTests.LoadTestsFromCompiledAssembly" executed="True" success="True" time="0.484" asserts="3" />
+                        </results>
+                      </test-suite>
+                      <test-suite name="TestTreeTests" executed="True" success="True" time="0.016" asserts="0">
+                        <results>
+                          <test-case name="NUnit.Fixtures.Tests.TestTreeTests.MatchingTreesAreEqual" executed="True" success="True" time="0.000" asserts="3" />
+                          <test-case name="NUnit.Fixtures.Tests.TestTreeTests.NonMatchingTreesAreNotEqual" executed="True" success="True" time="0.000" asserts="3" />
+                        </results>
+                      </test-suite>
+                    </results>
+                  </test-suite>
+                </results>
+              </test-suite>
+            </results>
+          </test-suite>
+        </results>
+      </test-suite>
+    </results>
+  </test-suite>
+</test-results>

--- a/src/test-nunit-summary.exe/TestInput/TestResult-2.6.0.xml
+++ b/src/test-nunit-summary.exe/TestInput/TestResult-2.6.0.xml
@@ -1,0 +1,6401 @@
+﻿<?xml version="1.0" encoding="utf-8" standalone="no"?>
+<!--This file represents the results of running a test suite-->
+<test-results name="C:\Program Files\NUnit 2.6\bin\NUnitTests.nunit" total="3242" errors="0" failures="0" not-run="8" inconclusive="17" ignored="0" skipped="8" invalid="0" date="2013-09-28" time="21:45:00">
+  <environment nunit-version="2.6.0.12051" clr-version="2.0.50727.5472" os-version="Microsoft Windows NT 6.1.7601 Service Pack 1" platform="Win32NT" cwd="C:\Program Files\NUnit 2.6\bin" machine-name="CHARLIE-LAPTOP" user="charlie" user-domain="charlie-laptop" />
+  <culture-info current-culture="en-US" current-uiculture="en-US" />
+  <test-suite type="Project" name="C:\Program Files\NUnit 2.6\bin\NUnitTests.nunit" executed="True" result="Success" success="True" time="58.148" asserts="0">
+    <results>
+      <test-suite type="Assembly" name="C:\Program Files\NUnit 2.6\bin\tests/nunit.framework.tests.dll" executed="True" result="Success" success="True" time="16.770" asserts="0">
+        <results>
+          <test-suite type="Namespace" name="NUnit" executed="True" result="Success" success="True" time="16.770" asserts="0">
+            <results>
+              <test-suite type="Namespace" name="Framework" executed="True" result="Success" success="True" time="16.770" asserts="0">
+                <results>
+                  <test-suite type="Namespace" name="Constraints" executed="True" result="Success" success="True" time="11.104" asserts="0">
+                    <results>
+                      <test-suite type="TestFixture" name="AfterConstraintTest" executed="True" result="Success" success="True" time="8.827" asserts="0">
+                        <results>
+                          <test-case name="NUnit.Framework.Constraints.AfterConstraintTest.CanTestContentsOfDelegateReturningList" executed="True" result="Success" success="True" time="0.100" asserts="1" />
+                          <test-case name="NUnit.Framework.Constraints.AfterConstraintTest.CanTestContentsOfList" executed="True" result="Success" success="True" time="0.100" asserts="1" />
+                          <test-case name="NUnit.Framework.Constraints.AfterConstraintTest.CanTestContentsOfRefList" executed="True" result="Success" success="True" time="0.100" asserts="1" />
+                          <test-case name="NUnit.Framework.Constraints.AfterConstraintTest.CanTestInitiallyNullDelegate" executed="True" result="Success" success="True" time="1.100" asserts="1" />
+                          <test-case name="NUnit.Framework.Constraints.AfterConstraintTest.CanTestInitiallyNullReference" executed="True" result="Success" success="True" time="1.100" asserts="1" />
+                          <test-case name="NUnit.Framework.Constraints.AfterConstraintTest.ConstraintTestBaseNoData.ProvidesProperDescription" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Framework.Constraints.AfterConstraintTest.ConstraintTestBaseNoData.ProvidesProperStringRepresentation" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                          <test-suite type="ParameterizedTest" name="FailsWithBadDelegates" executed="True" result="Success" success="True" time="1.005" asserts="0">
+                            <results>
+                              <test-case name="NUnit.Framework.Constraints.AfterConstraintTest.FailsWithBadDelegates(NUnit.Framework.Constraints.ActualValueDelegate)" executed="True" result="Success" success="True" time="0.500" asserts="1" />
+                              <test-case name="NUnit.Framework.Constraints.AfterConstraintTest.FailsWithBadDelegates(NUnit.Framework.Constraints.ActualValueDelegate)" executed="True" result="Success" success="True" time="0.500" asserts="1" />
+                            </results>
+                          </test-suite>
+                          <test-suite type="ParameterizedTest" name="FailsWithBadValues" executed="True" result="Success" success="True" time="1.511" asserts="0">
+                            <results>
+                              <test-case name="NUnit.Framework.Constraints.AfterConstraintTest.FailsWithBadValues(False)" executed="True" result="Success" success="True" time="0.501" asserts="1" />
+                              <test-case name="NUnit.Framework.Constraints.AfterConstraintTest.FailsWithBadValues(0)" executed="True" result="Success" success="True" time="0.500" asserts="1" />
+                              <test-case name="NUnit.Framework.Constraints.AfterConstraintTest.FailsWithBadValues(null)" executed="True" result="Success" success="True" time="0.500" asserts="1" />
+                            </results>
+                          </test-suite>
+                          <test-suite type="ParameterizedTest" name="ProvidesProperFailureMessage" executed="True" result="Success" success="True" time="1.509" asserts="0">
+                            <results>
+                              <test-case name="NUnit.Framework.Constraints.AfterConstraintTest.ProvidesProperFailureMessage(False,&quot;False&quot;)" executed="True" result="Success" success="True" time="0.500" asserts="1" />
+                              <test-case name="NUnit.Framework.Constraints.AfterConstraintTest.ProvidesProperFailureMessage(0,&quot;0&quot;)" executed="True" result="Success" success="True" time="0.500" asserts="1" />
+                              <test-case name="NUnit.Framework.Constraints.AfterConstraintTest.ProvidesProperFailureMessage(null,&quot;null&quot;)" executed="True" result="Success" success="True" time="0.500" asserts="1" />
+                            </results>
+                          </test-suite>
+                          <test-case name="NUnit.Framework.Constraints.AfterConstraintTest.SimpleTest" executed="True" result="Success" success="True" time="0.601" asserts="1" />
+                          <test-case name="NUnit.Framework.Constraints.AfterConstraintTest.SimpleTestUsingReference" executed="True" result="Success" success="True" time="0.601" asserts="1" />
+                          <test-suite type="ParameterizedTest" name="SucceedsWithGoodDelegates" executed="True" result="Success" success="True" time="0.502" asserts="0">
+                            <results>
+                              <test-case name="NUnit.Framework.Constraints.AfterConstraintTest.SucceedsWithGoodDelegates(NUnit.Framework.Constraints.ActualValueDelegate)" executed="True" result="Success" success="True" time="0.501" asserts="1" />
+                            </results>
+                          </test-suite>
+                          <test-suite type="ParameterizedTest" name="SucceedsWithGoodValues" executed="True" result="Success" success="True" time="0.502" asserts="0">
+                            <results>
+                              <test-case name="NUnit.Framework.Constraints.AfterConstraintTest.SucceedsWithGoodValues(True)" executed="True" result="Success" success="True" time="0.500" asserts="1" />
+                            </results>
+                          </test-suite>
+                          <test-case name="NUnit.Framework.Constraints.AfterConstraintTest.ThatOverload_DoesNotAcceptNegativeDelayValues" executed="True" result="Success" success="True" time="0.001" asserts="0" />
+                          <test-case name="NUnit.Framework.Constraints.AfterConstraintTest.ThatOverload_ZeroDelayIsAllowed" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                        </results>
+                      </test-suite>
+                      <test-suite type="TestFixture" name="AllItemsTests" executed="True" result="Success" success="True" time="0.033" asserts="0">
+                        <results>
+                          <test-case name="NUnit.Framework.Constraints.AllItemsTests.AllItemsAreInRange" executed="True" result="Success" success="True" time="0.001" asserts="1" />
+                          <test-case name="NUnit.Framework.Constraints.AllItemsTests.AllItemsAreInRange_UsingComparisonOfT" executed="True" result="Success" success="True" time="0.001" asserts="1" />
+                          <test-case name="NUnit.Framework.Constraints.AllItemsTests.AllItemsAreInRange_UsingIComparer" executed="True" result="Success" success="True" time="0.001" asserts="1" />
+                          <test-case name="NUnit.Framework.Constraints.AllItemsTests.AllItemsAreInRange_UsingIComparerOfT" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Framework.Constraints.AllItemsTests.AllItemsAreInRangeFailureMessage" executed="True" result="Success" success="True" time="0.001" asserts="2" />
+                          <test-case name="NUnit.Framework.Constraints.AllItemsTests.AllItemsAreInstancesOfType" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Framework.Constraints.AllItemsTests.AllItemsAreInstancesOfTypeFailureMessage" executed="True" result="Success" success="True" time="0.001" asserts="2" />
+                          <test-case name="NUnit.Framework.Constraints.AllItemsTests.AllItemsAreNotNull" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Framework.Constraints.AllItemsTests.AllItemsAreNotNullFails" executed="True" result="Success" success="True" time="0.001" asserts="2" />
+                        </results>
+                      </test-suite>
+                      <test-suite type="TestFixture" name="AndTest" executed="True" result="Success" success="True" time="0.023" asserts="0">
+                        <results>
+                          <test-case name="NUnit.Framework.Constraints.AndTest.CanCombineTestsWithAndOperator" executed="True" result="Success" success="True" time="0.001" asserts="1" />
+                          <test-case name="NUnit.Framework.Constraints.AndTest.ConstraintTestBaseNoData.ProvidesProperDescription" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Framework.Constraints.AndTest.ConstraintTestBaseNoData.ProvidesProperStringRepresentation" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                          <test-suite type="ParameterizedTest" name="FailsWithBadValues" executed="True" result="Success" success="True" time="0.003" asserts="0">
+                            <results>
+                              <test-case name="NUnit.Framework.Constraints.AndTest.FailsWithBadValues(37)" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                              <test-case name="NUnit.Framework.Constraints.AndTest.FailsWithBadValues(53)" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                            </results>
+                          </test-suite>
+                          <test-suite type="ParameterizedTest" name="ProvidesProperFailureMessage" executed="True" result="Success" success="True" time="0.004" asserts="0">
+                            <results>
+                              <test-case name="NUnit.Framework.Constraints.AndTest.ProvidesProperFailureMessage(37,&quot;37&quot;)" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                              <test-case name="NUnit.Framework.Constraints.AndTest.ProvidesProperFailureMessage(53,&quot;53&quot;)" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                            </results>
+                          </test-suite>
+                          <test-suite type="ParameterizedTest" name="SucceedsWithGoodValues" executed="True" result="Success" success="True" time="0.001" asserts="0">
+                            <results>
+                              <test-case name="NUnit.Framework.Constraints.AndTest.SucceedsWithGoodValues(42)" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                            </results>
+                          </test-suite>
+                        </results>
+                      </test-suite>
+                      <test-suite type="TestFixture" name="AssignableFromTest" executed="True" result="Success" success="True" time="0.017" asserts="0">
+                        <results>
+                          <test-case name="NUnit.Framework.Constraints.AssignableFromTest.ConstraintTestBaseNoData.ProvidesProperDescription" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Framework.Constraints.AssignableFromTest.ConstraintTestBaseNoData.ProvidesProperStringRepresentation" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                          <test-suite type="ParameterizedTest" name="FailsWithBadValues" executed="True" result="Success" success="True" time="0.001" asserts="0">
+                            <results>
+                              <test-case name="NUnit.Framework.Constraints.AssignableFromTest.FailsWithBadValues(NUnit.Framework.Constraints.D2)" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                            </results>
+                          </test-suite>
+                          <test-suite type="ParameterizedTest" name="ProvidesProperFailureMessage" executed="True" result="Success" success="True" time="0.001" asserts="0">
+                            <results>
+                              <test-case name="NUnit.Framework.Constraints.AssignableFromTest.ProvidesProperFailureMessage(NUnit.Framework.Constraints.D2,&quot;&lt;NUnit.Framework.Constraints.D2&gt;&quot;)" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                            </results>
+                          </test-suite>
+                          <test-suite type="ParameterizedTest" name="SucceedsWithGoodValues" executed="True" result="Success" success="True" time="0.004" asserts="0">
+                            <results>
+                              <test-case name="NUnit.Framework.Constraints.AssignableFromTest.SucceedsWithGoodValues(NUnit.Framework.Constraints.D1)" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                              <test-case name="NUnit.Framework.Constraints.AssignableFromTest.SucceedsWithGoodValues(NUnit.Framework.Constraints.B)" executed="True" result="Success" success="True" time="0.001" asserts="1" />
+                            </results>
+                          </test-suite>
+                        </results>
+                      </test-suite>
+                      <test-suite type="TestFixture" name="AssignableToTest" executed="True" result="Success" success="True" time="0.032" asserts="0">
+                        <results>
+                          <test-case name="NUnit.Framework.Constraints.AssignableToTest.ConstraintTestBaseNoData.ProvidesProperDescription" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Framework.Constraints.AssignableToTest.ConstraintTestBaseNoData.ProvidesProperStringRepresentation" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                          <test-suite type="ParameterizedTest" name="FailsWithBadValues" executed="True" result="Success" success="True" time="0.001" asserts="0">
+                            <results>
+                              <test-case name="NUnit.Framework.Constraints.AssignableToTest.FailsWithBadValues(NUnit.Framework.Constraints.B)" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                            </results>
+                          </test-suite>
+                          <test-suite type="ParameterizedTest" name="ProvidesProperFailureMessage" executed="True" result="Success" success="True" time="0.001" asserts="0">
+                            <results>
+                              <test-case name="NUnit.Framework.Constraints.AssignableToTest.ProvidesProperFailureMessage(NUnit.Framework.Constraints.B,&quot;&lt;NUnit.Framework.Constraints.B&gt;&quot;)" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                            </results>
+                          </test-suite>
+                          <test-suite type="ParameterizedTest" name="SucceedsWithGoodValues" executed="True" result="Success" success="True" time="0.003" asserts="0">
+                            <results>
+                              <test-case name="NUnit.Framework.Constraints.AssignableToTest.SucceedsWithGoodValues(NUnit.Framework.Constraints.D1)" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                              <test-case name="NUnit.Framework.Constraints.AssignableToTest.SucceedsWithGoodValues(NUnit.Framework.Constraints.D2)" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                            </results>
+                          </test-suite>
+                        </results>
+                      </test-suite>
+                      <test-suite type="TestFixture" name="AttributeExistsConstraintTest" executed="True" result="Success" success="True" time="0.015" asserts="0">
+                        <results>
+                          <test-case name="NUnit.Framework.Constraints.AttributeExistsConstraintTest.AttributeExistsOnMethodInfo" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Framework.Constraints.AttributeExistsConstraintTest.AttributeTestPropertyValueOnMethodInfo" description="my description" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Framework.Constraints.AttributeExistsConstraintTest.ConstraintTestBaseNoData.ProvidesProperDescription" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Framework.Constraints.AttributeExistsConstraintTest.ConstraintTestBaseNoData.ProvidesProperStringRepresentation" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                          <test-suite type="ParameterizedTest" name="FailsWithBadValues" executed="True" result="Success" success="True" time="0.000" asserts="0">
+                            <results>
+                              <test-case name="NUnit.Framework.Constraints.AttributeExistsConstraintTest.FailsWithBadValues(NUnit.Framework.Constraints.D2)" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                            </results>
+                          </test-suite>
+                          <test-case name="NUnit.Framework.Constraints.AttributeExistsConstraintTest.NonAttributeThrowsException" executed="True" result="Success" success="True" time="0.001" asserts="0" />
+                          <test-suite type="ParameterizedTest" name="ProvidesProperFailureMessage" executed="True" result="Success" success="True" time="0.002" asserts="0">
+                            <results>
+                              <test-case name="NUnit.Framework.Constraints.AttributeExistsConstraintTest.ProvidesProperFailureMessage(NUnit.Framework.Constraints.D2,&quot;&lt;NUnit.Framework.Constraints.D2&gt;&quot;)" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                            </results>
+                          </test-suite>
+                          <test-suite type="ParameterizedTest" name="SucceedsWithGoodValues" executed="True" result="Success" success="True" time="0.001" asserts="0">
+                            <results>
+                              <test-case name="NUnit.Framework.Constraints.AttributeExistsConstraintTest.SucceedsWithGoodValues(NUnit.Framework.Constraints.AttributeExistsConstraintTest)" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                            </results>
+                          </test-suite>
+                        </results>
+                      </test-suite>
+                      <test-suite type="TestFixture" name="BinarySerializableTest" executed="True" result="Success" success="True" time="0.020" asserts="0">
+                        <results>
+                          <test-case name="NUnit.Framework.Constraints.BinarySerializableTest.ConstraintTestBaseNoData.ProvidesProperDescription" executed="True" result="Success" success="True" time="0.001" asserts="1" />
+                          <test-case name="NUnit.Framework.Constraints.BinarySerializableTest.ConstraintTestBaseNoData.ProvidesProperStringRepresentation" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                          <test-suite type="ParameterizedTest" name="FailsWithBadValues" executed="True" result="Success" success="True" time="0.001" asserts="0">
+                            <results>
+                              <test-case name="NUnit.Framework.Constraints.BinarySerializableTest.FailsWithBadValues(NUnit.Framework.Constraints.InternalClass)" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                            </results>
+                          </test-suite>
+                          <test-suite type="ParameterizedTest" name="InvalidDataThrowsArgumentException" executed="True" result="Success" success="True" time="0.001" asserts="0">
+                            <results>
+                              <test-case name="NUnit.Framework.Constraints.BinarySerializableTest.InvalidDataThrowsArgumentException(null)" executed="True" result="Success" success="True" time="0.000" asserts="0" />
+                            </results>
+                          </test-suite>
+                          <test-suite type="ParameterizedTest" name="ProvidesProperFailureMessage" executed="True" result="Success" success="True" time="0.002" asserts="0">
+                            <results>
+                              <test-case name="NUnit.Framework.Constraints.BinarySerializableTest.ProvidesProperFailureMessage(NUnit.Framework.Constraints.InternalClass,&quot;&lt;InternalClass&gt;&quot;)" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                            </results>
+                          </test-suite>
+                          <test-suite type="ParameterizedTest" name="SucceedsWithGoodValues" executed="True" result="Success" success="True" time="0.005" asserts="0">
+                            <results>
+                              <test-case name="NUnit.Framework.Constraints.BinarySerializableTest.SucceedsWithGoodValues(1)" executed="True" result="Success" success="True" time="0.001" asserts="1" />
+                              <test-case name="NUnit.Framework.Constraints.BinarySerializableTest.SucceedsWithGoodValues(&quot;a&quot;)" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                              <test-case name="NUnit.Framework.Constraints.BinarySerializableTest.SucceedsWithGoodValues(System.Collections.ArrayList)" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                              <test-case name="NUnit.Framework.Constraints.BinarySerializableTest.SucceedsWithGoodValues(NUnit.Framework.Constraints.InternalWithSerializableAttributeClass)" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                            </results>
+                          </test-suite>
+                        </results>
+                      </test-suite>
+                      <test-suite type="TestFixture" name="CollectionContainsTests" executed="True" result="Success" success="True" time="0.017" asserts="0">
+                        <results>
+                          <test-case name="NUnit.Framework.Constraints.CollectionContainsTests.CanTestContentsOfArray" executed="True" result="Success" success="True" time="0.001" asserts="1" />
+                          <test-case name="NUnit.Framework.Constraints.CollectionContainsTests.CanTestContentsOfArrayList" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Framework.Constraints.CollectionContainsTests.CanTestContentsOfCollectionNotImplementingIList" executed="True" result="Success" success="True" time="0.001" asserts="1" />
+                          <test-case name="NUnit.Framework.Constraints.CollectionContainsTests.CanTestContentsOfSortedList" executed="True" result="Success" success="True" time="0.000" asserts="2" />
+                          <test-case name="NUnit.Framework.Constraints.CollectionContainsTests.IgnoreCaseIsHonored" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Framework.Constraints.CollectionContainsTests.UsesProvidedComparerOfT" executed="True" result="Success" success="True" time="0.000" asserts="2" />
+                          <test-case name="NUnit.Framework.Constraints.CollectionContainsTests.UsesProvidedComparisonOfT" executed="True" result="Success" success="True" time="0.000" asserts="2" />
+                          <test-case name="NUnit.Framework.Constraints.CollectionContainsTests.UsesProvidedEqualityComparer" executed="True" result="Success" success="True" time="0.000" asserts="2" />
+                          <test-case name="NUnit.Framework.Constraints.CollectionContainsTests.UsesProvidedEqualityComparerOfT" executed="True" result="Success" success="True" time="0.000" asserts="2" />
+                          <test-case name="NUnit.Framework.Constraints.CollectionContainsTests.UsesProvidedIComparer" executed="True" result="Success" success="True" time="0.000" asserts="2" />
+                          <test-case name="NUnit.Framework.Constraints.CollectionContainsTests.UsesProvidedLambdaExpression" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                        </results>
+                      </test-suite>
+                      <test-suite type="TestFixture" name="CollectionEquivalentTests" executed="True" result="Success" success="True" time="0.021" asserts="0">
+                        <results>
+                          <test-case name="NUnit.Framework.Constraints.CollectionEquivalentTests.EqualCollectionsAreEquivalent" executed="True" result="Success" success="True" time="0.001" asserts="1" />
+                          <test-case name="NUnit.Framework.Constraints.CollectionEquivalentTests.EquivalentFailsWithDuplicateElementInActual" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Framework.Constraints.CollectionEquivalentTests.EquivalentFailsWithDuplicateElementInExpected" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Framework.Constraints.CollectionEquivalentTests.EquivalentHandlesNull" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Framework.Constraints.CollectionEquivalentTests.EquivalentHonorsIgnoreCase" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Framework.Constraints.CollectionEquivalentTests.EquivalentHonorsUsing" executed="True" result="Success" success="True" time="0.001" asserts="1" />
+                          <test-case name="NUnit.Framework.Constraints.CollectionEquivalentTests.EquivalentIgnoresOrder" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Framework.Constraints.CollectionEquivalentTests.FailureMessageWithHashSetAndArray" executed="True" result="Success" success="True" time="0.000" asserts="2" />
+                          <test-case name="NUnit.Framework.Constraints.CollectionEquivalentTests.WorksWithArrayAndHashSet" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Framework.Constraints.CollectionEquivalentTests.WorksWithCollectionsOfArrays" executed="True" result="Success" success="True" time="0.000" asserts="2" />
+                          <test-case name="NUnit.Framework.Constraints.CollectionEquivalentTests.WorksWithHashSetAndArray" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Framework.Constraints.CollectionEquivalentTests.WorksWithHashSets" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                        </results>
+                      </test-suite>
+                      <test-suite type="TestFixture" name="CollectionOrderedTests" executed="True" result="Success" success="True" time="0.029" asserts="0">
+                        <results>
+                          <test-case name="NUnit.Framework.Constraints.CollectionOrderedTests.IsOrdered" executed="True" result="Success" success="True" time="0.001" asserts="1" />
+                          <test-case name="NUnit.Framework.Constraints.CollectionOrderedTests.IsOrdered_2" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Framework.Constraints.CollectionOrderedTests.IsOrdered_Allows_adjacent_equal_values" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Framework.Constraints.CollectionOrderedTests.IsOrdered_AtLeastOneArgMustImplementIComparable" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Framework.Constraints.CollectionOrderedTests.IsOrdered_Fails" executed="True" result="Success" success="True" time="0.000" asserts="2" />
+                          <test-case name="NUnit.Framework.Constraints.CollectionOrderedTests.IsOrdered_Handles_custom_comparison" executed="True" result="Success" success="True" time="0.001" asserts="2" />
+                          <test-case name="NUnit.Framework.Constraints.CollectionOrderedTests.IsOrdered_Handles_custom_comparison2" executed="True" result="Success" success="True" time="0.000" asserts="2" />
+                          <test-case name="NUnit.Framework.Constraints.CollectionOrderedTests.IsOrdered_Handles_null" executed="True" result="Success" success="True" time="0.001" asserts="1" />
+                          <test-case name="NUnit.Framework.Constraints.CollectionOrderedTests.IsOrdered_TypesMustBeComparable" executed="True" result="Success" success="True" time="0.001" asserts="1" />
+                          <test-case name="NUnit.Framework.Constraints.CollectionOrderedTests.IsOrderedBy" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Framework.Constraints.CollectionOrderedTests.IsOrderedBy_Comparer" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Framework.Constraints.CollectionOrderedTests.IsOrderedBy_Handles_heterogeneous_classes_as_long_as_the_property_is_of_same_type" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Framework.Constraints.CollectionOrderedTests.IsOrderedDescending" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Framework.Constraints.CollectionOrderedTests.IsOrderedDescending_2" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Framework.Constraints.CollectionOrderedTests.UsesProvidedComparerOfT" executed="True" result="Success" success="True" time="0.000" asserts="2" />
+                          <test-case name="NUnit.Framework.Constraints.CollectionOrderedTests.UsesProvidedComparisonOfT" executed="True" result="Success" success="True" time="0.000" asserts="2" />
+                          <test-case name="NUnit.Framework.Constraints.CollectionOrderedTests.UsesProvidedLambda" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                        </results>
+                      </test-suite>
+                      <test-suite type="TestFixture" name="ComparerTests" executed="True" result="Success" success="True" time="0.044" asserts="0">
+                        <results>
+                          <test-suite type="ParameterizedTest" name="EqualItems" executed="True" result="Success" success="True" time="0.015" asserts="0">
+                            <results>
+                              <test-case name="NUnit.Framework.Constraints.ComparerTests.EqualItems(4,4)" executed="True" result="Success" success="True" time="0.001" asserts="2" />
+                              <test-case name="NUnit.Framework.Constraints.ComparerTests.EqualItems(null,null)" executed="True" result="Success" success="True" time="0.000" asserts="2" />
+                              <test-case name="NUnit.Framework.Constraints.ComparerTests.EqualItems(null,null)" executed="True" result="Success" success="True" time="0.000" asserts="2" />
+                              <test-case name="NUnit.Framework.Constraints.ComparerTests.EqualItems(4.0d,4.0d)" executed="True" result="Success" success="True" time="0.001" asserts="2" />
+                              <test-case name="NUnit.Framework.Constraints.ComparerTests.EqualItems(4.0f,4.0f)" executed="True" result="Success" success="True" time="0.000" asserts="2" />
+                              <test-case name="NUnit.Framework.Constraints.ComparerTests.EqualItems(4.0f,4.0d)" executed="True" result="Success" success="True" time="0.000" asserts="2" />
+                              <test-case name="NUnit.Framework.Constraints.ComparerTests.EqualItems(4,4.0f)" executed="True" result="Success" success="True" time="0.000" asserts="2" />
+                              <test-case name="NUnit.Framework.Constraints.ComparerTests.EqualItems(4.0d,4)" executed="True" result="Success" success="True" time="0.000" asserts="2" />
+                              <test-case name="NUnit.Framework.Constraints.ComparerTests.EqualItems(4,4.0d)" executed="True" result="Success" success="True" time="0.000" asserts="2" />
+                              <test-case name="NUnit.Framework.Constraints.ComparerTests.EqualItems(4.0d,4.0f)" executed="True" result="Success" success="True" time="0.000" asserts="2" />
+                              <test-case name="NUnit.Framework.Constraints.ComparerTests.EqualItems(4.0f,4)" executed="True" result="Success" success="True" time="0.001" asserts="2" />
+                            </results>
+                          </test-suite>
+                          <test-suite type="ParameterizedTest" name="SpecialFloatingPointValues" executed="True" result="Success" success="True" time="0.008" asserts="0">
+                            <results>
+                              <test-case name="NUnit.Framework.Constraints.ComparerTests.SpecialFloatingPointValues(double.PositiveInfinity)" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                              <test-case name="NUnit.Framework.Constraints.ComparerTests.SpecialFloatingPointValues(float.NegativeInfinity)" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                              <test-case name="NUnit.Framework.Constraints.ComparerTests.SpecialFloatingPointValues(float.NaN)" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                              <test-case name="NUnit.Framework.Constraints.ComparerTests.SpecialFloatingPointValues(float.PositiveInfinity)" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                              <test-case name="NUnit.Framework.Constraints.ComparerTests.SpecialFloatingPointValues(double.NegativeInfinity)" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                              <test-case name="NUnit.Framework.Constraints.ComparerTests.SpecialFloatingPointValues(double.NaN)" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                            </results>
+                          </test-suite>
+                          <test-suite type="ParameterizedTest" name="UnequalItems" executed="True" result="Success" success="True" time="0.016" asserts="0">
+                            <results>
+                              <test-case name="NUnit.Framework.Constraints.ComparerTests.UnequalItems(4,2)" executed="True" result="Success" success="True" time="0.000" asserts="4" />
+                              <test-case name="NUnit.Framework.Constraints.ComparerTests.UnequalItems(4,null)" executed="True" result="Success" success="True" time="0.000" asserts="4" />
+                              <test-case name="NUnit.Framework.Constraints.ComparerTests.UnequalItems(4,null)" executed="True" result="Success" success="True" time="0.000" asserts="4" />
+                              <test-case name="NUnit.Framework.Constraints.ComparerTests.UnequalItems(4.0f,2.0f)" executed="True" result="Success" success="True" time="0.001" asserts="4" />
+                              <test-case name="NUnit.Framework.Constraints.ComparerTests.UnequalItems(4.0d,2.0d)" executed="True" result="Success" success="True" time="0.000" asserts="4" />
+                              <test-case name="NUnit.Framework.Constraints.ComparerTests.UnequalItems(4,2.0d)" executed="True" result="Success" success="True" time="0.000" asserts="4" />
+                              <test-case name="NUnit.Framework.Constraints.ComparerTests.UnequalItems(4,2.0f)" executed="True" result="Success" success="True" time="0.000" asserts="4" />
+                              <test-case name="NUnit.Framework.Constraints.ComparerTests.UnequalItems(4.0d,2)" executed="True" result="Success" success="True" time="0.000" asserts="4" />
+                              <test-case name="NUnit.Framework.Constraints.ComparerTests.UnequalItems(4.0d,2.0f)" executed="True" result="Success" success="True" time="0.000" asserts="4" />
+                              <test-case name="NUnit.Framework.Constraints.ComparerTests.UnequalItems(4.0f,2)" executed="True" result="Success" success="True" time="0.000" asserts="4" />
+                              <test-case name="NUnit.Framework.Constraints.ComparerTests.UnequalItems(4.0f,2.0d)" executed="True" result="Success" success="True" time="0.000" asserts="4" />
+                            </results>
+                          </test-suite>
+                        </results>
+                      </test-suite>
+                      <test-suite type="TestFixture" name="EmptyConstraintTest" executed="True" result="Success" success="True" time="0.022" asserts="0">
+                        <results>
+                          <test-case name="NUnit.Framework.Constraints.EmptyConstraintTest.ConstraintTestBaseNoData.ProvidesProperDescription" executed="True" result="Success" success="True" time="0.001" asserts="1" />
+                          <test-case name="NUnit.Framework.Constraints.EmptyConstraintTest.ConstraintTestBaseNoData.ProvidesProperStringRepresentation" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                          <test-suite type="ParameterizedTest" name="FailsWithBadValues" executed="True" result="Success" success="True" time="0.002" asserts="0">
+                            <results>
+                              <test-case name="NUnit.Framework.Constraints.EmptyConstraintTest.FailsWithBadValues(&quot;Hello&quot;)" executed="True" result="Success" success="True" time="0.001" asserts="1" />
+                              <test-case name="NUnit.Framework.Constraints.EmptyConstraintTest.FailsWithBadValues(System.Object[])" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                            </results>
+                          </test-suite>
+                          <test-suite type="ParameterizedTest" name="InvalidDataThrowsArgumentException" executed="True" result="Success" success="True" time="0.003" asserts="0">
+                            <results>
+                              <test-case name="NUnit.Framework.Constraints.EmptyConstraintTest.InvalidDataThrowsArgumentException(null)" executed="True" result="Success" success="True" time="0.001" asserts="0" />
+                              <test-case name="NUnit.Framework.Constraints.EmptyConstraintTest.InvalidDataThrowsArgumentException(5)" executed="True" result="Success" success="True" time="0.000" asserts="0" />
+                            </results>
+                          </test-suite>
+                          <test-suite type="ParameterizedTest" name="ProvidesProperFailureMessage" executed="True" result="Success" success="True" time="0.002" asserts="0">
+                            <results>
+                              <test-case name="NUnit.Framework.Constraints.EmptyConstraintTest.ProvidesProperFailureMessage(&quot;Hello&quot;,&quot;\&quot;Hello\&quot;&quot;)" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                              <test-case name="NUnit.Framework.Constraints.EmptyConstraintTest.ProvidesProperFailureMessage(System.Object[],&quot;&lt; 1, 2, 3 &gt;&quot;)" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                            </results>
+                          </test-suite>
+                          <test-suite type="ParameterizedTest" name="SucceedsWithGoodValues" executed="True" result="Success" success="True" time="0.005" asserts="0">
+                            <results>
+                              <test-case name="NUnit.Framework.Constraints.EmptyConstraintTest.SucceedsWithGoodValues(&quot;&quot;)" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                              <test-case name="NUnit.Framework.Constraints.EmptyConstraintTest.SucceedsWithGoodValues(System.Object[])" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                              <test-case name="NUnit.Framework.Constraints.EmptyConstraintTest.SucceedsWithGoodValues(System.Collections.ArrayList)" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                              <test-case name="NUnit.Framework.Constraints.EmptyConstraintTest.SucceedsWithGoodValues(System.Collections.Generic.List`1[System.Int32])" executed="True" result="Success" success="True" time="0.001" asserts="1" />
+                            </results>
+                          </test-suite>
+                        </results>
+                      </test-suite>
+                      <test-suite type="TestFixture" name="EndsWithTest" executed="True" result="Success" success="True" time="0.028" asserts="0">
+                        <results>
+                          <test-case name="NUnit.Framework.Constraints.EndsWithTest.ConstraintTestBaseNoData.ProvidesProperDescription" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Framework.Constraints.EndsWithTest.ConstraintTestBaseNoData.ProvidesProperStringRepresentation" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                          <test-suite type="ParameterizedTest" name="FailsWithBadValues" executed="True" result="Success" success="True" time="0.008" asserts="0">
+                            <results>
+                              <test-case name="NUnit.Framework.Constraints.EndsWithTest.FailsWithBadValues(&quot;goodbye&quot;)" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                              <test-case name="NUnit.Framework.Constraints.EndsWithTest.FailsWithBadValues(&quot;What the hell?&quot;)" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                              <test-case name="NUnit.Framework.Constraints.EndsWithTest.FailsWithBadValues(&quot;hello there&quot;)" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                              <test-case name="NUnit.Framework.Constraints.EndsWithTest.FailsWithBadValues(&quot;say hello to fred&quot;)" executed="True" result="Success" success="True" time="0.001" asserts="1" />
+                              <test-case name="NUnit.Framework.Constraints.EndsWithTest.FailsWithBadValues(&quot;&quot;)" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                              <test-case name="NUnit.Framework.Constraints.EndsWithTest.FailsWithBadValues(null)" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                            </results>
+                          </test-suite>
+                          <test-suite type="ParameterizedTest" name="ProvidesProperFailureMessage" executed="True" result="Success" success="True" time="0.008" asserts="0">
+                            <results>
+                              <test-case name="NUnit.Framework.Constraints.EndsWithTest.ProvidesProperFailureMessage(&quot;goodbye&quot;,&quot;\&quot;goodbye\&quot;&quot;)" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                              <test-case name="NUnit.Framework.Constraints.EndsWithTest.ProvidesProperFailureMessage(&quot;What the hell?&quot;,&quot;\&quot;What the hell?\&quot;&quot;)" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                              <test-case name="NUnit.Framework.Constraints.EndsWithTest.ProvidesProperFailureMessage(&quot;hello there&quot;,&quot;\&quot;hello there\&quot;&quot;)" executed="True" result="Success" success="True" time="0.001" asserts="1" />
+                              <test-case name="NUnit.Framework.Constraints.EndsWithTest.ProvidesProperFailureMessage(&quot;say hello to fred&quot;,&quot;\&quot;say hello to fred\&quot;&quot;)" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                              <test-case name="NUnit.Framework.Constraints.EndsWithTest.ProvidesProperFailureMessage(&quot;&quot;,&quot;&lt;string.Empty&gt;&quot;)" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                              <test-case name="NUnit.Framework.Constraints.EndsWithTest.ProvidesProperFailureMessage(null,&quot;null&quot;)" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                            </results>
+                          </test-suite>
+                          <test-suite type="ParameterizedTest" name="SucceedsWithGoodValues" executed="True" result="Success" success="True" time="0.002" asserts="0">
+                            <results>
+                              <test-case name="NUnit.Framework.Constraints.EndsWithTest.SucceedsWithGoodValues(&quot;hello&quot;)" executed="True" result="Success" success="True" time="0.001" asserts="1" />
+                              <test-case name="NUnit.Framework.Constraints.EndsWithTest.SucceedsWithGoodValues(&quot;I said hello&quot;)" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                            </results>
+                          </test-suite>
+                        </results>
+                      </test-suite>
+                      <test-suite type="TestFixture" name="EndsWithTestIgnoringCase" executed="True" result="Success" success="True" time="0.025" asserts="0">
+                        <results>
+                          <test-case name="NUnit.Framework.Constraints.EndsWithTestIgnoringCase.ConstraintTestBaseNoData.ProvidesProperDescription" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Framework.Constraints.EndsWithTestIgnoringCase.ConstraintTestBaseNoData.ProvidesProperStringRepresentation" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                          <test-suite type="ParameterizedTest" name="FailsWithBadValues" executed="True" result="Success" success="True" time="0.008" asserts="0">
+                            <results>
+                              <test-case name="NUnit.Framework.Constraints.EndsWithTestIgnoringCase.FailsWithBadValues(&quot;goodbye&quot;)" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                              <test-case name="NUnit.Framework.Constraints.EndsWithTestIgnoringCase.FailsWithBadValues(&quot;What the hell?&quot;)" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                              <test-case name="NUnit.Framework.Constraints.EndsWithTestIgnoringCase.FailsWithBadValues(&quot;hello there&quot;)" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                              <test-case name="NUnit.Framework.Constraints.EndsWithTestIgnoringCase.FailsWithBadValues(&quot;say hello to fred&quot;)" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                              <test-case name="NUnit.Framework.Constraints.EndsWithTestIgnoringCase.FailsWithBadValues(&quot;&quot;)" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                              <test-case name="NUnit.Framework.Constraints.EndsWithTestIgnoringCase.FailsWithBadValues(null)" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                            </results>
+                          </test-suite>
+                          <test-suite type="ParameterizedTest" name="ProvidesProperFailureMessage" executed="True" result="Success" success="True" time="0.008" asserts="0">
+                            <results>
+                              <test-case name="NUnit.Framework.Constraints.EndsWithTestIgnoringCase.ProvidesProperFailureMessage(&quot;goodbye&quot;,&quot;\&quot;goodbye\&quot;&quot;)" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                              <test-case name="NUnit.Framework.Constraints.EndsWithTestIgnoringCase.ProvidesProperFailureMessage(&quot;What the hell?&quot;,&quot;\&quot;What the hell?\&quot;&quot;)" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                              <test-case name="NUnit.Framework.Constraints.EndsWithTestIgnoringCase.ProvidesProperFailureMessage(&quot;hello there&quot;,&quot;\&quot;hello there\&quot;&quot;)" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                              <test-case name="NUnit.Framework.Constraints.EndsWithTestIgnoringCase.ProvidesProperFailureMessage(&quot;say hello to fred&quot;,&quot;\&quot;say hello to fred\&quot;&quot;)" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                              <test-case name="NUnit.Framework.Constraints.EndsWithTestIgnoringCase.ProvidesProperFailureMessage(&quot;&quot;,&quot;&lt;string.Empty&gt;&quot;)" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                              <test-case name="NUnit.Framework.Constraints.EndsWithTestIgnoringCase.ProvidesProperFailureMessage(null,&quot;null&quot;)" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                            </results>
+                          </test-suite>
+                          <test-suite type="ParameterizedTest" name="SucceedsWithGoodValues" executed="True" result="Success" success="True" time="0.002" asserts="0">
+                            <results>
+                              <test-case name="NUnit.Framework.Constraints.EndsWithTestIgnoringCase.SucceedsWithGoodValues(&quot;HELLO&quot;)" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                              <test-case name="NUnit.Framework.Constraints.EndsWithTestIgnoringCase.SucceedsWithGoodValues(&quot;I said Hello&quot;)" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                            </results>
+                          </test-suite>
+                        </results>
+                      </test-suite>
+                      <test-suite type="TestFixture" name="EqualConstraintTests" executed="True" result="Success" success="True" time="0.154" asserts="0">
+                        <results>
+                          <test-case name="NUnit.Framework.Constraints.EqualConstraintTests.CanMatchDates" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Framework.Constraints.EqualConstraintTests.CanMatchDatesWithinDays" executed="True" result="Success" success="True" time="0.001" asserts="1" />
+                          <test-case name="NUnit.Framework.Constraints.EqualConstraintTests.CanMatchDatesWithinHours" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Framework.Constraints.EqualConstraintTests.CanMatchDatesWithinMilliseconds" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Framework.Constraints.EqualConstraintTests.CanMatchDatesWithinMinutes" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Framework.Constraints.EqualConstraintTests.CanMatchDatesWithinSeconds" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Framework.Constraints.EqualConstraintTests.CanMatchDatesWithinTicks" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Framework.Constraints.EqualConstraintTests.CanMatchDatesWithinTimeSpan" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Framework.Constraints.EqualConstraintTests.CanMatchDictionaries_DifferentOrder" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Framework.Constraints.EqualConstraintTests.CanMatchDictionaries_Failure" executed="True" result="Success" success="True" time="0.001" asserts="1" />
+                          <test-case name="NUnit.Framework.Constraints.EqualConstraintTests.CanMatchDictionaries_SameOrder" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                          <test-suite type="ParameterizedTest" name="CanMatchDoublesWithRelativeTolerance" executed="True" result="Success" success="True" time="0.004" asserts="0">
+                            <results>
+                              <test-case name="NUnit.Framework.Constraints.EqualConstraintTests.CanMatchDoublesWithRelativeTolerance(10500.0d)" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                              <test-case name="NUnit.Framework.Constraints.EqualConstraintTests.CanMatchDoublesWithRelativeTolerance(9500.0d)" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                              <test-case name="NUnit.Framework.Constraints.EqualConstraintTests.CanMatchDoublesWithRelativeTolerance(10000.0d)" executed="True" result="Success" success="True" time="0.001" asserts="1" />
+                            </results>
+                          </test-suite>
+                          <test-suite type="ParameterizedTest" name="CanMatchDoublesWithUlpTolerance" executed="True" result="Success" success="True" time="0.002" asserts="0">
+                            <results>
+                              <test-case name="NUnit.Framework.Constraints.EqualConstraintTests.CanMatchDoublesWithUlpTolerance(2E+16.0d)" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                              <test-case name="NUnit.Framework.Constraints.EqualConstraintTests.CanMatchDoublesWithUlpTolerance(2E+16.0d)" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                            </results>
+                          </test-suite>
+                          <test-case name="NUnit.Framework.Constraints.EqualConstraintTests.CanMatchHashtables_DifferentOrder" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Framework.Constraints.EqualConstraintTests.CanMatchHashtables_Failure" executed="True" result="Success" success="True" time="0.001" asserts="1" />
+                          <test-case name="NUnit.Framework.Constraints.EqualConstraintTests.CanMatchHashtables_SameOrder" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Framework.Constraints.EqualConstraintTests.CanMatchHashtableWithDictionary" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                          <test-suite type="ParameterizedTest" name="CanMatchSinglesWithRelativeTolerance" executed="True" result="Success" success="True" time="0.004" asserts="0">
+                            <results>
+                              <test-case name="NUnit.Framework.Constraints.EqualConstraintTests.CanMatchSinglesWithRelativeTolerance(10000.0f)" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                              <test-case name="NUnit.Framework.Constraints.EqualConstraintTests.CanMatchSinglesWithRelativeTolerance(9500.0f)" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                              <test-case name="NUnit.Framework.Constraints.EqualConstraintTests.CanMatchSinglesWithRelativeTolerance(10500.0f)" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                            </results>
+                          </test-suite>
+                          <test-suite type="ParameterizedTest" name="CanMatchSinglesWithUlpTolerance" executed="True" result="Success" success="True" time="0.004" asserts="0">
+                            <results>
+                              <test-case name="NUnit.Framework.Constraints.EqualConstraintTests.CanMatchSinglesWithUlpTolerance(2E+07.0f)" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                              <test-case name="NUnit.Framework.Constraints.EqualConstraintTests.CanMatchSinglesWithUlpTolerance(2E+07.0f)" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                            </results>
+                          </test-suite>
+                          <test-suite type="ParameterizedTest" name="CanMatchSpecialFloatingPointValues" executed="True" result="Success" success="True" time="0.008" asserts="0">
+                            <results>
+                              <test-case name="NUnit.Framework.Constraints.EqualConstraintTests.CanMatchSpecialFloatingPointValues(double.NaN)" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                              <test-case name="NUnit.Framework.Constraints.EqualConstraintTests.CanMatchSpecialFloatingPointValues(float.PositiveInfinity)" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                              <test-case name="NUnit.Framework.Constraints.EqualConstraintTests.CanMatchSpecialFloatingPointValues(double.NegativeInfinity)" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                              <test-case name="NUnit.Framework.Constraints.EqualConstraintTests.CanMatchSpecialFloatingPointValues(double.PositiveInfinity)" executed="True" result="Success" success="True" time="0.001" asserts="1" />
+                              <test-case name="NUnit.Framework.Constraints.EqualConstraintTests.CanMatchSpecialFloatingPointValues(float.NaN)" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                              <test-case name="NUnit.Framework.Constraints.EqualConstraintTests.CanMatchSpecialFloatingPointValues(float.NegativeInfinity)" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                            </results>
+                          </test-suite>
+                          <test-case name="NUnit.Framework.Constraints.EqualConstraintTests.CanMatchTimeSpanWithinMinutes" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Framework.Constraints.EqualConstraintTests.ConstraintTestBaseNoData.ProvidesProperDescription" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Framework.Constraints.EqualConstraintTests.ConstraintTestBaseNoData.ProvidesProperStringRepresentation" executed="True" result="Success" success="True" time="0.001" asserts="1" />
+                          <test-case name="NUnit.Framework.Constraints.EqualConstraintTests.ErrorIfDaysPrecedesWithin" executed="True" result="Success" success="True" time="0.001" asserts="0" />
+                          <test-case name="NUnit.Framework.Constraints.EqualConstraintTests.ErrorIfHoursPrecedesWithin" executed="True" result="Success" success="True" time="0.000" asserts="0" />
+                          <test-case name="NUnit.Framework.Constraints.EqualConstraintTests.ErrorIfMillisecondsPrecedesWithin" executed="True" result="Success" success="True" time="0.000" asserts="0" />
+                          <test-case name="NUnit.Framework.Constraints.EqualConstraintTests.ErrorIfMinutesPrecedesWithin" executed="True" result="Success" success="True" time="0.001" asserts="0" />
+                          <test-case name="NUnit.Framework.Constraints.EqualConstraintTests.ErrorIfPercentPrecedesWithin" executed="True" result="Success" success="True" time="0.001" asserts="0" />
+                          <test-case name="NUnit.Framework.Constraints.EqualConstraintTests.ErrorIfSecondsPrecedesWithin" executed="True" result="Success" success="True" time="0.001" asserts="0" />
+                          <test-case name="NUnit.Framework.Constraints.EqualConstraintTests.ErrorIfTicksPrecedesWithin" executed="True" result="Success" success="True" time="0.001" asserts="0" />
+                          <test-case name="NUnit.Framework.Constraints.EqualConstraintTests.ErrorIfUlpsIsUsedOnDecimal" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                          <test-suite type="ParameterizedTest" name="ErrorIfUlpsIsUsedOnIntegralType" executed="True" result="Success" success="True" time="0.008" asserts="0">
+                            <results>
+                              <test-case name="NUnit.Framework.Constraints.EqualConstraintTests.ErrorIfUlpsIsUsedOnIntegralType(1000,1010)" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                              <test-case name="NUnit.Framework.Constraints.EqualConstraintTests.ErrorIfUlpsIsUsedOnIntegralType(1000L,1010L)" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                              <test-case name="NUnit.Framework.Constraints.EqualConstraintTests.ErrorIfUlpsIsUsedOnIntegralType(1000UL,1010UL)" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                              <test-case name="NUnit.Framework.Constraints.EqualConstraintTests.ErrorIfUlpsIsUsedOnIntegralType(1000,1010)" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                            </results>
+                          </test-suite>
+                          <test-case name="NUnit.Framework.Constraints.EqualConstraintTests.ErrorIfUlpsPrecedesWithin" executed="True" result="Success" success="True" time="0.001" asserts="0" />
+                          <test-case name="NUnit.Framework.Constraints.EqualConstraintTests.ErrorWithPercentAndUlpsToleranceModes" executed="True" result="Success" success="True" time="0.001" asserts="0" />
+                          <test-case name="NUnit.Framework.Constraints.EqualConstraintTests.ErrorWithUlpsAndPercentToleranceModes" executed="True" result="Success" success="True" time="0.000" asserts="0" />
+                          <test-suite type="ParameterizedTest" name="FailsOnDoublesOutsideOfRelativeTolerance" executed="True" result="Success" success="True" time="0.004" asserts="0">
+                            <results>
+                              <test-case name="NUnit.Framework.Constraints.EqualConstraintTests.FailsOnDoublesOutsideOfRelativeTolerance(8500.0d)" executed="True" result="Success" success="True" time="0.001" asserts="1" />
+                              <test-case name="NUnit.Framework.Constraints.EqualConstraintTests.FailsOnDoublesOutsideOfRelativeTolerance(11500.0d)" executed="True" result="Success" success="True" time="0.001" asserts="1" />
+                            </results>
+                          </test-suite>
+                          <test-suite type="ParameterizedTest" name="FailsOnDoublesOutsideOfUlpTolerance" executed="True" result="Success" success="True" time="0.003" asserts="0">
+                            <results>
+                              <test-case name="NUnit.Framework.Constraints.EqualConstraintTests.FailsOnDoublesOutsideOfUlpTolerance(2E+16.0d)" executed="True" result="Success" success="True" time="0.001" asserts="1" />
+                              <test-case name="NUnit.Framework.Constraints.EqualConstraintTests.FailsOnDoublesOutsideOfUlpTolerance(2E+16.0d)" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                            </results>
+                          </test-suite>
+                          <test-suite type="ParameterizedTest" name="FailsOnSinglesOutsideOfRelativeTolerance" executed="True" result="Success" success="True" time="0.003" asserts="0">
+                            <results>
+                              <test-case name="NUnit.Framework.Constraints.EqualConstraintTests.FailsOnSinglesOutsideOfRelativeTolerance(11500.0f)" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                              <test-case name="NUnit.Framework.Constraints.EqualConstraintTests.FailsOnSinglesOutsideOfRelativeTolerance(8500.0f)" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                            </results>
+                          </test-suite>
+                          <test-suite type="ParameterizedTest" name="FailsOnSinglesOutsideOfUlpTolerance" executed="True" result="Success" success="True" time="0.003" asserts="0">
+                            <results>
+                              <test-case name="NUnit.Framework.Constraints.EqualConstraintTests.FailsOnSinglesOutsideOfUlpTolerance(2E+07.0f)" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                              <test-case name="NUnit.Framework.Constraints.EqualConstraintTests.FailsOnSinglesOutsideOfUlpTolerance(2E+07.0f)" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                            </results>
+                          </test-suite>
+                          <test-suite type="ParameterizedTest" name="FailsWithBadValues" executed="True" result="Success" success="True" time="0.008" asserts="0">
+                            <results>
+                              <test-case name="NUnit.Framework.Constraints.EqualConstraintTests.FailsWithBadValues(5)" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                              <test-case name="NUnit.Framework.Constraints.EqualConstraintTests.FailsWithBadValues(null)" executed="True" result="Success" success="True" time="0.001" asserts="1" />
+                              <test-case name="NUnit.Framework.Constraints.EqualConstraintTests.FailsWithBadValues(&quot;Hello&quot;)" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                              <test-case name="NUnit.Framework.Constraints.EqualConstraintTests.FailsWithBadValues(double.NaN)" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                              <test-case name="NUnit.Framework.Constraints.EqualConstraintTests.FailsWithBadValues(double.PositiveInfinity)" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                            </results>
+                          </test-suite>
+                          <test-suite type="ParameterizedTest" name="ProvidesProperFailureMessage" executed="True" result="Success" success="True" time="0.008" asserts="0">
+                            <results>
+                              <test-case name="NUnit.Framework.Constraints.EqualConstraintTests.ProvidesProperFailureMessage(5,&quot;5&quot;)" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                              <test-case name="NUnit.Framework.Constraints.EqualConstraintTests.ProvidesProperFailureMessage(null,&quot;null&quot;)" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                              <test-case name="NUnit.Framework.Constraints.EqualConstraintTests.ProvidesProperFailureMessage(&quot;Hello&quot;,&quot;\&quot;Hello\&quot;&quot;)" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                              <test-case name="NUnit.Framework.Constraints.EqualConstraintTests.ProvidesProperFailureMessage(double.NaN,&quot;NaN&quot;)" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                              <test-case name="NUnit.Framework.Constraints.EqualConstraintTests.ProvidesProperFailureMessage(double.PositiveInfinity,&quot;Infinity&quot;)" executed="True" result="Success" success="True" time="0.001" asserts="1" />
+                            </results>
+                          </test-suite>
+                          <test-suite type="ParameterizedTest" name="SucceedsWithGoodValues" executed="True" result="Success" success="True" time="0.007" asserts="0">
+                            <results>
+                              <test-case name="NUnit.Framework.Constraints.EqualConstraintTests.SucceedsWithGoodValues(4)" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                              <test-case name="NUnit.Framework.Constraints.EqualConstraintTests.SucceedsWithGoodValues(4.0f)" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                              <test-case name="NUnit.Framework.Constraints.EqualConstraintTests.SucceedsWithGoodValues(4.0d)" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                              <test-case name="NUnit.Framework.Constraints.EqualConstraintTests.SucceedsWithGoodValues(4.0000m)" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                            </results>
+                          </test-suite>
+                          <test-case name="NUnit.Framework.Constraints.EqualConstraintTests.UsesProvidedArrayComparer" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Framework.Constraints.EqualConstraintTests.UsesProvidedComparerOfT" executed="True" result="Success" success="True" time="0.001" asserts="2" />
+                          <test-case name="NUnit.Framework.Constraints.EqualConstraintTests.UsesProvidedComparisonOfT" executed="True" result="Success" success="True" time="0.000" asserts="2" />
+                          <test-case name="NUnit.Framework.Constraints.EqualConstraintTests.UsesProvidedEqualityComparer" executed="True" result="Success" success="True" time="0.000" asserts="2" />
+                          <test-case name="NUnit.Framework.Constraints.EqualConstraintTests.UsesProvidedEqualityComparerOfT" executed="True" result="Success" success="True" time="0.000" asserts="2" />
+                          <test-case name="NUnit.Framework.Constraints.EqualConstraintTests.UsesProvidedIComparer" executed="True" result="Success" success="True" time="0.000" asserts="2" />
+                          <test-case name="NUnit.Framework.Constraints.EqualConstraintTests.UsesProvidedLambda_IntArgs" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Framework.Constraints.EqualConstraintTests.UsesProvidedLambda_StringArgs" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Framework.Constraints.EqualConstraintTests.UsesProvidedListComparer" executed="True" result="Success" success="True" time="0.001" asserts="1" />
+                        </results>
+                      </test-suite>
+                      <test-suite type="TestFixture" name="EqualityComparerTests" executed="True" result="Success" success="True" time="0.011" asserts="0">
+                        <results>
+                          <test-case name="NUnit.Framework.Constraints.EqualityComparerTests.CanCompareArrayContainingSelfToSelf" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Framework.Constraints.EqualityComparerTests.IEquatableDifferentTypesSuccess_WhenActualImplementsIEquatable" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Framework.Constraints.EqualityComparerTests.IEquatableDifferentTypesSuccess_WhenExpectedImplementsIEquatable" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Framework.Constraints.EqualityComparerTests.IEquatableHasPrecedenceOverDefaultEquals" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Framework.Constraints.EqualityComparerTests.IEquatableSuccess" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Framework.Constraints.EqualityComparerTests.ReferenceEqualityHasPrecedenceOverIEquatable" executed="True" result="Success" success="True" time="0.001" asserts="1" />
+                        </results>
+                      </test-suite>
+                      <test-suite type="TestFixture" name="EqualTest" executed="True" result="Success" success="True" time="0.010" asserts="0">
+                        <results>
+                          <test-case name="NUnit.Framework.Constraints.EqualTest.FailedStringMatchShowsFailurePosition" executed="True" result="Success" success="True" time="0.001" asserts="2" />
+                          <test-case name="NUnit.Framework.Constraints.EqualTest.LongStringsAreTruncated" executed="True" result="Success" success="True" time="0.001" asserts="2" />
+                          <test-case name="NUnit.Framework.Constraints.EqualTest.LongStringsAreTruncatedAtBothEndsIfNecessary" executed="True" result="Success" success="True" time="0.000" asserts="2" />
+                          <test-case name="NUnit.Framework.Constraints.EqualTest.LongStringsAreTruncatedAtFrontEndIfNecessary" executed="True" result="Success" success="True" time="0.000" asserts="2" />
+                          <test-case name="NUnit.Framework.Constraints.EqualTest.TestPropertyWithPrivateSetter" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                        </results>
+                      </test-suite>
+                      <test-suite type="TestFixture" name="ExactCountConstraintTests" executed="True" result="Success" success="True" time="0.011" asserts="0">
+                        <results>
+                          <test-case name="NUnit.Framework.Constraints.ExactCountConstraintTests.ExactlyOneItemMatches" executed="True" result="Success" success="True" time="0.000" asserts="2" />
+                          <test-case name="NUnit.Framework.Constraints.ExactCountConstraintTests.ExactlyOneItemMatchFails" executed="True" result="Success" success="True" time="0.001" asserts="2" />
+                          <test-case name="NUnit.Framework.Constraints.ExactCountConstraintTests.ExactlyTwoItemsMatch" executed="True" result="Success" success="True" time="0.000" asserts="2" />
+                          <test-case name="NUnit.Framework.Constraints.ExactCountConstraintTests.ExactlyTwoItemsMatchFails" executed="True" result="Success" success="True" time="0.001" asserts="2" />
+                          <test-case name="NUnit.Framework.Constraints.ExactCountConstraintTests.ZeroItemsMatch" executed="True" result="Success" success="True" time="0.000" asserts="2" />
+                          <test-case name="NUnit.Framework.Constraints.ExactCountConstraintTests.ZeroItemsMatchFails" executed="True" result="Success" success="True" time="0.001" asserts="2" />
+                        </results>
+                      </test-suite>
+                      <test-suite type="TestFixture" name="ExactTypeTest" executed="True" result="Success" success="True" time="0.015" asserts="0">
+                        <results>
+                          <test-case name="NUnit.Framework.Constraints.ExactTypeTest.ConstraintTestBaseNoData.ProvidesProperDescription" executed="True" result="Success" success="True" time="0.001" asserts="1" />
+                          <test-case name="NUnit.Framework.Constraints.ExactTypeTest.ConstraintTestBaseNoData.ProvidesProperStringRepresentation" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                          <test-suite type="ParameterizedTest" name="FailsWithBadValues" executed="True" result="Success" success="True" time="0.002" asserts="0">
+                            <results>
+                              <test-case name="NUnit.Framework.Constraints.ExactTypeTest.FailsWithBadValues(NUnit.Framework.Constraints.B)" executed="True" result="Success" success="True" time="0.001" asserts="1" />
+                              <test-case name="NUnit.Framework.Constraints.ExactTypeTest.FailsWithBadValues(NUnit.Framework.Constraints.D2)" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                            </results>
+                          </test-suite>
+                          <test-suite type="ParameterizedTest" name="ProvidesProperFailureMessage" executed="True" result="Success" success="True" time="0.005" asserts="0">
+                            <results>
+                              <test-case name="NUnit.Framework.Constraints.ExactTypeTest.ProvidesProperFailureMessage(NUnit.Framework.Constraints.B,&quot;&lt;NUnit.Framework.Constraints.B&gt;&quot;)" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                              <test-case name="NUnit.Framework.Constraints.ExactTypeTest.ProvidesProperFailureMessage(NUnit.Framework.Constraints.D2,&quot;&lt;NUnit.Framework.Constraints.D2&gt;&quot;)" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                            </results>
+                          </test-suite>
+                          <test-suite type="ParameterizedTest" name="SucceedsWithGoodValues" executed="True" result="Success" success="True" time="0.001" asserts="0">
+                            <results>
+                              <test-case name="NUnit.Framework.Constraints.ExactTypeTest.SucceedsWithGoodValues(NUnit.Framework.Constraints.D1)" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                            </results>
+                          </test-suite>
+                        </results>
+                      </test-suite>
+                      <test-suite type="TestFixture" name="FalseConstraintTest" executed="True" result="Success" success="True" time="0.018" asserts="0">
+                        <results>
+                          <test-case name="NUnit.Framework.Constraints.FalseConstraintTest.ConstraintTestBaseNoData.ProvidesProperDescription" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Framework.Constraints.FalseConstraintTest.ConstraintTestBaseNoData.ProvidesProperStringRepresentation" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                          <test-suite type="ParameterizedTest" name="FailsWithBadValues" executed="True" result="Success" success="True" time="0.004" asserts="0">
+                            <results>
+                              <test-case name="NUnit.Framework.Constraints.FalseConstraintTest.FailsWithBadValues(null)" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                              <test-case name="NUnit.Framework.Constraints.FalseConstraintTest.FailsWithBadValues(&quot;hello&quot;)" executed="True" result="Success" success="True" time="0.001" asserts="1" />
+                              <test-case name="NUnit.Framework.Constraints.FalseConstraintTest.FailsWithBadValues(True)" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                              <test-case name="NUnit.Framework.Constraints.FalseConstraintTest.FailsWithBadValues(True)" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                            </results>
+                          </test-suite>
+                          <test-suite type="ParameterizedTest" name="ProvidesProperFailureMessage" executed="True" result="Success" success="True" time="0.005" asserts="0">
+                            <results>
+                              <test-case name="NUnit.Framework.Constraints.FalseConstraintTest.ProvidesProperFailureMessage(null,&quot;null&quot;)" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                              <test-case name="NUnit.Framework.Constraints.FalseConstraintTest.ProvidesProperFailureMessage(&quot;hello&quot;,&quot;\&quot;hello\&quot;&quot;)" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                              <test-case name="NUnit.Framework.Constraints.FalseConstraintTest.ProvidesProperFailureMessage(True,&quot;True&quot;)" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                              <test-case name="NUnit.Framework.Constraints.FalseConstraintTest.ProvidesProperFailureMessage(True,&quot;True&quot;)" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                            </results>
+                          </test-suite>
+                          <test-suite type="ParameterizedTest" name="SucceedsWithGoodValues" executed="True" result="Success" success="True" time="0.002" asserts="0">
+                            <results>
+                              <test-case name="NUnit.Framework.Constraints.FalseConstraintTest.SucceedsWithGoodValues(False)" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                              <test-case name="NUnit.Framework.Constraints.FalseConstraintTest.SucceedsWithGoodValues(False)" executed="True" result="Success" success="True" time="0.001" asserts="1" />
+                            </results>
+                          </test-suite>
+                        </results>
+                      </test-suite>
+                      <test-suite type="TestFixture" name="FloatingPointNumericsTest" executed="True" result="Success" success="True" time="0.010" asserts="0">
+                        <results>
+                          <test-case name="NUnit.Framework.Constraints.FloatingPointNumericsTest.DoubleEqualityWithUlps" executed="True" result="Success" success="True" time="0.000" asserts="4" />
+                          <test-case name="NUnit.Framework.Constraints.FloatingPointNumericsTest.FloatEqualityWithUlps" executed="True" result="Success" success="True" time="0.001" asserts="4" />
+                          <test-case name="NUnit.Framework.Constraints.FloatingPointNumericsTest.MirroredDoubleReinterpretation" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Framework.Constraints.FloatingPointNumericsTest.MirroredFloatReinterpretation" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Framework.Constraints.FloatingPointNumericsTest.MirroredIntegerReinterpretation" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Framework.Constraints.FloatingPointNumericsTest.MirroredLongReinterpretation" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                        </results>
+                      </test-suite>
+                      <test-suite type="TestFixture" name="GreaterThanOrEqualTest" executed="True" result="Success" success="True" time="0.023" asserts="0">
+                        <results>
+                          <test-case name="NUnit.Framework.Constraints.GreaterThanOrEqualTest.CanCompareIComparables" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Framework.Constraints.GreaterThanOrEqualTest.CanCompareIComparablesOfT" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Framework.Constraints.GreaterThanOrEqualTest.ComparisonConstraintTest.UsesProvidedComparerOfT" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Framework.Constraints.GreaterThanOrEqualTest.ComparisonConstraintTest.UsesProvidedComparisonOfT" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Framework.Constraints.GreaterThanOrEqualTest.ComparisonConstraintTest.UsesProvidedIComparer" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Framework.Constraints.GreaterThanOrEqualTest.ComparisonConstraintTest.UsesProvidedLambda" executed="True" result="Success" success="True" time="0.000" asserts="0" />
+                          <test-case name="NUnit.Framework.Constraints.GreaterThanOrEqualTest.ConstraintTestBaseNoData.ProvidesProperDescription" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Framework.Constraints.GreaterThanOrEqualTest.ConstraintTestBaseNoData.ProvidesProperStringRepresentation" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                          <test-suite type="ParameterizedTest" name="FailsWithBadValues" executed="True" result="Success" success="True" time="0.002" asserts="0">
+                            <results>
+                              <test-case name="NUnit.Framework.Constraints.GreaterThanOrEqualTest.FailsWithBadValues(4)" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                            </results>
+                          </test-suite>
+                          <test-suite type="ParameterizedTest" name="InvalidDataThrowsArgumentException" executed="True" result="Success" success="True" time="0.003" asserts="0">
+                            <results>
+                              <test-case name="NUnit.Framework.Constraints.GreaterThanOrEqualTest.InvalidDataThrowsArgumentException(null)" executed="True" result="Success" success="True" time="0.000" asserts="0" />
+                              <test-case name="NUnit.Framework.Constraints.GreaterThanOrEqualTest.InvalidDataThrowsArgumentException(&quot;xxx&quot;)" executed="True" result="Success" success="True" time="0.000" asserts="0" />
+                            </results>
+                          </test-suite>
+                          <test-suite type="ParameterizedTest" name="ProvidesProperFailureMessage" executed="True" result="Success" success="True" time="0.001" asserts="0">
+                            <results>
+                              <test-case name="NUnit.Framework.Constraints.GreaterThanOrEqualTest.ProvidesProperFailureMessage(4,&quot;4&quot;)" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                            </results>
+                          </test-suite>
+                          <test-suite type="ParameterizedTest" name="SucceedsWithGoodValues" executed="True" result="Success" success="True" time="0.002" asserts="0">
+                            <results>
+                              <test-case name="NUnit.Framework.Constraints.GreaterThanOrEqualTest.SucceedsWithGoodValues(6)" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                              <test-case name="NUnit.Framework.Constraints.GreaterThanOrEqualTest.SucceedsWithGoodValues(5)" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                            </results>
+                          </test-suite>
+                        </results>
+                      </test-suite>
+                      <test-suite type="TestFixture" name="GreaterThanTest" executed="True" result="Success" success="True" time="0.029" asserts="0">
+                        <results>
+                          <test-case name="NUnit.Framework.Constraints.GreaterThanTest.CanCompareIComparables" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Framework.Constraints.GreaterThanTest.CanCompareIComparablesOfT" executed="True" result="Success" success="True" time="0.001" asserts="1" />
+                          <test-case name="NUnit.Framework.Constraints.GreaterThanTest.ComparisonConstraintTest.UsesProvidedComparerOfT" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Framework.Constraints.GreaterThanTest.ComparisonConstraintTest.UsesProvidedComparisonOfT" executed="True" result="Success" success="True" time="0.001" asserts="1" />
+                          <test-case name="NUnit.Framework.Constraints.GreaterThanTest.ComparisonConstraintTest.UsesProvidedIComparer" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Framework.Constraints.GreaterThanTest.ComparisonConstraintTest.UsesProvidedLambda" executed="True" result="Success" success="True" time="0.000" asserts="0" />
+                          <test-case name="NUnit.Framework.Constraints.GreaterThanTest.ConstraintTestBaseNoData.ProvidesProperDescription" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Framework.Constraints.GreaterThanTest.ConstraintTestBaseNoData.ProvidesProperStringRepresentation" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                          <test-suite type="ParameterizedTest" name="FailsWithBadValues" executed="True" result="Success" success="True" time="0.002" asserts="0">
+                            <results>
+                              <test-case name="NUnit.Framework.Constraints.GreaterThanTest.FailsWithBadValues(4)" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                              <test-case name="NUnit.Framework.Constraints.GreaterThanTest.FailsWithBadValues(5)" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                            </results>
+                          </test-suite>
+                          <test-suite type="ParameterizedTest" name="InvalidDataThrowsArgumentException" executed="True" result="Success" success="True" time="0.004" asserts="0">
+                            <results>
+                              <test-case name="NUnit.Framework.Constraints.GreaterThanTest.InvalidDataThrowsArgumentException(null)" executed="True" result="Success" success="True" time="0.001" asserts="0" />
+                              <test-case name="NUnit.Framework.Constraints.GreaterThanTest.InvalidDataThrowsArgumentException(&quot;xxx&quot;)" executed="True" result="Success" success="True" time="0.001" asserts="0" />
+                            </results>
+                          </test-suite>
+                          <test-suite type="ParameterizedTest" name="ProvidesProperFailureMessage" executed="True" result="Success" success="True" time="0.002" asserts="0">
+                            <results>
+                              <test-case name="NUnit.Framework.Constraints.GreaterThanTest.ProvidesProperFailureMessage(4,&quot;4&quot;)" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                              <test-case name="NUnit.Framework.Constraints.GreaterThanTest.ProvidesProperFailureMessage(5,&quot;5&quot;)" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                            </results>
+                          </test-suite>
+                          <test-suite type="ParameterizedTest" name="SucceedsWithGoodValues" executed="True" result="Success" success="True" time="0.002" asserts="0">
+                            <results>
+                              <test-case name="NUnit.Framework.Constraints.GreaterThanTest.SucceedsWithGoodValues(6)" executed="True" result="Success" success="True" time="0.001" asserts="1" />
+                              <test-case name="NUnit.Framework.Constraints.GreaterThanTest.SucceedsWithGoodValues(5.001d)" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                            </results>
+                          </test-suite>
+                        </results>
+                      </test-suite>
+                      <test-suite type="TestFixture" name="InstanceOfTypeTest" executed="True" result="Success" success="True" time="0.012" asserts="0">
+                        <results>
+                          <test-case name="NUnit.Framework.Constraints.InstanceOfTypeTest.ConstraintTestBaseNoData.ProvidesProperDescription" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Framework.Constraints.InstanceOfTypeTest.ConstraintTestBaseNoData.ProvidesProperStringRepresentation" executed="True" result="Success" success="True" time="0.001" asserts="1" />
+                          <test-suite type="ParameterizedTest" name="FailsWithBadValues" executed="True" result="Success" success="True" time="0.000" asserts="0">
+                            <results>
+                              <test-case name="NUnit.Framework.Constraints.InstanceOfTypeTest.FailsWithBadValues(NUnit.Framework.Constraints.B)" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                            </results>
+                          </test-suite>
+                          <test-suite type="ParameterizedTest" name="ProvidesProperFailureMessage" executed="True" result="Success" success="True" time="0.002" asserts="0">
+                            <results>
+                              <test-case name="NUnit.Framework.Constraints.InstanceOfTypeTest.ProvidesProperFailureMessage(NUnit.Framework.Constraints.B,&quot;&lt;NUnit.Framework.Constraints.B&gt;&quot;)" executed="True" result="Success" success="True" time="0.001" asserts="1" />
+                            </results>
+                          </test-suite>
+                          <test-suite type="ParameterizedTest" name="SucceedsWithGoodValues" executed="True" result="Success" success="True" time="0.002" asserts="0">
+                            <results>
+                              <test-case name="NUnit.Framework.Constraints.InstanceOfTypeTest.SucceedsWithGoodValues(NUnit.Framework.Constraints.D1)" executed="True" result="Success" success="True" time="0.001" asserts="1" />
+                              <test-case name="NUnit.Framework.Constraints.InstanceOfTypeTest.SucceedsWithGoodValues(NUnit.Framework.Constraints.D2)" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                            </results>
+                          </test-suite>
+                        </results>
+                      </test-suite>
+                      <test-suite type="TestFixture" name="LessThanOrEqualTest" executed="True" result="Success" success="True" time="0.023" asserts="0">
+                        <results>
+                          <test-case name="NUnit.Framework.Constraints.LessThanOrEqualTest.CanCompareIComparables" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Framework.Constraints.LessThanOrEqualTest.CanCompareIComparablesOfT" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Framework.Constraints.LessThanOrEqualTest.ComparisonConstraintTest.UsesProvidedComparerOfT" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Framework.Constraints.LessThanOrEqualTest.ComparisonConstraintTest.UsesProvidedComparisonOfT" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Framework.Constraints.LessThanOrEqualTest.ComparisonConstraintTest.UsesProvidedIComparer" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Framework.Constraints.LessThanOrEqualTest.ComparisonConstraintTest.UsesProvidedLambda" executed="True" result="Success" success="True" time="0.000" asserts="0" />
+                          <test-case name="NUnit.Framework.Constraints.LessThanOrEqualTest.ConstraintTestBaseNoData.ProvidesProperDescription" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Framework.Constraints.LessThanOrEqualTest.ConstraintTestBaseNoData.ProvidesProperStringRepresentation" executed="True" result="Success" success="True" time="0.001" asserts="1" />
+                          <test-suite type="ParameterizedTest" name="FailsWithBadValues" executed="True" result="Success" success="True" time="0.000" asserts="0">
+                            <results>
+                              <test-case name="NUnit.Framework.Constraints.LessThanOrEqualTest.FailsWithBadValues(6)" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                            </results>
+                          </test-suite>
+                          <test-suite type="ParameterizedTest" name="InvalidDataThrowsArgumentException" executed="True" result="Success" success="True" time="0.003" asserts="0">
+                            <results>
+                              <test-case name="NUnit.Framework.Constraints.LessThanOrEqualTest.InvalidDataThrowsArgumentException(null)" executed="True" result="Success" success="True" time="0.001" asserts="0" />
+                              <test-case name="NUnit.Framework.Constraints.LessThanOrEqualTest.InvalidDataThrowsArgumentException(&quot;xxx&quot;)" executed="True" result="Success" success="True" time="0.001" asserts="0" />
+                            </results>
+                          </test-suite>
+                          <test-suite type="ParameterizedTest" name="ProvidesProperFailureMessage" executed="True" result="Success" success="True" time="0.001" asserts="0">
+                            <results>
+                              <test-case name="NUnit.Framework.Constraints.LessThanOrEqualTest.ProvidesProperFailureMessage(6,&quot;6&quot;)" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                            </results>
+                          </test-suite>
+                          <test-suite type="ParameterizedTest" name="SucceedsWithGoodValues" executed="True" result="Success" success="True" time="0.003" asserts="0">
+                            <results>
+                              <test-case name="NUnit.Framework.Constraints.LessThanOrEqualTest.SucceedsWithGoodValues(4)" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                              <test-case name="NUnit.Framework.Constraints.LessThanOrEqualTest.SucceedsWithGoodValues(5)" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                            </results>
+                          </test-suite>
+                        </results>
+                      </test-suite>
+                      <test-suite type="TestFixture" name="LessThanTest" executed="True" result="Success" success="True" time="0.027" asserts="0">
+                        <results>
+                          <test-case name="NUnit.Framework.Constraints.LessThanTest.CanCompareIComparables" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Framework.Constraints.LessThanTest.CanCompareIComparablesOfT" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Framework.Constraints.LessThanTest.ComparisonConstraintTest.UsesProvidedComparerOfT" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Framework.Constraints.LessThanTest.ComparisonConstraintTest.UsesProvidedComparisonOfT" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Framework.Constraints.LessThanTest.ComparisonConstraintTest.UsesProvidedIComparer" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Framework.Constraints.LessThanTest.ComparisonConstraintTest.UsesProvidedLambda" executed="True" result="Success" success="True" time="0.000" asserts="0" />
+                          <test-case name="NUnit.Framework.Constraints.LessThanTest.ConstraintTestBaseNoData.ProvidesProperDescription" executed="True" result="Success" success="True" time="0.001" asserts="1" />
+                          <test-case name="NUnit.Framework.Constraints.LessThanTest.ConstraintTestBaseNoData.ProvidesProperStringRepresentation" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                          <test-suite type="ParameterizedTest" name="FailsWithBadValues" executed="True" result="Success" success="True" time="0.002" asserts="0">
+                            <results>
+                              <test-case name="NUnit.Framework.Constraints.LessThanTest.FailsWithBadValues(6)" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                              <test-case name="NUnit.Framework.Constraints.LessThanTest.FailsWithBadValues(5)" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                            </results>
+                          </test-suite>
+                          <test-suite type="ParameterizedTest" name="InvalidDataThrowsArgumentException" executed="True" result="Success" success="True" time="0.003" asserts="0">
+                            <results>
+                              <test-case name="NUnit.Framework.Constraints.LessThanTest.InvalidDataThrowsArgumentException(null)" executed="True" result="Success" success="True" time="0.000" asserts="0" />
+                              <test-case name="NUnit.Framework.Constraints.LessThanTest.InvalidDataThrowsArgumentException(&quot;xxx&quot;)" executed="True" result="Success" success="True" time="0.000" asserts="0" />
+                            </results>
+                          </test-suite>
+                          <test-suite type="ParameterizedTest" name="ProvidesProperFailureMessage" executed="True" result="Success" success="True" time="0.002" asserts="0">
+                            <results>
+                              <test-case name="NUnit.Framework.Constraints.LessThanTest.ProvidesProperFailureMessage(6,&quot;6&quot;)" executed="True" result="Success" success="True" time="0.001" asserts="1" />
+                              <test-case name="NUnit.Framework.Constraints.LessThanTest.ProvidesProperFailureMessage(5,&quot;5&quot;)" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                            </results>
+                          </test-suite>
+                          <test-suite type="ParameterizedTest" name="SucceedsWithGoodValues" executed="True" result="Success" success="True" time="0.002" asserts="0">
+                            <results>
+                              <test-case name="NUnit.Framework.Constraints.LessThanTest.SucceedsWithGoodValues(4)" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                              <test-case name="NUnit.Framework.Constraints.LessThanTest.SucceedsWithGoodValues(4.999d)" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                            </results>
+                          </test-suite>
+                        </results>
+                      </test-suite>
+                      <test-suite type="TestFixture" name="MsgUtilTests" executed="True" result="Success" success="True" time="0.046" asserts="0">
+                        <results>
+                          <test-case name="NUnit.Framework.Constraints.MsgUtilTests.ClipExpectedAndActual_StringsDoNotFitInLine" executed="True" result="Success" success="True" time="0.000" asserts="4" />
+                          <test-case name="NUnit.Framework.Constraints.MsgUtilTests.ClipExpectedAndActual_StringsFitInLine" executed="True" result="Success" success="True" time="0.000" asserts="4" />
+                          <test-case name="NUnit.Framework.Constraints.MsgUtilTests.ClipExpectedAndActual_StringTailsFitInLine" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                          <test-suite type="ParameterizedTest" name="EscapeControlCharsTest" executed="True" result="Success" success="True" time="0.031" asserts="0">
+                            <results>
+                              <test-case name="NUnit.Framework.Constraints.MsgUtilTests.EscapeControlCharsTest(&quot;\f&quot;,&quot;\\f&quot;)" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                              <test-case name="NUnit.Framework.Constraints.MsgUtilTests.EscapeControlCharsTest(&quot;This is a\rtest message&quot;,&quot;This is a\\rtest message&quot;)" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                              <test-case name="NUnit.Framework.Constraints.MsgUtilTests.EscapeControlCharsTest(&quot;\r\r\r&quot;,&quot;\\r\\r\\r&quot;)" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                              <test-case name="NUnit.Framework.Constraints.MsgUtilTests.EscapeControlCharsTest(&quot;\t&quot;,&quot;\\t&quot;)" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                              <test-case name="NUnit.Framework.Constraints.MsgUtilTests.EscapeControlCharsTest(&quot;\t\n&quot;,&quot;\\t\\n&quot;)" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                              <test-case name="NUnit.Framework.Constraints.MsgUtilTests.EscapeControlCharsTest(&quot;\\r\\n&quot;,&quot;\\\\r\\\\n&quot;)" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                              <test-case name="NUnit.Framework.Constraints.MsgUtilTests.EscapeControlCharsTest(&quot;\a&quot;,&quot;\\a&quot;)" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                              <test-case name="NUnit.Framework.Constraints.MsgUtilTests.EscapeControlCharsTest(&quot;\b&quot;,&quot;\\b&quot;)" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                              <test-case name="NUnit.Framework.Constraints.MsgUtilTests.EscapeControlCharsTest(&quot;\n&quot;,&quot;\\n&quot;)" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                              <test-case name="NUnit.Framework.Constraints.MsgUtilTests.EscapeControlCharsTest(&quot;\v&quot;,&quot;\\v&quot;)" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                              <test-case name="NUnit.Framework.Constraints.MsgUtilTests.EscapeControlCharsTest(&quot;\x0085&quot;,&quot;\\x0085&quot;)" description="Next line character" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                              <test-case name="NUnit.Framework.Constraints.MsgUtilTests.EscapeControlCharsTest(&quot;\x2028&quot;,&quot;\\x2028&quot;)" description="Line separator character" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                              <test-case name="NUnit.Framework.Constraints.MsgUtilTests.EscapeControlCharsTest(&quot;\x2029&quot;,&quot;\\x2029&quot;)" description="Paragraph separator character" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                              <test-case name="NUnit.Framework.Constraints.MsgUtilTests.EscapeControlCharsTest(&quot;\r\n&quot;,&quot;\\r\\n&quot;)" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                              <test-case name="NUnit.Framework.Constraints.MsgUtilTests.EscapeControlCharsTest(&quot;\n\n&quot;,&quot;\\n\\n&quot;)" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                              <test-case name="NUnit.Framework.Constraints.MsgUtilTests.EscapeControlCharsTest(&quot;&quot;,&quot;&quot;)" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                              <test-case name="NUnit.Framework.Constraints.MsgUtilTests.EscapeControlCharsTest(&quot;\n\r&quot;,&quot;\\n\\r&quot;)" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                              <test-case name="NUnit.Framework.Constraints.MsgUtilTests.EscapeControlCharsTest(null,null)" executed="True" result="Success" success="True" time="0.001" asserts="1" />
+                              <test-case name="NUnit.Framework.Constraints.MsgUtilTests.EscapeControlCharsTest(&quot;\n\n\n&quot;,&quot;\\n\\n\\n&quot;)" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                              <test-case name="NUnit.Framework.Constraints.MsgUtilTests.EscapeControlCharsTest(&quot;\r&quot;,&quot;\\r&quot;)" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                              <test-case name="NUnit.Framework.Constraints.MsgUtilTests.EscapeControlCharsTest(&quot;\r\r&quot;,&quot;\\r\\r&quot;)" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                            </results>
+                          </test-suite>
+                          <test-suite type="ParameterizedTest" name="TestClipString" executed="True" result="Success" success="True" time="0.006" asserts="0">
+                            <results>
+                              <test-case name="NUnit.Framework.Constraints.MsgUtilTests.ClipAtStart" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                              <test-case name="NUnit.Framework.Constraints.MsgUtilTests.ClipAtEnd" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                              <test-case name="NUnit.Framework.Constraints.MsgUtilTests.NoClippingNeeded" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                              <test-case name="NUnit.Framework.Constraints.MsgUtilTests.ClipAtStartAndEnd" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                            </results>
+                          </test-suite>
+                        </results>
+                      </test-suite>
+                      <test-suite type="TestFixture" name="NaNConstraintTest" executed="True" result="Success" success="True" time="0.030" asserts="0">
+                        <results>
+                          <test-case name="NUnit.Framework.Constraints.NaNConstraintTest.ConstraintTestBaseNoData.ProvidesProperDescription" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Framework.Constraints.NaNConstraintTest.ConstraintTestBaseNoData.ProvidesProperStringRepresentation" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                          <test-suite type="ParameterizedTest" name="FailsWithBadValues" executed="True" result="Success" success="True" time="0.009" asserts="0">
+                            <results>
+                              <test-case name="NUnit.Framework.Constraints.NaNConstraintTest.FailsWithBadValues(null)" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                              <test-case name="NUnit.Framework.Constraints.NaNConstraintTest.FailsWithBadValues(&quot;hello&quot;)" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                              <test-case name="NUnit.Framework.Constraints.NaNConstraintTest.FailsWithBadValues(42)" executed="True" result="Success" success="True" time="0.001" asserts="1" />
+                              <test-case name="NUnit.Framework.Constraints.NaNConstraintTest.FailsWithBadValues(double.PositiveInfinity)" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                              <test-case name="NUnit.Framework.Constraints.NaNConstraintTest.FailsWithBadValues(double.NegativeInfinity)" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                              <test-case name="NUnit.Framework.Constraints.NaNConstraintTest.FailsWithBadValues(float.PositiveInfinity)" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                              <test-case name="NUnit.Framework.Constraints.NaNConstraintTest.FailsWithBadValues(float.NegativeInfinity)" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                            </results>
+                          </test-suite>
+                          <test-suite type="ParameterizedTest" name="ProvidesProperFailureMessage" executed="True" result="Success" success="True" time="0.009" asserts="0">
+                            <results>
+                              <test-case name="NUnit.Framework.Constraints.NaNConstraintTest.ProvidesProperFailureMessage(null,&quot;null&quot;)" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                              <test-case name="NUnit.Framework.Constraints.NaNConstraintTest.ProvidesProperFailureMessage(&quot;hello&quot;,&quot;\&quot;hello\&quot;&quot;)" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                              <test-case name="NUnit.Framework.Constraints.NaNConstraintTest.ProvidesProperFailureMessage(42,&quot;42&quot;)" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                              <test-case name="NUnit.Framework.Constraints.NaNConstraintTest.ProvidesProperFailureMessage(double.PositiveInfinity,&quot;Infinity&quot;)" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                              <test-case name="NUnit.Framework.Constraints.NaNConstraintTest.ProvidesProperFailureMessage(double.NegativeInfinity,&quot;-Infinity&quot;)" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                              <test-case name="NUnit.Framework.Constraints.NaNConstraintTest.ProvidesProperFailureMessage(float.PositiveInfinity,&quot;Infinity&quot;)" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                              <test-case name="NUnit.Framework.Constraints.NaNConstraintTest.ProvidesProperFailureMessage(float.NegativeInfinity,&quot;-Infinity&quot;)" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                            </results>
+                          </test-suite>
+                          <test-suite type="ParameterizedTest" name="SucceedsWithGoodValues" executed="True" result="Success" success="True" time="0.002" asserts="0">
+                            <results>
+                              <test-case name="NUnit.Framework.Constraints.NaNConstraintTest.SucceedsWithGoodValues(double.NaN)" executed="True" result="Success" success="True" time="0.001" asserts="1" />
+                              <test-case name="NUnit.Framework.Constraints.NaNConstraintTest.SucceedsWithGoodValues(float.NaN)" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                            </results>
+                          </test-suite>
+                        </results>
+                      </test-suite>
+                      <test-suite type="TestFixture" name="NotTest" executed="True" result="Success" success="True" time="0.018" asserts="0">
+                        <results>
+                          <test-case name="NUnit.Framework.Constraints.NotTest.CanUseNotOperator" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Framework.Constraints.NotTest.ConstraintTestBaseNoData.ProvidesProperDescription" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Framework.Constraints.NotTest.ConstraintTestBaseNoData.ProvidesProperStringRepresentation" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                          <test-suite type="ParameterizedTest" name="FailsWithBadValues" executed="True" result="Success" success="True" time="0.000" asserts="0">
+                            <results>
+                              <test-case name="NUnit.Framework.Constraints.NotTest.FailsWithBadValues(null)" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                            </results>
+                          </test-suite>
+                          <test-case name="NUnit.Framework.Constraints.NotTest.NotHonorsIgnoreCaseUsingConstructors" executed="True" result="Success" success="True" time="0.001" asserts="1" />
+                          <test-case name="NUnit.Framework.Constraints.NotTest.NotHonorsIgnoreCaseUsingPrefixNotation" executed="True" result="Success" success="True" time="0.001" asserts="1" />
+                          <test-case name="NUnit.Framework.Constraints.NotTest.NotHonorsTolerance" executed="True" result="Success" success="True" time="0.001" asserts="1" />
+                          <test-suite type="ParameterizedTest" name="ProvidesProperFailureMessage" executed="True" result="Success" success="True" time="0.001" asserts="0">
+                            <results>
+                              <test-case name="NUnit.Framework.Constraints.NotTest.ProvidesProperFailureMessage(null,&quot;null&quot;)" executed="True" result="Success" success="True" time="0.001" asserts="1" />
+                            </results>
+                          </test-suite>
+                          <test-suite type="ParameterizedTest" name="SucceedsWithGoodValues" executed="True" result="Success" success="True" time="0.002" asserts="0">
+                            <results>
+                              <test-case name="NUnit.Framework.Constraints.NotTest.SucceedsWithGoodValues(42)" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                              <test-case name="NUnit.Framework.Constraints.NotTest.SucceedsWithGoodValues(&quot;Hello&quot;)" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                            </results>
+                          </test-suite>
+                        </results>
+                      </test-suite>
+                      <test-suite type="TestFixture" name="NullConstraintTest" executed="True" result="Success" success="True" time="0.009" asserts="0">
+                        <results>
+                          <test-case name="NUnit.Framework.Constraints.NullConstraintTest.ConstraintTestBaseNoData.ProvidesProperDescription" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Framework.Constraints.NullConstraintTest.ConstraintTestBaseNoData.ProvidesProperStringRepresentation" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                          <test-suite type="ParameterizedTest" name="FailsWithBadValues" executed="True" result="Success" success="True" time="0.001" asserts="0">
+                            <results>
+                              <test-case name="NUnit.Framework.Constraints.NullConstraintTest.FailsWithBadValues(&quot;hello&quot;)" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                            </results>
+                          </test-suite>
+                          <test-suite type="ParameterizedTest" name="ProvidesProperFailureMessage" executed="True" result="Success" success="True" time="0.001" asserts="0">
+                            <results>
+                              <test-case name="NUnit.Framework.Constraints.NullConstraintTest.ProvidesProperFailureMessage(&quot;hello&quot;,&quot;\&quot;hello\&quot;&quot;)" executed="True" result="Success" success="True" time="0.001" asserts="1" />
+                            </results>
+                          </test-suite>
+                          <test-suite type="ParameterizedTest" name="SucceedsWithGoodValues" executed="True" result="Success" success="True" time="0.001" asserts="0">
+                            <results>
+                              <test-case name="NUnit.Framework.Constraints.NullConstraintTest.SucceedsWithGoodValues(null)" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                            </results>
+                          </test-suite>
+                        </results>
+                      </test-suite>
+                      <test-suite type="TestFixture" name="NullOrEmptyStringConstraintTest" executed="True" result="Success" success="True" time="0.013" asserts="0">
+                        <results>
+                          <test-case name="NUnit.Framework.Constraints.NullOrEmptyStringConstraintTest.ConstraintTestBaseNoData.ProvidesProperDescription" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Framework.Constraints.NullOrEmptyStringConstraintTest.ConstraintTestBaseNoData.ProvidesProperStringRepresentation" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                          <test-suite type="ParameterizedTest" name="FailsWithBadValues" executed="True" result="Success" success="True" time="0.001" asserts="0">
+                            <results>
+                              <test-case name="NUnit.Framework.Constraints.NullOrEmptyStringConstraintTest.FailsWithBadValues(&quot;Hello&quot;)" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                            </results>
+                          </test-suite>
+                          <test-suite type="ParameterizedTest" name="InvalidDataThrowsArgumentException" executed="True" result="Success" success="True" time="0.001" asserts="0">
+                            <results>
+                              <test-case name="NUnit.Framework.Constraints.NullOrEmptyStringConstraintTest.InvalidDataThrowsArgumentException(5)" executed="True" result="Success" success="True" time="0.001" asserts="0" />
+                            </results>
+                          </test-suite>
+                          <test-suite type="ParameterizedTest" name="ProvidesProperFailureMessage" executed="True" result="Success" success="True" time="0.000" asserts="0">
+                            <results>
+                              <test-case name="NUnit.Framework.Constraints.NullOrEmptyStringConstraintTest.ProvidesProperFailureMessage(&quot;Hello&quot;,&quot;\&quot;Hello\&quot;&quot;)" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                            </results>
+                          </test-suite>
+                          <test-suite type="ParameterizedTest" name="SucceedsWithGoodValues" executed="True" result="Success" success="True" time="0.003" asserts="0">
+                            <results>
+                              <test-case name="NUnit.Framework.Constraints.NullOrEmptyStringConstraintTest.SucceedsWithGoodValues(&quot;&quot;)" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                              <test-case name="NUnit.Framework.Constraints.NullOrEmptyStringConstraintTest.SucceedsWithGoodValues(null)" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                            </results>
+                          </test-suite>
+                        </results>
+                      </test-suite>
+                      <test-suite type="TestFixture" name="NumericsTest" executed="True" result="Success" success="True" time="0.053" asserts="0">
+                        <results>
+                          <test-case name="NUnit.Framework.Constraints.NumericsTest.CanMatchDecimalWithoutToleranceMode" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Framework.Constraints.NumericsTest.CanMatchDecimalWithPercentage" executed="True" result="Success" success="True" time="0.000" asserts="3" />
+                          <test-suite type="ParameterizedTest" name="CanMatchIntegralsWithPercentage" executed="True" result="Success" success="True" time="0.018" asserts="0">
+                            <results>
+                              <test-case name="NUnit.Framework.Constraints.NumericsTest.CanMatchIntegralsWithPercentage(9500)" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                              <test-case name="NUnit.Framework.Constraints.NumericsTest.CanMatchIntegralsWithPercentage(10500)" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                              <test-case name="NUnit.Framework.Constraints.NumericsTest.CanMatchIntegralsWithPercentage(9500L)" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                              <test-case name="NUnit.Framework.Constraints.NumericsTest.CanMatchIntegralsWithPercentage(10000L)" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                              <test-case name="NUnit.Framework.Constraints.NumericsTest.CanMatchIntegralsWithPercentage(10500L)" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                              <test-case name="NUnit.Framework.Constraints.NumericsTest.CanMatchIntegralsWithPercentage(10000)" executed="True" result="Success" success="True" time="0.001" asserts="1" />
+                              <test-case name="NUnit.Framework.Constraints.NumericsTest.CanMatchIntegralsWithPercentage(10000UL)" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                              <test-case name="NUnit.Framework.Constraints.NumericsTest.CanMatchIntegralsWithPercentage(10500UL)" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                              <test-case name="NUnit.Framework.Constraints.NumericsTest.CanMatchIntegralsWithPercentage(9500UL)" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                              <test-case name="NUnit.Framework.Constraints.NumericsTest.CanMatchIntegralsWithPercentage(10000)" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                              <test-case name="NUnit.Framework.Constraints.NumericsTest.CanMatchIntegralsWithPercentage(10500)" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                              <test-case name="NUnit.Framework.Constraints.NumericsTest.CanMatchIntegralsWithPercentage(9500)" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                            </results>
+                          </test-suite>
+                          <test-suite type="ParameterizedTest" name="CanMatchWithoutToleranceMode" executed="True" result="Success" success="True" time="0.008" asserts="0">
+                            <results>
+                              <test-case name="NUnit.Framework.Constraints.NumericsTest.CanMatchWithoutToleranceMode(1234.568f)" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                              <test-case name="NUnit.Framework.Constraints.NumericsTest.CanMatchWithoutToleranceMode(1234.5678d)" executed="True" result="Success" success="True" time="0.001" asserts="1" />
+                              <test-case name="NUnit.Framework.Constraints.NumericsTest.CanMatchWithoutToleranceMode(123456789L)" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                              <test-case name="NUnit.Framework.Constraints.NumericsTest.CanMatchWithoutToleranceMode(123456789)" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                              <test-case name="NUnit.Framework.Constraints.NumericsTest.CanMatchWithoutToleranceMode(123456789)" executed="True" result="Success" success="True" time="0.001" asserts="1" />
+                              <test-case name="NUnit.Framework.Constraints.NumericsTest.CanMatchWithoutToleranceMode(123456789UL)" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                            </results>
+                          </test-suite>
+                          <test-case name="NUnit.Framework.Constraints.NumericsTest.FailsOnDecimalAbovePercentage" executed="True" result="Success" success="True" time="0.001" asserts="1" />
+                          <test-case name="NUnit.Framework.Constraints.NumericsTest.FailsOnDecimalBelowPercentage" executed="True" result="Success" success="True" time="0.001" asserts="1" />
+                          <test-suite type="ParameterizedTest" name="FailsOnIntegralsOutsideOfPercentage" executed="True" result="Success" success="True" time="0.014" asserts="0">
+                            <results>
+                              <test-case name="NUnit.Framework.Constraints.NumericsTest.FailsOnIntegralsOutsideOfPercentage(8500)" executed="True" result="Success" success="True" time="0.001" asserts="1" />
+                              <test-case name="NUnit.Framework.Constraints.NumericsTest.FailsOnIntegralsOutsideOfPercentage(11500L)" executed="True" result="Success" success="True" time="0.001" asserts="1" />
+                              <test-case name="NUnit.Framework.Constraints.NumericsTest.FailsOnIntegralsOutsideOfPercentage(8500UL)" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                              <test-case name="NUnit.Framework.Constraints.NumericsTest.FailsOnIntegralsOutsideOfPercentage(11500UL)" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                              <test-case name="NUnit.Framework.Constraints.NumericsTest.FailsOnIntegralsOutsideOfPercentage(11500)" executed="True" result="Success" success="True" time="0.001" asserts="1" />
+                              <test-case name="NUnit.Framework.Constraints.NumericsTest.FailsOnIntegralsOutsideOfPercentage(8500)" executed="True" result="Success" success="True" time="0.001" asserts="1" />
+                              <test-case name="NUnit.Framework.Constraints.NumericsTest.FailsOnIntegralsOutsideOfPercentage(11500)" executed="True" result="Success" success="True" time="0.001" asserts="1" />
+                              <test-case name="NUnit.Framework.Constraints.NumericsTest.FailsOnIntegralsOutsideOfPercentage(8500L)" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                            </results>
+                          </test-suite>
+                        </results>
+                      </test-suite>
+                      <test-suite type="TestFixture" name="OrTest" executed="True" result="Success" success="True" time="0.013" asserts="0">
+                        <results>
+                          <test-case name="NUnit.Framework.Constraints.OrTest.CanCombineTestsWithOrOperator" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Framework.Constraints.OrTest.ConstraintTestBaseNoData.ProvidesProperDescription" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Framework.Constraints.OrTest.ConstraintTestBaseNoData.ProvidesProperStringRepresentation" executed="True" result="Success" success="True" time="0.001" asserts="1" />
+                          <test-suite type="ParameterizedTest" name="FailsWithBadValues" executed="True" result="Success" success="True" time="0.000" asserts="0">
+                            <results>
+                              <test-case name="NUnit.Framework.Constraints.OrTest.FailsWithBadValues(37)" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                            </results>
+                          </test-suite>
+                          <test-suite type="ParameterizedTest" name="ProvidesProperFailureMessage" executed="True" result="Success" success="True" time="0.001" asserts="0">
+                            <results>
+                              <test-case name="NUnit.Framework.Constraints.OrTest.ProvidesProperFailureMessage(37,&quot;37&quot;)" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                            </results>
+                          </test-suite>
+                          <test-suite type="ParameterizedTest" name="SucceedsWithGoodValues" executed="True" result="Success" success="True" time="0.002" asserts="0">
+                            <results>
+                              <test-case name="NUnit.Framework.Constraints.OrTest.SucceedsWithGoodValues(99)" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                              <test-case name="NUnit.Framework.Constraints.OrTest.SucceedsWithGoodValues(42)" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                            </results>
+                          </test-suite>
+                        </results>
+                      </test-suite>
+                      <test-suite type="TestFixture" name="PropertyExistsTest" executed="True" result="Success" success="True" time="0.026" asserts="0">
+                        <results>
+                          <test-case name="NUnit.Framework.Constraints.PropertyExistsTest.ConstraintTestBaseNoData.ProvidesProperDescription" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Framework.Constraints.PropertyExistsTest.ConstraintTestBaseNoData.ProvidesProperStringRepresentation" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                          <test-suite type="ParameterizedTest" name="FailsWithBadValues" executed="True" result="Success" success="True" time="0.004" asserts="0">
+                            <results>
+                              <test-case name="NUnit.Framework.Constraints.PropertyExistsTest.FailsWithBadValues(42)" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                              <test-case name="NUnit.Framework.Constraints.PropertyExistsTest.FailsWithBadValues(System.Collections.ArrayList)" executed="True" result="Success" success="True" time="0.001" asserts="1" />
+                              <test-case name="NUnit.Framework.Constraints.PropertyExistsTest.FailsWithBadValues(System.Int32)" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                            </results>
+                          </test-suite>
+                          <test-suite type="ParameterizedTest" name="InvalidDataThrowsException" executed="True" result="Success" success="True" time="0.002" asserts="0">
+                            <results>
+                              <test-case name="NUnit.Framework.Constraints.PropertyExistsTest.InvalidDataThrowsException(null)" executed="True" result="Success" success="True" time="0.001" asserts="0" />
+                            </results>
+                          </test-suite>
+                          <test-suite type="ParameterizedTest" name="ProvidesProperFailureMessage" executed="True" result="Success" success="True" time="0.004" asserts="0">
+                            <results>
+                              <test-case name="NUnit.Framework.Constraints.PropertyExistsTest.ProvidesProperFailureMessage(42,&quot;&lt;System.Int32&gt;&quot;)" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                              <test-case name="NUnit.Framework.Constraints.PropertyExistsTest.ProvidesProperFailureMessage(System.Collections.ArrayList,&quot;&lt;System.Collections.ArrayList&gt;&quot;)" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                              <test-case name="NUnit.Framework.Constraints.PropertyExistsTest.ProvidesProperFailureMessage(System.Int32,&quot;&lt;System.Int32&gt;&quot;)" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                            </results>
+                          </test-suite>
+                          <test-suite type="ParameterizedTest" name="SucceedsWithGoodValues" executed="True" result="Success" success="True" time="0.006" asserts="0">
+                            <results>
+                              <test-case name="NUnit.Framework.Constraints.PropertyExistsTest.SucceedsWithGoodValues(System.Int32[])" executed="True" result="Success" success="True" time="0.001" asserts="1" />
+                              <test-case name="NUnit.Framework.Constraints.PropertyExistsTest.SucceedsWithGoodValues(&quot;hello&quot;)" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                              <test-case name="NUnit.Framework.Constraints.PropertyExistsTest.SucceedsWithGoodValues(System.Array)" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                            </results>
+                          </test-suite>
+                        </results>
+                      </test-suite>
+                      <test-suite type="TestFixture" name="PropertyTest" executed="True" result="Success" success="True" time="0.025" asserts="0">
+                        <results>
+                          <test-case name="NUnit.Framework.Constraints.PropertyTest.ConstraintTestBaseNoData.ProvidesProperDescription" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Framework.Constraints.PropertyTest.ConstraintTestBaseNoData.ProvidesProperStringRepresentation" executed="True" result="Success" success="True" time="0.001" asserts="1" />
+                          <test-suite type="ParameterizedTest" name="FailsWithBadValues" executed="True" result="Success" success="True" time="0.002" asserts="0">
+                            <results>
+                              <test-case name="NUnit.Framework.Constraints.PropertyTest.FailsWithBadValues(System.Int32[])" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                              <test-case name="NUnit.Framework.Constraints.PropertyTest.FailsWithBadValues(&quot;goodbye&quot;)" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                            </results>
+                          </test-suite>
+                          <test-suite type="ParameterizedTest" name="InvalidDataThrowsException" executed="True" result="Success" success="True" time="0.006" asserts="0">
+                            <results>
+                              <test-case name="NUnit.Framework.Constraints.PropertyTest.InvalidDataThrowsException(null)" executed="True" result="Success" success="True" time="0.001" asserts="0" />
+                              <test-case name="NUnit.Framework.Constraints.PropertyTest.InvalidDataThrowsException(42)" executed="True" result="Success" success="True" time="0.001" asserts="0" />
+                              <test-case name="NUnit.Framework.Constraints.PropertyTest.InvalidDataThrowsException(System.Collections.ArrayList)" executed="True" result="Success" success="True" time="0.001" asserts="0" />
+                            </results>
+                          </test-suite>
+                          <test-case name="NUnit.Framework.Constraints.PropertyTest.PropertyEqualToValueWithTolerance" executed="True" result="Success" success="True" time="0.001" asserts="2" />
+                          <test-suite type="ParameterizedTest" name="ProvidesProperFailureMessage" executed="True" result="Success" success="True" time="0.003" asserts="0">
+                            <results>
+                              <test-case name="NUnit.Framework.Constraints.PropertyTest.ProvidesProperFailureMessage(System.Int32[],&quot;3&quot;)" executed="True" result="Success" success="True" time="0.001" asserts="1" />
+                              <test-case name="NUnit.Framework.Constraints.PropertyTest.ProvidesProperFailureMessage(&quot;goodbye&quot;,&quot;7&quot;)" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                            </results>
+                          </test-suite>
+                          <test-suite type="ParameterizedTest" name="SucceedsWithGoodValues" executed="True" result="Success" success="True" time="0.003" asserts="0">
+                            <results>
+                              <test-case name="NUnit.Framework.Constraints.PropertyTest.SucceedsWithGoodValues(System.Int32[])" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                              <test-case name="NUnit.Framework.Constraints.PropertyTest.SucceedsWithGoodValues(&quot;hello&quot;)" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                            </results>
+                          </test-suite>
+                        </results>
+                      </test-suite>
+                      <test-suite type="TestFixture" name="RangeConstraintTest" executed="True" result="Success" success="True" time="0.031" asserts="0">
+                        <results>
+                          <test-case name="NUnit.Framework.Constraints.RangeConstraintTest.ConstraintTestBaseNoData.ProvidesProperDescription" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Framework.Constraints.RangeConstraintTest.ConstraintTestBaseNoData.ProvidesProperStringRepresentation" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                          <test-suite type="ParameterizedTest" name="FailsWithBadValues" executed="True" result="Success" success="True" time="0.002" asserts="0">
+                            <results>
+                              <test-case name="NUnit.Framework.Constraints.RangeConstraintTest.FailsWithBadValues(4)" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                              <test-case name="NUnit.Framework.Constraints.RangeConstraintTest.FailsWithBadValues(43)" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                            </results>
+                          </test-suite>
+                          <test-suite type="ParameterizedTest" name="InvalidDataThrowsArgumentException" executed="True" result="Success" success="True" time="0.004" asserts="0">
+                            <results>
+                              <test-case name="NUnit.Framework.Constraints.RangeConstraintTest.InvalidDataThrowsArgumentException(null)" executed="True" result="Success" success="True" time="0.001" asserts="0" />
+                              <test-case name="NUnit.Framework.Constraints.RangeConstraintTest.InvalidDataThrowsArgumentException(&quot;xxx&quot;)" executed="True" result="Success" success="True" time="0.001" asserts="0" />
+                            </results>
+                          </test-suite>
+                          <test-suite type="ParameterizedTest" name="ProvidesProperFailureMessage" executed="True" result="Success" success="True" time="0.002" asserts="0">
+                            <results>
+                              <test-case name="NUnit.Framework.Constraints.RangeConstraintTest.ProvidesProperFailureMessage(4,&quot;4&quot;)" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                              <test-case name="NUnit.Framework.Constraints.RangeConstraintTest.ProvidesProperFailureMessage(43,&quot;43&quot;)" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                            </results>
+                          </test-suite>
+                          <test-suite type="ParameterizedTest" name="SucceedsWithGoodValues" executed="True" result="Success" success="True" time="0.004" asserts="0">
+                            <results>
+                              <test-case name="NUnit.Framework.Constraints.RangeConstraintTest.SucceedsWithGoodValues(5)" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                              <test-case name="NUnit.Framework.Constraints.RangeConstraintTest.SucceedsWithGoodValues(23)" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                              <test-case name="NUnit.Framework.Constraints.RangeConstraintTest.SucceedsWithGoodValues(42)" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                            </results>
+                          </test-suite>
+                          <test-case name="NUnit.Framework.Constraints.RangeConstraintTest.UsesProvidedComparerOfT" executed="True" result="Success" success="True" time="0.000" asserts="2" />
+                          <test-case name="NUnit.Framework.Constraints.RangeConstraintTest.UsesProvidedComparisonOfT" executed="True" result="Success" success="True" time="0.000" asserts="2" />
+                          <test-case name="NUnit.Framework.Constraints.RangeConstraintTest.UsesProvidedIComparer" executed="True" result="Success" success="True" time="0.000" asserts="2" />
+                          <test-case name="NUnit.Framework.Constraints.RangeConstraintTest.UsesProvidedLambda" executed="True" result="Success" success="True" time="0.001" asserts="1" />
+                        </results>
+                      </test-suite>
+                      <test-suite type="TestFixture" name="ReusableConstraintTests" executed="True" result="Success" success="True" time="0.008" asserts="0">
+                        <results>
+                          <test-case name="NUnit.Framework.Constraints.ReusableConstraintTests.CanCreateReusableConstraintByImplicitConversion" executed="True" result="Success" success="True" time="0.000" asserts="3" />
+                          <test-suite type="Theory" name="CanReuseReusableConstraintMultipleTimes" executed="True" result="Success" success="True" time="0.006" asserts="0">
+                            <results>
+                              <test-case name="NUnit.Framework.Constraints.ReusableConstraintTests.CanReuseReusableConstraintMultipleTimes(&lt;not &lt;empty&gt;&gt;)" executed="True" result="Success" success="True" time="0.000" asserts="3" />
+                              <test-case name="NUnit.Framework.Constraints.ReusableConstraintTests.CanReuseReusableConstraintMultipleTimes(&lt;not &lt;null&gt;&gt;)" executed="True" result="Success" success="True" time="0.000" asserts="3" />
+                              <test-case name="NUnit.Framework.Constraints.ReusableConstraintTests.CanReuseReusableConstraintMultipleTimes(&lt;property Length &lt;greaterthan 3&gt;&gt;)" executed="True" result="Success" success="True" time="0.000" asserts="3" />
+                              <test-case name="NUnit.Framework.Constraints.ReusableConstraintTests.CanReuseReusableConstraintMultipleTimes(&lt;and &lt;property Length &lt;equal 4&gt;&gt; &lt;startswith &quot;te&quot;&gt;&gt;)" executed="True" result="Success" success="True" time="0.000" asserts="3" />
+                            </results>
+                          </test-suite>
+                        </results>
+                      </test-suite>
+                      <test-suite type="TestFixture" name="SameAsTest" executed="True" result="Success" success="True" time="0.018" asserts="0">
+                        <results>
+                          <test-case name="NUnit.Framework.Constraints.SameAsTest.ConstraintTestBaseNoData.ProvidesProperDescription" executed="True" result="Success" success="True" time="0.001" asserts="1" />
+                          <test-case name="NUnit.Framework.Constraints.SameAsTest.ConstraintTestBaseNoData.ProvidesProperStringRepresentation" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                          <test-suite type="ParameterizedTest" name="FailsWithBadValues" executed="True" result="Success" success="True" time="0.004" asserts="0">
+                            <results>
+                              <test-case name="NUnit.Framework.Constraints.SameAsTest.FailsWithBadValues(System.Object)" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                              <test-case name="NUnit.Framework.Constraints.SameAsTest.FailsWithBadValues(3)" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                              <test-case name="NUnit.Framework.Constraints.SameAsTest.FailsWithBadValues(&quot;Hello&quot;)" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                            </results>
+                          </test-suite>
+                          <test-suite type="ParameterizedTest" name="ProvidesProperFailureMessage" executed="True" result="Success" success="True" time="0.005" asserts="0">
+                            <results>
+                              <test-case name="NUnit.Framework.Constraints.SameAsTest.ProvidesProperFailureMessage(System.Object,&quot;&lt;System.Object&gt;&quot;)" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                              <test-case name="NUnit.Framework.Constraints.SameAsTest.ProvidesProperFailureMessage(3,&quot;3&quot;)" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                              <test-case name="NUnit.Framework.Constraints.SameAsTest.ProvidesProperFailureMessage(&quot;Hello&quot;,&quot;\&quot;Hello\&quot;&quot;)" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                            </results>
+                          </test-suite>
+                          <test-suite type="ParameterizedTest" name="SucceedsWithGoodValues" executed="True" result="Success" success="True" time="0.001" asserts="0">
+                            <results>
+                              <test-case name="NUnit.Framework.Constraints.SameAsTest.SucceedsWithGoodValues(System.Object)" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                            </results>
+                          </test-suite>
+                        </results>
+                      </test-suite>
+                      <test-suite type="TestFixture" name="SamePathOrUnderTest_Linux" executed="True" result="Success" success="True" time="0.045" asserts="0">
+                        <results>
+                          <test-case name="NUnit.Framework.Constraints.SamePathOrUnderTest_Linux.ConstraintTestBaseNoData.ProvidesProperDescription" executed="True" result="Success" success="True" time="0.001" asserts="1" />
+                          <test-case name="NUnit.Framework.Constraints.SamePathOrUnderTest_Linux.ConstraintTestBaseNoData.ProvidesProperStringRepresentation" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                          <test-suite type="ParameterizedTest" name="FailsWithBadValues" executed="True" result="Success" success="True" time="0.011" asserts="0">
+                            <results>
+                              <test-case name="NUnit.Framework.Constraints.SamePathOrUnderTest_Linux.FailsWithBadValues(123)" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                              <test-case name="NUnit.Framework.Constraints.SamePathOrUnderTest_Linux.FailsWithBadValues(&quot;/Folder1/Folder2&quot;)" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                              <test-case name="NUnit.Framework.Constraints.SamePathOrUnderTest_Linux.FailsWithBadValues(&quot;/FOLDER1/./junk/../Folder2&quot;)" executed="True" result="Success" success="True" time="0.001" asserts="1" />
+                              <test-case name="NUnit.Framework.Constraints.SamePathOrUnderTest_Linux.FailsWithBadValues(&quot;/FOLDER1/./junk/../Folder2/temp/../Folder3&quot;)" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                              <test-case name="NUnit.Framework.Constraints.SamePathOrUnderTest_Linux.FailsWithBadValues(&quot;/folder1/folder3&quot;)" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                              <test-case name="NUnit.Framework.Constraints.SamePathOrUnderTest_Linux.FailsWithBadValues(&quot;/folder1/./folder2/../folder3&quot;)" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                              <test-case name="NUnit.Framework.Constraints.SamePathOrUnderTest_Linux.FailsWithBadValues(&quot;/folder1&quot;)" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                            </results>
+                          </test-suite>
+                          <test-suite type="ParameterizedTest" name="ProvidesProperFailureMessage" executed="True" result="Success" success="True" time="0.011" asserts="0">
+                            <results>
+                              <test-case name="NUnit.Framework.Constraints.SamePathOrUnderTest_Linux.ProvidesProperFailureMessage(123,&quot;123&quot;)" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                              <test-case name="NUnit.Framework.Constraints.SamePathOrUnderTest_Linux.ProvidesProperFailureMessage(&quot;/Folder1/Folder2&quot;,&quot;\&quot;/Folder1/Folder2\&quot;&quot;)" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                              <test-case name="NUnit.Framework.Constraints.SamePathOrUnderTest_Linux.ProvidesProperFailureMessage(&quot;/FOLDER1/./junk/../Folder2&quot;,&quot;\&quot;/FOLDER1/./junk/../Folder2\&quot;&quot;)" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                              <test-case name="NUnit.Framework.Constraints.SamePathOrUnderTest_Linux.ProvidesProperFailureMessage(&quot;/FOLDER1/./junk/../Folder2/temp/../Folder3&quot;,&quot;\&quot;/FOLDER1/./junk/../Folder2/temp/../Folder3\&quot;&quot;)" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                              <test-case name="NUnit.Framework.Constraints.SamePathOrUnderTest_Linux.ProvidesProperFailureMessage(&quot;/folder1/folder3&quot;,&quot;\&quot;/folder1/folder3\&quot;&quot;)" executed="True" result="Success" success="True" time="0.001" asserts="1" />
+                              <test-case name="NUnit.Framework.Constraints.SamePathOrUnderTest_Linux.ProvidesProperFailureMessage(&quot;/folder1/./folder2/../folder3&quot;,&quot;\&quot;/folder1/./folder2/../folder3\&quot;&quot;)" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                              <test-case name="NUnit.Framework.Constraints.SamePathOrUnderTest_Linux.ProvidesProperFailureMessage(&quot;/folder1&quot;,&quot;\&quot;/folder1\&quot;&quot;)" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                            </results>
+                          </test-suite>
+                          <test-suite type="ParameterizedTest" name="SucceedsWithGoodValues" executed="True" result="Success" success="True" time="0.014" asserts="0">
+                            <results>
+                              <test-case name="NUnit.Framework.Constraints.SamePathOrUnderTest_Linux.SucceedsWithGoodValues(&quot;/folder1/folder2&quot;)" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                              <test-case name="NUnit.Framework.Constraints.SamePathOrUnderTest_Linux.SucceedsWithGoodValues(&quot;/folder1/./folder2&quot;)" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                              <test-case name="NUnit.Framework.Constraints.SamePathOrUnderTest_Linux.SucceedsWithGoodValues(&quot;/folder1/junk/../folder2&quot;)" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                              <test-case name="NUnit.Framework.Constraints.SamePathOrUnderTest_Linux.SucceedsWithGoodValues(&quot;\\folder1\\folder2&quot;)" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                              <test-case name="NUnit.Framework.Constraints.SamePathOrUnderTest_Linux.SucceedsWithGoodValues(&quot;/folder1/folder2/folder3&quot;)" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                              <test-case name="NUnit.Framework.Constraints.SamePathOrUnderTest_Linux.SucceedsWithGoodValues(&quot;/folder1/./folder2/folder3&quot;)" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                              <test-case name="NUnit.Framework.Constraints.SamePathOrUnderTest_Linux.SucceedsWithGoodValues(&quot;/folder1/junk/../folder2/folder3&quot;)" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                              <test-case name="NUnit.Framework.Constraints.SamePathOrUnderTest_Linux.SucceedsWithGoodValues(&quot;\\folder1\\folder2\\folder3&quot;)" executed="True" result="Success" success="True" time="0.001" asserts="1" />
+                            </results>
+                          </test-suite>
+                        </results>
+                      </test-suite>
+                      <test-suite type="TestFixture" name="SamePathOrUnderTest_Windows" executed="True" result="Success" success="True" time="0.039" asserts="0">
+                        <results>
+                          <test-case name="NUnit.Framework.Constraints.SamePathOrUnderTest_Windows.ConstraintTestBaseNoData.ProvidesProperDescription" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Framework.Constraints.SamePathOrUnderTest_Windows.ConstraintTestBaseNoData.ProvidesProperStringRepresentation" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                          <test-suite type="ParameterizedTest" name="FailsWithBadValues" executed="True" result="Success" success="True" time="0.009" asserts="0">
+                            <results>
+                              <test-case name="NUnit.Framework.Constraints.SamePathOrUnderTest_Windows.FailsWithBadValues(123)" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                              <test-case name="NUnit.Framework.Constraints.SamePathOrUnderTest_Windows.FailsWithBadValues(&quot;C:\\folder1\\folder3&quot;)" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                              <test-case name="NUnit.Framework.Constraints.SamePathOrUnderTest_Windows.FailsWithBadValues(&quot;C:\\folder1\\.\\folder2\\..\\file.temp&quot;)" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                            </results>
+                          </test-suite>
+                          <test-suite type="ParameterizedTest" name="ProvidesProperFailureMessage" executed="True" result="Success" success="True" time="0.004" asserts="0">
+                            <results>
+                              <test-case name="NUnit.Framework.Constraints.SamePathOrUnderTest_Windows.ProvidesProperFailureMessage(123,&quot;123&quot;)" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                              <test-case name="NUnit.Framework.Constraints.SamePathOrUnderTest_Windows.ProvidesProperFailureMessage(&quot;C:\\folder1\\folder3&quot;,&quot;\&quot;C:\\folder1\\folder3\&quot;&quot;)" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                              <test-case name="NUnit.Framework.Constraints.SamePathOrUnderTest_Windows.ProvidesProperFailureMessage(&quot;C:\\folder1\\.\\folder2\\..\\file.temp&quot;,&quot;\&quot;C:\\folder1\\.\\folder2\\..\\file.temp\&quot;&quot;)" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                            </results>
+                          </test-suite>
+                          <test-suite type="ParameterizedTest" name="SucceedsWithGoodValues" executed="True" result="Success" success="True" time="0.019" asserts="0">
+                            <results>
+                              <test-case name="NUnit.Framework.Constraints.SamePathOrUnderTest_Windows.SucceedsWithGoodValues(&quot;C:\\folder1\\folder2&quot;)" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                              <test-case name="NUnit.Framework.Constraints.SamePathOrUnderTest_Windows.SucceedsWithGoodValues(&quot;C:\\Folder1\\Folder2&quot;)" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                              <test-case name="NUnit.Framework.Constraints.SamePathOrUnderTest_Windows.SucceedsWithGoodValues(&quot;C:\\folder1\\.\\folder2&quot;)" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                              <test-case name="NUnit.Framework.Constraints.SamePathOrUnderTest_Windows.SucceedsWithGoodValues(&quot;C:\\folder1\\junk\\..\\folder2&quot;)" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                              <test-case name="NUnit.Framework.Constraints.SamePathOrUnderTest_Windows.SucceedsWithGoodValues(&quot;C:\\FOLDER1\\.\\junk\\..\\Folder2&quot;)" executed="True" result="Success" success="True" time="0.001" asserts="1" />
+                              <test-case name="NUnit.Framework.Constraints.SamePathOrUnderTest_Windows.SucceedsWithGoodValues(&quot;C:/folder1/folder2&quot;)" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                              <test-case name="NUnit.Framework.Constraints.SamePathOrUnderTest_Windows.SucceedsWithGoodValues(&quot;C:\\folder1\\folder2\\folder3&quot;)" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                              <test-case name="NUnit.Framework.Constraints.SamePathOrUnderTest_Windows.SucceedsWithGoodValues(&quot;C:\\folder1\\.\\folder2\\folder3&quot;)" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                              <test-case name="NUnit.Framework.Constraints.SamePathOrUnderTest_Windows.SucceedsWithGoodValues(&quot;C:\\folder1\\junk\\..\\folder2\\folder3&quot;)" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                              <test-case name="NUnit.Framework.Constraints.SamePathOrUnderTest_Windows.SucceedsWithGoodValues(&quot;C:\\FOLDER1\\.\\junk\\..\\Folder2\\temp\\..\\Folder3&quot;)" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                              <test-case name="NUnit.Framework.Constraints.SamePathOrUnderTest_Windows.SucceedsWithGoodValues(&quot;C:/folder1/folder2/folder3&quot;)" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                            </results>
+                          </test-suite>
+                        </results>
+                      </test-suite>
+                      <test-suite type="TestFixture" name="SamePathTest_Linux" executed="True" result="Success" success="True" time="0.034" asserts="0">
+                        <results>
+                          <test-case name="NUnit.Framework.Constraints.SamePathTest_Linux.ConstraintTestBaseNoData.ProvidesProperDescription" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Framework.Constraints.SamePathTest_Linux.ConstraintTestBaseNoData.ProvidesProperStringRepresentation" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                          <test-suite type="ParameterizedTest" name="FailsWithBadValues" executed="True" result="Success" success="True" time="0.009" asserts="0">
+                            <results>
+                              <test-case name="NUnit.Framework.Constraints.SamePathTest_Linux.FailsWithBadValues(123)" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                              <test-case name="NUnit.Framework.Constraints.SamePathTest_Linux.FailsWithBadValues(&quot;/folder2/file.tmp&quot;)" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                              <test-case name="NUnit.Framework.Constraints.SamePathTest_Linux.FailsWithBadValues(&quot;/folder1/./folder2/../file.temp&quot;)" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                              <test-case name="NUnit.Framework.Constraints.SamePathTest_Linux.FailsWithBadValues(&quot;/Folder1/File.TMP&quot;)" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                              <test-case name="NUnit.Framework.Constraints.SamePathTest_Linux.FailsWithBadValues(&quot;/FOLDER1/./folder2/../File.TMP&quot;)" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                            </results>
+                          </test-suite>
+                          <test-suite type="ParameterizedTest" name="ProvidesProperFailureMessage" executed="True" result="Success" success="True" time="0.008" asserts="0">
+                            <results>
+                              <test-case name="NUnit.Framework.Constraints.SamePathTest_Linux.ProvidesProperFailureMessage(123,&quot;123&quot;)" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                              <test-case name="NUnit.Framework.Constraints.SamePathTest_Linux.ProvidesProperFailureMessage(&quot;/folder2/file.tmp&quot;,&quot;\&quot;/folder2/file.tmp\&quot;&quot;)" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                              <test-case name="NUnit.Framework.Constraints.SamePathTest_Linux.ProvidesProperFailureMessage(&quot;/folder1/./folder2/../file.temp&quot;,&quot;\&quot;/folder1/./folder2/../file.temp\&quot;&quot;)" executed="True" result="Success" success="True" time="0.001" asserts="1" />
+                              <test-case name="NUnit.Framework.Constraints.SamePathTest_Linux.ProvidesProperFailureMessage(&quot;/Folder1/File.TMP&quot;,&quot;\&quot;/Folder1/File.TMP\&quot;&quot;)" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                              <test-case name="NUnit.Framework.Constraints.SamePathTest_Linux.ProvidesProperFailureMessage(&quot;/FOLDER1/./folder2/../File.TMP&quot;,&quot;\&quot;/FOLDER1/./folder2/../File.TMP\&quot;&quot;)" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                            </results>
+                          </test-suite>
+                          <test-case name="NUnit.Framework.Constraints.SamePathTest_Linux.RootPathEquality" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                          <test-suite type="ParameterizedTest" name="SucceedsWithGoodValues" executed="True" result="Success" success="True" time="0.008" asserts="0">
+                            <results>
+                              <test-case name="NUnit.Framework.Constraints.SamePathTest_Linux.SucceedsWithGoodValues(&quot;/folder1/file.tmp&quot;)" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                              <test-case name="NUnit.Framework.Constraints.SamePathTest_Linux.SucceedsWithGoodValues(&quot;/folder1/./file.tmp&quot;)" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                              <test-case name="NUnit.Framework.Constraints.SamePathTest_Linux.SucceedsWithGoodValues(&quot;/folder1/folder2/../file.tmp&quot;)" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                              <test-case name="NUnit.Framework.Constraints.SamePathTest_Linux.SucceedsWithGoodValues(&quot;/folder1/./folder2/../file.tmp&quot;)" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                              <test-case name="NUnit.Framework.Constraints.SamePathTest_Linux.SucceedsWithGoodValues(&quot;\\folder1\\file.tmp&quot;)" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                            </results>
+                          </test-suite>
+                        </results>
+                      </test-suite>
+                      <test-suite type="TestFixture" name="SamePathTest_Windows" executed="True" result="Success" success="True" time="0.030" asserts="0">
+                        <results>
+                          <test-case name="NUnit.Framework.Constraints.SamePathTest_Windows.ConstraintTestBaseNoData.ProvidesProperDescription" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Framework.Constraints.SamePathTest_Windows.ConstraintTestBaseNoData.ProvidesProperStringRepresentation" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                          <test-suite type="ParameterizedTest" name="FailsWithBadValues" executed="True" result="Success" success="True" time="0.004" asserts="0">
+                            <results>
+                              <test-case name="NUnit.Framework.Constraints.SamePathTest_Windows.FailsWithBadValues(123)" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                              <test-case name="NUnit.Framework.Constraints.SamePathTest_Windows.FailsWithBadValues(&quot;C:\\folder2\\file.tmp&quot;)" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                              <test-case name="NUnit.Framework.Constraints.SamePathTest_Windows.FailsWithBadValues(&quot;C:\\folder1\\.\\folder2\\..\\file.temp&quot;)" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                            </results>
+                          </test-suite>
+                          <test-suite type="ParameterizedTest" name="ProvidesProperFailureMessage" executed="True" result="Success" success="True" time="0.005" asserts="0">
+                            <results>
+                              <test-case name="NUnit.Framework.Constraints.SamePathTest_Windows.ProvidesProperFailureMessage(123,&quot;123&quot;)" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                              <test-case name="NUnit.Framework.Constraints.SamePathTest_Windows.ProvidesProperFailureMessage(&quot;C:\\folder2\\file.tmp&quot;,&quot;\&quot;C:\\folder2\\file.tmp\&quot;&quot;)" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                              <test-case name="NUnit.Framework.Constraints.SamePathTest_Windows.ProvidesProperFailureMessage(&quot;C:\\folder1\\.\\folder2\\..\\file.temp&quot;,&quot;\&quot;C:\\folder1\\.\\folder2\\..\\file.temp\&quot;&quot;)" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                            </results>
+                          </test-suite>
+                          <test-case name="NUnit.Framework.Constraints.SamePathTest_Windows.RootPathEquality" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                          <test-suite type="ParameterizedTest" name="SucceedsWithGoodValues" executed="True" result="Success" success="True" time="0.010" asserts="0">
+                            <results>
+                              <test-case name="NUnit.Framework.Constraints.SamePathTest_Windows.SucceedsWithGoodValues(&quot;C:\\folder1\\file.tmp&quot;)" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                              <test-case name="NUnit.Framework.Constraints.SamePathTest_Windows.SucceedsWithGoodValues(&quot;C:\\Folder1\\File.TMP&quot;)" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                              <test-case name="NUnit.Framework.Constraints.SamePathTest_Windows.SucceedsWithGoodValues(&quot;C:\\folder1\\.\\file.tmp&quot;)" executed="True" result="Success" success="True" time="0.001" asserts="1" />
+                              <test-case name="NUnit.Framework.Constraints.SamePathTest_Windows.SucceedsWithGoodValues(&quot;C:\\folder1\\folder2\\..\\file.tmp&quot;)" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                              <test-case name="NUnit.Framework.Constraints.SamePathTest_Windows.SucceedsWithGoodValues(&quot;C:\\FOLDER1\\.\\folder2\\..\\File.TMP&quot;)" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                              <test-case name="NUnit.Framework.Constraints.SamePathTest_Windows.SucceedsWithGoodValues(&quot;C:/folder1/file.tmp&quot;)" executed="True" result="Success" success="True" time="0.001" asserts="1" />
+                            </results>
+                          </test-suite>
+                        </results>
+                      </test-suite>
+                      <test-suite type="TestFixture" name="StartsWithTest" executed="True" result="Success" success="True" time="0.028" asserts="0">
+                        <results>
+                          <test-case name="NUnit.Framework.Constraints.StartsWithTest.ConstraintTestBaseNoData.ProvidesProperDescription" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Framework.Constraints.StartsWithTest.ConstraintTestBaseNoData.ProvidesProperStringRepresentation" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                          <test-suite type="ParameterizedTest" name="FailsWithBadValues" executed="True" result="Success" success="True" time="0.009" asserts="0">
+                            <results>
+                              <test-case name="NUnit.Framework.Constraints.StartsWithTest.FailsWithBadValues(&quot;goodbye&quot;)" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                              <test-case name="NUnit.Framework.Constraints.StartsWithTest.FailsWithBadValues(&quot;HELLO THERE&quot;)" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                              <test-case name="NUnit.Framework.Constraints.StartsWithTest.FailsWithBadValues(&quot;I said hello&quot;)" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                              <test-case name="NUnit.Framework.Constraints.StartsWithTest.FailsWithBadValues(&quot;say hello to fred&quot;)" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                              <test-case name="NUnit.Framework.Constraints.StartsWithTest.FailsWithBadValues(&quot;&quot;)" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                              <test-case name="NUnit.Framework.Constraints.StartsWithTest.FailsWithBadValues(null)" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                            </results>
+                          </test-suite>
+                          <test-suite type="ParameterizedTest" name="ProvidesProperFailureMessage" executed="True" result="Success" success="True" time="0.009" asserts="0">
+                            <results>
+                              <test-case name="NUnit.Framework.Constraints.StartsWithTest.ProvidesProperFailureMessage(&quot;goodbye&quot;,&quot;\&quot;goodbye\&quot;&quot;)" executed="True" result="Success" success="True" time="0.001" asserts="1" />
+                              <test-case name="NUnit.Framework.Constraints.StartsWithTest.ProvidesProperFailureMessage(&quot;HELLO THERE&quot;,&quot;\&quot;HELLO THERE\&quot;&quot;)" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                              <test-case name="NUnit.Framework.Constraints.StartsWithTest.ProvidesProperFailureMessage(&quot;I said hello&quot;,&quot;\&quot;I said hello\&quot;&quot;)" executed="True" result="Success" success="True" time="0.001" asserts="1" />
+                              <test-case name="NUnit.Framework.Constraints.StartsWithTest.ProvidesProperFailureMessage(&quot;say hello to fred&quot;,&quot;\&quot;say hello to fred\&quot;&quot;)" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                              <test-case name="NUnit.Framework.Constraints.StartsWithTest.ProvidesProperFailureMessage(&quot;&quot;,&quot;&lt;string.Empty&gt;&quot;)" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                              <test-case name="NUnit.Framework.Constraints.StartsWithTest.ProvidesProperFailureMessage(null,&quot;null&quot;)" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                            </results>
+                          </test-suite>
+                          <test-suite type="ParameterizedTest" name="SucceedsWithGoodValues" executed="True" result="Success" success="True" time="0.002" asserts="0">
+                            <results>
+                              <test-case name="NUnit.Framework.Constraints.StartsWithTest.SucceedsWithGoodValues(&quot;hello&quot;)" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                              <test-case name="NUnit.Framework.Constraints.StartsWithTest.SucceedsWithGoodValues(&quot;hello there&quot;)" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                            </results>
+                          </test-suite>
+                        </results>
+                      </test-suite>
+                      <test-suite type="TestFixture" name="StartsWithTestIgnoringCase" executed="True" result="Success" success="True" time="0.027" asserts="0">
+                        <results>
+                          <test-case name="NUnit.Framework.Constraints.StartsWithTestIgnoringCase.ConstraintTestBaseNoData.ProvidesProperDescription" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Framework.Constraints.StartsWithTestIgnoringCase.ConstraintTestBaseNoData.ProvidesProperStringRepresentation" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                          <test-suite type="ParameterizedTest" name="FailsWithBadValues" executed="True" result="Success" success="True" time="0.008" asserts="0">
+                            <results>
+                              <test-case name="NUnit.Framework.Constraints.StartsWithTestIgnoringCase.FailsWithBadValues(&quot;goodbye&quot;)" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                              <test-case name="NUnit.Framework.Constraints.StartsWithTestIgnoringCase.FailsWithBadValues(&quot;What the hell?&quot;)" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                              <test-case name="NUnit.Framework.Constraints.StartsWithTestIgnoringCase.FailsWithBadValues(&quot;I said hello&quot;)" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                              <test-case name="NUnit.Framework.Constraints.StartsWithTestIgnoringCase.FailsWithBadValues(&quot;say Hello to fred&quot;)" executed="True" result="Success" success="True" time="0.001" asserts="1" />
+                              <test-case name="NUnit.Framework.Constraints.StartsWithTestIgnoringCase.FailsWithBadValues(&quot;&quot;)" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                              <test-case name="NUnit.Framework.Constraints.StartsWithTestIgnoringCase.FailsWithBadValues(null)" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                            </results>
+                          </test-suite>
+                          <test-suite type="ParameterizedTest" name="ProvidesProperFailureMessage" executed="True" result="Success" success="True" time="0.009" asserts="0">
+                            <results>
+                              <test-case name="NUnit.Framework.Constraints.StartsWithTestIgnoringCase.ProvidesProperFailureMessage(&quot;goodbye&quot;,&quot;\&quot;goodbye\&quot;&quot;)" executed="True" result="Success" success="True" time="0.001" asserts="1" />
+                              <test-case name="NUnit.Framework.Constraints.StartsWithTestIgnoringCase.ProvidesProperFailureMessage(&quot;What the hell?&quot;,&quot;\&quot;What the hell?\&quot;&quot;)" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                              <test-case name="NUnit.Framework.Constraints.StartsWithTestIgnoringCase.ProvidesProperFailureMessage(&quot;I said hello&quot;,&quot;\&quot;I said hello\&quot;&quot;)" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                              <test-case name="NUnit.Framework.Constraints.StartsWithTestIgnoringCase.ProvidesProperFailureMessage(&quot;say Hello to fred&quot;,&quot;\&quot;say Hello to fred\&quot;&quot;)" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                              <test-case name="NUnit.Framework.Constraints.StartsWithTestIgnoringCase.ProvidesProperFailureMessage(&quot;&quot;,&quot;&lt;string.Empty&gt;&quot;)" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                              <test-case name="NUnit.Framework.Constraints.StartsWithTestIgnoringCase.ProvidesProperFailureMessage(null,&quot;null&quot;)" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                            </results>
+                          </test-suite>
+                          <test-suite type="ParameterizedTest" name="SucceedsWithGoodValues" executed="True" result="Success" success="True" time="0.003" asserts="0">
+                            <results>
+                              <test-case name="NUnit.Framework.Constraints.StartsWithTestIgnoringCase.SucceedsWithGoodValues(&quot;Hello&quot;)" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                              <test-case name="NUnit.Framework.Constraints.StartsWithTestIgnoringCase.SucceedsWithGoodValues(&quot;HELLO there&quot;)" executed="True" result="Success" success="True" time="0.001" asserts="1" />
+                            </results>
+                          </test-suite>
+                        </results>
+                      </test-suite>
+                      <test-suite type="TestFixture" name="SubPathTest_Linux" executed="True" result="Success" success="True" time="0.048" asserts="0">
+                        <results>
+                          <test-case name="NUnit.Framework.Constraints.SubPathTest_Linux.ConstraintTestBaseNoData.ProvidesProperDescription" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Framework.Constraints.SubPathTest_Linux.ConstraintTestBaseNoData.ProvidesProperStringRepresentation" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                          <test-suite type="ParameterizedTest" name="FailsWithBadValues" executed="True" result="Success" success="True" time="0.016" asserts="0">
+                            <results>
+                              <test-case name="NUnit.Framework.Constraints.SubPathTest_Linux.FailsWithBadValues(123)" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                              <test-case name="NUnit.Framework.Constraints.SubPathTest_Linux.FailsWithBadValues(&quot;/Folder1/Folder2&quot;)" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                              <test-case name="NUnit.Framework.Constraints.SubPathTest_Linux.FailsWithBadValues(&quot;/FOLDER1/./junk/../Folder2&quot;)" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                              <test-case name="NUnit.Framework.Constraints.SubPathTest_Linux.FailsWithBadValues(&quot;/FOLDER1/./junk/../Folder2/temp/../Folder3&quot;)" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                              <test-case name="NUnit.Framework.Constraints.SubPathTest_Linux.FailsWithBadValues(&quot;/folder1/folder3&quot;)" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                              <test-case name="NUnit.Framework.Constraints.SubPathTest_Linux.FailsWithBadValues(&quot;/folder1/./folder2/../folder3&quot;)" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                              <test-case name="NUnit.Framework.Constraints.SubPathTest_Linux.FailsWithBadValues(&quot;/folder1&quot;)" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                              <test-case name="NUnit.Framework.Constraints.SubPathTest_Linux.FailsWithBadValues(&quot;/folder1/folder2&quot;)" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                              <test-case name="NUnit.Framework.Constraints.SubPathTest_Linux.FailsWithBadValues(&quot;/folder1/./folder2&quot;)" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                              <test-case name="NUnit.Framework.Constraints.SubPathTest_Linux.FailsWithBadValues(&quot;/folder1/junk/../folder2&quot;)" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                              <test-case name="NUnit.Framework.Constraints.SubPathTest_Linux.FailsWithBadValues(&quot;\\folder1\\folder2&quot;)" executed="True" result="Success" success="True" time="0.001" asserts="1" />
+                            </results>
+                          </test-suite>
+                          <test-suite type="ParameterizedTest" name="ProvidesProperFailureMessage" executed="True" result="Success" success="True" time="0.017" asserts="0">
+                            <results>
+                              <test-case name="NUnit.Framework.Constraints.SubPathTest_Linux.ProvidesProperFailureMessage(123,&quot;123&quot;)" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                              <test-case name="NUnit.Framework.Constraints.SubPathTest_Linux.ProvidesProperFailureMessage(&quot;/Folder1/Folder2&quot;,&quot;\&quot;/Folder1/Folder2\&quot;&quot;)" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                              <test-case name="NUnit.Framework.Constraints.SubPathTest_Linux.ProvidesProperFailureMessage(&quot;/FOLDER1/./junk/../Folder2&quot;,&quot;\&quot;/FOLDER1/./junk/../Folder2\&quot;&quot;)" executed="True" result="Success" success="True" time="0.002" asserts="1" />
+                              <test-case name="NUnit.Framework.Constraints.SubPathTest_Linux.ProvidesProperFailureMessage(&quot;/FOLDER1/./junk/../Folder2/temp/../Folder3&quot;,&quot;\&quot;/FOLDER1/./junk/../Folder2/temp/../Folder3\&quot;&quot;)" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                              <test-case name="NUnit.Framework.Constraints.SubPathTest_Linux.ProvidesProperFailureMessage(&quot;/folder1/folder3&quot;,&quot;\&quot;/folder1/folder3\&quot;&quot;)" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                              <test-case name="NUnit.Framework.Constraints.SubPathTest_Linux.ProvidesProperFailureMessage(&quot;/folder1/./folder2/../folder3&quot;,&quot;\&quot;/folder1/./folder2/../folder3\&quot;&quot;)" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                              <test-case name="NUnit.Framework.Constraints.SubPathTest_Linux.ProvidesProperFailureMessage(&quot;/folder1&quot;,&quot;\&quot;/folder1\&quot;&quot;)" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                              <test-case name="NUnit.Framework.Constraints.SubPathTest_Linux.ProvidesProperFailureMessage(&quot;/folder1/folder2&quot;,&quot;\&quot;/folder1/folder2\&quot;&quot;)" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                              <test-case name="NUnit.Framework.Constraints.SubPathTest_Linux.ProvidesProperFailureMessage(&quot;/folder1/./folder2&quot;,&quot;\&quot;/folder1/./folder2\&quot;&quot;)" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                              <test-case name="NUnit.Framework.Constraints.SubPathTest_Linux.ProvidesProperFailureMessage(&quot;/folder1/junk/../folder2&quot;,&quot;\&quot;/folder1/junk/../folder2\&quot;&quot;)" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                              <test-case name="NUnit.Framework.Constraints.SubPathTest_Linux.ProvidesProperFailureMessage(&quot;\\folder1\\folder2&quot;,&quot;\&quot;\\folder1\\folder2\&quot;&quot;)" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                            </results>
+                          </test-suite>
+                          <test-case name="NUnit.Framework.Constraints.SubPathTest_Linux.SubPathOfRoot" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                          <test-suite type="ParameterizedTest" name="SucceedsWithGoodValues" executed="True" result="Success" success="True" time="0.006" asserts="0">
+                            <results>
+                              <test-case name="NUnit.Framework.Constraints.SubPathTest_Linux.SucceedsWithGoodValues(&quot;/folder1/folder2/folder3&quot;)" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                              <test-case name="NUnit.Framework.Constraints.SubPathTest_Linux.SucceedsWithGoodValues(&quot;/folder1/./folder2/folder3&quot;)" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                              <test-case name="NUnit.Framework.Constraints.SubPathTest_Linux.SucceedsWithGoodValues(&quot;/folder1/junk/../folder2/folder3&quot;)" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                              <test-case name="NUnit.Framework.Constraints.SubPathTest_Linux.SucceedsWithGoodValues(&quot;\\folder1\\folder2\\folder3&quot;)" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                            </results>
+                          </test-suite>
+                        </results>
+                      </test-suite>
+                      <test-suite type="TestFixture" name="SubPathTest_Windows" executed="True" result="Success" success="True" time="0.044" asserts="0">
+                        <results>
+                          <test-case name="NUnit.Framework.Constraints.SubPathTest_Windows.ConstraintTestBaseNoData.ProvidesProperDescription" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Framework.Constraints.SubPathTest_Windows.ConstraintTestBaseNoData.ProvidesProperStringRepresentation" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                          <test-suite type="ParameterizedTest" name="FailsWithBadValues" executed="True" result="Success" success="True" time="0.015" asserts="0">
+                            <results>
+                              <test-case name="NUnit.Framework.Constraints.SubPathTest_Windows.FailsWithBadValues(123)" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                              <test-case name="NUnit.Framework.Constraints.SubPathTest_Windows.FailsWithBadValues(&quot;C:\\folder1\\folder3&quot;)" executed="True" result="Success" success="True" time="0.001" asserts="1" />
+                              <test-case name="NUnit.Framework.Constraints.SubPathTest_Windows.FailsWithBadValues(&quot;C:\\folder1\\.\\folder2\\..\\file.temp&quot;)" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                              <test-case name="NUnit.Framework.Constraints.SubPathTest_Windows.FailsWithBadValues(&quot;C:\\folder1\\folder2&quot;)" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                              <test-case name="NUnit.Framework.Constraints.SubPathTest_Windows.FailsWithBadValues(&quot;C:\\Folder1\\Folder2&quot;)" executed="True" result="Success" success="True" time="0.001" asserts="1" />
+                              <test-case name="NUnit.Framework.Constraints.SubPathTest_Windows.FailsWithBadValues(&quot;C:\\folder1\\.\\folder2&quot;)" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                              <test-case name="NUnit.Framework.Constraints.SubPathTest_Windows.FailsWithBadValues(&quot;C:\\folder1\\junk\\..\\folder2&quot;)" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                              <test-case name="NUnit.Framework.Constraints.SubPathTest_Windows.FailsWithBadValues(&quot;C:\\FOLDER1\\.\\junk\\..\\Folder2&quot;)" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                              <test-case name="NUnit.Framework.Constraints.SubPathTest_Windows.FailsWithBadValues(&quot;C:/folder1/folder2&quot;)" executed="True" result="Success" success="True" time="0.001" asserts="1" />
+                            </results>
+                          </test-suite>
+                          <test-suite type="ParameterizedTest" name="ProvidesProperFailureMessage" executed="True" result="Success" success="True" time="0.013" asserts="0">
+                            <results>
+                              <test-case name="NUnit.Framework.Constraints.SubPathTest_Windows.ProvidesProperFailureMessage(123,&quot;123&quot;)" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                              <test-case name="NUnit.Framework.Constraints.SubPathTest_Windows.ProvidesProperFailureMessage(&quot;C:\\folder1\\folder3&quot;,&quot;\&quot;C:\\folder1\\folder3\&quot;&quot;)" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                              <test-case name="NUnit.Framework.Constraints.SubPathTest_Windows.ProvidesProperFailureMessage(&quot;C:\\folder1\\.\\folder2\\..\\file.temp&quot;,&quot;\&quot;C:\\folder1\\.\\folder2\\..\\file.temp\&quot;&quot;)" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                              <test-case name="NUnit.Framework.Constraints.SubPathTest_Windows.ProvidesProperFailureMessage(&quot;C:\\folder1\\folder2&quot;,&quot;\&quot;C:\\folder1\\folder2\&quot;&quot;)" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                              <test-case name="NUnit.Framework.Constraints.SubPathTest_Windows.ProvidesProperFailureMessage(&quot;C:\\Folder1\\Folder2&quot;,&quot;\&quot;C:\\Folder1\\Folder2\&quot;&quot;)" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                              <test-case name="NUnit.Framework.Constraints.SubPathTest_Windows.ProvidesProperFailureMessage(&quot;C:\\folder1\\.\\folder2&quot;,&quot;\&quot;C:\\folder1\\.\\folder2\&quot;&quot;)" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                              <test-case name="NUnit.Framework.Constraints.SubPathTest_Windows.ProvidesProperFailureMessage(&quot;C:\\folder1\\junk\\..\\folder2&quot;,&quot;\&quot;C:\\folder1\\junk\\..\\folder2\&quot;&quot;)" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                              <test-case name="NUnit.Framework.Constraints.SubPathTest_Windows.ProvidesProperFailureMessage(&quot;C:\\FOLDER1\\.\\junk\\..\\Folder2&quot;,&quot;\&quot;C:\\FOLDER1\\.\\junk\\..\\Folder2\&quot;&quot;)" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                              <test-case name="NUnit.Framework.Constraints.SubPathTest_Windows.ProvidesProperFailureMessage(&quot;C:/folder1/folder2&quot;,&quot;\&quot;C:/folder1/folder2\&quot;&quot;)" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                            </results>
+                          </test-suite>
+                          <test-case name="NUnit.Framework.Constraints.SubPathTest_Windows.SubPathOfRoot" executed="True" result="Success" success="True" time="0.001" asserts="1" />
+                          <test-suite type="ParameterizedTest" name="SucceedsWithGoodValues" executed="True" result="Success" success="True" time="0.007" asserts="0">
+                            <results>
+                              <test-case name="NUnit.Framework.Constraints.SubPathTest_Windows.SucceedsWithGoodValues(&quot;C:\\folder1\\folder2\\folder3&quot;)" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                              <test-case name="NUnit.Framework.Constraints.SubPathTest_Windows.SucceedsWithGoodValues(&quot;C:\\folder1\\.\\folder2\\folder3&quot;)" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                              <test-case name="NUnit.Framework.Constraints.SubPathTest_Windows.SucceedsWithGoodValues(&quot;C:\\folder1\\junk\\..\\folder2\\folder3&quot;)" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                              <test-case name="NUnit.Framework.Constraints.SubPathTest_Windows.SucceedsWithGoodValues(&quot;C:\\FOLDER1\\.\\junk\\..\\Folder2\\temp\\..\\Folder3&quot;)" executed="True" result="Success" success="True" time="0.001" asserts="1" />
+                              <test-case name="NUnit.Framework.Constraints.SubPathTest_Windows.SucceedsWithGoodValues(&quot;C:/folder1/folder2/folder3&quot;)" executed="True" result="Success" success="True" time="0.001" asserts="1" />
+                            </results>
+                          </test-suite>
+                        </results>
+                      </test-suite>
+                      <test-suite type="TestFixture" name="SubstringTest" executed="True" result="Success" success="True" time="0.026" asserts="0">
+                        <results>
+                          <test-case name="NUnit.Framework.Constraints.SubstringTest.ConstraintTestBaseNoData.ProvidesProperDescription" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Framework.Constraints.SubstringTest.ConstraintTestBaseNoData.ProvidesProperStringRepresentation" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                          <test-suite type="ParameterizedTest" name="FailsWithBadValues" executed="True" result="Success" success="True" time="0.007" asserts="0">
+                            <results>
+                              <test-case name="NUnit.Framework.Constraints.SubstringTest.FailsWithBadValues(&quot;goodbye&quot;)" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                              <test-case name="NUnit.Framework.Constraints.SubstringTest.FailsWithBadValues(&quot;HELLO&quot;)" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                              <test-case name="NUnit.Framework.Constraints.SubstringTest.FailsWithBadValues(&quot;What the hell?&quot;)" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                              <test-case name="NUnit.Framework.Constraints.SubstringTest.FailsWithBadValues(&quot;&quot;)" executed="True" result="Success" success="True" time="0.001" asserts="1" />
+                              <test-case name="NUnit.Framework.Constraints.SubstringTest.FailsWithBadValues(null)" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                            </results>
+                          </test-suite>
+                          <test-suite type="ParameterizedTest" name="ProvidesProperFailureMessage" executed="True" result="Success" success="True" time="0.007" asserts="0">
+                            <results>
+                              <test-case name="NUnit.Framework.Constraints.SubstringTest.ProvidesProperFailureMessage(&quot;goodbye&quot;,&quot;\&quot;goodbye\&quot;&quot;)" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                              <test-case name="NUnit.Framework.Constraints.SubstringTest.ProvidesProperFailureMessage(&quot;HELLO&quot;,&quot;\&quot;HELLO\&quot;&quot;)" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                              <test-case name="NUnit.Framework.Constraints.SubstringTest.ProvidesProperFailureMessage(&quot;What the hell?&quot;,&quot;\&quot;What the hell?\&quot;&quot;)" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                              <test-case name="NUnit.Framework.Constraints.SubstringTest.ProvidesProperFailureMessage(&quot;&quot;,&quot;&lt;string.Empty&gt;&quot;)" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                              <test-case name="NUnit.Framework.Constraints.SubstringTest.ProvidesProperFailureMessage(null,&quot;null&quot;)" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                            </results>
+                          </test-suite>
+                          <test-suite type="ParameterizedTest" name="SucceedsWithGoodValues" executed="True" result="Success" success="True" time="0.006" asserts="0">
+                            <results>
+                              <test-case name="NUnit.Framework.Constraints.SubstringTest.SucceedsWithGoodValues(&quot;hello&quot;)" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                              <test-case name="NUnit.Framework.Constraints.SubstringTest.SucceedsWithGoodValues(&quot;hello there&quot;)" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                              <test-case name="NUnit.Framework.Constraints.SubstringTest.SucceedsWithGoodValues(&quot;I said hello&quot;)" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                              <test-case name="NUnit.Framework.Constraints.SubstringTest.SucceedsWithGoodValues(&quot;say hello to fred&quot;)" executed="True" result="Success" success="True" time="0.001" asserts="1" />
+                            </results>
+                          </test-suite>
+                        </results>
+                      </test-suite>
+                      <test-suite type="TestFixture" name="SubstringTestIgnoringCase" executed="True" result="Success" success="True" time="0.022" asserts="0">
+                        <results>
+                          <test-case name="NUnit.Framework.Constraints.SubstringTestIgnoringCase.ConstraintTestBaseNoData.ProvidesProperDescription" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Framework.Constraints.SubstringTestIgnoringCase.ConstraintTestBaseNoData.ProvidesProperStringRepresentation" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                          <test-suite type="ParameterizedTest" name="FailsWithBadValues" executed="True" result="Success" success="True" time="0.005" asserts="0">
+                            <results>
+                              <test-case name="NUnit.Framework.Constraints.SubstringTestIgnoringCase.FailsWithBadValues(&quot;goodbye&quot;)" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                              <test-case name="NUnit.Framework.Constraints.SubstringTestIgnoringCase.FailsWithBadValues(&quot;What the hell?&quot;)" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                              <test-case name="NUnit.Framework.Constraints.SubstringTestIgnoringCase.FailsWithBadValues(&quot;&quot;)" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                              <test-case name="NUnit.Framework.Constraints.SubstringTestIgnoringCase.FailsWithBadValues(null)" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                            </results>
+                          </test-suite>
+                          <test-suite type="ParameterizedTest" name="ProvidesProperFailureMessage" executed="True" result="Success" success="True" time="0.005" asserts="0">
+                            <results>
+                              <test-case name="NUnit.Framework.Constraints.SubstringTestIgnoringCase.ProvidesProperFailureMessage(&quot;goodbye&quot;,&quot;\&quot;goodbye\&quot;&quot;)" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                              <test-case name="NUnit.Framework.Constraints.SubstringTestIgnoringCase.ProvidesProperFailureMessage(&quot;What the hell?&quot;,&quot;\&quot;What the hell?\&quot;&quot;)" executed="True" result="Success" success="True" time="0.001" asserts="1" />
+                              <test-case name="NUnit.Framework.Constraints.SubstringTestIgnoringCase.ProvidesProperFailureMessage(&quot;&quot;,&quot;&lt;string.Empty&gt;&quot;)" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                              <test-case name="NUnit.Framework.Constraints.SubstringTestIgnoringCase.ProvidesProperFailureMessage(null,&quot;null&quot;)" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                            </results>
+                          </test-suite>
+                          <test-suite type="ParameterizedTest" name="SucceedsWithGoodValues" executed="True" result="Success" success="True" time="0.005" asserts="0">
+                            <results>
+                              <test-case name="NUnit.Framework.Constraints.SubstringTestIgnoringCase.SucceedsWithGoodValues(&quot;Hello&quot;)" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                              <test-case name="NUnit.Framework.Constraints.SubstringTestIgnoringCase.SucceedsWithGoodValues(&quot;HellO there&quot;)" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                              <test-case name="NUnit.Framework.Constraints.SubstringTestIgnoringCase.SucceedsWithGoodValues(&quot;I said HELLO&quot;)" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                              <test-case name="NUnit.Framework.Constraints.SubstringTestIgnoringCase.SucceedsWithGoodValues(&quot;say hello to fred&quot;)" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                            </results>
+                          </test-suite>
+                        </results>
+                      </test-suite>
+                      <test-suite type="TestFixture" name="ThrowsConstraintTest_ExactType" executed="True" result="Success" success="True" time="0.016" asserts="0">
+                        <results>
+                          <test-case name="NUnit.Framework.Constraints.ThrowsConstraintTest_ExactType.ConstraintTestBaseNoData.ProvidesProperDescription" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Framework.Constraints.ThrowsConstraintTest_ExactType.ConstraintTestBaseNoData.ProvidesProperStringRepresentation" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                          <test-suite type="ParameterizedTest" name="FailsWithBadValues" executed="True" result="Success" success="True" time="0.003" asserts="0">
+                            <results>
+                              <test-case name="NUnit.Framework.Constraints.ThrowsConstraintTest_ExactType.FailsWithBadValues(NUnit.Framework.TestDelegate)" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                              <test-case name="NUnit.Framework.Constraints.ThrowsConstraintTest_ExactType.FailsWithBadValues(NUnit.Framework.TestDelegate)" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                              <test-case name="NUnit.Framework.Constraints.ThrowsConstraintTest_ExactType.FailsWithBadValues(NUnit.Framework.TestDelegate)" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                            </results>
+                          </test-suite>
+                          <test-suite type="ParameterizedTest" name="ProvidesProperFailureMessage" executed="True" result="Success" success="True" time="0.005" asserts="0">
+                            <results>
+                              <test-case name="NUnit.Framework.Constraints.ThrowsConstraintTest_ExactType.ProvidesProperFailureMessage(NUnit.Framework.TestDelegate,&quot;&lt;System.ApplicationException&gt;&quot;)" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                              <test-case name="NUnit.Framework.Constraints.ThrowsConstraintTest_ExactType.ProvidesProperFailureMessage(NUnit.Framework.TestDelegate,&quot;no exception thrown&quot;)" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                              <test-case name="NUnit.Framework.Constraints.ThrowsConstraintTest_ExactType.ProvidesProperFailureMessage(NUnit.Framework.TestDelegate,&quot;&lt;System.Exception&gt;&quot;)" executed="True" result="Success" success="True" time="0.001" asserts="1" />
+                            </results>
+                          </test-suite>
+                          <test-suite type="ParameterizedTest" name="SucceedsWithGoodValues" executed="True" result="Success" success="True" time="0.000" asserts="0">
+                            <results>
+                              <test-case name="NUnit.Framework.Constraints.ThrowsConstraintTest_ExactType.SucceedsWithGoodValues(NUnit.Framework.TestDelegate)" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                            </results>
+                          </test-suite>
+                        </results>
+                      </test-suite>
+                      <test-suite type="TestFixture" name="ThrowsConstraintTest_InstanceOfType" executed="True" result="Success" success="True" time="0.016" asserts="0">
+                        <results>
+                          <test-case name="NUnit.Framework.Constraints.ThrowsConstraintTest_InstanceOfType.ConstraintTestBaseNoData.ProvidesProperDescription" executed="True" result="Success" success="True" time="0.001" asserts="1" />
+                          <test-case name="NUnit.Framework.Constraints.ThrowsConstraintTest_InstanceOfType.ConstraintTestBaseNoData.ProvidesProperStringRepresentation" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                          <test-suite type="ParameterizedTest" name="FailsWithBadValues" executed="True" result="Success" success="True" time="0.003" asserts="0">
+                            <results>
+                              <test-case name="NUnit.Framework.Constraints.ThrowsConstraintTest_InstanceOfType.FailsWithBadValues(NUnit.Framework.TestDelegate)" executed="True" result="Success" success="True" time="0.001" asserts="1" />
+                              <test-case name="NUnit.Framework.Constraints.ThrowsConstraintTest_InstanceOfType.FailsWithBadValues(NUnit.Framework.TestDelegate)" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                              <test-case name="NUnit.Framework.Constraints.ThrowsConstraintTest_InstanceOfType.FailsWithBadValues(NUnit.Framework.TestDelegate)" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                            </results>
+                          </test-suite>
+                          <test-suite type="ParameterizedTest" name="ProvidesProperFailureMessage" executed="True" result="Success" success="True" time="0.003" asserts="0">
+                            <results>
+                              <test-case name="NUnit.Framework.Constraints.ThrowsConstraintTest_InstanceOfType.ProvidesProperFailureMessage(NUnit.Framework.TestDelegate,&quot;&lt;System.ArgumentException&gt;&quot;)" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                              <test-case name="NUnit.Framework.Constraints.ThrowsConstraintTest_InstanceOfType.ProvidesProperFailureMessage(NUnit.Framework.TestDelegate,&quot;no exception thrown&quot;)" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                              <test-case name="NUnit.Framework.Constraints.ThrowsConstraintTest_InstanceOfType.ProvidesProperFailureMessage(NUnit.Framework.TestDelegate,&quot;&lt;System.Exception&gt;&quot;)" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                            </results>
+                          </test-suite>
+                          <test-suite type="ParameterizedTest" name="SucceedsWithGoodValues" executed="True" result="Success" success="True" time="0.002" asserts="0">
+                            <results>
+                              <test-case name="NUnit.Framework.Constraints.ThrowsConstraintTest_InstanceOfType.SucceedsWithGoodValues(NUnit.Framework.TestDelegate)" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                              <test-case name="NUnit.Framework.Constraints.ThrowsConstraintTest_InstanceOfType.SucceedsWithGoodValues(NUnit.Framework.TestDelegate)" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                            </results>
+                          </test-suite>
+                        </results>
+                      </test-suite>
+                      <test-suite type="TestFixture" name="ThrowsConstraintTest_WithConstraint" executed="True" result="Success" success="True" time="0.017" asserts="0">
+                        <results>
+                          <test-case name="NUnit.Framework.Constraints.ThrowsConstraintTest_WithConstraint.ConstraintTestBaseNoData.ProvidesProperDescription" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Framework.Constraints.ThrowsConstraintTest_WithConstraint.ConstraintTestBaseNoData.ProvidesProperStringRepresentation" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                          <test-suite type="ParameterizedTest" name="FailsWithBadValues" executed="True" result="Success" success="True" time="0.005" asserts="0">
+                            <results>
+                              <test-case name="NUnit.Framework.Constraints.ThrowsConstraintTest_WithConstraint.FailsWithBadValues(NUnit.Framework.TestDelegate)" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                              <test-case name="NUnit.Framework.Constraints.ThrowsConstraintTest_WithConstraint.FailsWithBadValues(NUnit.Framework.TestDelegate)" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                              <test-case name="NUnit.Framework.Constraints.ThrowsConstraintTest_WithConstraint.FailsWithBadValues(NUnit.Framework.TestDelegate)" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                            </results>
+                          </test-suite>
+                          <test-suite type="ParameterizedTest" name="ProvidesProperFailureMessage" executed="True" result="Success" success="True" time="0.004" asserts="0">
+                            <results>
+                              <test-case name="NUnit.Framework.Constraints.ThrowsConstraintTest_WithConstraint.ProvidesProperFailureMessage(NUnit.Framework.TestDelegate,&quot;&lt;System.ApplicationException&gt;&quot;)" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                              <test-case name="NUnit.Framework.Constraints.ThrowsConstraintTest_WithConstraint.ProvidesProperFailureMessage(NUnit.Framework.TestDelegate,&quot;no exception thrown&quot;)" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                              <test-case name="NUnit.Framework.Constraints.ThrowsConstraintTest_WithConstraint.ProvidesProperFailureMessage(NUnit.Framework.TestDelegate,&quot;&lt;System.Exception&gt;&quot;)" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                            </results>
+                          </test-suite>
+                          <test-suite type="ParameterizedTest" name="SucceedsWithGoodValues" executed="True" result="Success" success="True" time="0.000" asserts="0">
+                            <results>
+                              <test-case name="NUnit.Framework.Constraints.ThrowsConstraintTest_WithConstraint.SucceedsWithGoodValues(NUnit.Framework.TestDelegate)" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                            </results>
+                          </test-suite>
+                        </results>
+                      </test-suite>
+                      <test-suite type="TestFixture" name="ToStringTests" executed="True" result="Success" success="True" time="0.008" asserts="0">
+                        <results>
+                          <test-case name="NUnit.Framework.Constraints.ToStringTests.CanDisplayPrefixConstraints_Resolved" executed="True" result="Success" success="True" time="0.000" asserts="3" />
+                          <test-case name="NUnit.Framework.Constraints.ToStringTests.CanDisplaySimpleConstraints_Resolved" executed="True" result="Success" success="True" time="0.000" asserts="3" />
+                          <test-case name="NUnit.Framework.Constraints.ToStringTests.CanDisplaySimpleConstraints_Unresolved" executed="True" result="Success" success="True" time="0.000" asserts="3" />
+                          <test-case name="NUnit.Framework.Constraints.ToStringTests.DisplayBinaryConstraints_Resolved" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Framework.Constraints.ToStringTests.DisplayBinaryConstraints_UnResolved" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Framework.Constraints.ToStringTests.DisplayPrefixConstraints_Unresolved" executed="True" result="Success" success="True" time="0.000" asserts="4" />
+                        </results>
+                      </test-suite>
+                      <test-suite type="TestFixture" name="TrueConstraintTest" executed="True" result="Success" success="True" time="0.023" asserts="0">
+                        <results>
+                          <test-case name="NUnit.Framework.Constraints.TrueConstraintTest.ConstraintTestBaseNoData.ProvidesProperDescription" executed="True" result="Success" success="True" time="0.001" asserts="1" />
+                          <test-case name="NUnit.Framework.Constraints.TrueConstraintTest.ConstraintTestBaseNoData.ProvidesProperStringRepresentation" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                          <test-suite type="ParameterizedTest" name="FailsWithBadValues" executed="True" result="Success" success="True" time="0.005" asserts="0">
+                            <results>
+                              <test-case name="NUnit.Framework.Constraints.TrueConstraintTest.FailsWithBadValues(null)" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                              <test-case name="NUnit.Framework.Constraints.TrueConstraintTest.FailsWithBadValues(&quot;hello&quot;)" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                              <test-case name="NUnit.Framework.Constraints.TrueConstraintTest.FailsWithBadValues(False)" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                              <test-case name="NUnit.Framework.Constraints.TrueConstraintTest.FailsWithBadValues(False)" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                            </results>
+                          </test-suite>
+                          <test-suite type="ParameterizedTest" name="ProvidesProperFailureMessage" executed="True" result="Success" success="True" time="0.009" asserts="0">
+                            <results>
+                              <test-case name="NUnit.Framework.Constraints.TrueConstraintTest.ProvidesProperFailureMessage(null,&quot;null&quot;)" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                              <test-case name="NUnit.Framework.Constraints.TrueConstraintTest.ProvidesProperFailureMessage(&quot;hello&quot;,&quot;\&quot;hello\&quot;&quot;)" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                              <test-case name="NUnit.Framework.Constraints.TrueConstraintTest.ProvidesProperFailureMessage(False,&quot;False&quot;)" executed="True" result="Success" success="True" time="0.001" asserts="1" />
+                              <test-case name="NUnit.Framework.Constraints.TrueConstraintTest.ProvidesProperFailureMessage(False,&quot;False&quot;)" executed="True" result="Success" success="True" time="0.001" asserts="1" />
+                            </results>
+                          </test-suite>
+                          <test-suite type="ParameterizedTest" name="SucceedsWithGoodValues" executed="True" result="Success" success="True" time="0.002" asserts="0">
+                            <results>
+                              <test-case name="NUnit.Framework.Constraints.TrueConstraintTest.SucceedsWithGoodValues(True)" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                              <test-case name="NUnit.Framework.Constraints.TrueConstraintTest.SucceedsWithGoodValues(True)" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                            </results>
+                          </test-suite>
+                        </results>
+                      </test-suite>
+                      <test-suite type="TestFixture" name="XmlSerializableTest" executed="True" result="Success" success="True" time="0.692" asserts="0">
+                        <results>
+                          <test-case name="NUnit.Framework.Constraints.XmlSerializableTest.ConstraintTestBaseNoData.ProvidesProperDescription" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Framework.Constraints.XmlSerializableTest.ConstraintTestBaseNoData.ProvidesProperStringRepresentation" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                          <test-suite type="ParameterizedTest" name="FailsWithBadValues" executed="True" result="Success" success="True" time="0.313" asserts="0">
+                            <results>
+                              <test-case name="NUnit.Framework.Constraints.XmlSerializableTest.FailsWithBadValues(System.Collections.Generic.Dictionary`2[System.String,System.String])" executed="True" result="Success" success="True" time="0.104" asserts="1" />
+                              <test-case name="NUnit.Framework.Constraints.XmlSerializableTest.FailsWithBadValues(NUnit.Framework.Constraints.InternalClass)" executed="True" result="Success" success="True" time="0.099" asserts="1" />
+                              <test-case name="NUnit.Framework.Constraints.XmlSerializableTest.FailsWithBadValues(NUnit.Framework.Constraints.InternalWithSerializableAttributeClass)" executed="True" result="Success" success="True" time="0.104" asserts="1" />
+                            </results>
+                          </test-suite>
+                          <test-suite type="ParameterizedTest" name="InvalidDataThrowsArgumentException" executed="True" result="Success" success="True" time="0.001" asserts="0">
+                            <results>
+                              <test-case name="NUnit.Framework.Constraints.XmlSerializableTest.InvalidDataThrowsArgumentException(null)" executed="True" result="Success" success="True" time="0.001" asserts="0" />
+                            </results>
+                          </test-suite>
+                          <test-suite type="ParameterizedTest" name="ProvidesProperFailureMessage" executed="True" result="Success" success="True" time="0.359" asserts="0">
+                            <results>
+                              <test-case name="NUnit.Framework.Constraints.XmlSerializableTest.ProvidesProperFailureMessage(System.Collections.Generic.Dictionary`2[System.String,System.String],&quot;&lt;Dictionary`2&gt;&quot;)" executed="True" result="Success" success="True" time="0.094" asserts="1" />
+                              <test-case name="NUnit.Framework.Constraints.XmlSerializableTest.ProvidesProperFailureMessage(NUnit.Framework.Constraints.InternalClass,&quot;&lt;InternalClass&gt;&quot;)" executed="True" result="Success" success="True" time="0.127" asserts="1" />
+                              <test-case name="NUnit.Framework.Constraints.XmlSerializableTest.ProvidesProperFailureMessage(NUnit.Framework.Constraints.InternalWithSerializableAttributeClass,&quot;&lt;InternalWithSerializableAttributeClass&gt;&quot;)" executed="True" result="Success" success="True" time="0.134" asserts="1" />
+                            </results>
+                          </test-suite>
+                          <test-suite type="ParameterizedTest" name="SucceedsWithGoodValues" executed="True" result="Success" success="True" time="0.009" asserts="0">
+                            <results>
+                              <test-case name="NUnit.Framework.Constraints.XmlSerializableTest.SucceedsWithGoodValues(1)" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                              <test-case name="NUnit.Framework.Constraints.XmlSerializableTest.SucceedsWithGoodValues(&quot;a&quot;)" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                              <test-case name="NUnit.Framework.Constraints.XmlSerializableTest.SucceedsWithGoodValues(System.Collections.ArrayList)" executed="True" result="Success" success="True" time="0.004" asserts="1" />
+                            </results>
+                          </test-suite>
+                        </results>
+                      </test-suite>
+                    </results>
+                  </test-suite>
+                  <test-suite type="Namespace" name="Syntax" executed="True" result="Success" success="True" time="4.463" asserts="0">
+                    <results>
+                      <test-suite type="TestFixture" name="AfterSyntaxUsingActualPassedByRef" executed="True" result="Success" success="True" time="1.429" asserts="0">
+                        <results>
+                          <test-case name="NUnit.Framework.Syntax.AfterSyntaxUsingActualPassedByRef.EqualToTest" executed="True" result="Success" success="True" time="0.200" asserts="1" />
+                          <test-case name="NUnit.Framework.Syntax.AfterSyntaxUsingActualPassedByRef.GreaterTest" executed="True" result="Success" success="True" time="0.200" asserts="1" />
+                          <test-case name="NUnit.Framework.Syntax.AfterSyntaxUsingActualPassedByRef.HasMemberTest" executed="True" result="Success" success="True" time="0.201" asserts="1" />
+                          <test-case name="NUnit.Framework.Syntax.AfterSyntaxUsingActualPassedByRef.NullTest" executed="True" result="Success" success="True" time="0.217" asserts="1" />
+                          <test-case name="NUnit.Framework.Syntax.AfterSyntaxUsingActualPassedByRef.SameAsTest" executed="True" result="Success" success="True" time="0.200" asserts="1" />
+                          <test-case name="NUnit.Framework.Syntax.AfterSyntaxUsingActualPassedByRef.TextTest" executed="True" result="Success" success="True" time="0.201" asserts="1" />
+                          <test-case name="NUnit.Framework.Syntax.AfterSyntaxUsingActualPassedByRef.TrueTest" executed="True" result="Success" success="True" time="0.200" asserts="1" />
+                        </results>
+                      </test-suite>
+                      <test-suite type="TestFixture" name="AfterSyntaxUsingAnonymousDelegates" executed="True" result="Success" success="True" time="1.432" asserts="0">
+                        <results>
+                          <test-case name="NUnit.Framework.Syntax.AfterSyntaxUsingAnonymousDelegates.EqualToTest" executed="True" result="Success" success="True" time="0.201" asserts="1" />
+                          <test-case name="NUnit.Framework.Syntax.AfterSyntaxUsingAnonymousDelegates.GreaterTest" executed="True" result="Success" success="True" time="0.201" asserts="1" />
+                          <test-case name="NUnit.Framework.Syntax.AfterSyntaxUsingAnonymousDelegates.HasMemberTest" executed="True" result="Success" success="True" time="0.201" asserts="1" />
+                          <test-case name="NUnit.Framework.Syntax.AfterSyntaxUsingAnonymousDelegates.NullTest" executed="True" result="Success" success="True" time="0.201" asserts="1" />
+                          <test-case name="NUnit.Framework.Syntax.AfterSyntaxUsingAnonymousDelegates.SameAsTest" executed="True" result="Success" success="True" time="0.201" asserts="1" />
+                          <test-case name="NUnit.Framework.Syntax.AfterSyntaxUsingAnonymousDelegates.TextTest" executed="True" result="Success" success="True" time="0.201" asserts="1" />
+                          <test-case name="NUnit.Framework.Syntax.AfterSyntaxUsingAnonymousDelegates.TrueTest" executed="True" result="Success" success="True" time="0.201" asserts="1" />
+                        </results>
+                      </test-suite>
+                      <test-suite type="TestFixture" name="AfterTest_AndOperator" executed="True" result="Success" success="True" time="0.010" asserts="0">
+                        <results>
+                          <test-case name="NUnit.Framework.Syntax.AfterTest_AndOperator.SyntaxTest.SupportedByConstraintBuilder" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Framework.Syntax.AfterTest_AndOperator.SyntaxTest.SupportedByInheritedSyntax" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Framework.Syntax.AfterTest_AndOperator.SyntaxTest.SupportedByStaticSyntax" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                        </results>
+                      </test-suite>
+                      <test-suite type="TestFixture" name="AfterTest_ProperyTest" executed="True" result="Success" success="True" time="0.010" asserts="0">
+                        <results>
+                          <test-case name="NUnit.Framework.Syntax.AfterTest_ProperyTest.SyntaxTest.SupportedByConstraintBuilder" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Framework.Syntax.AfterTest_ProperyTest.SyntaxTest.SupportedByInheritedSyntax" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Framework.Syntax.AfterTest_ProperyTest.SyntaxTest.SupportedByStaticSyntax" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                        </results>
+                      </test-suite>
+                      <test-suite type="TestFixture" name="AfterTest_SimpleConstraint" executed="True" result="Success" success="True" time="0.017" asserts="0">
+                        <results>
+                          <test-case name="NUnit.Framework.Syntax.AfterTest_SimpleConstraint.SyntaxTest.SupportedByConstraintBuilder" executed="True" result="Success" success="True" time="0.009" asserts="1" />
+                          <test-case name="NUnit.Framework.Syntax.AfterTest_SimpleConstraint.SyntaxTest.SupportedByInheritedSyntax" executed="True" result="Success" success="True" time="0.001" asserts="1" />
+                          <test-case name="NUnit.Framework.Syntax.AfterTest_SimpleConstraint.SyntaxTest.SupportedByStaticSyntax" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                        </results>
+                      </test-suite>
+                      <test-suite type="TestFixture" name="AllTest" executed="True" result="Success" success="True" time="0.007" asserts="0">
+                        <results>
+                          <test-case name="NUnit.Framework.Syntax.AllTest.SyntaxTest.SupportedByConstraintBuilder" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Framework.Syntax.AllTest.SyntaxTest.SupportedByInheritedSyntax" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Framework.Syntax.AllTest.SyntaxTest.SupportedByStaticSyntax" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                        </results>
+                      </test-suite>
+                      <test-suite type="TestFixture" name="AndIsEvaluatedBeforeFollowingOr" executed="True" result="Success" success="True" time="0.006" asserts="0">
+                        <results>
+                          <test-case name="NUnit.Framework.Syntax.AndIsEvaluatedBeforeFollowingOr.SyntaxTest.SupportedByConstraintBuilder" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Framework.Syntax.AndIsEvaluatedBeforeFollowingOr.SyntaxTest.SupportedByInheritedSyntax" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Framework.Syntax.AndIsEvaluatedBeforeFollowingOr.SyntaxTest.SupportedByStaticSyntax" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                        </results>
+                      </test-suite>
+                      <test-suite type="TestFixture" name="AndIsEvaluatedBeforePrecedingOr" executed="True" result="Success" success="True" time="0.005" asserts="0">
+                        <results>
+                          <test-case name="NUnit.Framework.Syntax.AndIsEvaluatedBeforePrecedingOr.SyntaxTest.SupportedByConstraintBuilder" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Framework.Syntax.AndIsEvaluatedBeforePrecedingOr.SyntaxTest.SupportedByInheritedSyntax" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Framework.Syntax.AndIsEvaluatedBeforePrecedingOr.SyntaxTest.SupportedByStaticSyntax" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                        </results>
+                      </test-suite>
+                      <test-suite type="TestFixture" name="AndOperatorOverride" executed="True" result="Success" success="True" time="0.005" asserts="0">
+                        <results>
+                          <test-case name="NUnit.Framework.Syntax.AndOperatorOverride.SyntaxTest.SupportedByConstraintBuilder" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Framework.Syntax.AndOperatorOverride.SyntaxTest.SupportedByInheritedSyntax" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Framework.Syntax.AndOperatorOverride.SyntaxTest.SupportedByStaticSyntax" executed="True" result="Success" success="True" time="0.001" asserts="1" />
+                        </results>
+                      </test-suite>
+                      <test-suite type="TestFixture" name="AndTest" executed="True" result="Success" success="True" time="0.004" asserts="0">
+                        <results>
+                          <test-case name="NUnit.Framework.Syntax.AndTest.SyntaxTest.SupportedByConstraintBuilder" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Framework.Syntax.AndTest.SyntaxTest.SupportedByInheritedSyntax" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Framework.Syntax.AndTest.SyntaxTest.SupportedByStaticSyntax" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                        </results>
+                      </test-suite>
+                      <test-suite type="TestFixture" name="AndTest_ThreeAndsWithNot" executed="True" result="Success" success="True" time="0.005" asserts="0">
+                        <results>
+                          <test-case name="NUnit.Framework.Syntax.AndTest_ThreeAndsWithNot.SyntaxTest.SupportedByConstraintBuilder" executed="True" result="Success" success="True" time="0.001" asserts="1" />
+                          <test-case name="NUnit.Framework.Syntax.AndTest_ThreeAndsWithNot.SyntaxTest.SupportedByInheritedSyntax" executed="True" result="Success" success="True" time="0.001" asserts="1" />
+                          <test-case name="NUnit.Framework.Syntax.AndTest_ThreeAndsWithNot.SyntaxTest.SupportedByStaticSyntax" executed="True" result="Success" success="True" time="0.001" asserts="1" />
+                        </results>
+                      </test-suite>
+                      <test-suite type="TestFixture" name="ArbitraryConstraintMatching" executed="True" result="Success" success="True" time="0.007" asserts="0">
+                        <results>
+                          <test-case name="NUnit.Framework.Syntax.ArbitraryConstraintMatching.CanMatchCustomConstraint" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Framework.Syntax.ArbitraryConstraintMatching.CanMatchCustomConstraintAfterPrefix" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Framework.Syntax.ArbitraryConstraintMatching.CanMatchCustomConstraintsUnderAndOperator" executed="True" result="Success" success="True" time="0.001" asserts="1" />
+                          <test-case name="NUnit.Framework.Syntax.ArbitraryConstraintMatching.CanMatchLambda" executed="True" result="Success" success="True" time="0.000" asserts="2" />
+                          <test-case name="NUnit.Framework.Syntax.ArbitraryConstraintMatching.CanMatchPredicate" executed="True" result="Success" success="True" time="0.000" asserts="2" />
+                        </results>
+                      </test-suite>
+                      <test-suite type="TestFixture" name="AssignableFromTest" executed="True" result="Success" success="True" time="0.004" asserts="0">
+                        <results>
+                          <test-case name="NUnit.Framework.Syntax.AssignableFromTest.SyntaxTest.SupportedByConstraintBuilder" executed="True" result="Success" success="True" time="0.001" asserts="1" />
+                          <test-case name="NUnit.Framework.Syntax.AssignableFromTest.SyntaxTest.SupportedByInheritedSyntax" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Framework.Syntax.AssignableFromTest.SyntaxTest.SupportedByStaticSyntax" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                        </results>
+                      </test-suite>
+                      <test-suite type="TestFixture" name="AssignableFromTest_Generic" executed="True" result="Success" success="True" time="0.004" asserts="0">
+                        <results>
+                          <test-case name="NUnit.Framework.Syntax.AssignableFromTest_Generic.SyntaxTest.SupportedByConstraintBuilder" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Framework.Syntax.AssignableFromTest_Generic.SyntaxTest.SupportedByInheritedSyntax" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Framework.Syntax.AssignableFromTest_Generic.SyntaxTest.SupportedByStaticSyntax" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                        </results>
+                      </test-suite>
+                      <test-suite type="TestFixture" name="AssignableToTest" executed="True" result="Success" success="True" time="0.004" asserts="0">
+                        <results>
+                          <test-case name="NUnit.Framework.Syntax.AssignableToTest.SyntaxTest.SupportedByConstraintBuilder" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Framework.Syntax.AssignableToTest.SyntaxTest.SupportedByInheritedSyntax" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Framework.Syntax.AssignableToTest.SyntaxTest.SupportedByStaticSyntax" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                        </results>
+                      </test-suite>
+                      <test-suite type="TestFixture" name="AssignableToTest_Generic" executed="True" result="Success" success="True" time="0.005" asserts="0">
+                        <results>
+                          <test-case name="NUnit.Framework.Syntax.AssignableToTest_Generic.SyntaxTest.SupportedByConstraintBuilder" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Framework.Syntax.AssignableToTest_Generic.SyntaxTest.SupportedByInheritedSyntax" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Framework.Syntax.AssignableToTest_Generic.SyntaxTest.SupportedByStaticSyntax" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                        </results>
+                      </test-suite>
+                      <test-suite type="TestFixture" name="AtLeastTest" executed="True" result="Success" success="True" time="0.004" asserts="0">
+                        <results>
+                          <test-case name="NUnit.Framework.Syntax.AtLeastTest.SyntaxTest.SupportedByConstraintBuilder" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Framework.Syntax.AtLeastTest.SyntaxTest.SupportedByInheritedSyntax" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Framework.Syntax.AtLeastTest.SyntaxTest.SupportedByStaticSyntax" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                        </results>
+                      </test-suite>
+                      <test-suite type="TestFixture" name="AtMostTest" executed="True" result="Success" success="True" time="0.004" asserts="0">
+                        <results>
+                          <test-case name="NUnit.Framework.Syntax.AtMostTest.SyntaxTest.SupportedByConstraintBuilder" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Framework.Syntax.AtMostTest.SyntaxTest.SupportedByInheritedSyntax" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Framework.Syntax.AtMostTest.SyntaxTest.SupportedByStaticSyntax" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                        </results>
+                      </test-suite>
+                      <test-suite type="TestFixture" name="AttributeTest" executed="True" result="Success" success="True" time="0.004" asserts="0">
+                        <results>
+                          <test-case name="NUnit.Framework.Syntax.AttributeTest.SyntaxTest.SupportedByConstraintBuilder" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Framework.Syntax.AttributeTest.SyntaxTest.SupportedByInheritedSyntax" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Framework.Syntax.AttributeTest.SyntaxTest.SupportedByStaticSyntax" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                        </results>
+                      </test-suite>
+                      <test-suite type="TestFixture" name="AttributeTest_Generic" executed="True" result="Success" success="True" time="0.004" asserts="0">
+                        <results>
+                          <test-case name="NUnit.Framework.Syntax.AttributeTest_Generic.SyntaxTest.SupportedByConstraintBuilder" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Framework.Syntax.AttributeTest_Generic.SyntaxTest.SupportedByInheritedSyntax" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Framework.Syntax.AttributeTest_Generic.SyntaxTest.SupportedByStaticSyntax" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                        </results>
+                      </test-suite>
+                      <test-suite type="TestFixture" name="AttributeTestWithFollowingConstraint" executed="True" result="Success" success="True" time="0.004" asserts="0">
+                        <results>
+                          <test-case name="NUnit.Framework.Syntax.AttributeTestWithFollowingConstraint.SyntaxTest.SupportedByConstraintBuilder" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Framework.Syntax.AttributeTestWithFollowingConstraint.SyntaxTest.SupportedByInheritedSyntax" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Framework.Syntax.AttributeTestWithFollowingConstraint.SyntaxTest.SupportedByStaticSyntax" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                        </results>
+                      </test-suite>
+                      <test-suite type="TestFixture" name="BinarySerializableTest" executed="True" result="Success" success="True" time="0.004" asserts="0">
+                        <results>
+                          <test-case name="NUnit.Framework.Syntax.BinarySerializableTest.SyntaxTest.SupportedByConstraintBuilder" executed="True" result="Success" success="True" time="0.001" asserts="1" />
+                          <test-case name="NUnit.Framework.Syntax.BinarySerializableTest.SyntaxTest.SupportedByInheritedSyntax" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Framework.Syntax.BinarySerializableTest.SyntaxTest.SupportedByStaticSyntax" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                        </results>
+                      </test-suite>
+                      <test-suite type="TestFixture" name="CollectionContainsTest" executed="True" result="Success" success="True" time="0.004" asserts="0">
+                        <results>
+                          <test-case name="NUnit.Framework.Syntax.CollectionContainsTest.SyntaxTest.SupportedByConstraintBuilder" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Framework.Syntax.CollectionContainsTest.SyntaxTest.SupportedByInheritedSyntax" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Framework.Syntax.CollectionContainsTest.SyntaxTest.SupportedByStaticSyntax" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                        </results>
+                      </test-suite>
+                      <test-suite type="TestFixture" name="CollectionContainsTest_Comparer" executed="True" result="Success" success="True" time="0.008" asserts="0">
+                        <results>
+                          <test-case name="NUnit.Framework.Syntax.CollectionContainsTest_Comparer.ComparerIsCalled" executed="True" result="Success" success="True" time="0.000" asserts="2" />
+                          <test-case name="NUnit.Framework.Syntax.CollectionContainsTest_Comparer.ComparerIsCalledInExpression" executed="True" result="Success" success="True" time="0.000" asserts="2" />
+                          <test-case name="NUnit.Framework.Syntax.CollectionContainsTest_Comparer.SyntaxTest.SupportedByConstraintBuilder" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Framework.Syntax.CollectionContainsTest_Comparer.SyntaxTest.SupportedByInheritedSyntax" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Framework.Syntax.CollectionContainsTest_Comparer.SyntaxTest.SupportedByStaticSyntax" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                        </results>
+                      </test-suite>
+                      <test-suite type="TestFixture" name="CollectionContainsTest_Comparer_String" executed="True" result="Success" success="True" time="0.007" asserts="0">
+                        <results>
+                          <test-case name="NUnit.Framework.Syntax.CollectionContainsTest_Comparer_String.ComparerIsCalled" executed="True" result="Success" success="True" time="0.000" asserts="2" />
+                          <test-case name="NUnit.Framework.Syntax.CollectionContainsTest_Comparer_String.ComparerIsCalledInExpression" executed="True" result="Success" success="True" time="0.000" asserts="2" />
+                          <test-case name="NUnit.Framework.Syntax.CollectionContainsTest_Comparer_String.SyntaxTest.SupportedByConstraintBuilder" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Framework.Syntax.CollectionContainsTest_Comparer_String.SyntaxTest.SupportedByInheritedSyntax" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Framework.Syntax.CollectionContainsTest_Comparer_String.SyntaxTest.SupportedByStaticSyntax" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                        </results>
+                      </test-suite>
+                      <test-suite type="TestFixture" name="CollectionContainsTest_String" executed="True" result="Success" success="True" time="0.004" asserts="0">
+                        <results>
+                          <test-case name="NUnit.Framework.Syntax.CollectionContainsTest_String.SyntaxTest.SupportedByConstraintBuilder" executed="True" result="Success" success="True" time="0.001" asserts="1" />
+                          <test-case name="NUnit.Framework.Syntax.CollectionContainsTest_String.SyntaxTest.SupportedByInheritedSyntax" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Framework.Syntax.CollectionContainsTest_String.SyntaxTest.SupportedByStaticSyntax" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                        </results>
+                      </test-suite>
+                      <test-suite type="TestFixture" name="CollectionEquivalentTest" executed="True" result="Success" success="True" time="0.004" asserts="0">
+                        <results>
+                          <test-case name="NUnit.Framework.Syntax.CollectionEquivalentTest.SyntaxTest.SupportedByConstraintBuilder" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Framework.Syntax.CollectionEquivalentTest.SyntaxTest.SupportedByInheritedSyntax" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Framework.Syntax.CollectionEquivalentTest.SyntaxTest.SupportedByStaticSyntax" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                        </results>
+                      </test-suite>
+                      <test-suite type="TestFixture" name="CollectionMemberTest" executed="True" result="Success" success="True" time="0.004" asserts="0">
+                        <results>
+                          <test-case name="NUnit.Framework.Syntax.CollectionMemberTest.SyntaxTest.SupportedByConstraintBuilder" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Framework.Syntax.CollectionMemberTest.SyntaxTest.SupportedByInheritedSyntax" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Framework.Syntax.CollectionMemberTest.SyntaxTest.SupportedByStaticSyntax" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                        </results>
+                      </test-suite>
+                      <test-suite type="TestFixture" name="CollectionMemberTest_Comparer" executed="True" result="Success" success="True" time="0.005" asserts="0">
+                        <results>
+                          <test-case name="NUnit.Framework.Syntax.CollectionMemberTest_Comparer.SyntaxTest.SupportedByConstraintBuilder" executed="True" result="Success" success="True" time="0.001" asserts="1" />
+                          <test-case name="NUnit.Framework.Syntax.CollectionMemberTest_Comparer.SyntaxTest.SupportedByInheritedSyntax" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Framework.Syntax.CollectionMemberTest_Comparer.SyntaxTest.SupportedByStaticSyntax" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                        </results>
+                      </test-suite>
+                      <test-suite type="TestFixture" name="CollectionOrderedByTest" executed="True" result="Success" success="True" time="0.003" asserts="0">
+                        <results>
+                          <test-case name="NUnit.Framework.Syntax.CollectionOrderedByTest.SyntaxTest.SupportedByConstraintBuilder" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Framework.Syntax.CollectionOrderedByTest.SyntaxTest.SupportedByInheritedSyntax" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Framework.Syntax.CollectionOrderedByTest.SyntaxTest.SupportedByStaticSyntax" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                        </results>
+                      </test-suite>
+                      <test-suite type="TestFixture" name="CollectionOrderedByTest_Comparer" executed="True" result="Success" success="True" time="0.004" asserts="0">
+                        <results>
+                          <test-case name="NUnit.Framework.Syntax.CollectionOrderedByTest_Comparer.SyntaxTest.SupportedByConstraintBuilder" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Framework.Syntax.CollectionOrderedByTest_Comparer.SyntaxTest.SupportedByInheritedSyntax" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Framework.Syntax.CollectionOrderedByTest_Comparer.SyntaxTest.SupportedByStaticSyntax" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                        </results>
+                      </test-suite>
+                      <test-suite type="TestFixture" name="CollectionOrderedByTest_Comparer_Descending" executed="True" result="Success" success="True" time="0.004" asserts="0">
+                        <results>
+                          <test-case name="NUnit.Framework.Syntax.CollectionOrderedByTest_Comparer_Descending.SyntaxTest.SupportedByConstraintBuilder" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Framework.Syntax.CollectionOrderedByTest_Comparer_Descending.SyntaxTest.SupportedByInheritedSyntax" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Framework.Syntax.CollectionOrderedByTest_Comparer_Descending.SyntaxTest.SupportedByStaticSyntax" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                        </results>
+                      </test-suite>
+                      <test-suite type="TestFixture" name="CollectionOrderedByTest_Descending" executed="True" result="Success" success="True" time="0.003" asserts="0">
+                        <results>
+                          <test-case name="NUnit.Framework.Syntax.CollectionOrderedByTest_Descending.SyntaxTest.SupportedByConstraintBuilder" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Framework.Syntax.CollectionOrderedByTest_Descending.SyntaxTest.SupportedByInheritedSyntax" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Framework.Syntax.CollectionOrderedByTest_Descending.SyntaxTest.SupportedByStaticSyntax" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                        </results>
+                      </test-suite>
+                      <test-suite type="TestFixture" name="CollectionOrderedTest" executed="True" result="Success" success="True" time="0.004" asserts="0">
+                        <results>
+                          <test-case name="NUnit.Framework.Syntax.CollectionOrderedTest.SyntaxTest.SupportedByConstraintBuilder" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Framework.Syntax.CollectionOrderedTest.SyntaxTest.SupportedByInheritedSyntax" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Framework.Syntax.CollectionOrderedTest.SyntaxTest.SupportedByStaticSyntax" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                        </results>
+                      </test-suite>
+                      <test-suite type="TestFixture" name="CollectionOrderedTest_Comparer" executed="True" result="Success" success="True" time="0.010" asserts="0">
+                        <results>
+                          <test-case name="NUnit.Framework.Syntax.CollectionOrderedTest_Comparer.SyntaxTest.SupportedByConstraintBuilder" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Framework.Syntax.CollectionOrderedTest_Comparer.SyntaxTest.SupportedByInheritedSyntax" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Framework.Syntax.CollectionOrderedTest_Comparer.SyntaxTest.SupportedByStaticSyntax" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                        </results>
+                      </test-suite>
+                      <test-suite type="TestFixture" name="CollectionOrderedTest_Comparer_Descending" executed="True" result="Success" success="True" time="0.004" asserts="0">
+                        <results>
+                          <test-case name="NUnit.Framework.Syntax.CollectionOrderedTest_Comparer_Descending.SyntaxTest.SupportedByConstraintBuilder" executed="True" result="Success" success="True" time="0.001" asserts="1" />
+                          <test-case name="NUnit.Framework.Syntax.CollectionOrderedTest_Comparer_Descending.SyntaxTest.SupportedByInheritedSyntax" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Framework.Syntax.CollectionOrderedTest_Comparer_Descending.SyntaxTest.SupportedByStaticSyntax" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                        </results>
+                      </test-suite>
+                      <test-suite type="TestFixture" name="CollectionOrderedTest_Descending" executed="True" result="Success" success="True" time="0.004" asserts="0">
+                        <results>
+                          <test-case name="NUnit.Framework.Syntax.CollectionOrderedTest_Descending.SyntaxTest.SupportedByConstraintBuilder" executed="True" result="Success" success="True" time="0.001" asserts="1" />
+                          <test-case name="NUnit.Framework.Syntax.CollectionOrderedTest_Descending.SyntaxTest.SupportedByInheritedSyntax" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Framework.Syntax.CollectionOrderedTest_Descending.SyntaxTest.SupportedByStaticSyntax" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                        </results>
+                      </test-suite>
+                      <test-suite type="TestFixture" name="CollectionSubsetTest" executed="True" result="Success" success="True" time="0.003" asserts="0">
+                        <results>
+                          <test-case name="NUnit.Framework.Syntax.CollectionSubsetTest.SyntaxTest.SupportedByConstraintBuilder" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Framework.Syntax.CollectionSubsetTest.SyntaxTest.SupportedByInheritedSyntax" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Framework.Syntax.CollectionSubsetTest.SyntaxTest.SupportedByStaticSyntax" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                        </results>
+                      </test-suite>
+                      <test-suite type="TestFixture" name="CountTest" executed="True" result="Success" success="True" time="0.004" asserts="0">
+                        <results>
+                          <test-case name="NUnit.Framework.Syntax.CountTest.SyntaxTest.SupportedByConstraintBuilder" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Framework.Syntax.CountTest.SyntaxTest.SupportedByInheritedSyntax" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Framework.Syntax.CountTest.SyntaxTest.SupportedByStaticSyntax" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                        </results>
+                      </test-suite>
+                      <test-suite type="TestFixture" name="EmptyTest" executed="True" result="Success" success="True" time="0.004" asserts="0">
+                        <results>
+                          <test-case name="NUnit.Framework.Syntax.EmptyTest.SyntaxTest.SupportedByConstraintBuilder" executed="True" result="Success" success="True" time="0.001" asserts="1" />
+                          <test-case name="NUnit.Framework.Syntax.EmptyTest.SyntaxTest.SupportedByInheritedSyntax" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Framework.Syntax.EmptyTest.SyntaxTest.SupportedByStaticSyntax" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                        </results>
+                      </test-suite>
+                      <test-suite type="TestFixture" name="EndsWithTest" executed="True" result="Success" success="True" time="0.004" asserts="0">
+                        <results>
+                          <test-case name="NUnit.Framework.Syntax.EndsWithTest.SyntaxTest.SupportedByConstraintBuilder" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Framework.Syntax.EndsWithTest.SyntaxTest.SupportedByInheritedSyntax" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Framework.Syntax.EndsWithTest.SyntaxTest.SupportedByStaticSyntax" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                        </results>
+                      </test-suite>
+                      <test-suite type="TestFixture" name="EndsWithTest_IgnoreCase" executed="True" result="Success" success="True" time="0.005" asserts="0">
+                        <results>
+                          <test-case name="NUnit.Framework.Syntax.EndsWithTest_IgnoreCase.SyntaxTest.SupportedByConstraintBuilder" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Framework.Syntax.EndsWithTest_IgnoreCase.SyntaxTest.SupportedByInheritedSyntax" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Framework.Syntax.EndsWithTest_IgnoreCase.SyntaxTest.SupportedByStaticSyntax" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                        </results>
+                      </test-suite>
+                      <test-suite type="TestFixture" name="EqualityTests" executed="True" result="Success" success="True" time="0.007" asserts="0">
+                        <results>
+                          <test-case name="NUnit.Framework.Syntax.EqualityTests.EqualityTestsUsingDefaultFloatingPointTolerance" executed="True" result="Success" success="True" time="0.000" asserts="3" />
+                          <test-case name="NUnit.Framework.Syntax.EqualityTests.EqualityTestsWithTolerance" executed="True" result="Success" success="True" time="0.001" asserts="8" />
+                          <test-case name="NUnit.Framework.Syntax.EqualityTests.EqualityTestsWithTolerance_MixedFloatAndDouble" executed="True" result="Success" success="True" time="0.000" asserts="6" />
+                          <test-case name="NUnit.Framework.Syntax.EqualityTests.EqualityTestsWithTolerance_MixingTypesGenerally" executed="True" result="Success" success="True" time="0.001" asserts="7" />
+                          <test-case name="NUnit.Framework.Syntax.EqualityTests.SimpleEqualityTests" executed="True" result="Success" success="True" time="0.000" asserts="6" />
+                        </results>
+                      </test-suite>
+                      <test-suite type="TestFixture" name="EqualToTest" executed="True" result="Success" success="True" time="0.004" asserts="0">
+                        <results>
+                          <test-case name="NUnit.Framework.Syntax.EqualToTest.SyntaxTest.SupportedByConstraintBuilder" executed="True" result="Success" success="True" time="0.001" asserts="1" />
+                          <test-case name="NUnit.Framework.Syntax.EqualToTest.SyntaxTest.SupportedByInheritedSyntax" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Framework.Syntax.EqualToTest.SyntaxTest.SupportedByStaticSyntax" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                        </results>
+                      </test-suite>
+                      <test-suite type="TestFixture" name="EqualToTest_IgnoreCase" executed="True" result="Success" success="True" time="0.005" asserts="0">
+                        <results>
+                          <test-case name="NUnit.Framework.Syntax.EqualToTest_IgnoreCase.SyntaxTest.SupportedByConstraintBuilder" executed="True" result="Success" success="True" time="0.001" asserts="1" />
+                          <test-case name="NUnit.Framework.Syntax.EqualToTest_IgnoreCase.SyntaxTest.SupportedByInheritedSyntax" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Framework.Syntax.EqualToTest_IgnoreCase.SyntaxTest.SupportedByStaticSyntax" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                        </results>
+                      </test-suite>
+                      <test-suite type="TestFixture" name="EqualToTest_WithinTolerance" executed="True" result="Success" success="True" time="0.004" asserts="0">
+                        <results>
+                          <test-case name="NUnit.Framework.Syntax.EqualToTest_WithinTolerance.SyntaxTest.SupportedByConstraintBuilder" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Framework.Syntax.EqualToTest_WithinTolerance.SyntaxTest.SupportedByInheritedSyntax" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Framework.Syntax.EqualToTest_WithinTolerance.SyntaxTest.SupportedByStaticSyntax" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                        </results>
+                      </test-suite>
+                      <test-suite type="TestFixture" name="ExactTypeTest" executed="True" result="Success" success="True" time="0.004" asserts="0">
+                        <results>
+                          <test-case name="NUnit.Framework.Syntax.ExactTypeTest.SyntaxTest.SupportedByConstraintBuilder" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Framework.Syntax.ExactTypeTest.SyntaxTest.SupportedByInheritedSyntax" executed="True" result="Success" success="True" time="0.001" asserts="1" />
+                          <test-case name="NUnit.Framework.Syntax.ExactTypeTest.SyntaxTest.SupportedByStaticSyntax" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                        </results>
+                      </test-suite>
+                      <test-suite type="TestFixture" name="ExactTypeTest_Generic" executed="True" result="Success" success="True" time="0.004" asserts="0">
+                        <results>
+                          <test-case name="NUnit.Framework.Syntax.ExactTypeTest_Generic.SyntaxTest.SupportedByConstraintBuilder" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Framework.Syntax.ExactTypeTest_Generic.SyntaxTest.SupportedByInheritedSyntax" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Framework.Syntax.ExactTypeTest_Generic.SyntaxTest.SupportedByStaticSyntax" executed="True" result="Success" success="True" time="0.001" asserts="1" />
+                        </results>
+                      </test-suite>
+                      <test-suite type="TestFixture" name="FalseTest" executed="True" result="Success" success="True" time="0.004" asserts="0">
+                        <results>
+                          <test-case name="NUnit.Framework.Syntax.FalseTest.SyntaxTest.SupportedByConstraintBuilder" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Framework.Syntax.FalseTest.SyntaxTest.SupportedByInheritedSyntax" executed="True" result="Success" success="True" time="0.001" asserts="1" />
+                          <test-case name="NUnit.Framework.Syntax.FalseTest.SyntaxTest.SupportedByStaticSyntax" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                        </results>
+                      </test-suite>
+                      <test-suite type="TestFixture" name="GreaterThanOrEqualTest" executed="True" result="Success" success="True" time="0.004" asserts="0">
+                        <results>
+                          <test-case name="NUnit.Framework.Syntax.GreaterThanOrEqualTest.SyntaxTest.SupportedByConstraintBuilder" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Framework.Syntax.GreaterThanOrEqualTest.SyntaxTest.SupportedByInheritedSyntax" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Framework.Syntax.GreaterThanOrEqualTest.SyntaxTest.SupportedByStaticSyntax" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                        </results>
+                      </test-suite>
+                      <test-suite type="TestFixture" name="GreaterThanTest" executed="True" result="Success" success="True" time="0.003" asserts="0">
+                        <results>
+                          <test-case name="NUnit.Framework.Syntax.GreaterThanTest.SyntaxTest.SupportedByConstraintBuilder" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Framework.Syntax.GreaterThanTest.SyntaxTest.SupportedByInheritedSyntax" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Framework.Syntax.GreaterThanTest.SyntaxTest.SupportedByStaticSyntax" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                        </results>
+                      </test-suite>
+                      <test-suite type="TestFixture" name="InstanceOfTest" executed="True" result="Success" success="True" time="0.004" asserts="0">
+                        <results>
+                          <test-case name="NUnit.Framework.Syntax.InstanceOfTest.SyntaxTest.SupportedByConstraintBuilder" executed="True" result="Success" success="True" time="0.001" asserts="1" />
+                          <test-case name="NUnit.Framework.Syntax.InstanceOfTest.SyntaxTest.SupportedByInheritedSyntax" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Framework.Syntax.InstanceOfTest.SyntaxTest.SupportedByStaticSyntax" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                        </results>
+                      </test-suite>
+                      <test-suite type="TestFixture" name="InstanceOfTest_Generic" executed="True" result="Success" success="True" time="0.005" asserts="0">
+                        <results>
+                          <test-case name="NUnit.Framework.Syntax.InstanceOfTest_Generic.SyntaxTest.SupportedByConstraintBuilder" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Framework.Syntax.InstanceOfTest_Generic.SyntaxTest.SupportedByInheritedSyntax" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Framework.Syntax.InstanceOfTest_Generic.SyntaxTest.SupportedByStaticSyntax" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                        </results>
+                      </test-suite>
+                      <test-suite type="TestFixture" name="InstanceOfTypeTest" executed="True" result="Success" success="True" time="0.005" asserts="0">
+                        <results>
+                          <test-case name="NUnit.Framework.Syntax.InstanceOfTypeTest.SyntaxTest.SupportedByConstraintBuilder" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Framework.Syntax.InstanceOfTypeTest.SyntaxTest.SupportedByInheritedSyntax" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Framework.Syntax.InstanceOfTypeTest.SyntaxTest.SupportedByStaticSyntax" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                        </results>
+                      </test-suite>
+                      <test-suite type="TestFixture" name="InstanceOfTypeTest_Generic" executed="True" result="Success" success="True" time="0.003" asserts="0">
+                        <results>
+                          <test-case name="NUnit.Framework.Syntax.InstanceOfTypeTest_Generic.SyntaxTest.SupportedByConstraintBuilder" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Framework.Syntax.InstanceOfTypeTest_Generic.SyntaxTest.SupportedByInheritedSyntax" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Framework.Syntax.InstanceOfTypeTest_Generic.SyntaxTest.SupportedByStaticSyntax" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                        </results>
+                      </test-suite>
+                      <test-suite type="TestFixture" name="InvalidCodeTests" executed="True" result="Success" success="True" time="0.887" asserts="0">
+                        <results>
+                          <test-suite type="ParameterizedTest" name="CodeShouldNotCompile" executed="True" result="Success" success="True" time="0.567" asserts="0">
+                            <results>
+                              <test-case name="NUnit.Framework.Syntax.InvalidCodeTests.CodeShouldNotCompile(&quot;Is.Null.All&quot;)" executed="True" result="Success" success="True" time="0.174" asserts="0" />
+                              <test-case name="NUnit.Framework.Syntax.InvalidCodeTests.CodeShouldNotCompile(&quot;Is.And&quot;)" executed="True" result="Success" success="True" time="0.076" asserts="0" />
+                              <test-case name="NUnit.Framework.Syntax.InvalidCodeTests.CodeShouldNotCompile(&quot;Is.All.And.And&quot;)" executed="True" result="Success" success="True" time="0.077" asserts="0" />
+                              <test-case name="NUnit.Framework.Syntax.InvalidCodeTests.CodeShouldNotCompile(&quot;Is.Null.And.Throws&quot;)" executed="True" result="Success" success="True" time="0.075" asserts="0" />
+                              <test-case name="NUnit.Framework.Syntax.InvalidCodeTests.CodeShouldNotCompile(&quot;Is.Null.Not&quot;)" executed="True" result="Success" success="True" time="0.077" asserts="0" />
+                              <test-case name="NUnit.Framework.Syntax.InvalidCodeTests.CodeShouldNotCompile(&quot;Is.Not.Null.GreaterThan(10))&quot;)" executed="True" result="Success" success="True" time="0.076" asserts="0" />
+                            </results>
+                          </test-suite>
+                          <test-suite type="ParameterizedTest" name="CodeShouldNotCompileAsFinishedConstraint" executed="True" result="Success" success="True" time="0.317" asserts="0">
+                            <results>
+                              <test-case name="NUnit.Framework.Syntax.InvalidCodeTests.CodeShouldNotCompileAsFinishedConstraint(&quot;Is.All&quot;)" executed="True" result="Success" success="True" time="0.080" asserts="0" />
+                              <test-case name="NUnit.Framework.Syntax.InvalidCodeTests.CodeShouldNotCompileAsFinishedConstraint(&quot;Is.Not&quot;)" executed="True" result="Success" success="True" time="0.077" asserts="0" />
+                              <test-case name="NUnit.Framework.Syntax.InvalidCodeTests.CodeShouldNotCompileAsFinishedConstraint(&quot;Is.Not.All&quot;)" executed="True" result="Success" success="True" time="0.076" asserts="0" />
+                              <test-case name="NUnit.Framework.Syntax.InvalidCodeTests.CodeShouldNotCompileAsFinishedConstraint(&quot;Is.All.Not&quot;)" executed="True" result="Success" success="True" time="0.077" asserts="0" />
+                            </results>
+                          </test-suite>
+                        </results>
+                      </test-suite>
+                      <test-suite type="TestFixture" name="LengthTest" executed="True" result="Success" success="True" time="0.004" asserts="0">
+                        <results>
+                          <test-case name="NUnit.Framework.Syntax.LengthTest.SyntaxTest.SupportedByConstraintBuilder" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Framework.Syntax.LengthTest.SyntaxTest.SupportedByInheritedSyntax" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Framework.Syntax.LengthTest.SyntaxTest.SupportedByStaticSyntax" executed="True" result="Success" success="True" time="0.001" asserts="1" />
+                        </results>
+                      </test-suite>
+                      <test-suite type="TestFixture" name="LessThanOrEqualTest" executed="True" result="Success" success="True" time="0.005" asserts="0">
+                        <results>
+                          <test-case name="NUnit.Framework.Syntax.LessThanOrEqualTest.SyntaxTest.SupportedByConstraintBuilder" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Framework.Syntax.LessThanOrEqualTest.SyntaxTest.SupportedByInheritedSyntax" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Framework.Syntax.LessThanOrEqualTest.SyntaxTest.SupportedByStaticSyntax" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                        </results>
+                      </test-suite>
+                      <test-suite type="TestFixture" name="LessThanTest" executed="True" result="Success" success="True" time="0.004" asserts="0">
+                        <results>
+                          <test-case name="NUnit.Framework.Syntax.LessThanTest.SyntaxTest.SupportedByConstraintBuilder" executed="True" result="Success" success="True" time="0.001" asserts="1" />
+                          <test-case name="NUnit.Framework.Syntax.LessThanTest.SyntaxTest.SupportedByInheritedSyntax" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Framework.Syntax.LessThanTest.SyntaxTest.SupportedByStaticSyntax" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                        </results>
+                      </test-suite>
+                      <test-suite type="TestFixture" name="MessageTest" executed="True" result="Success" success="True" time="0.004" asserts="0">
+                        <results>
+                          <test-case name="NUnit.Framework.Syntax.MessageTest.SyntaxTest.SupportedByConstraintBuilder" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Framework.Syntax.MessageTest.SyntaxTest.SupportedByInheritedSyntax" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Framework.Syntax.MessageTest.SyntaxTest.SupportedByStaticSyntax" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                        </results>
+                      </test-suite>
+                      <test-suite type="TestFixture" name="MixedOperatorOverrides" executed="True" result="Success" success="True" time="0.001" asserts="0">
+                        <results>
+                          <test-case name="NUnit.Framework.Syntax.MixedOperatorOverrides.ComplexTests" executed="True" result="Success" success="True" time="0.000" asserts="3" />
+                        </results>
+                      </test-suite>
+                      <test-suite type="TestFixture" name="NaNTest" executed="True" result="Success" success="True" time="0.006" asserts="0">
+                        <results>
+                          <test-case name="NUnit.Framework.Syntax.NaNTest.SyntaxTest.SupportedByConstraintBuilder" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Framework.Syntax.NaNTest.SyntaxTest.SupportedByInheritedSyntax" executed="True" result="Success" success="True" time="0.001" asserts="1" />
+                          <test-case name="NUnit.Framework.Syntax.NaNTest.SyntaxTest.SupportedByStaticSyntax" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                        </results>
+                      </test-suite>
+                      <test-suite type="TestFixture" name="NegativeTest" executed="True" result="Success" success="True" time="0.005" asserts="0">
+                        <results>
+                          <test-case name="NUnit.Framework.Syntax.NegativeTest.SyntaxTest.SupportedByConstraintBuilder" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Framework.Syntax.NegativeTest.SyntaxTest.SupportedByInheritedSyntax" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Framework.Syntax.NegativeTest.SyntaxTest.SupportedByStaticSyntax" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                        </results>
+                      </test-suite>
+                      <test-suite type="TestFixture" name="NoneTest" executed="True" result="Success" success="True" time="0.005" asserts="0">
+                        <results>
+                          <test-case name="NUnit.Framework.Syntax.NoneTest.SyntaxTest.SupportedByConstraintBuilder" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Framework.Syntax.NoneTest.SyntaxTest.SupportedByInheritedSyntax" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Framework.Syntax.NoneTest.SyntaxTest.SupportedByStaticSyntax" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                        </results>
+                      </test-suite>
+                      <test-suite type="TestFixture" name="NotOperatorOverride" executed="True" result="Success" success="True" time="0.006" asserts="0">
+                        <results>
+                          <test-case name="NUnit.Framework.Syntax.NotOperatorOverride.SyntaxTest.SupportedByConstraintBuilder" executed="True" result="Success" success="True" time="0.001" asserts="1" />
+                          <test-case name="NUnit.Framework.Syntax.NotOperatorOverride.SyntaxTest.SupportedByInheritedSyntax" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Framework.Syntax.NotOperatorOverride.SyntaxTest.SupportedByStaticSyntax" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                        </results>
+                      </test-suite>
+                      <test-suite type="TestFixture" name="NotSamePathOrUnderTest_IgnoreCase" executed="True" result="Success" success="True" time="0.004" asserts="0">
+                        <results>
+                          <test-case name="NUnit.Framework.Syntax.NotSamePathOrUnderTest_IgnoreCase.SyntaxTest.SupportedByConstraintBuilder" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Framework.Syntax.NotSamePathOrUnderTest_IgnoreCase.SyntaxTest.SupportedByInheritedSyntax" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Framework.Syntax.NotSamePathOrUnderTest_IgnoreCase.SyntaxTest.SupportedByStaticSyntax" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                        </results>
+                      </test-suite>
+                      <test-suite type="TestFixture" name="NotSamePathOrUnderTest_RespectCase" executed="True" result="Success" success="True" time="0.004" asserts="0">
+                        <results>
+                          <test-case name="NUnit.Framework.Syntax.NotSamePathOrUnderTest_RespectCase.SyntaxTest.SupportedByConstraintBuilder" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Framework.Syntax.NotSamePathOrUnderTest_RespectCase.SyntaxTest.SupportedByInheritedSyntax" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Framework.Syntax.NotSamePathOrUnderTest_RespectCase.SyntaxTest.SupportedByStaticSyntax" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                        </results>
+                      </test-suite>
+                      <test-suite type="TestFixture" name="NotSamePathTest_IgnoreCase" executed="True" result="Success" success="True" time="0.004" asserts="0">
+                        <results>
+                          <test-case name="NUnit.Framework.Syntax.NotSamePathTest_IgnoreCase.SyntaxTest.SupportedByConstraintBuilder" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Framework.Syntax.NotSamePathTest_IgnoreCase.SyntaxTest.SupportedByInheritedSyntax" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Framework.Syntax.NotSamePathTest_IgnoreCase.SyntaxTest.SupportedByStaticSyntax" executed="True" result="Success" success="True" time="0.001" asserts="1" />
+                        </results>
+                      </test-suite>
+                      <test-suite type="TestFixture" name="NotSamePathTest_RespectCase" executed="True" result="Success" success="True" time="0.004" asserts="0">
+                        <results>
+                          <test-case name="NUnit.Framework.Syntax.NotSamePathTest_RespectCase.SyntaxTest.SupportedByConstraintBuilder" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Framework.Syntax.NotSamePathTest_RespectCase.SyntaxTest.SupportedByInheritedSyntax" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Framework.Syntax.NotSamePathTest_RespectCase.SyntaxTest.SupportedByStaticSyntax" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                        </results>
+                      </test-suite>
+                      <test-suite type="TestFixture" name="NotTest" executed="True" result="Success" success="True" time="0.004" asserts="0">
+                        <results>
+                          <test-case name="NUnit.Framework.Syntax.NotTest.SyntaxTest.SupportedByConstraintBuilder" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Framework.Syntax.NotTest.SyntaxTest.SupportedByInheritedSyntax" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Framework.Syntax.NotTest.SyntaxTest.SupportedByStaticSyntax" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                        </results>
+                      </test-suite>
+                      <test-suite type="TestFixture" name="NotTest_Cascaded" executed="True" result="Success" success="True" time="0.005" asserts="0">
+                        <results>
+                          <test-case name="NUnit.Framework.Syntax.NotTest_Cascaded.SyntaxTest.SupportedByConstraintBuilder" executed="True" result="Success" success="True" time="0.001" asserts="1" />
+                          <test-case name="NUnit.Framework.Syntax.NotTest_Cascaded.SyntaxTest.SupportedByInheritedSyntax" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Framework.Syntax.NotTest_Cascaded.SyntaxTest.SupportedByStaticSyntax" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                        </results>
+                      </test-suite>
+                      <test-suite type="TestFixture" name="NullTest" executed="True" result="Success" success="True" time="0.004" asserts="0">
+                        <results>
+                          <test-case name="NUnit.Framework.Syntax.NullTest.SyntaxTest.SupportedByConstraintBuilder" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Framework.Syntax.NullTest.SyntaxTest.SupportedByInheritedSyntax" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Framework.Syntax.NullTest.SyntaxTest.SupportedByStaticSyntax" executed="True" result="Success" success="True" time="0.001" asserts="1" />
+                        </results>
+                      </test-suite>
+                      <test-suite type="TestFixture" name="OperatorPrecedenceTests" executed="True" result="Success" success="True" time="0.002" asserts="0">
+                        <results>
+                          <test-case name="NUnit.Framework.Syntax.OperatorPrecedenceTests.SomeTests" executed="True" result="Success" success="True" time="0.001" asserts="2" />
+                          <test-case name="NUnit.Framework.Syntax.OperatorPrecedenceTests.WithTests" executed="True" result="Success" success="True" time="0.000" asserts="6" />
+                        </results>
+                      </test-suite>
+                      <test-suite type="TestFixture" name="OrOperatorOverride" executed="True" result="Success" success="True" time="0.004" asserts="0">
+                        <results>
+                          <test-case name="NUnit.Framework.Syntax.OrOperatorOverride.SyntaxTest.SupportedByConstraintBuilder" executed="True" result="Success" success="True" time="0.001" asserts="1" />
+                          <test-case name="NUnit.Framework.Syntax.OrOperatorOverride.SyntaxTest.SupportedByInheritedSyntax" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Framework.Syntax.OrOperatorOverride.SyntaxTest.SupportedByStaticSyntax" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                        </results>
+                      </test-suite>
+                      <test-suite type="TestFixture" name="OrTest" executed="True" result="Success" success="True" time="0.004" asserts="0">
+                        <results>
+                          <test-case name="NUnit.Framework.Syntax.OrTest.SyntaxTest.SupportedByConstraintBuilder" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Framework.Syntax.OrTest.SyntaxTest.SupportedByInheritedSyntax" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Framework.Syntax.OrTest.SyntaxTest.SupportedByStaticSyntax" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                        </results>
+                      </test-suite>
+                      <test-suite type="TestFixture" name="OrTest_ThreeOrs" executed="True" result="Success" success="True" time="0.004" asserts="0">
+                        <results>
+                          <test-case name="NUnit.Framework.Syntax.OrTest_ThreeOrs.SyntaxTest.SupportedByConstraintBuilder" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Framework.Syntax.OrTest_ThreeOrs.SyntaxTest.SupportedByInheritedSyntax" executed="True" result="Success" success="True" time="0.001" asserts="1" />
+                          <test-case name="NUnit.Framework.Syntax.OrTest_ThreeOrs.SyntaxTest.SupportedByStaticSyntax" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                        </results>
+                      </test-suite>
+                      <test-suite type="TestFixture" name="PositiveTest" executed="True" result="Success" success="True" time="0.004" asserts="0">
+                        <results>
+                          <test-case name="NUnit.Framework.Syntax.PositiveTest.SyntaxTest.SupportedByConstraintBuilder" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Framework.Syntax.PositiveTest.SyntaxTest.SupportedByInheritedSyntax" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Framework.Syntax.PositiveTest.SyntaxTest.SupportedByStaticSyntax" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                        </results>
+                      </test-suite>
+                      <test-suite type="TestFixture" name="PropertyExistsTest" executed="True" result="Success" success="True" time="0.007" asserts="0">
+                        <results>
+                          <test-case name="NUnit.Framework.Syntax.PropertyExistsTest.SyntaxTest.SupportedByConstraintBuilder" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Framework.Syntax.PropertyExistsTest.SyntaxTest.SupportedByInheritedSyntax" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Framework.Syntax.PropertyExistsTest.SyntaxTest.SupportedByStaticSyntax" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                        </results>
+                      </test-suite>
+                      <test-suite type="TestFixture" name="PropertyExistsTest_AndFollows" executed="True" result="Success" success="True" time="0.004" asserts="0">
+                        <results>
+                          <test-case name="NUnit.Framework.Syntax.PropertyExistsTest_AndFollows.SyntaxTest.SupportedByConstraintBuilder" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Framework.Syntax.PropertyExistsTest_AndFollows.SyntaxTest.SupportedByInheritedSyntax" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Framework.Syntax.PropertyExistsTest_AndFollows.SyntaxTest.SupportedByStaticSyntax" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                        </results>
+                      </test-suite>
+                      <test-suite type="TestFixture" name="PropertySyntaxVariations" executed="True" result="Success" success="True" time="0.002" asserts="0">
+                        <results>
+                          <test-case name="NUnit.Framework.Syntax.PropertySyntaxVariations.ExistenceTest" executed="True" result="Success" success="True" time="0.000" asserts="2" />
+                          <test-case name="NUnit.Framework.Syntax.PropertySyntaxVariations.SeparateConstraintTest" executed="True" result="Success" success="True" time="0.000" asserts="2" />
+                        </results>
+                      </test-suite>
+                      <test-suite type="TestFixture" name="PropertyTest_ConstraintFollows" executed="True" result="Success" success="True" time="0.004" asserts="0">
+                        <results>
+                          <test-case name="NUnit.Framework.Syntax.PropertyTest_ConstraintFollows.SyntaxTest.SupportedByConstraintBuilder" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Framework.Syntax.PropertyTest_ConstraintFollows.SyntaxTest.SupportedByInheritedSyntax" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Framework.Syntax.PropertyTest_ConstraintFollows.SyntaxTest.SupportedByStaticSyntax" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                        </results>
+                      </test-suite>
+                      <test-suite type="TestFixture" name="PropertyTest_NotFollows" executed="True" result="Success" success="True" time="0.004" asserts="0">
+                        <results>
+                          <test-case name="NUnit.Framework.Syntax.PropertyTest_NotFollows.SyntaxTest.SupportedByConstraintBuilder" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Framework.Syntax.PropertyTest_NotFollows.SyntaxTest.SupportedByInheritedSyntax" executed="True" result="Success" success="True" time="0.001" asserts="1" />
+                          <test-case name="NUnit.Framework.Syntax.PropertyTest_NotFollows.SyntaxTest.SupportedByStaticSyntax" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                        </results>
+                      </test-suite>
+                      <test-suite type="TestFixture" name="RegexTest" executed="True" result="Success" success="True" time="0.004" asserts="0">
+                        <results>
+                          <test-case name="NUnit.Framework.Syntax.RegexTest.SyntaxTest.SupportedByConstraintBuilder" executed="True" result="Success" success="True" time="0.001" asserts="1" />
+                          <test-case name="NUnit.Framework.Syntax.RegexTest.SyntaxTest.SupportedByInheritedSyntax" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Framework.Syntax.RegexTest.SyntaxTest.SupportedByStaticSyntax" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                        </results>
+                      </test-suite>
+                      <test-suite type="TestFixture" name="RegexTest_IgnoreCase" executed="True" result="Success" success="True" time="0.006" asserts="0">
+                        <results>
+                          <test-case name="NUnit.Framework.Syntax.RegexTest_IgnoreCase.SyntaxTest.SupportedByConstraintBuilder" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Framework.Syntax.RegexTest_IgnoreCase.SyntaxTest.SupportedByInheritedSyntax" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Framework.Syntax.RegexTest_IgnoreCase.SyntaxTest.SupportedByStaticSyntax" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                        </results>
+                      </test-suite>
+                      <test-suite type="TestFixture" name="SamePathOrUnderTest" executed="True" result="Success" success="True" time="0.004" asserts="0">
+                        <results>
+                          <test-case name="NUnit.Framework.Syntax.SamePathOrUnderTest.SyntaxTest.SupportedByConstraintBuilder" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Framework.Syntax.SamePathOrUnderTest.SyntaxTest.SupportedByInheritedSyntax" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Framework.Syntax.SamePathOrUnderTest.SyntaxTest.SupportedByStaticSyntax" executed="True" result="Success" success="True" time="0.001" asserts="1" />
+                        </results>
+                      </test-suite>
+                      <test-suite type="TestFixture" name="SamePathOrUnderTest_IgnoreCase" executed="True" result="Success" success="True" time="0.004" asserts="0">
+                        <results>
+                          <test-case name="NUnit.Framework.Syntax.SamePathOrUnderTest_IgnoreCase.SyntaxTest.SupportedByConstraintBuilder" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Framework.Syntax.SamePathOrUnderTest_IgnoreCase.SyntaxTest.SupportedByInheritedSyntax" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Framework.Syntax.SamePathOrUnderTest_IgnoreCase.SyntaxTest.SupportedByStaticSyntax" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                        </results>
+                      </test-suite>
+                      <test-suite type="TestFixture" name="SamePathOrUnderTest_RespectCase" executed="True" result="Success" success="True" time="0.004" asserts="0">
+                        <results>
+                          <test-case name="NUnit.Framework.Syntax.SamePathOrUnderTest_RespectCase.SyntaxTest.SupportedByConstraintBuilder" executed="True" result="Success" success="True" time="0.001" asserts="1" />
+                          <test-case name="NUnit.Framework.Syntax.SamePathOrUnderTest_RespectCase.SyntaxTest.SupportedByInheritedSyntax" executed="True" result="Success" success="True" time="0.001" asserts="1" />
+                          <test-case name="NUnit.Framework.Syntax.SamePathOrUnderTest_RespectCase.SyntaxTest.SupportedByStaticSyntax" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                        </results>
+                      </test-suite>
+                      <test-suite type="TestFixture" name="SamePathTest" executed="True" result="Success" success="True" time="0.004" asserts="0">
+                        <results>
+                          <test-case name="NUnit.Framework.Syntax.SamePathTest.SyntaxTest.SupportedByConstraintBuilder" executed="True" result="Success" success="True" time="0.001" asserts="1" />
+                          <test-case name="NUnit.Framework.Syntax.SamePathTest.SyntaxTest.SupportedByInheritedSyntax" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Framework.Syntax.SamePathTest.SyntaxTest.SupportedByStaticSyntax" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                        </results>
+                      </test-suite>
+                      <test-suite type="TestFixture" name="SamePathTest_IgnoreCase" executed="True" result="Success" success="True" time="0.004" asserts="0">
+                        <results>
+                          <test-case name="NUnit.Framework.Syntax.SamePathTest_IgnoreCase.SyntaxTest.SupportedByConstraintBuilder" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Framework.Syntax.SamePathTest_IgnoreCase.SyntaxTest.SupportedByInheritedSyntax" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Framework.Syntax.SamePathTest_IgnoreCase.SyntaxTest.SupportedByStaticSyntax" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                        </results>
+                      </test-suite>
+                      <test-suite type="TestFixture" name="SamePathTest_RespectCase" executed="True" result="Success" success="True" time="0.004" asserts="0">
+                        <results>
+                          <test-case name="NUnit.Framework.Syntax.SamePathTest_RespectCase.SyntaxTest.SupportedByConstraintBuilder" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Framework.Syntax.SamePathTest_RespectCase.SyntaxTest.SupportedByInheritedSyntax" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Framework.Syntax.SamePathTest_RespectCase.SyntaxTest.SupportedByStaticSyntax" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                        </results>
+                      </test-suite>
+                      <test-suite type="TestFixture" name="SomeTest" executed="True" result="Success" success="True" time="0.004" asserts="0">
+                        <results>
+                          <test-case name="NUnit.Framework.Syntax.SomeTest.SyntaxTest.SupportedByConstraintBuilder" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Framework.Syntax.SomeTest.SyntaxTest.SupportedByInheritedSyntax" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Framework.Syntax.SomeTest.SyntaxTest.SupportedByStaticSyntax" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                        </results>
+                      </test-suite>
+                      <test-suite type="TestFixture" name="SomeTest_BeforeBinaryOperators" executed="True" result="Success" success="True" time="0.004" asserts="0">
+                        <results>
+                          <test-case name="NUnit.Framework.Syntax.SomeTest_BeforeBinaryOperators.SyntaxTest.SupportedByConstraintBuilder" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Framework.Syntax.SomeTest_BeforeBinaryOperators.SyntaxTest.SupportedByInheritedSyntax" executed="True" result="Success" success="True" time="0.001" asserts="1" />
+                          <test-case name="NUnit.Framework.Syntax.SomeTest_BeforeBinaryOperators.SyntaxTest.SupportedByStaticSyntax" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                        </results>
+                      </test-suite>
+                      <test-suite type="TestFixture" name="SomeTest_NestedSome" executed="True" result="Success" success="True" time="0.004" asserts="0">
+                        <results>
+                          <test-case name="NUnit.Framework.Syntax.SomeTest_NestedSome.SyntaxTest.SupportedByConstraintBuilder" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Framework.Syntax.SomeTest_NestedSome.SyntaxTest.SupportedByInheritedSyntax" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Framework.Syntax.SomeTest_NestedSome.SyntaxTest.SupportedByStaticSyntax" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                        </results>
+                      </test-suite>
+                      <test-suite type="TestFixture" name="SomeTest_UseOfAndSome" executed="True" result="Success" success="True" time="0.004" asserts="0">
+                        <results>
+                          <test-case name="NUnit.Framework.Syntax.SomeTest_UseOfAndSome.SyntaxTest.SupportedByConstraintBuilder" executed="True" result="Success" success="True" time="0.001" asserts="1" />
+                          <test-case name="NUnit.Framework.Syntax.SomeTest_UseOfAndSome.SyntaxTest.SupportedByInheritedSyntax" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Framework.Syntax.SomeTest_UseOfAndSome.SyntaxTest.SupportedByStaticSyntax" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                        </results>
+                      </test-suite>
+                      <test-suite type="TestFixture" name="StartsWithTest" executed="True" result="Success" success="True" time="0.004" asserts="0">
+                        <results>
+                          <test-case name="NUnit.Framework.Syntax.StartsWithTest.SyntaxTest.SupportedByConstraintBuilder" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Framework.Syntax.StartsWithTest.SyntaxTest.SupportedByInheritedSyntax" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Framework.Syntax.StartsWithTest.SyntaxTest.SupportedByStaticSyntax" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                        </results>
+                      </test-suite>
+                      <test-suite type="TestFixture" name="StartsWithTest_IgnoreCase" executed="True" result="Success" success="True" time="0.004" asserts="0">
+                        <results>
+                          <test-case name="NUnit.Framework.Syntax.StartsWithTest_IgnoreCase.SyntaxTest.SupportedByConstraintBuilder" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Framework.Syntax.StartsWithTest_IgnoreCase.SyntaxTest.SupportedByInheritedSyntax" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Framework.Syntax.StartsWithTest_IgnoreCase.SyntaxTest.SupportedByStaticSyntax" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                        </results>
+                      </test-suite>
+                      <test-suite type="TestFixture" name="SubstringTest" executed="True" result="Success" success="True" time="0.005" asserts="0">
+                        <results>
+                          <test-case name="NUnit.Framework.Syntax.SubstringTest.SyntaxTest.SupportedByConstraintBuilder" executed="True" result="Success" success="True" time="0.001" asserts="1" />
+                          <test-case name="NUnit.Framework.Syntax.SubstringTest.SyntaxTest.SupportedByInheritedSyntax" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Framework.Syntax.SubstringTest.SyntaxTest.SupportedByStaticSyntax" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                        </results>
+                      </test-suite>
+                      <test-suite type="TestFixture" name="SubstringTest_IgnoreCase" executed="True" result="Success" success="True" time="0.005" asserts="0">
+                        <results>
+                          <test-case name="NUnit.Framework.Syntax.SubstringTest_IgnoreCase.SyntaxTest.SupportedByConstraintBuilder" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Framework.Syntax.SubstringTest_IgnoreCase.SyntaxTest.SupportedByInheritedSyntax" executed="True" result="Success" success="True" time="0.001" asserts="1" />
+                          <test-case name="NUnit.Framework.Syntax.SubstringTest_IgnoreCase.SyntaxTest.SupportedByStaticSyntax" executed="True" result="Success" success="True" time="0.001" asserts="1" />
+                        </results>
+                      </test-suite>
+                      <test-suite type="TestFixture" name="TextContains" executed="True" result="Success" success="True" time="0.004" asserts="0">
+                        <results>
+                          <test-case name="NUnit.Framework.Syntax.TextContains.SyntaxTest.SupportedByConstraintBuilder" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Framework.Syntax.TextContains.SyntaxTest.SupportedByInheritedSyntax" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Framework.Syntax.TextContains.SyntaxTest.SupportedByStaticSyntax" executed="True" result="Success" success="True" time="0.001" asserts="1" />
+                        </results>
+                      </test-suite>
+                      <test-suite type="TestFixture" name="TextEndsWithTest" executed="True" result="Success" success="True" time="0.005" asserts="0">
+                        <results>
+                          <test-case name="NUnit.Framework.Syntax.TextEndsWithTest.SyntaxTest.SupportedByConstraintBuilder" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Framework.Syntax.TextEndsWithTest.SyntaxTest.SupportedByInheritedSyntax" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Framework.Syntax.TextEndsWithTest.SyntaxTest.SupportedByStaticSyntax" executed="True" result="Success" success="True" time="0.001" asserts="1" />
+                        </results>
+                      </test-suite>
+                      <test-suite type="TestFixture" name="TextMatchesTest" executed="True" result="Success" success="True" time="0.005" asserts="0">
+                        <results>
+                          <test-case name="NUnit.Framework.Syntax.TextMatchesTest.SyntaxTest.SupportedByConstraintBuilder" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Framework.Syntax.TextMatchesTest.SyntaxTest.SupportedByInheritedSyntax" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Framework.Syntax.TextMatchesTest.SyntaxTest.SupportedByStaticSyntax" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                        </results>
+                      </test-suite>
+                      <test-suite type="TestFixture" name="TextStartsWithTest" executed="True" result="Success" success="True" time="0.004" asserts="0">
+                        <results>
+                          <test-case name="NUnit.Framework.Syntax.TextStartsWithTest.SyntaxTest.SupportedByConstraintBuilder" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Framework.Syntax.TextStartsWithTest.SyntaxTest.SupportedByInheritedSyntax" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Framework.Syntax.TextStartsWithTest.SyntaxTest.SupportedByStaticSyntax" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                        </results>
+                      </test-suite>
+                      <test-suite type="TestFixture" name="ThrowsTests" executed="True" result="Success" success="True" time="0.037" asserts="0">
+                        <results>
+                          <test-case name="NUnit.Framework.Syntax.ThrowsTests.DelegateThrowsException" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Framework.Syntax.ThrowsTests.LambdaThrowsExceptionWithMessage" executed="True" result="Success" success="True" time="0.003" asserts="1" />
+                          <test-case name="NUnit.Framework.Syntax.ThrowsTests.LambdaThrowsExcepton" executed="True" result="Success" success="True" time="0.001" asserts="1" />
+                          <test-case name="NUnit.Framework.Syntax.ThrowsTests.LambdaThrowsNothing" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Framework.Syntax.ThrowsTests.ThrowsArgumentException" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Framework.Syntax.ThrowsTests.ThrowsException" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Framework.Syntax.ThrowsTests.ThrowsExceptionInstanceOf" executed="True" result="Success" success="True" time="0.001" asserts="1" />
+                          <test-case name="NUnit.Framework.Syntax.ThrowsTests.ThrowsExceptionTypeOf" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Framework.Syntax.ThrowsTests.ThrowsExceptionTypeOfAndConstraint" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Framework.Syntax.ThrowsTests.ThrowsExceptionWithConstraint" executed="True" result="Success" success="True" time="0.001" asserts="1" />
+                          <test-case name="NUnit.Framework.Syntax.ThrowsTests.ThrowsExceptionWithInnerException" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Framework.Syntax.ThrowsTests.ThrowsInnerException" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Framework.Syntax.ThrowsTests.ThrowsInstanceOf" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Framework.Syntax.ThrowsTests.ThrowsInvalidOperationException" executed="True" result="Success" success="True" time="0.001" asserts="1" />
+                          <test-case name="NUnit.Framework.Syntax.ThrowsTests.ThrowsTargetInvocationExceptionWithInnerException" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Framework.Syntax.ThrowsTests.ThrowsTypeOf" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Framework.Syntax.ThrowsTests.ThrowsTypeOfAndConstraint" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Framework.Syntax.ThrowsTests.ThrowsTypeOfWithConstraint" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Framework.Syntax.ThrowsTests.ThrowsTypeOfWithInnerException" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Framework.Syntax.ThrowsTests.ThrowsTypeofWithMessage" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                        </results>
+                      </test-suite>
+                      <test-suite type="TestFixture" name="TrueTest" executed="True" result="Success" success="True" time="0.005" asserts="0">
+                        <results>
+                          <test-case name="NUnit.Framework.Syntax.TrueTest.SyntaxTest.SupportedByConstraintBuilder" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Framework.Syntax.TrueTest.SyntaxTest.SupportedByInheritedSyntax" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Framework.Syntax.TrueTest.SyntaxTest.SupportedByStaticSyntax" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                        </results>
+                      </test-suite>
+                      <test-suite type="TestFixture" name="UniqueTest" executed="True" result="Success" success="True" time="0.004" asserts="0">
+                        <results>
+                          <test-case name="NUnit.Framework.Syntax.UniqueTest.SyntaxTest.SupportedByConstraintBuilder" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Framework.Syntax.UniqueTest.SyntaxTest.SupportedByInheritedSyntax" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Framework.Syntax.UniqueTest.SyntaxTest.SupportedByStaticSyntax" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                        </results>
+                      </test-suite>
+                      <test-suite type="TestFixture" name="XmlSerializableTest" executed="True" result="Success" success="True" time="0.005" asserts="0">
+                        <results>
+                          <test-case name="NUnit.Framework.Syntax.XmlSerializableTest.SyntaxTest.SupportedByConstraintBuilder" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Framework.Syntax.XmlSerializableTest.SyntaxTest.SupportedByInheritedSyntax" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Framework.Syntax.XmlSerializableTest.SyntaxTest.SupportedByStaticSyntax" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                        </results>
+                      </test-suite>
+                    </results>
+                  </test-suite>
+                  <test-suite type="Namespace" name="Tests" executed="True" result="Success" success="True" time="1.043" asserts="0">
+                    <results>
+                      <test-suite type="TestFixture" name="ArrayEqualsFailureMessageFixture" executed="True" result="Success" success="True" time="0.031" asserts="0">
+                        <results>
+                          <test-case name="NUnit.Framework.Tests.ArrayEqualsFailureMessageFixture.ActualArrayIsLonger" executed="True" result="Success" success="True" time="0.001" asserts="2" />
+                          <test-case name="NUnit.Framework.Tests.ArrayEqualsFailureMessageFixture.ArrayAndCollection_Failure" executed="True" result="Success" success="True" time="0.001" asserts="1" />
+                          <test-case name="NUnit.Framework.Tests.ArrayEqualsFailureMessageFixture.ArraysDeclaredAsDifferentTypes" executed="True" result="Success" success="True" time="0.001" asserts="2" />
+                          <test-case name="NUnit.Framework.Tests.ArrayEqualsFailureMessageFixture.ArraysHaveDifferentRanks" executed="True" result="Success" success="True" time="0.001" asserts="2" />
+                          <test-case name="NUnit.Framework.Tests.ArrayEqualsFailureMessageFixture.ArraysWithDifferentDimensionsAsCollection" executed="True" result="Success" success="True" time="0.001" asserts="2" />
+                          <test-case name="NUnit.Framework.Tests.ArrayEqualsFailureMessageFixture.ArraysWithDifferentRanksAsCollection" executed="True" result="Success" success="True" time="0.001" asserts="2" />
+                          <test-case name="NUnit.Framework.Tests.ArrayEqualsFailureMessageFixture.DifferentArrayTypesEqualFails" executed="True" result="Success" success="True" time="0.001" asserts="2" />
+                          <test-case name="NUnit.Framework.Tests.ArrayEqualsFailureMessageFixture.DoubleDimensionedArrays" executed="True" result="Success" success="True" time="0.001" asserts="2" />
+                          <test-case name="NUnit.Framework.Tests.ArrayEqualsFailureMessageFixture.ExpectedArrayIsLonger" executed="True" result="Success" success="True" time="0.001" asserts="2" />
+                          <test-case name="NUnit.Framework.Tests.ArrayEqualsFailureMessageFixture.FailureOnSingleDimensionedArrays" executed="True" result="Success" success="True" time="0.000" asserts="2" />
+                          <test-case name="NUnit.Framework.Tests.ArrayEqualsFailureMessageFixture.FiveDimensionedArrays" executed="True" result="Success" success="True" time="0.000" asserts="2" />
+                          <test-case name="NUnit.Framework.Tests.ArrayEqualsFailureMessageFixture.JaggedArrayComparedToSimpleArray" executed="True" result="Success" success="True" time="0.000" asserts="2" />
+                          <test-case name="NUnit.Framework.Tests.ArrayEqualsFailureMessageFixture.JaggedArrays" executed="True" result="Success" success="True" time="0.001" asserts="2" />
+                          <test-case name="NUnit.Framework.Tests.ArrayEqualsFailureMessageFixture.SameLengthDifferentContent" executed="True" result="Success" success="True" time="0.001" asserts="2" />
+                          <test-case name="NUnit.Framework.Tests.ArrayEqualsFailureMessageFixture.TripleDimensionedArrays" executed="True" result="Success" success="True" time="0.001" asserts="2" />
+                        </results>
+                      </test-suite>
+                      <test-suite type="TestFixture" name="ArrayEqualsFixture" executed="True" result="Success" success="True" time="0.029" asserts="0">
+                        <results>
+                          <test-case name="NUnit.Framework.Tests.ArrayEqualsFixture.ArrayAndCollection" executed="True" result="Success" success="True" time="0.000" asserts="4" />
+                          <test-case name="NUnit.Framework.Tests.ArrayEqualsFixture.ArrayIsEqualToItself" executed="True" result="Success" success="True" time="0.000" asserts="3" />
+                          <test-case name="NUnit.Framework.Tests.ArrayEqualsFixture.ArrayOfIntAndArrayOfDouble" executed="True" result="Success" success="True" time="0.000" asserts="4" />
+                          <test-case name="NUnit.Framework.Tests.ArrayEqualsFixture.ArraysDeclaredAsDifferentTypes" executed="True" result="Success" success="True" time="0.000" asserts="4" />
+                          <test-case name="NUnit.Framework.Tests.ArrayEqualsFixture.ArraysOfArrays" executed="True" result="Success" success="True" time="0.001" asserts="4" />
+                          <test-case name="NUnit.Framework.Tests.ArrayEqualsFixture.ArraysOfDecimal" executed="True" result="Success" success="True" time="0.000" asserts="4" />
+                          <test-case name="NUnit.Framework.Tests.ArrayEqualsFixture.ArraysOfDouble" executed="True" result="Success" success="True" time="0.000" asserts="4" />
+                          <test-case name="NUnit.Framework.Tests.ArrayEqualsFixture.ArraysOfInt" executed="True" result="Success" success="True" time="0.000" asserts="4" />
+                          <test-case name="NUnit.Framework.Tests.ArrayEqualsFixture.ArraysOfMixedTypes" executed="True" result="Success" success="True" time="0.000" asserts="4" />
+                          <test-case name="NUnit.Framework.Tests.ArrayEqualsFixture.ArraysOfString" executed="True" result="Success" success="True" time="0.000" asserts="5" />
+                          <test-case name="NUnit.Framework.Tests.ArrayEqualsFixture.ArraysPassedAsObjects" executed="True" result="Success" success="True" time="0.001" asserts="4" />
+                          <test-case name="NUnit.Framework.Tests.ArrayEqualsFixture.ArraysWithDifferentDimensionsMatchedAsCollection" executed="True" result="Success" success="True" time="0.000" asserts="3" />
+                          <test-case name="NUnit.Framework.Tests.ArrayEqualsFixture.ArraysWithDifferentRanksComparedAsCollection" executed="True" result="Success" success="True" time="0.000" asserts="3" />
+                          <test-case name="NUnit.Framework.Tests.ArrayEqualsFixture.DoubleDimensionedArrays" executed="True" result="Success" success="True" time="0.000" asserts="4" />
+                          <test-case name="NUnit.Framework.Tests.ArrayEqualsFixture.FiveDimensionedArrays" executed="True" result="Success" success="True" time="0.001" asserts="2" />
+                          <test-case name="NUnit.Framework.Tests.ArrayEqualsFixture.JaggedArrays" executed="True" result="Success" success="True" time="0.000" asserts="2" />
+                          <test-case name="NUnit.Framework.Tests.ArrayEqualsFixture.TripleDimensionedArrays" executed="True" result="Success" success="True" time="0.000" asserts="2" />
+                        </results>
+                      </test-suite>
+                      <test-suite type="TestFixture" name="ArrayNotEqualFixture" executed="True" result="Success" success="True" time="0.005" asserts="0">
+                        <results>
+                          <test-case name="NUnit.Framework.Tests.ArrayNotEqualFixture.ArraysDeclaredAsDifferentTypes" executed="True" result="Success" success="True" time="0.000" asserts="3" />
+                          <test-case name="NUnit.Framework.Tests.ArrayNotEqualFixture.DifferentLengthArrays" executed="True" result="Success" success="True" time="0.000" asserts="4" />
+                          <test-case name="NUnit.Framework.Tests.ArrayNotEqualFixture.SameLengthDifferentContent" executed="True" result="Success" success="True" time="0.001" asserts="4" />
+                        </results>
+                      </test-suite>
+                      <test-suite type="TestFixture" name="AssertThrowsTests" executed="True" result="Success" success="True" time="0.029" asserts="0">
+                        <results>
+                          <test-case name="NUnit.Framework.Tests.AssertThrowsTests.BaseExceptionThrown" executed="True" result="Success" success="True" time="0.000" asserts="2" />
+                          <test-case name="NUnit.Framework.Tests.AssertThrowsTests.CanCatchExceptionOfDerivedType" executed="True" result="Success" success="True" time="0.000" asserts="4" />
+                          <test-case name="NUnit.Framework.Tests.AssertThrowsTests.CanCatchExceptionOfExactType" executed="True" result="Success" success="True" time="0.001" asserts="4" />
+                          <test-case name="NUnit.Framework.Tests.AssertThrowsTests.CanCatchUnspecifiedException" executed="True" result="Success" success="True" time="0.000" asserts="4" />
+                          <test-case name="NUnit.Framework.Tests.AssertThrowsTests.CorrectExceptionIsReturnedToMethod" executed="True" result="Success" success="True" time="0.001" asserts="16" />
+                          <test-case name="NUnit.Framework.Tests.AssertThrowsTests.CorrectExceptionThrown" executed="True" result="Success" success="True" time="0.000" asserts="5" />
+                          <test-case name="NUnit.Framework.Tests.AssertThrowsTests.DerivedExceptionThrown" executed="True" result="Success" success="True" time="0.001" asserts="2" />
+                          <test-case name="NUnit.Framework.Tests.AssertThrowsTests.DoesNotThrowFails" executed="True" result="Success" success="True" time="0.001" asserts="0" />
+                          <test-case name="NUnit.Framework.Tests.AssertThrowsTests.DoesNotThrowSuceeds" executed="True" result="Success" success="True" time="0.000" asserts="0" />
+                          <test-case name="NUnit.Framework.Tests.AssertThrowsTests.NoExceptionThrown" executed="True" result="Success" success="True" time="0.000" asserts="2" />
+                          <test-case name="NUnit.Framework.Tests.AssertThrowsTests.UnrelatedExceptionThrown" executed="True" result="Success" success="True" time="0.010" asserts="2" />
+                        </results>
+                      </test-suite>
+                      <test-suite type="TestFixture" name="AssumeThatTests" executed="True" result="Success" success="True" time="0.042" asserts="0">
+                        <results>
+                          <test-case name="NUnit.Framework.Tests.AssumeThatTests.AssumptionPasses_ActualAndConstraint" executed="True" result="Success" success="True" time="0.000" asserts="0" />
+                          <test-case name="NUnit.Framework.Tests.AssumeThatTests.AssumptionPasses_ActualAndConstraintWithMessage" executed="True" result="Success" success="True" time="0.000" asserts="0" />
+                          <test-case name="NUnit.Framework.Tests.AssumeThatTests.AssumptionPasses_ActualAndConstraintWithMessageAndArgs" executed="True" result="Success" success="True" time="0.000" asserts="0" />
+                          <test-case name="NUnit.Framework.Tests.AssumeThatTests.AssumptionPasses_Boolean" executed="True" result="Success" success="True" time="0.000" asserts="0" />
+                          <test-case name="NUnit.Framework.Tests.AssumeThatTests.AssumptionPasses_BooleanWithMessage" executed="True" result="Success" success="True" time="0.000" asserts="0" />
+                          <test-case name="NUnit.Framework.Tests.AssumeThatTests.AssumptionPasses_BooleanWithMessageAndArgs" executed="True" result="Success" success="True" time="0.000" asserts="0" />
+                          <test-case name="NUnit.Framework.Tests.AssumeThatTests.AssumptionPasses_DelegateAndConstraint" executed="True" result="Success" success="True" time="0.000" asserts="0" />
+                          <test-case name="NUnit.Framework.Tests.AssumeThatTests.AssumptionPasses_DelegateAndConstraintWithMessage" executed="True" result="Success" success="True" time="0.001" asserts="0" />
+                          <test-case name="NUnit.Framework.Tests.AssumeThatTests.AssumptionPasses_DelegateAndConstraintWithMessageAndArgs" executed="True" result="Success" success="True" time="0.001" asserts="0" />
+                          <test-case name="NUnit.Framework.Tests.AssumeThatTests.AssumptionPasses_ReferenceAndConstraint" executed="True" result="Success" success="True" time="0.000" asserts="0" />
+                          <test-case name="NUnit.Framework.Tests.AssumeThatTests.AssumptionPasses_ReferenceAndConstraintWithMessage" executed="True" result="Success" success="True" time="0.000" asserts="0" />
+                          <test-case name="NUnit.Framework.Tests.AssumeThatTests.AssumptionPasses_ReferenceAndConstraintWithMessageAndArgs" executed="True" result="Success" success="True" time="0.000" asserts="0" />
+                          <test-case name="NUnit.Framework.Tests.AssumeThatTests.FailureThrowsInconclusiveException_ActualAndConstraint" executed="True" result="Success" success="True" time="0.000" asserts="0" />
+                          <test-case name="NUnit.Framework.Tests.AssumeThatTests.FailureThrowsInconclusiveException_ActualAndConstraintWithMessage" executed="True" result="Success" success="True" time="0.000" asserts="0" />
+                          <test-case name="NUnit.Framework.Tests.AssumeThatTests.FailureThrowsInconclusiveException_ActualAndConstraintWithMessageAndArgs" executed="True" result="Success" success="True" time="0.000" asserts="0" />
+                          <test-case name="NUnit.Framework.Tests.AssumeThatTests.FailureThrowsInconclusiveException_Boolean" executed="True" result="Success" success="True" time="0.000" asserts="0" />
+                          <test-case name="NUnit.Framework.Tests.AssumeThatTests.FailureThrowsInconclusiveException_BooleanWithMessage" executed="True" result="Success" success="True" time="0.000" asserts="0" />
+                          <test-case name="NUnit.Framework.Tests.AssumeThatTests.FailureThrowsInconclusiveException_BooleanWithMessageAndArgs" executed="True" result="Success" success="True" time="0.001" asserts="0" />
+                          <test-case name="NUnit.Framework.Tests.AssumeThatTests.FailureThrowsInconclusiveException_DelegateAndConstraint" executed="True" result="Success" success="True" time="0.001" asserts="0" />
+                          <test-case name="NUnit.Framework.Tests.AssumeThatTests.FailureThrowsInconclusiveException_DelegateAndConstraintWithMessage" executed="True" result="Success" success="True" time="0.001" asserts="0" />
+                          <test-case name="NUnit.Framework.Tests.AssumeThatTests.FailureThrowsInconclusiveException_DelegateAndConstraintWithMessageAndArgs" executed="True" result="Success" success="True" time="0.001" asserts="0" />
+                          <test-case name="NUnit.Framework.Tests.AssumeThatTests.FailureThrowsInconclusiveException_ReferenceAndConstraint" executed="True" result="Success" success="True" time="0.001" asserts="0" />
+                          <test-case name="NUnit.Framework.Tests.AssumeThatTests.FailureThrowsInconclusiveException_ReferenceAndConstraintWithMessage" executed="True" result="Success" success="True" time="0.001" asserts="0" />
+                          <test-case name="NUnit.Framework.Tests.AssumeThatTests.FailureThrowsInconclusiveException_ReferenceAndConstraintWithMessageAndArgs" executed="True" result="Success" success="True" time="0.001" asserts="0" />
+                        </results>
+                      </test-suite>
+                      <test-suite type="TestFixture" name="CollectionAssertTest" executed="True" result="Success" success="True" time="0.092" asserts="0">
+                        <results>
+                          <test-case name="NUnit.Framework.Tests.CollectionAssertTest.AreEqual" executed="True" result="Success" success="True" time="0.000" asserts="3" />
+                          <test-case name="NUnit.Framework.Tests.CollectionAssertTest.AreEqual_HandlesNull" executed="True" result="Success" success="True" time="0.000" asserts="2" />
+                          <test-case name="NUnit.Framework.Tests.CollectionAssertTest.AreEqual_UsingIterator" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Framework.Tests.CollectionAssertTest.AreEqual_UsingIterator_Fails" executed="True" result="Success" success="True" time="0.000" asserts="2" />
+                          <test-case name="NUnit.Framework.Tests.CollectionAssertTest.AreEqual_UsingLinqQuery" executed="True" result="Success" success="True" time="0.001" asserts="1" />
+                          <test-case name="NUnit.Framework.Tests.CollectionAssertTest.AreEqual_UsingLinqQuery_Fails" executed="True" result="Success" success="True" time="0.000" asserts="2" />
+                          <test-case name="NUnit.Framework.Tests.CollectionAssertTest.AreEqualFail" executed="True" result="Success" success="True" time="0.000" asserts="2" />
+                          <test-case name="NUnit.Framework.Tests.CollectionAssertTest.AreEqualFailCount" executed="True" result="Success" success="True" time="0.000" asserts="2" />
+                          <test-case name="NUnit.Framework.Tests.CollectionAssertTest.AreEquivalentHandlesNull" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Framework.Tests.CollectionAssertTest.AreNotEqual" executed="True" result="Success" success="True" time="0.000" asserts="6" />
+                          <test-case name="NUnit.Framework.Tests.CollectionAssertTest.AreNotEqual_Fails" executed="True" result="Success" success="True" time="0.001" asserts="2" />
+                          <test-case name="NUnit.Framework.Tests.CollectionAssertTest.AreNotEqual_HandlesNull" executed="True" result="Success" success="True" time="0.000" asserts="2" />
+                          <test-case name="NUnit.Framework.Tests.CollectionAssertTest.Contains_ICollection" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Framework.Tests.CollectionAssertTest.Contains_IList" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Framework.Tests.CollectionAssertTest.ContainsFails_EmptyICollection" executed="True" result="Success" success="True" time="0.000" asserts="2" />
+                          <test-case name="NUnit.Framework.Tests.CollectionAssertTest.ContainsFails_EmptyIList" executed="True" result="Success" success="True" time="0.000" asserts="2" />
+                          <test-case name="NUnit.Framework.Tests.CollectionAssertTest.ContainsFails_ICollection" executed="True" result="Success" success="True" time="0.000" asserts="2" />
+                          <test-case name="NUnit.Framework.Tests.CollectionAssertTest.ContainsFails_ILIst" executed="True" result="Success" success="True" time="0.001" asserts="2" />
+                          <test-case name="NUnit.Framework.Tests.CollectionAssertTest.ContainsNull_ICollection" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Framework.Tests.CollectionAssertTest.ContainsNull_IList" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Framework.Tests.CollectionAssertTest.DoesNotContain" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Framework.Tests.CollectionAssertTest.DoesNotContain_Empty" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Framework.Tests.CollectionAssertTest.DoesNotContain_Fails" executed="True" result="Success" success="True" time="0.000" asserts="2" />
+                          <test-case name="NUnit.Framework.Tests.CollectionAssertTest.EnsureComparerIsUsed" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Framework.Tests.CollectionAssertTest.Equivalent" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Framework.Tests.CollectionAssertTest.EquivalentFailOne" executed="True" result="Success" success="True" time="0.000" asserts="2" />
+                          <test-case name="NUnit.Framework.Tests.CollectionAssertTest.EquivalentFailTwo" executed="True" result="Success" success="True" time="0.000" asserts="2" />
+                          <test-case name="NUnit.Framework.Tests.CollectionAssertTest.IsNotSubsetOf" executed="True" result="Success" success="True" time="0.000" asserts="2" />
+                          <test-case name="NUnit.Framework.Tests.CollectionAssertTest.IsNotSubsetOf_Fails" executed="True" result="Success" success="True" time="0.001" asserts="2" />
+                          <test-case name="NUnit.Framework.Tests.CollectionAssertTest.IsNotSubsetOfHandlesNull" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Framework.Tests.CollectionAssertTest.IsOrdered" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Framework.Tests.CollectionAssertTest.IsOrdered_Allows_adjacent_equal_values" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Framework.Tests.CollectionAssertTest.IsOrdered_ContainedTypesMustBeCompatible" executed="True" result="Success" success="True" time="0.001" asserts="1" />
+                          <test-case name="NUnit.Framework.Tests.CollectionAssertTest.IsOrdered_Fails" executed="True" result="Success" success="True" time="0.001" asserts="2" />
+                          <test-case name="NUnit.Framework.Tests.CollectionAssertTest.IsOrdered_Handles_custom_comparison" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Framework.Tests.CollectionAssertTest.IsOrdered_Handles_custom_comparison2" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Framework.Tests.CollectionAssertTest.IsOrdered_Handles_null" executed="True" result="Success" success="True" time="0.001" asserts="1" />
+                          <test-case name="NUnit.Framework.Tests.CollectionAssertTest.IsOrdered_TypesMustImplementIComparable" executed="True" result="Success" success="True" time="0.001" asserts="1" />
+                          <test-case name="NUnit.Framework.Tests.CollectionAssertTest.IsSubsetOf" executed="True" result="Success" success="True" time="0.001" asserts="2" />
+                          <test-case name="NUnit.Framework.Tests.CollectionAssertTest.IsSubsetOf_Fails" executed="True" result="Success" success="True" time="0.001" asserts="2" />
+                          <test-case name="NUnit.Framework.Tests.CollectionAssertTest.IsSubsetOfHandlesNull" executed="True" result="Success" success="True" time="0.000" asserts="2" />
+                          <test-case name="NUnit.Framework.Tests.CollectionAssertTest.ItemsNotNull" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Framework.Tests.CollectionAssertTest.ItemsNotNullFailure" executed="True" result="Success" success="True" time="0.001" asserts="2" />
+                          <test-case name="NUnit.Framework.Tests.CollectionAssertTest.ItemsOfType" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Framework.Tests.CollectionAssertTest.ItemsOfTypeFailure" executed="True" result="Success" success="True" time="0.000" asserts="2" />
+                          <test-case name="NUnit.Framework.Tests.CollectionAssertTest.NotEquivalent" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Framework.Tests.CollectionAssertTest.NotEquivalent_Fails" executed="True" result="Success" success="True" time="0.001" asserts="2" />
+                          <test-case name="NUnit.Framework.Tests.CollectionAssertTest.NotEquivalentHandlesNull" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Framework.Tests.CollectionAssertTest.Unique_WithNull" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Framework.Tests.CollectionAssertTest.Unique_WithObjects" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Framework.Tests.CollectionAssertTest.Unique_WithStrings" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Framework.Tests.CollectionAssertTest.UniqueFailure" executed="True" result="Success" success="True" time="0.000" asserts="2" />
+                          <test-case name="NUnit.Framework.Tests.CollectionAssertTest.UniqueFailure_WithTwoNulls" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                        </results>
+                      </test-suite>
+                      <test-suite type="TestFixture" name="ConditionAssertTests" executed="True" result="Success" success="True" time="0.045" asserts="0">
+                        <results>
+                          <test-case name="NUnit.Framework.Tests.ConditionAssertTests.IsEmpty" executed="True" result="Success" success="True" time="0.000" asserts="5" />
+                          <test-case name="NUnit.Framework.Tests.ConditionAssertTests.IsEmptyFailsOnNonEmptyArray" executed="True" result="Success" success="True" time="0.001" asserts="2" />
+                          <test-case name="NUnit.Framework.Tests.ConditionAssertTests.IsEmptyFailsOnNonEmptyIEnumerable" executed="True" result="Success" success="True" time="0.001" asserts="2" />
+                          <test-case name="NUnit.Framework.Tests.ConditionAssertTests.IsEmptyFailsOnNullString" executed="True" result="Success" success="True" time="0.001" asserts="2" />
+                          <test-case name="NUnit.Framework.Tests.ConditionAssertTests.IsEmptyFailsOnString" executed="True" result="Success" success="True" time="0.001" asserts="2" />
+                          <test-case name="NUnit.Framework.Tests.ConditionAssertTests.IsFalse" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Framework.Tests.ConditionAssertTests.IsFalseFails" executed="True" result="Success" success="True" time="0.001" asserts="2" />
+                          <test-case name="NUnit.Framework.Tests.ConditionAssertTests.IsNaN" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Framework.Tests.ConditionAssertTests.IsNaNFails" executed="True" result="Success" success="True" time="0.000" asserts="2" />
+                          <test-case name="NUnit.Framework.Tests.ConditionAssertTests.IsNotEmpty" executed="True" result="Success" success="True" time="0.000" asserts="5" />
+                          <test-case name="NUnit.Framework.Tests.ConditionAssertTests.IsNotEmptyFailsOnEmptyArray" executed="True" result="Success" success="True" time="0.001" asserts="2" />
+                          <test-case name="NUnit.Framework.Tests.ConditionAssertTests.IsNotEmptyFailsOnEmptyArrayList" executed="True" result="Success" success="True" time="0.001" asserts="2" />
+                          <test-case name="NUnit.Framework.Tests.ConditionAssertTests.IsNotEmptyFailsOnEmptyHashTable" executed="True" result="Success" success="True" time="0.001" asserts="2" />
+                          <test-case name="NUnit.Framework.Tests.ConditionAssertTests.IsNotEmptyFailsOnEmptyIEnumerable" executed="True" result="Success" success="True" time="0.001" asserts="2" />
+                          <test-case name="NUnit.Framework.Tests.ConditionAssertTests.IsNotEmptyFailsOnEmptyString" executed="True" result="Success" success="True" time="0.000" asserts="2" />
+                          <test-case name="NUnit.Framework.Tests.ConditionAssertTests.IsNotNull" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Framework.Tests.ConditionAssertTests.IsNotNullFails" executed="True" result="Success" success="True" time="0.001" asserts="2" />
+                          <test-case name="NUnit.Framework.Tests.ConditionAssertTests.IsNull" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Framework.Tests.ConditionAssertTests.IsNullFails" executed="True" result="Success" success="True" time="0.001" asserts="2" />
+                          <test-case name="NUnit.Framework.Tests.ConditionAssertTests.IsTrue" executed="True" result="Success" success="True" time="0.005" asserts="1" />
+                          <test-case name="NUnit.Framework.Tests.ConditionAssertTests.IsTrueFails" executed="True" result="Success" success="True" time="0.001" asserts="2" />
+                        </results>
+                      </test-suite>
+                      <test-suite type="TestFixture" name="DirectoryAssertTests" executed="True" result="Success" success="True" time="0.219" asserts="0">
+                        <results>
+                          <test-case name="NUnit.Framework.Tests.DirectoryAssertTests.AreEqualFailsWhenOneDoesNotExist" executed="True" result="Success" success="True" time="0.006" asserts="1" />
+                          <test-case name="NUnit.Framework.Tests.DirectoryAssertTests.AreEqualFailsWhenOneIsNull" executed="True" result="Success" success="True" time="0.005" asserts="1" />
+                          <test-case name="NUnit.Framework.Tests.DirectoryAssertTests.AreEqualFailsWithDirectoryInfos" executed="True" result="Success" success="True" time="0.010" asserts="1" />
+                          <test-case name="NUnit.Framework.Tests.DirectoryAssertTests.AreEqualFailsWithStringPath" executed="True" result="Success" success="True" time="0.009" asserts="1" />
+                          <test-case name="NUnit.Framework.Tests.DirectoryAssertTests.AreEqualPassesWhenBothAreNull" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Framework.Tests.DirectoryAssertTests.AreEqualPassesWithDirectoryInfos" executed="True" result="Success" success="True" time="0.004" asserts="1" />
+                          <test-case name="NUnit.Framework.Tests.DirectoryAssertTests.AreEqualPassesWithStringPath" executed="True" result="Success" success="True" time="0.006" asserts="1" />
+                          <test-case name="NUnit.Framework.Tests.DirectoryAssertTests.AreNotEqualFailsWhenBothAreNull" executed="True" result="Success" success="True" time="0.000" asserts="2" />
+                          <test-case name="NUnit.Framework.Tests.DirectoryAssertTests.AreNotEqualFailsWithDirectoryInfos" executed="True" result="Success" success="True" time="0.005" asserts="1" />
+                          <test-case name="NUnit.Framework.Tests.DirectoryAssertTests.AreNotEqualFailsWithStringPath" executed="True" result="Success" success="True" time="0.006" asserts="1" />
+                          <test-case name="NUnit.Framework.Tests.DirectoryAssertTests.AreNotEqualPassesIfOneIsNull" executed="True" result="Success" success="True" time="0.005" asserts="1" />
+                          <test-case name="NUnit.Framework.Tests.DirectoryAssertTests.AreNotEqualPassesWhenOneDoesNotExist" executed="True" result="Success" success="True" time="0.005" asserts="1" />
+                          <test-case name="NUnit.Framework.Tests.DirectoryAssertTests.AreNotEqualPassesWithStringPath" executed="True" result="Success" success="True" time="0.010" asserts="1" />
+                          <test-case name="NUnit.Framework.Tests.DirectoryAssertTests.IsEmptyFailsWithInvalidDirectory" executed="True" result="Success" success="True" time="0.003" asserts="1" />
+                          <test-case name="NUnit.Framework.Tests.DirectoryAssertTests.IsEmptyFailsWithNonEmptyDirectoryUsingDirectoryInfo" executed="True" result="Success" success="True" time="0.006" asserts="1" />
+                          <test-case name="NUnit.Framework.Tests.DirectoryAssertTests.IsEmptyFailsWithNonEmptyDirectoryUsingStringPath" executed="True" result="Success" success="True" time="0.006" asserts="1" />
+                          <test-case name="NUnit.Framework.Tests.DirectoryAssertTests.IsEmptyPassesWithEmptyDirectoryUsingDirectoryInfo" executed="True" result="Success" success="True" time="0.004" asserts="2" />
+                          <test-case name="NUnit.Framework.Tests.DirectoryAssertTests.IsEmptyPassesWithEmptyDirectoryUsingStringPath" executed="True" result="Success" success="True" time="0.003" asserts="1" />
+                          <test-case name="NUnit.Framework.Tests.DirectoryAssertTests.IsEmptyThrowsUsingNull" executed="True" result="Success" success="True" time="0.001" asserts="1" />
+                          <test-case name="NUnit.Framework.Tests.DirectoryAssertTests.IsNotEmptyFailsWithEmptyDirectoryUsingDirectoryInfo" executed="True" result="Success" success="True" time="0.003" asserts="1" />
+                          <test-case name="NUnit.Framework.Tests.DirectoryAssertTests.IsNotEmptyFailsWithEmptyDirectoryUsingStringPath" executed="True" result="Success" success="True" time="0.003" asserts="1" />
+                          <test-case name="NUnit.Framework.Tests.DirectoryAssertTests.IsNotEmptyFailsWithInvalidDirectory" executed="True" result="Success" success="True" time="0.003" asserts="1" />
+                          <test-case name="NUnit.Framework.Tests.DirectoryAssertTests.IsNotEmptyPassesWithNonEmptyDirectoryUsingDirectoryInfo" executed="True" result="Success" success="True" time="0.006" asserts="2" />
+                          <test-case name="NUnit.Framework.Tests.DirectoryAssertTests.IsNotEmptyPassesWithNonEmptyDirectoryUsingStringPath" executed="True" result="Success" success="True" time="0.005" asserts="1" />
+                          <test-case name="NUnit.Framework.Tests.DirectoryAssertTests.IsNotEmptyThrowsUsingNull" executed="True" result="Success" success="True" time="0.001" asserts="1" />
+                          <test-case name="NUnit.Framework.Tests.DirectoryAssertTests.IsNotWithinFailsWithDirectoryInfo" executed="True" result="Success" success="True" time="0.005" asserts="1" />
+                          <test-case name="NUnit.Framework.Tests.DirectoryAssertTests.IsNotWithinFailsWithStringPath" executed="True" result="Success" success="True" time="0.006" asserts="1" />
+                          <test-case name="NUnit.Framework.Tests.DirectoryAssertTests.IsNotWithinPassesWhenOutsidePathUsingDirectoryInfo" executed="True" result="Success" success="True" time="0.005" asserts="1" />
+                          <test-case name="NUnit.Framework.Tests.DirectoryAssertTests.IsNotWithinPassesWhenOutsidePathUsingStringPath" executed="True" result="Success" success="True" time="0.004" asserts="1" />
+                          <test-case name="NUnit.Framework.Tests.DirectoryAssertTests.IsNotWithinThrowsWhenBothAreNull" executed="True" result="Success" success="True" time="0.001" asserts="0" />
+                          <test-case name="NUnit.Framework.Tests.DirectoryAssertTests.IsWithinFailsWhenOutsidePathUsingDirectoryInfo" executed="True" result="Success" success="True" time="0.005" asserts="1" />
+                          <test-case name="NUnit.Framework.Tests.DirectoryAssertTests.IsWithinFailsWhenOutsidePathUsingStringPath" executed="True" result="Success" success="True" time="0.006" asserts="1" />
+                          <test-case name="NUnit.Framework.Tests.DirectoryAssertTests.IsWithinPassesWithDirectoryInfo" executed="True" result="Success" success="True" time="0.005" asserts="1" />
+                          <test-case name="NUnit.Framework.Tests.DirectoryAssertTests.IsWithinPassesWithStringPath" executed="True" result="Success" success="True" time="0.005" asserts="1" />
+                          <test-case name="NUnit.Framework.Tests.DirectoryAssertTests.IsWithinPassesWithTempPath" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Framework.Tests.DirectoryAssertTests.IsWithinThrowsWhenBothAreNull" executed="True" result="Success" success="True" time="0.001" asserts="0" />
+                        </results>
+                      </test-suite>
+                      <test-suite type="TestFixture" name="EqualsFixture" executed="True" result="Success" success="True" time="0.075" asserts="0">
+                        <results>
+                          <test-case name="NUnit.Framework.Tests.EqualsFixture.Bug575936Int32Int64Comparison" executed="True" result="Success" success="True" time="0.001" asserts="1" />
+                          <test-case name="NUnit.Framework.Tests.EqualsFixture.Byte" executed="True" result="Success" success="True" time="0.000" asserts="2" />
+                          <test-case name="NUnit.Framework.Tests.EqualsFixture.DateTimeEqual" executed="True" result="Success" success="True" time="0.005" asserts="1" />
+                          <test-case name="NUnit.Framework.Tests.EqualsFixture.DateTimeNotEqual" executed="True" result="Success" success="True" time="0.001" asserts="2" />
+                          <test-case name="NUnit.Framework.Tests.EqualsFixture.Decimal" executed="True" result="Success" success="True" time="0.000" asserts="6" />
+                          <test-case name="NUnit.Framework.Tests.EqualsFixture.DirectoryInfoEquality" executed="True" result="Success" success="True" time="0.001" asserts="1" />
+                          <test-case name="NUnit.Framework.Tests.EqualsFixture.DirectoryInfoEqualityIgnoresTrailingDirectorySeparator" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Framework.Tests.EqualsFixture.DoubleNotEqualMessageDisplaysAllDigits" executed="True" result="Success" success="True" time="0.000" asserts="2" />
+                          <test-case name="NUnit.Framework.Tests.EqualsFixture.DoubleNotEqualMessageDisplaysDefaultTolerance" executed="True" result="Success" success="True" time="0.001" asserts="2" />
+                          <test-case name="NUnit.Framework.Tests.EqualsFixture.DoubleNotEqualMessageDisplaysTolerance" executed="True" result="Success" success="True" time="0.000" asserts="2" />
+                          <test-case name="NUnit.Framework.Tests.EqualsFixture.DoubleNotEqualWithNanDoesNotDisplayDefaultTolerance" executed="True" result="Success" success="True" time="0.001" asserts="2" />
+                          <test-case name="NUnit.Framework.Tests.EqualsFixture.EnumsEqual" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Framework.Tests.EqualsFixture.EnumsNotEqual" executed="True" result="Success" success="True" time="0.001" asserts="2" />
+                          <test-case name="NUnit.Framework.Tests.EqualsFixture.Equals" executed="True" result="Success" success="True" time="0.000" asserts="2" />
+                          <test-case name="NUnit.Framework.Tests.EqualsFixture.EqualsFail" executed="True" result="Success" success="True" time="0.001" asserts="2" />
+                          <test-case name="NUnit.Framework.Tests.EqualsFixture.EqualsNaNFails" executed="True" result="Success" success="True" time="0.000" asserts="2" />
+                          <test-case name="NUnit.Framework.Tests.EqualsFixture.EqualsNull" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Framework.Tests.EqualsFixture.EqualsSameTypes" executed="True" result="Success" success="True" time="0.000" asserts="31" />
+                          <test-case name="NUnit.Framework.Tests.EqualsFixture.EqualsThrowsException" executed="True" result="Success" success="True" time="0.001" asserts="0" />
+                          <test-case name="NUnit.Framework.Tests.EqualsFixture.Float" executed="True" result="Success" success="True" time="0.000" asserts="2" />
+                          <test-case name="NUnit.Framework.Tests.EqualsFixture.FloatNotEqualMessageDisplaysAllDigits" executed="True" result="Success" success="True" time="0.000" asserts="2" />
+                          <test-case name="NUnit.Framework.Tests.EqualsFixture.FloatNotEqualMessageDisplaysTolerance" executed="True" result="Success" success="True" time="0.000" asserts="2" />
+                          <test-case name="NUnit.Framework.Tests.EqualsFixture.IEquatableSuccess_ConstraintSyntax" executed="True" result="Success" success="True" time="0.000" asserts="2" />
+                          <test-case name="NUnit.Framework.Tests.EqualsFixture.IEquatableSuccess_OldSyntax" executed="True" result="Success" success="True" time="0.001" asserts="2" />
+                          <test-case name="NUnit.Framework.Tests.EqualsFixture.Int" executed="True" result="Success" success="True" time="0.000" asserts="2" />
+                          <test-case name="NUnit.Framework.Tests.EqualsFixture.IntegerEquals" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Framework.Tests.EqualsFixture.IntegerLongComparison" executed="True" result="Success" success="True" time="0.000" asserts="2" />
+                          <test-case name="NUnit.Framework.Tests.EqualsFixture.NanEqualsFails" executed="True" result="Success" success="True" time="0.001" asserts="2" />
+                          <test-case name="NUnit.Framework.Tests.EqualsFixture.NanEqualsNaNSucceeds" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Framework.Tests.EqualsFixture.NegInfinityEqualsInfinity" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Framework.Tests.EqualsFixture.PosInfinityEqualsInfinity" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Framework.Tests.EqualsFixture.PosInfinityNotEquals" executed="True" result="Success" success="True" time="0.001" asserts="2" />
+                          <test-case name="NUnit.Framework.Tests.EqualsFixture.PosInfinityNotEqualsNegInfinity" executed="True" result="Success" success="True" time="0.001" asserts="2" />
+                          <test-case name="NUnit.Framework.Tests.EqualsFixture.ReferenceEqualsThrowsException" executed="True" result="Success" success="True" time="0.000" asserts="0" />
+                          <test-case name="NUnit.Framework.Tests.EqualsFixture.Short" executed="True" result="Success" success="True" time="0.000" asserts="2" />
+                          <test-case name="NUnit.Framework.Tests.EqualsFixture.SinglePosInfinityNotEqualsNegInfinity" executed="True" result="Success" success="True" time="0.001" asserts="2" />
+                          <test-case name="NUnit.Framework.Tests.EqualsFixture.String" executed="True" result="Success" success="True" time="0.001" asserts="2" />
+                          <test-case name="NUnit.Framework.Tests.EqualsFixture.UInt" executed="True" result="Success" success="True" time="0.000" asserts="2" />
+                        </results>
+                      </test-suite>
+                      <test-suite type="TestFixture" name="FileAssertTests" executed="True" result="Success" success="True" time="0.117" asserts="0">
+                        <results>
+                          <test-case name="NUnit.Framework.Tests.FileAssertTests.AreEqualFailsWhenOneIsNull" executed="True" result="Success" success="True" time="0.002" asserts="2" />
+                          <test-case name="NUnit.Framework.Tests.FileAssertTests.AreEqualFailsWithFileInfos" executed="True" result="Success" success="True" time="0.004" asserts="2" />
+                          <test-case name="NUnit.Framework.Tests.FileAssertTests.AreEqualFailsWithFiles" executed="True" result="Success" success="True" time="0.004" asserts="2" />
+                          <test-case name="NUnit.Framework.Tests.FileAssertTests.AreEqualFailsWithStreams" executed="True" result="Success" success="True" time="0.004" asserts="2" />
+                          <test-case name="NUnit.Framework.Tests.FileAssertTests.AreEqualFailsWithTextFilesAfterReadingBothFiles" executed="True" result="Success" success="True" time="0.005" asserts="1" />
+                          <test-case name="NUnit.Framework.Tests.FileAssertTests.AreEqualPassesUsingSameFileTwice" executed="True" result="Success" success="True" time="0.001" asserts="1" />
+                          <test-case name="NUnit.Framework.Tests.FileAssertTests.AreEqualPassesWhenBothAreNull" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Framework.Tests.FileAssertTests.AreEqualPassesWithEqualStreams" executed="True" result="Success" success="True" time="0.004" asserts="1" />
+                          <test-case name="NUnit.Framework.Tests.FileAssertTests.AreEqualPassesWithFileInfos" executed="True" result="Success" success="True" time="0.003" asserts="2" />
+                          <test-case name="NUnit.Framework.Tests.FileAssertTests.AreEqualPassesWithFiles" executed="True" result="Success" success="True" time="0.003" asserts="1" />
+                          <test-case name="NUnit.Framework.Tests.FileAssertTests.AreEqualPassesWithSameStream" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Framework.Tests.FileAssertTests.AreEqualPassesWithTextFiles" executed="True" result="Success" success="True" time="0.004" asserts="1" />
+                          <test-case name="NUnit.Framework.Tests.FileAssertTests.AreNotEqualFailsWhenBothAreNull" executed="True" result="Success" success="True" time="0.001" asserts="2" />
+                          <test-case name="NUnit.Framework.Tests.FileAssertTests.AreNotEqualFailsWithFileInfos" executed="True" result="Success" success="True" time="0.005" asserts="2" />
+                          <test-case name="NUnit.Framework.Tests.FileAssertTests.AreNotEqualFailsWithFiles" executed="True" result="Success" success="True" time="0.002" asserts="2" />
+                          <test-case name="NUnit.Framework.Tests.FileAssertTests.AreNotEqualFailsWithStreams" executed="True" result="Success" success="True" time="0.004" asserts="2" />
+                          <test-case name="NUnit.Framework.Tests.FileAssertTests.AreNotEqualIteratesOverTheEntireFile" executed="True" result="Success" success="True" time="0.003" asserts="1" />
+                          <test-case name="NUnit.Framework.Tests.FileAssertTests.AreNotEqualIteratesOverTheEntireFileAndFails" executed="True" result="Success" success="True" time="0.005" asserts="2" />
+                          <test-case name="NUnit.Framework.Tests.FileAssertTests.AreNotEqualPassesIfOneIsNull" executed="True" result="Success" success="True" time="0.001" asserts="1" />
+                          <test-case name="NUnit.Framework.Tests.FileAssertTests.AreNotEqualPassesWithFileInfos" executed="True" result="Success" success="True" time="0.003" asserts="1" />
+                          <test-case name="NUnit.Framework.Tests.FileAssertTests.AreNotEqualPassesWithFiles" executed="True" result="Success" success="True" time="0.003" asserts="1" />
+                          <test-case name="NUnit.Framework.Tests.FileAssertTests.AreNotEqualPassesWithStreams" executed="True" result="Success" success="True" time="0.003" asserts="1" />
+                          <test-case name="NUnit.Framework.Tests.FileAssertTests.NonReadableStreamGivesException" executed="True" result="Success" success="True" time="0.003" asserts="1" />
+                          <test-case name="NUnit.Framework.Tests.FileAssertTests.NonSeekableStreamGivesException" executed="True" result="Success" success="True" time="0.002" asserts="1" />
+                        </results>
+                      </test-suite>
+                      <test-suite type="TestFixture" name="GreaterEqualFixture" executed="True" result="Success" success="True" time="0.020" asserts="0">
+                        <results>
+                          <test-case name="NUnit.Framework.Tests.GreaterEqualFixture.FailureMessage" executed="True" result="Success" success="True" time="0.000" asserts="3" />
+                          <test-case name="NUnit.Framework.Tests.GreaterEqualFixture.GreaterOrEqual_Decimal" executed="True" result="Success" success="True" time="0.000" asserts="2" />
+                          <test-case name="NUnit.Framework.Tests.GreaterEqualFixture.GreaterOrEqual_Double" executed="True" result="Success" success="True" time="0.000" asserts="2" />
+                          <test-case name="NUnit.Framework.Tests.GreaterEqualFixture.GreaterOrEqual_Float" executed="True" result="Success" success="True" time="0.000" asserts="2" />
+                          <test-case name="NUnit.Framework.Tests.GreaterEqualFixture.GreaterOrEqual_Int32" executed="True" result="Success" success="True" time="0.000" asserts="2" />
+                          <test-case name="NUnit.Framework.Tests.GreaterEqualFixture.GreaterOrEqual_Long" executed="True" result="Success" success="True" time="0.000" asserts="2" />
+                          <test-case name="NUnit.Framework.Tests.GreaterEqualFixture.GreaterOrEqual_UInt32" executed="True" result="Success" success="True" time="0.000" asserts="2" />
+                          <test-case name="NUnit.Framework.Tests.GreaterEqualFixture.GreaterOrEqual_ULong" executed="True" result="Success" success="True" time="0.000" asserts="2" />
+                          <test-case name="NUnit.Framework.Tests.GreaterEqualFixture.MixedTypes" executed="True" result="Success" success="True" time="0.000" asserts="42" />
+                          <test-case name="NUnit.Framework.Tests.GreaterEqualFixture.NotGreaterEqualIComparable" executed="True" result="Success" success="True" time="0.001" asserts="2" />
+                          <test-case name="NUnit.Framework.Tests.GreaterEqualFixture.NotGreaterOrEqual" executed="True" result="Success" success="True" time="0.000" asserts="2" />
+                        </results>
+                      </test-suite>
+                      <test-suite type="TestFixture" name="GreaterFixture" executed="True" result="Success" success="True" time="0.012" asserts="0">
+                        <results>
+                          <test-case name="NUnit.Framework.Tests.GreaterFixture.FailureMessage" executed="True" result="Success" success="True" time="0.000" asserts="2" />
+                          <test-case name="NUnit.Framework.Tests.GreaterFixture.Greater" executed="True" result="Success" success="True" time="0.000" asserts="7" />
+                          <test-case name="NUnit.Framework.Tests.GreaterFixture.MixedTypes" executed="True" result="Success" success="True" time="0.001" asserts="42" />
+                          <test-case name="NUnit.Framework.Tests.GreaterFixture.NotGreater" executed="True" result="Success" success="True" time="0.001" asserts="2" />
+                          <test-case name="NUnit.Framework.Tests.GreaterFixture.NotGreaterIComparable" executed="True" result="Success" success="True" time="0.000" asserts="2" />
+                          <test-case name="NUnit.Framework.Tests.GreaterFixture.NotGreaterWhenEqual" executed="True" result="Success" success="True" time="0.000" asserts="2" />
+                        </results>
+                      </test-suite>
+                      <test-suite type="TestFixture" name="LessEqualFixture" executed="True" result="Success" success="True" time="0.009" asserts="0">
+                        <results>
+                          <test-case name="NUnit.Framework.Tests.LessEqualFixture.FailureMessage" executed="True" result="Success" success="True" time="0.001" asserts="2" />
+                          <test-case name="NUnit.Framework.Tests.LessEqualFixture.LessOrEqual" executed="True" result="Success" success="True" time="0.000" asserts="42" />
+                          <test-case name="NUnit.Framework.Tests.LessEqualFixture.MixedTypes" executed="True" result="Success" success="True" time="0.000" asserts="42" />
+                          <test-case name="NUnit.Framework.Tests.LessEqualFixture.NotLessEqualIComparable" executed="True" result="Success" success="True" time="0.001" asserts="2" />
+                          <test-case name="NUnit.Framework.Tests.LessEqualFixture.NotLessOrEqual" executed="True" result="Success" success="True" time="0.000" asserts="2" />
+                        </results>
+                      </test-suite>
+                      <test-suite type="TestFixture" name="LessFixture" executed="True" result="Success" success="True" time="0.012" asserts="0">
+                        <results>
+                          <test-case name="NUnit.Framework.Tests.LessFixture.FailureMessage" executed="True" result="Success" success="True" time="0.000" asserts="3" />
+                          <test-case name="NUnit.Framework.Tests.LessFixture.Less" executed="True" result="Success" success="True" time="0.000" asserts="18" />
+                          <test-case name="NUnit.Framework.Tests.LessFixture.MixedTypes" executed="True" result="Success" success="True" time="0.000" asserts="42" />
+                          <test-case name="NUnit.Framework.Tests.LessFixture.NotLess" executed="True" result="Success" success="True" time="0.000" asserts="2" />
+                          <test-case name="NUnit.Framework.Tests.LessFixture.NotLessIComparable" executed="True" result="Success" success="True" time="0.000" asserts="2" />
+                          <test-case name="NUnit.Framework.Tests.LessFixture.NotLessWhenEqual" executed="True" result="Success" success="True" time="0.001" asserts="2" />
+                        </results>
+                      </test-suite>
+                      <test-suite type="TestFixture" name="ListContentsTests" executed="True" result="Success" success="True" time="0.015" asserts="0">
+                        <results>
+                          <test-case name="NUnit.Framework.Tests.ListContentsTests.ArrayFails" executed="True" result="Success" success="True" time="0.001" asserts="2" />
+                          <test-case name="NUnit.Framework.Tests.ListContentsTests.ArrayListFails" executed="True" result="Success" success="True" time="0.000" asserts="2" />
+                          <test-case name="NUnit.Framework.Tests.ListContentsTests.ArrayListSucceeds" executed="True" result="Success" success="True" time="0.000" asserts="3" />
+                          <test-case name="NUnit.Framework.Tests.ListContentsTests.ArraySucceeds" executed="True" result="Success" success="True" time="0.000" asserts="3" />
+                          <test-case name="NUnit.Framework.Tests.ListContentsTests.DifferentTypesMayBeEqual" executed="True" result="Success" success="True" time="0.001" asserts="1" />
+                          <test-case name="NUnit.Framework.Tests.ListContentsTests.EmptyArrayFails" executed="True" result="Success" success="True" time="0.001" asserts="2" />
+                          <test-case name="NUnit.Framework.Tests.ListContentsTests.NullArrayIsError" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                        </results>
+                      </test-suite>
+                      <test-suite type="TestFixture" name="NotEqualFixture" executed="True" result="Success" success="True" time="0.014" asserts="0">
+                        <results>
+                          <test-case name="NUnit.Framework.Tests.NotEqualFixture.ArraysNotEqual" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Framework.Tests.NotEqualFixture.ArraysNotEqualFails" executed="True" result="Success" success="True" time="0.000" asserts="2" />
+                          <test-case name="NUnit.Framework.Tests.NotEqualFixture.NotEqual" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Framework.Tests.NotEqualFixture.NotEqualFails" executed="True" result="Success" success="True" time="0.001" asserts="2" />
+                          <test-case name="NUnit.Framework.Tests.NotEqualFixture.NotEqualSameTypes" executed="True" result="Success" success="True" time="0.000" asserts="21" />
+                          <test-case name="NUnit.Framework.Tests.NotEqualFixture.NullEqualsNull" executed="True" result="Success" success="True" time="0.000" asserts="2" />
+                          <test-case name="NUnit.Framework.Tests.NotEqualFixture.NullNotEqualToNonNull" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Framework.Tests.NotEqualFixture.UInt" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                        </results>
+                      </test-suite>
+                      <test-suite type="TestFixture" name="NotSameFixture" executed="True" result="Success" success="True" time="0.003" asserts="0">
+                        <results>
+                          <test-case name="NUnit.Framework.Tests.NotSameFixture.NotSame" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Framework.Tests.NotSameFixture.NotSameFails" executed="True" result="Success" success="True" time="0.001" asserts="2" />
+                        </results>
+                      </test-suite>
+                      <test-suite type="TestFixture" name="NullableTypesTests" executed="True" result="Success" success="True" time="0.010" asserts="0">
+                        <categories>
+                          <category name="Generics" />
+                        </categories>
+                        <results>
+                          <test-case name="NUnit.Framework.Tests.NullableTypesTests.CanCompareNullableEnums" executed="True" result="Success" success="True" time="0.001" asserts="3" />
+                          <test-case name="NUnit.Framework.Tests.NullableTypesTests.CanCompareNullableMixedNumerics" executed="True" result="Success" success="True" time="0.000" asserts="36" />
+                          <test-case name="NUnit.Framework.Tests.NullableTypesTests.CanCompareNullableStructs" executed="True" result="Success" success="True" time="0.001" asserts="4" />
+                          <test-case name="NUnit.Framework.Tests.NullableTypesTests.CanCompareWithTolerance" executed="True" result="Success" success="True" time="0.000" asserts="4" />
+                          <test-case name="NUnit.Framework.Tests.NullableTypesTests.CanTestForNaN" executed="True" result="Success" success="True" time="0.000" asserts="2" />
+                          <test-case name="NUnit.Framework.Tests.NullableTypesTests.CanTestForNull" executed="True" result="Success" success="True" time="0.000" asserts="4" />
+                        </results>
+                      </test-suite>
+                      <test-suite type="TestFixture" name="RandomizerTests" executed="True" result="Success" success="True" time="0.013" asserts="0">
+                        <results>
+                          <test-case name="NUnit.Framework.Tests.RandomizerTests.RandomDoublesAreUnique" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Framework.Tests.RandomizerTests.RandomIntsAreUnique" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Framework.Tests.RandomizerTests.RandomizersWithDifferentSeedsReturnDifferentValues" executed="True" result="Success" success="True" time="0.000" asserts="10" />
+                          <test-case name="NUnit.Framework.Tests.RandomizerTests.RandomizersWithSameSeedsReturnSameValues" executed="True" result="Success" success="True" time="0.000" asserts="10" />
+                          <test-case name="NUnit.Framework.Tests.RandomizerTests.RandomSeedsAreUnique" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Framework.Tests.RandomizerTests.ReturnsDifferentRandomizersForDifferentMethods" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Framework.Tests.RandomizerTests.ReturnsSameRandomizerForDifferentParametersOfSameMethod" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Framework.Tests.RandomizerTests.ReturnsSameRandomizerForSameMethod" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Framework.Tests.RandomizerTests.ReturnsSameRandomizerForSameParameter" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                        </results>
+                      </test-suite>
+                      <test-suite type="TestFixture" name="RangeTests" executed="True" result="Success" success="True" time="0.006" asserts="0">
+                        <results>
+                          <test-case name="NUnit.Framework.Tests.RangeTests.InRangeFails" executed="True" result="Success" success="True" time="0.000" asserts="2" />
+                          <test-case name="NUnit.Framework.Tests.RangeTests.InRangeSucceeds" executed="True" result="Success" success="True" time="0.000" asserts="3" />
+                          <test-case name="NUnit.Framework.Tests.RangeTests.NotInRangeFails" executed="True" result="Success" success="True" time="0.000" asserts="2" />
+                          <test-case name="NUnit.Framework.Tests.RangeTests.NotInRangeSucceeds" executed="True" result="Success" success="True" time="0.001" asserts="2" />
+                        </results>
+                      </test-suite>
+                      <test-suite type="TestFixture" name="SameFixture" executed="True" result="Success" success="True" time="0.005" asserts="0">
+                        <results>
+                          <test-case name="NUnit.Framework.Tests.SameFixture.Same" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Framework.Tests.SameFixture.SameFails" executed="True" result="Success" success="True" time="0.001" asserts="2" />
+                          <test-case name="NUnit.Framework.Tests.SameFixture.SameValueTypes" executed="True" result="Success" success="True" time="0.001" asserts="2" />
+                        </results>
+                      </test-suite>
+                      <test-suite type="TestFixture" name="StringAssertTests" executed="True" result="Success" success="True" time="0.032" asserts="0">
+                        <results>
+                          <test-case name="NUnit.Framework.Tests.StringAssertTests.CaseInsensitiveCompare" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Framework.Tests.StringAssertTests.CaseInsensitiveCompareFails" executed="True" result="Success" success="True" time="0.000" asserts="2" />
+                          <test-case name="NUnit.Framework.Tests.StringAssertTests.Contains" executed="True" result="Success" success="True" time="0.000" asserts="3" />
+                          <test-case name="NUnit.Framework.Tests.StringAssertTests.ContainsFails" executed="True" result="Success" success="True" time="0.001" asserts="2" />
+                          <test-case name="NUnit.Framework.Tests.StringAssertTests.DifferentEncodingsOfSameStringAreNotEqual" executed="True" result="Success" success="True" time="0.001" asserts="1" />
+                          <test-case name="NUnit.Framework.Tests.StringAssertTests.DoesNotContain" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Framework.Tests.StringAssertTests.DoesNotContainFails" executed="True" result="Success" success="True" time="0.001" asserts="1" />
+                          <test-case name="NUnit.Framework.Tests.StringAssertTests.DoesNotEndWith" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Framework.Tests.StringAssertTests.DoesNotEndWithFails" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Framework.Tests.StringAssertTests.DoesNotStartWith" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Framework.Tests.StringAssertTests.DoesNotStartWithFails" executed="True" result="Success" success="True" time="0.001" asserts="1" />
+                          <test-case name="NUnit.Framework.Tests.StringAssertTests.EndsWith" executed="True" result="Success" success="True" time="0.000" asserts="2" />
+                          <test-case name="NUnit.Framework.Tests.StringAssertTests.EndsWithFails" executed="True" result="Success" success="True" time="0.000" asserts="2" />
+                          <test-case name="NUnit.Framework.Tests.StringAssertTests.IsMatch" executed="True" result="Success" success="True" time="0.001" asserts="1" />
+                          <test-case name="NUnit.Framework.Tests.StringAssertTests.IsMatchFails" executed="True" result="Success" success="True" time="0.000" asserts="2" />
+                          <test-case name="NUnit.Framework.Tests.StringAssertTests.StartsWith" executed="True" result="Success" success="True" time="0.000" asserts="2" />
+                          <test-case name="NUnit.Framework.Tests.StringAssertTests.StartsWithFails" executed="True" result="Success" success="True" time="0.001" asserts="2" />
+                        </results>
+                      </test-suite>
+                      <test-suite type="TestFixture" name="TestFixtureAttributeTests" executed="True" result="Success" success="True" time="0.008" asserts="0">
+                        <results>
+                          <test-case name="NUnit.Framework.Tests.TestFixtureAttributeTests.ConstructWithCombinedArgs" executed="True" result="Success" success="True" time="0.000" asserts="2">
+                            <categories>
+                              <category name="Generics" />
+                            </categories>
+                          </test-case>
+                          <test-case name="NUnit.Framework.Tests.TestFixtureAttributeTests.ConstructWithFixtureArgs" executed="True" result="Success" success="True" time="0.000" asserts="2" />
+                          <test-case name="NUnit.Framework.Tests.TestFixtureAttributeTests.ConstructWithFixtureArgsAndSetTypeArgs" executed="True" result="Success" success="True" time="0.000" asserts="2">
+                            <categories>
+                              <category name="Generics" />
+                            </categories>
+                          </test-case>
+                          <test-case name="NUnit.Framework.Tests.TestFixtureAttributeTests.ConstructWithJustTypeArgs" executed="True" result="Success" success="True" time="0.000" asserts="2">
+                            <categories>
+                              <category name="Generics" />
+                            </categories>
+                          </test-case>
+                          <test-case name="NUnit.Framework.Tests.TestFixtureAttributeTests.ConstructWithNoArgumentsAndSetTypeArgs" executed="True" result="Success" success="True" time="0.000" asserts="2">
+                            <categories>
+                              <category name="Generics" />
+                            </categories>
+                          </test-case>
+                          <test-case name="NUnit.Framework.Tests.TestFixtureAttributeTests.ConstructWithoutArguments" executed="True" result="Success" success="True" time="0.000" asserts="2" />
+                        </results>
+                      </test-suite>
+                      <test-suite type="TestFixture" name="TextMessageWriterTests" executed="True" result="Success" success="True" time="0.021" asserts="0">
+                        <results>
+                          <test-case name="NUnit.Framework.Tests.TextMessageWriterTests.ConnectorIsWrittenWithSurroundingSpaces" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Framework.Tests.TextMessageWriterTests.DateTimeTest" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Framework.Tests.TextMessageWriterTests.DecimalIsWrittenToTwentyNineDigits" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Framework.Tests.TextMessageWriterTests.DecimalIsWrittenWithTrailingM" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Framework.Tests.TextMessageWriterTests.DisplayStringDifferences" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Framework.Tests.TextMessageWriterTests.DisplayStringDifferences_NoClipping" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Framework.Tests.TextMessageWriterTests.DoubleIsWrittenToSeventeenDigits" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Framework.Tests.TextMessageWriterTests.DoubleIsWrittenWithTrailingD" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Framework.Tests.TextMessageWriterTests.FloatIsWrittenToNineDigits" executed="True" result="Success" success="True" time="0.000" asserts="2" />
+                          <test-case name="NUnit.Framework.Tests.TextMessageWriterTests.FloatIsWrittenWithTrailingF" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Framework.Tests.TextMessageWriterTests.IntegerIsWrittenAsIs" executed="True" result="Success" success="True" time="0.001" asserts="1" />
+                          <test-case name="NUnit.Framework.Tests.TextMessageWriterTests.PredicateIsWrittenWithTrailingSpace" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Framework.Tests.TextMessageWriterTests.StringIsWrittenWithQuotes" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                        </results>
+                      </test-suite>
+                      <test-suite type="TestFixture" name="TypeAssertTests" executed="True" result="Success" success="True" time="0.018" asserts="0">
+                        <results>
+                          <test-case name="NUnit.Framework.Tests.TypeAssertTests.ExactType" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Framework.Tests.TypeAssertTests.ExactTypeFails" executed="True" result="Success" success="True" time="0.001" asserts="2" />
+                          <test-case name="NUnit.Framework.Tests.TypeAssertTests.IsAssignableFrom" executed="True" result="Success" success="True" time="0.001" asserts="3" />
+                          <test-case name="NUnit.Framework.Tests.TypeAssertTests.IsAssignableFromFails" executed="True" result="Success" success="True" time="0.001" asserts="2" />
+                          <test-case name="NUnit.Framework.Tests.TypeAssertTests.IsInstanceOf" executed="True" result="Success" success="True" time="0.000" asserts="3" />
+                          <test-case name="NUnit.Framework.Tests.TypeAssertTests.IsInstanceOfFails" executed="True" result="Success" success="True" time="0.001" asserts="2" />
+                          <test-case name="NUnit.Framework.Tests.TypeAssertTests.IsNotAssignableFrom" executed="True" result="Success" success="True" time="0.000" asserts="3" />
+                          <test-case name="NUnit.Framework.Tests.TypeAssertTests.IsNotAssignableFromFails" executed="True" result="Success" success="True" time="0.001" asserts="2" />
+                          <test-case name="NUnit.Framework.Tests.TypeAssertTests.IsNotInstanceOf" executed="True" result="Success" success="True" time="0.001" asserts="3" />
+                          <test-case name="NUnit.Framework.Tests.TypeAssertTests.IsNotInstanceOfFails" executed="True" result="Success" success="True" time="0.001" asserts="2" />
+                        </results>
+                      </test-suite>
+                      <test-suite type="TestFixture" name="ValuesAttributeTests" executed="True" result="Success" success="True" time="0.084" asserts="0">
+                        <results>
+                          <test-suite type="ParameterizedTest" name="CanConverDoubleToDecimal" executed="True" result="Success" success="True" time="0.001" asserts="0">
+                            <results>
+                              <test-case name="NUnit.Framework.Tests.ValuesAttributeTests.CanConverDoubleToDecimal(12.5m)" executed="True" result="Success" success="True" time="0.000" asserts="0" />
+                            </results>
+                          </test-suite>
+                          <test-suite type="ParameterizedTest" name="CanConvertDoubleRangeToDecimal" executed="True" result="Success" success="True" time="0.006" asserts="0">
+                            <results>
+                              <test-case name="NUnit.Framework.Tests.ValuesAttributeTests.CanConvertDoubleRangeToDecimal(1m)" executed="True" result="Success" success="True" time="0.000" asserts="0" />
+                              <test-case name="NUnit.Framework.Tests.ValuesAttributeTests.CanConvertDoubleRangeToDecimal(1.1m)" executed="True" result="Success" success="True" time="0.000" asserts="0" />
+                              <test-case name="NUnit.Framework.Tests.ValuesAttributeTests.CanConvertDoubleRangeToDecimal(1.2m)" executed="True" result="Success" success="True" time="0.001" asserts="0" />
+                              <test-case name="NUnit.Framework.Tests.ValuesAttributeTests.CanConvertDoubleRangeToDecimal(1.3m)" executed="True" result="Success" success="True" time="0.000" asserts="0" />
+                            </results>
+                          </test-suite>
+                          <test-suite type="ParameterizedTest" name="CanConvertIntRangeToByte" executed="True" result="Success" success="True" time="0.003" asserts="0">
+                            <results>
+                              <test-case name="NUnit.Framework.Tests.ValuesAttributeTests.CanConvertIntRangeToByte(1)" executed="True" result="Success" success="True" time="0.000" asserts="0" />
+                              <test-case name="NUnit.Framework.Tests.ValuesAttributeTests.CanConvertIntRangeToByte(2)" executed="True" result="Success" success="True" time="0.000" asserts="0" />
+                              <test-case name="NUnit.Framework.Tests.ValuesAttributeTests.CanConvertIntRangeToByte(3)" executed="True" result="Success" success="True" time="0.000" asserts="0" />
+                            </results>
+                          </test-suite>
+                          <test-suite type="ParameterizedTest" name="CanConvertIntRangeToDecimal" executed="True" result="Success" success="True" time="0.003" asserts="0">
+                            <results>
+                              <test-case name="NUnit.Framework.Tests.ValuesAttributeTests.CanConvertIntRangeToDecimal(1m)" executed="True" result="Success" success="True" time="0.000" asserts="0" />
+                              <test-case name="NUnit.Framework.Tests.ValuesAttributeTests.CanConvertIntRangeToDecimal(2m)" executed="True" result="Success" success="True" time="0.000" asserts="0" />
+                              <test-case name="NUnit.Framework.Tests.ValuesAttributeTests.CanConvertIntRangeToDecimal(3m)" executed="True" result="Success" success="True" time="0.000" asserts="0" />
+                            </results>
+                          </test-suite>
+                          <test-suite type="ParameterizedTest" name="CanConvertIntRangeToSByte" executed="True" result="Success" success="True" time="0.004" asserts="0">
+                            <results>
+                              <test-case name="NUnit.Framework.Tests.ValuesAttributeTests.CanConvertIntRangeToSByte(1)" executed="True" result="Success" success="True" time="0.000" asserts="0" />
+                              <test-case name="NUnit.Framework.Tests.ValuesAttributeTests.CanConvertIntRangeToSByte(2)" executed="True" result="Success" success="True" time="0.000" asserts="0" />
+                              <test-case name="NUnit.Framework.Tests.ValuesAttributeTests.CanConvertIntRangeToSByte(3)" executed="True" result="Success" success="True" time="0.000" asserts="0" />
+                            </results>
+                          </test-suite>
+                          <test-suite type="ParameterizedTest" name="CanConvertIntRangeToShort" executed="True" result="Success" success="True" time="0.003" asserts="0">
+                            <results>
+                              <test-case name="NUnit.Framework.Tests.ValuesAttributeTests.CanConvertIntRangeToShort(1)" executed="True" result="Success" success="True" time="0.000" asserts="0" />
+                              <test-case name="NUnit.Framework.Tests.ValuesAttributeTests.CanConvertIntRangeToShort(2)" executed="True" result="Success" success="True" time="0.000" asserts="0" />
+                              <test-case name="NUnit.Framework.Tests.ValuesAttributeTests.CanConvertIntRangeToShort(3)" executed="True" result="Success" success="True" time="0.000" asserts="0" />
+                            </results>
+                          </test-suite>
+                          <test-suite type="ParameterizedTest" name="CanConvertIntToDecimal" executed="True" result="Success" success="True" time="0.001" asserts="0">
+                            <results>
+                              <test-case name="NUnit.Framework.Tests.ValuesAttributeTests.CanConvertIntToDecimal(12m)" executed="True" result="Success" success="True" time="0.000" asserts="0" />
+                            </results>
+                          </test-suite>
+                          <test-suite type="ParameterizedTest" name="CanConvertRandomDoubleToDecimal" executed="True" result="Success" success="True" time="0.004" asserts="0">
+                            <results>
+                              <test-case name="NUnit.Framework.Tests.ValuesAttributeTests.CanConvertRandomDoubleToDecimal(4.08439278839361m)" executed="True" result="Success" success="True" time="0.000" asserts="0" />
+                              <test-case name="NUnit.Framework.Tests.ValuesAttributeTests.CanConvertRandomDoubleToDecimal(9.87522940750943m)" executed="True" result="Success" success="True" time="0.000" asserts="0" />
+                              <test-case name="NUnit.Framework.Tests.ValuesAttributeTests.CanConvertRandomDoubleToDecimal(4.14481929044464m)" executed="True" result="Success" success="True" time="0.000" asserts="0" />
+                            </results>
+                          </test-suite>
+                          <test-suite type="ParameterizedTest" name="CanConvertRandomIntToByte" executed="True" result="Success" success="True" time="0.005" asserts="0">
+                            <results>
+                              <test-case name="NUnit.Framework.Tests.ValuesAttributeTests.CanConvertRandomIntToByte(8)" executed="True" result="Success" success="True" time="0.000" asserts="0" />
+                              <test-case name="NUnit.Framework.Tests.ValuesAttributeTests.CanConvertRandomIntToByte(4)" executed="True" result="Success" success="True" time="0.000" asserts="0" />
+                              <test-case name="NUnit.Framework.Tests.ValuesAttributeTests.CanConvertRandomIntToByte(4)" executed="True" result="Success" success="True" time="0.000" asserts="0" />
+                            </results>
+                          </test-suite>
+                          <test-suite type="ParameterizedTest" name="CanConvertRandomIntToDecimal" executed="True" result="Success" success="True" time="0.003" asserts="0">
+                            <results>
+                              <test-case name="NUnit.Framework.Tests.ValuesAttributeTests.CanConvertRandomIntToDecimal(3m)" executed="True" result="Success" success="True" time="0.000" asserts="0" />
+                              <test-case name="NUnit.Framework.Tests.ValuesAttributeTests.CanConvertRandomIntToDecimal(7m)" executed="True" result="Success" success="True" time="0.000" asserts="0" />
+                              <test-case name="NUnit.Framework.Tests.ValuesAttributeTests.CanConvertRandomIntToDecimal(5m)" executed="True" result="Success" success="True" time="0.000" asserts="0" />
+                            </results>
+                          </test-suite>
+                          <test-suite type="ParameterizedTest" name="CanConvertRandomIntToSByte" executed="True" result="Success" success="True" time="0.004" asserts="0">
+                            <results>
+                              <test-case name="NUnit.Framework.Tests.ValuesAttributeTests.CanConvertRandomIntToSByte(2)" executed="True" result="Success" success="True" time="0.000" asserts="0" />
+                              <test-case name="NUnit.Framework.Tests.ValuesAttributeTests.CanConvertRandomIntToSByte(9)" executed="True" result="Success" success="True" time="0.000" asserts="0" />
+                              <test-case name="NUnit.Framework.Tests.ValuesAttributeTests.CanConvertRandomIntToSByte(8)" executed="True" result="Success" success="True" time="0.001" asserts="0" />
+                            </results>
+                          </test-suite>
+                          <test-suite type="ParameterizedTest" name="CanConvertRandomIntToShort" executed="True" result="Success" success="True" time="0.005" asserts="0">
+                            <results>
+                              <test-case name="NUnit.Framework.Tests.ValuesAttributeTests.CanConvertRandomIntToShort(6)" executed="True" result="Success" success="True" time="0.000" asserts="0" />
+                              <test-case name="NUnit.Framework.Tests.ValuesAttributeTests.CanConvertRandomIntToShort(1)" executed="True" result="Success" success="True" time="0.000" asserts="0" />
+                              <test-case name="NUnit.Framework.Tests.ValuesAttributeTests.CanConvertRandomIntToShort(6)" executed="True" result="Success" success="True" time="0.001" asserts="0" />
+                            </results>
+                          </test-suite>
+                          <test-suite type="ParameterizedTest" name="CanConvertSmallIntsToByte" executed="True" result="Success" success="True" time="0.001" asserts="0">
+                            <results>
+                              <test-case name="NUnit.Framework.Tests.ValuesAttributeTests.CanConvertSmallIntsToByte(5)" executed="True" result="Success" success="True" time="0.000" asserts="0" />
+                            </results>
+                          </test-suite>
+                          <test-suite type="ParameterizedTest" name="CanConvertSmallIntsToSByte" executed="True" result="Success" success="True" time="0.000" asserts="0">
+                            <results>
+                              <test-case name="NUnit.Framework.Tests.ValuesAttributeTests.CanConvertSmallIntsToSByte(5)" executed="True" result="Success" success="True" time="0.000" asserts="0" />
+                            </results>
+                          </test-suite>
+                          <test-suite type="ParameterizedTest" name="CanConvertSmallIntsToShort" executed="True" result="Success" success="True" time="0.000" asserts="0">
+                            <results>
+                              <test-case name="NUnit.Framework.Tests.ValuesAttributeTests.CanConvertSmallIntsToShort(5)" executed="True" result="Success" success="True" time="0.000" asserts="0" />
+                            </results>
+                          </test-suite>
+                          <test-suite type="ParameterizedTest" name="CanConvertStringToDecimal" executed="True" result="Success" success="True" time="0.001" asserts="0">
+                            <results>
+                              <test-case name="NUnit.Framework.Tests.ValuesAttributeTests.CanConvertStringToDecimal(12.5m)" executed="True" result="Success" success="True" time="0.000" asserts="0" />
+                            </results>
+                          </test-suite>
+                          <test-case name="NUnit.Framework.Tests.ValuesAttributeTests.RangeAttributeWithDoubleRangeAndStep" executed="True" result="Success" success="True" time="0.001" asserts="1" />
+                          <test-case name="NUnit.Framework.Tests.ValuesAttributeTests.RangeAttributeWithFloatRangeAndStep" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Framework.Tests.ValuesAttributeTests.RangeAttributeWithIntRange" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Framework.Tests.ValuesAttributeTests.RangeAttributeWithIntRangeAndStep" executed="True" result="Success" success="True" time="0.001" asserts="1" />
+                          <test-case name="NUnit.Framework.Tests.ValuesAttributeTests.RangeAttributeWithLongRangeAndStep" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Framework.Tests.ValuesAttributeTests.ValuesAttributeProvidesSpecifiedValues" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                        </results>
+                      </test-suite>
+                    </results>
+                  </test-suite>
+                </results>
+              </test-suite>
+            </results>
+          </test-suite>
+        </results>
+      </test-suite>
+      <test-suite type="Assembly" name="C:\Program Files\NUnit 2.6\bin\tests/nunit.core.tests.dll" executed="True" result="Success" success="True" time="9.996" asserts="0">
+        <results>
+          <test-suite type="Namespace" name="NUnit" executed="True" result="Success" success="True" time="9.996" asserts="0">
+            <results>
+              <test-suite type="Namespace" name="Core" executed="True" result="Success" success="True" time="9.996" asserts="0">
+                <results>
+                  <test-suite type="Namespace" name="Tests" executed="True" result="Success" success="True" time="9.996" asserts="0">
+                    <results>
+                      <test-suite type="TestFixture" name="ActionAttributeExceptionTests" executed="True" result="Success" success="True" time="0.355" asserts="0">
+                        <results>
+                          <test-case name="NUnit.Core.Tests.ActionAttributeExceptionTests.AfterTestException" executed="True" result="Success" success="True" time="0.008" asserts="2" />
+                          <test-case name="NUnit.Core.Tests.ActionAttributeExceptionTests.BeforeTestException" executed="True" result="Success" success="True" time="0.002" asserts="2" />
+                        </results>
+                      </test-suite>
+                      <test-suite type="TestFixture" name="ActionAttributeTests" executed="True" result="Success" success="True" time="0.025" asserts="0">
+                        <results>
+                          <test-case name="NUnit.Core.Tests.ActionAttributeTests.ExpectedOutput_InCorrectOrder" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Core.Tests.ActionAttributeTests.TestsRunsSuccessfully" executed="True" result="Success" success="True" time="0.001" asserts="1" />
+                        </results>
+                      </test-suite>
+                      <test-suite type="TestFixture" name="AssemblyHelperTests" executed="True" result="Success" success="True" time="0.040" asserts="0">
+                        <results>
+                          <test-suite type="ParameterizedTest" name="GetAssemblyPathFromFileUri_Linux" executed="False" result="Skipped">
+                            <reason>
+                              <message><![CDATA[Only supported on Linux]]></message>
+                            </reason>
+                            <results>
+                              <test-case name="NUnit.Core.Tests.AssemblyHelperTests.GetAssemblyPathFromFileUri_Linux(&quot;file://path/to/assembly.dll&quot;)" executed="False" result="Skipped">
+                                <reason>
+                                  <message><![CDATA[Only supported on Linux]]></message>
+                                </reason>
+                              </test-case>
+                              <test-case name="NUnit.Core.Tests.AssemblyHelperTests.GetAssemblyPathFromFileUri_Linux(&quot;file:///dev/C#/assembly.dll&quot;)" executed="False" result="Skipped">
+                                <reason>
+                                  <message><![CDATA[Only supported on Linux]]></message>
+                                </reason>
+                              </test-case>
+                              <test-case name="NUnit.Core.Tests.AssemblyHelperTests.GetAssemblyPathFromFileUri_Linux(&quot;file:///dev/funnychars?:=/assembly.dll&quot;)" executed="False" result="Skipped">
+                                <reason>
+                                  <message><![CDATA[Only supported on Linux]]></message>
+                                </reason>
+                              </test-case>
+                              <test-case name="NUnit.Core.Tests.AssemblyHelperTests.GetAssemblyPathFromFileUri_Linux(&quot;file:///path/to/assembly.dll&quot;)" executed="False" result="Skipped">
+                                <reason>
+                                  <message><![CDATA[Only supported on Linux]]></message>
+                                </reason>
+                              </test-case>
+                              <test-case name="NUnit.Core.Tests.AssemblyHelperTests.GetAssemblyPathFromFileUri_Linux(&quot;file:///my path/to my/assembly.dll&quot;)" executed="False" result="Skipped">
+                                <reason>
+                                  <message><![CDATA[Only supported on Linux]]></message>
+                                </reason>
+                              </test-case>
+                              <test-case name="NUnit.Core.Tests.AssemblyHelperTests.GetAssemblyPathFromFileUri_Linux(&quot;file://my path/to my/assembly.dll&quot;)" executed="False" result="Skipped">
+                                <reason>
+                                  <message><![CDATA[Only supported on Linux]]></message>
+                                </reason>
+                              </test-case>
+                            </results>
+                          </test-suite>
+                          <test-suite type="ParameterizedTest" name="GetAssemblyPathFromFileUri_Windows" executed="True" result="Success" success="True" time="0.022" asserts="0">
+                            <results>
+                              <test-case name="NUnit.Core.Tests.AssemblyHelperTests.GetAssemblyPathFromFileUri_Windows(&quot;file:///C:/path/to/assembly.dll&quot;)" executed="True" result="Success" success="True" time="0.001" asserts="1" />
+                              <test-case name="NUnit.Core.Tests.AssemblyHelperTests.GetAssemblyPathFromFileUri_Windows(&quot;file://C:/path/to/assembly.dll&quot;)" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                              <test-case name="NUnit.Core.Tests.AssemblyHelperTests.GetAssemblyPathFromFileUri_Windows(&quot;file://C:/my path/to my/assembly.dll&quot;)" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                              <test-case name="NUnit.Core.Tests.AssemblyHelperTests.GetAssemblyPathFromFileUri_Windows(&quot;file://path/to/assembly.dll&quot;)" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                              <test-case name="NUnit.Core.Tests.AssemblyHelperTests.GetAssemblyPathFromFileUri_Windows(&quot;file:///C:/dev/C#/assembly.dll&quot;)" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                              <test-case name="NUnit.Core.Tests.AssemblyHelperTests.GetAssemblyPathFromFileUri_Windows(&quot;file:///C:/dev/funnychars?:=/assembly.dll&quot;)" executed="True" result="Success" success="True" time="0.001" asserts="1" />
+                              <test-case name="NUnit.Core.Tests.AssemblyHelperTests.GetAssemblyPathFromFileUri_Windows(&quot;file:///dev/funnychars?:=/assembly.dll&quot;)" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                              <test-case name="NUnit.Core.Tests.AssemblyHelperTests.GetAssemblyPathFromFileUri_Windows(&quot;file:///path/to/assembly.dll&quot;)" executed="True" result="Success" success="True" time="0.001" asserts="1" />
+                              <test-case name="NUnit.Core.Tests.AssemblyHelperTests.GetAssemblyPathFromFileUri_Windows(&quot;file:///dev/C#/assembly.dll&quot;)" executed="True" result="Success" success="True" time="0.001" asserts="1" />
+                              <test-case name="NUnit.Core.Tests.AssemblyHelperTests.GetAssemblyPathFromFileUri_Windows(&quot;file:///my path/to my/assembly.dll&quot;)" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                              <test-case name="NUnit.Core.Tests.AssemblyHelperTests.GetAssemblyPathFromFileUri_Windows(&quot;file://my path/to my/assembly.dll&quot;)" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                            </results>
+                          </test-suite>
+                          <test-case name="NUnit.Core.Tests.AssemblyHelperTests.GetPathForAssembly" executed="True" result="Success" success="True" time="0.000" asserts="2" />
+                          <test-case name="NUnit.Core.Tests.AssemblyHelperTests.GetPathForType" executed="True" result="Success" success="True" time="0.000" asserts="2" />
+                        </results>
+                      </test-suite>
+                      <test-suite type="TestFixture" name="AssemblyReaderTests" executed="True" result="Success" success="True" time="0.013" asserts="0">
+                        <results>
+                          <test-case name="NUnit.Core.Tests.AssemblyReaderTests.CreateFromAssembly" executed="True" result="Success" success="True" time="0.001" asserts="1" />
+                          <test-case name="NUnit.Core.Tests.AssemblyReaderTests.CreateFromPath" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Core.Tests.AssemblyReaderTests.ImageRuntimeVersion" executed="True" result="Success" success="True" time="0.001" asserts="1" />
+                          <test-case name="NUnit.Core.Tests.AssemblyReaderTests.IsDotNetFile" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Core.Tests.AssemblyReaderTests.IsValidPeFile" executed="True" result="Success" success="True" time="0.001" asserts="1" />
+                          <test-case name="NUnit.Core.Tests.AssemblyReaderTests.IsValidPeFile_Fails" executed="True" result="Success" success="True" time="0.001" asserts="1" />
+                        </results>
+                      </test-suite>
+                      <test-suite type="TestFixture" name="AssemblyResolverTests" executed="True" result="Success" success="True" time="0.047" asserts="0">
+                        <results>
+                          <test-case name="NUnit.Core.Tests.AssemblyResolverTests.AddFile" executed="True" result="Success" success="True" time="0.043" asserts="0" />
+                        </results>
+                      </test-suite>
+                      <test-suite type="TestFixture" name="AssemblyTests" executed="True" result="Success" success="True" time="0.384" asserts="0">
+                        <results>
+                          <test-case name="NUnit.Core.Tests.AssemblyTests.AppSettingsLoaded" executed="True" result="Success" success="True" time="0.040" asserts="3" />
+                          <test-case name="NUnit.Core.Tests.AssemblyTests.LoadAssembly" executed="True" result="Success" success="True" time="0.296" asserts="2" />
+                          <test-case name="NUnit.Core.Tests.AssemblyTests.LoadAssemblyNotFound" executed="True" result="Success" success="True" time="0.008" asserts="0" />
+                          <test-case name="NUnit.Core.Tests.AssemblyTests.LoadAssemblyWithoutTestFixtures" executed="True" result="Success" success="True" time="0.016" asserts="3" />
+                          <test-case name="NUnit.Core.Tests.AssemblyTests.LoadTestFixtureFromAssembly" executed="True" result="Success" success="True" time="0.012" asserts="1" />
+                          <test-case name="NUnit.Core.Tests.AssemblyTests.RunSetsCurrentDirectory" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                        </results>
+                      </test-suite>
+                      <test-suite type="TestFixture" name="AssemblyVersionFixture" executed="True" result="Success" success="True" time="0.012" asserts="0">
+                        <results>
+                          <test-case name="NUnit.Core.Tests.AssemblyVersionFixture.Version" executed="True" result="Success" success="True" time="0.011" asserts="1" />
+                        </results>
+                      </test-suite>
+                      <test-suite type="TestFixture" name="AssertInconclusiveFixture" executed="True" result="Success" success="True" time="0.001" asserts="0">
+                        <results>
+                          <test-case name="NUnit.Core.Tests.AssertInconclusiveFixture.AssertInconclusiveThrowsException" executed="True" result="Success" success="True" time="0.001" asserts="2" />
+                        </results>
+                      </test-suite>
+                      <test-suite type="TestFixture" name="AssertPassFixture" executed="True" result="Success" success="True" time="0.006" asserts="0">
+                        <results>
+                          <test-case name="NUnit.Core.Tests.AssertPassFixture.AssertPassReturnsSuccess" executed="True" result="Success" success="True" time="0.002" asserts="0">
+                            <reason>
+                              <message><![CDATA[This test is OK!]]></message>
+                            </reason>
+                          </test-case>
+                          <test-case name="NUnit.Core.Tests.AssertPassFixture.SubsequentFailureIsIrrelevant" executed="True" result="Success" success="True" time="0.001" asserts="0">
+                            <reason>
+                              <message><![CDATA[This test is OK!]]></message>
+                            </reason>
+                          </test-case>
+                        </results>
+                      </test-suite>
+                      <test-suite type="TestFixture" name="AttributeInheritance" executed="True" result="Success" success="True" time="0.012" asserts="0">
+                        <results>
+                          <test-case name="NUnit.Core.Tests.AttributeInheritance.InheritedExplicitAttributeIsRecognized" executed="True" result="Success" success="True" time="0.002" asserts="2" />
+                          <test-case name="NUnit.Core.Tests.AttributeInheritance.InheritedFixtureAttributeIsRecognized" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Core.Tests.AttributeInheritance.InheritedIgnoreAttributeIsRecognized" executed="True" result="Success" success="True" time="0.002" asserts="2" />
+                          <test-case name="NUnit.Core.Tests.AttributeInheritance.InheritedTestAttributeIsRecognized" executed="True" result="Success" success="True" time="0.001" asserts="1" />
+                        </results>
+                      </test-suite>
+                      <test-suite type="TestFixture" name="CallContextTests" executed="True" result="Success" success="True" time="0.011" asserts="0">
+                        <results>
+                          <test-case name="NUnit.Core.Tests.CallContextTests.GenericPrincipalTest" executed="True" result="Success" success="True" time="0.000" asserts="0" />
+                          <test-case name="NUnit.Core.Tests.CallContextTests.ILogicalThreadAffinativeTest" executed="True" result="Success" success="True" time="0.000" asserts="0" />
+                          <test-case name="NUnit.Core.Tests.CallContextTests.ILogicalThreadAffinativeTestConsole" executed="True" result="Success" success="True" time="0.000" asserts="0" />
+                          <test-case name="NUnit.Core.Tests.CallContextTests.SetCustomPrincipalOnThread" executed="True" result="Success" success="True" time="0.001" asserts="0" />
+                          <test-case name="NUnit.Core.Tests.CallContextTests.SetGenericPrincipalOnThread" executed="True" result="Success" success="True" time="0.001" asserts="0" />
+                          <test-case name="NUnit.Core.Tests.CallContextTests.UseCustomIdentity" executed="True" result="Success" success="True" time="0.001" asserts="0" />
+                        </results>
+                      </test-suite>
+                      <test-suite type="TestFixture" name="CategoryAttributeTests" executed="True" result="Success" success="True" time="0.033" asserts="0">
+                        <results>
+                          <test-case name="NUnit.Core.Tests.CategoryAttributeTests.CanDeriveFromCategoryAttribute" executed="True" result="Success" success="True" time="0.002" asserts="1" />
+                          <test-case name="NUnit.Core.Tests.CategoryAttributeTests.CategoryOnFixture" executed="True" result="Success" success="True" time="0.001" asserts="1" />
+                          <test-case name="NUnit.Core.Tests.CategoryAttributeTests.CategoryOnTestCase" executed="True" result="Success" success="True" time="0.002" asserts="1" />
+                          <test-suite type="ParameterizedTest" name="CountTestsUsingCategoryFilter" executed="True" result="Success" success="True" time="0.014" asserts="0">
+                            <results>
+                              <test-case name="NUnit.Core.Tests.CategoryAttributeTests.CountTestsUsingCategoryFilter(&quot;Critical&quot;)" executed="True" result="Success" success="True" time="0.002" asserts="1" />
+                              <test-case name="NUnit.Core.Tests.CategoryAttributeTests.CountTestsUsingCategoryFilter(&quot;Long&quot;)" executed="True" result="Success" success="True" time="0.002" asserts="1" />
+                              <test-case name="NUnit.Core.Tests.CategoryAttributeTests.CountTestsUsingCategoryFilter(&quot;Database&quot;)" executed="True" result="Success" success="True" time="0.002" asserts="1" />
+                            </results>
+                          </test-suite>
+                          <test-case name="NUnit.Core.Tests.CategoryAttributeTests.CountTestsWithoutCategoryFilter" executed="True" result="Success" success="True" time="0.002" asserts="1" />
+                          <test-case name="NUnit.Core.Tests.CategoryAttributeTests.DerivedCategoryMayBeInherited" executed="True" result="Success" success="True" time="0.002" asserts="1" />
+                        </results>
+                      </test-suite>
+                      <test-suite type="TestFixture" name="CombinatorialTests" executed="True" result="Success" success="True" time="0.098" asserts="0">
+                        <results>
+                          <test-suite type="ParameterizedTest" name="RandomArgsAreIndependent" executed="True" result="Success" success="True" time="0.001" asserts="0">
+                            <results>
+                              <test-case name="NUnit.Core.Tests.CombinatorialTests.RandomArgsAreIndependent(0.523696007916562d,0.270873801443201d)" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                            </results>
+                          </test-suite>
+                          <test-suite type="ParameterizedTest" name="RandomTest" executed="True" result="Success" success="True" time="0.008" asserts="0">
+                            <results>
+                              <test-case name="NUnit.Core.Tests.CombinatorialTests.RandomTest(205,0.982476789030468d)" executed="True" result="Success" success="True" time="0.001" asserts="2" />
+                              <test-case name="NUnit.Core.Tests.CombinatorialTests.RandomTest(40,0.472922925126237d)" executed="True" result="Success" success="True" time="0.001" asserts="2" />
+                              <test-case name="NUnit.Core.Tests.CombinatorialTests.RandomTest(44,0.658738728453749d)" executed="True" result="Success" success="True" time="0.000" asserts="2" />
+                              <test-case name="NUnit.Core.Tests.CombinatorialTests.RandomTest(45,0.855445025421421d)" executed="True" result="Success" success="True" time="0.000" asserts="2" />
+                              <test-case name="NUnit.Core.Tests.CombinatorialTests.RandomTest(169,0.812351247674018d)" executed="True" result="Success" success="True" time="0.000" asserts="2" />
+                            </results>
+                          </test-suite>
+                          <test-suite type="ParameterizedTest" name="RangeTest" executed="True" result="Success" success="True" time="0.015" asserts="0">
+                            <results>
+                              <test-case name="NUnit.Core.Tests.CombinatorialTests.RangeTest(0.2d,10)" executed="True" result="Success" success="True" time="0.000" asserts="0" />
+                              <test-case name="NUnit.Core.Tests.CombinatorialTests.RangeTest(0.2d,15)" executed="True" result="Success" success="True" time="0.000" asserts="0" />
+                              <test-case name="NUnit.Core.Tests.CombinatorialTests.RangeTest(0.2d,20)" executed="True" result="Success" success="True" time="0.000" asserts="0" />
+                              <test-case name="NUnit.Core.Tests.CombinatorialTests.RangeTest(0.4d,10)" executed="True" result="Success" success="True" time="0.000" asserts="0" />
+                              <test-case name="NUnit.Core.Tests.CombinatorialTests.RangeTest(0.4d,15)" executed="True" result="Success" success="True" time="0.000" asserts="0" />
+                              <test-case name="NUnit.Core.Tests.CombinatorialTests.RangeTest(0.4d,20)" executed="True" result="Success" success="True" time="0.000" asserts="0" />
+                              <test-case name="NUnit.Core.Tests.CombinatorialTests.RangeTest(0.6d,10)" executed="True" result="Success" success="True" time="0.000" asserts="0" />
+                              <test-case name="NUnit.Core.Tests.CombinatorialTests.RangeTest(0.6d,15)" executed="True" result="Success" success="True" time="0.000" asserts="0" />
+                              <test-case name="NUnit.Core.Tests.CombinatorialTests.RangeTest(0.6d,20)" executed="True" result="Success" success="True" time="0.000" asserts="0" />
+                            </results>
+                          </test-suite>
+                          <test-suite type="ParameterizedTest" name="SingleArgument" executed="True" result="Success" success="True" time="0.005" asserts="0">
+                            <results>
+                              <test-case name="NUnit.Core.Tests.CombinatorialTests.SingleArgument(1.3d)" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                              <test-case name="NUnit.Core.Tests.CombinatorialTests.SingleArgument(1.7d)" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                              <test-case name="NUnit.Core.Tests.CombinatorialTests.SingleArgument(1.5d)" executed="True" result="Success" success="True" time="0.001" asserts="1" />
+                            </results>
+                          </test-suite>
+                          <test-suite type="ParameterizedTest" name="ThreeArguments_Combinatorial" executed="True" result="Success" success="True" time="0.031" asserts="0">
+                            <results>
+                              <test-case name="NUnit.Core.Tests.CombinatorialTests.ThreeArguments_Combinatorial(1,10,&quot;Charlie&quot;)" executed="True" result="Success" success="True" time="0.001" asserts="2" />
+                              <test-case name="NUnit.Core.Tests.CombinatorialTests.ThreeArguments_Combinatorial(1,10,&quot;Joe&quot;)" executed="True" result="Success" success="True" time="0.001" asserts="2" />
+                              <test-case name="NUnit.Core.Tests.CombinatorialTests.ThreeArguments_Combinatorial(1,10,&quot;Frank&quot;)" executed="True" result="Success" success="True" time="0.000" asserts="2" />
+                              <test-case name="NUnit.Core.Tests.CombinatorialTests.ThreeArguments_Combinatorial(1,20,&quot;Charlie&quot;)" executed="True" result="Success" success="True" time="0.000" asserts="2" />
+                              <test-case name="NUnit.Core.Tests.CombinatorialTests.ThreeArguments_Combinatorial(1,20,&quot;Joe&quot;)" executed="True" result="Success" success="True" time="0.000" asserts="2" />
+                              <test-case name="NUnit.Core.Tests.CombinatorialTests.ThreeArguments_Combinatorial(1,20,&quot;Frank&quot;)" executed="True" result="Success" success="True" time="0.000" asserts="2" />
+                              <test-case name="NUnit.Core.Tests.CombinatorialTests.ThreeArguments_Combinatorial(2,10,&quot;Charlie&quot;)" executed="True" result="Success" success="True" time="0.000" asserts="2" />
+                              <test-case name="NUnit.Core.Tests.CombinatorialTests.ThreeArguments_Combinatorial(2,10,&quot;Joe&quot;)" executed="True" result="Success" success="True" time="0.001" asserts="2" />
+                              <test-case name="NUnit.Core.Tests.CombinatorialTests.ThreeArguments_Combinatorial(2,10,&quot;Frank&quot;)" executed="True" result="Success" success="True" time="0.000" asserts="2" />
+                              <test-case name="NUnit.Core.Tests.CombinatorialTests.ThreeArguments_Combinatorial(2,20,&quot;Charlie&quot;)" executed="True" result="Success" success="True" time="0.000" asserts="2" />
+                              <test-case name="NUnit.Core.Tests.CombinatorialTests.ThreeArguments_Combinatorial(2,20,&quot;Joe&quot;)" executed="True" result="Success" success="True" time="0.000" asserts="2" />
+                              <test-case name="NUnit.Core.Tests.CombinatorialTests.ThreeArguments_Combinatorial(2,20,&quot;Frank&quot;)" executed="True" result="Success" success="True" time="0.000" asserts="2" />
+                              <test-case name="NUnit.Core.Tests.CombinatorialTests.ThreeArguments_Combinatorial(3,10,&quot;Charlie&quot;)" executed="True" result="Success" success="True" time="0.000" asserts="2" />
+                              <test-case name="NUnit.Core.Tests.CombinatorialTests.ThreeArguments_Combinatorial(3,10,&quot;Joe&quot;)" executed="True" result="Success" success="True" time="0.000" asserts="2" />
+                              <test-case name="NUnit.Core.Tests.CombinatorialTests.ThreeArguments_Combinatorial(3,10,&quot;Frank&quot;)" executed="True" result="Success" success="True" time="0.000" asserts="2" />
+                              <test-case name="NUnit.Core.Tests.CombinatorialTests.ThreeArguments_Combinatorial(3,20,&quot;Charlie&quot;)" executed="True" result="Success" success="True" time="0.000" asserts="2" />
+                              <test-case name="NUnit.Core.Tests.CombinatorialTests.ThreeArguments_Combinatorial(3,20,&quot;Joe&quot;)" executed="True" result="Success" success="True" time="0.000" asserts="2" />
+                              <test-case name="NUnit.Core.Tests.CombinatorialTests.ThreeArguments_Combinatorial(3,20,&quot;Frank&quot;)" executed="True" result="Success" success="True" time="0.000" asserts="2" />
+                            </results>
+                          </test-suite>
+                          <test-suite type="ParameterizedTest" name="ThreeArguments_Sequential" executed="True" result="Success" success="True" time="0.006" asserts="0">
+                            <results>
+                              <test-case name="NUnit.Core.Tests.CombinatorialTests.ThreeArguments_Sequential(1,10,&quot;Charlie&quot;)" executed="True" result="Success" success="True" time="0.000" asserts="2" />
+                              <test-case name="NUnit.Core.Tests.CombinatorialTests.ThreeArguments_Sequential(2,20,&quot;Joe&quot;)" executed="True" result="Success" success="True" time="0.000" asserts="2" />
+                              <test-case name="NUnit.Core.Tests.CombinatorialTests.ThreeArguments_Sequential(3,null,&quot;Frank&quot;)" executed="True" result="Success" success="True" time="0.000" asserts="2" />
+                            </results>
+                          </test-suite>
+                          <test-suite type="ParameterizedTest" name="TwoArguments_Combinatorial" executed="True" result="Success" success="True" time="0.011" asserts="0">
+                            <results>
+                              <test-case name="NUnit.Core.Tests.CombinatorialTests.TwoArguments_Combinatorial(1,10)" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                              <test-case name="NUnit.Core.Tests.CombinatorialTests.TwoArguments_Combinatorial(1,20)" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                              <test-case name="NUnit.Core.Tests.CombinatorialTests.TwoArguments_Combinatorial(2,10)" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                              <test-case name="NUnit.Core.Tests.CombinatorialTests.TwoArguments_Combinatorial(2,20)" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                              <test-case name="NUnit.Core.Tests.CombinatorialTests.TwoArguments_Combinatorial(3,10)" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                              <test-case name="NUnit.Core.Tests.CombinatorialTests.TwoArguments_Combinatorial(3,20)" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                            </results>
+                          </test-suite>
+                          <test-suite type="ParameterizedTest" name="TwoArguments_Sequential" executed="True" result="Success" success="True" time="0.004" asserts="0">
+                            <results>
+                              <test-case name="NUnit.Core.Tests.CombinatorialTests.TwoArguments_Sequential(1,10)" executed="True" result="Success" success="True" time="0.001" asserts="1" />
+                              <test-case name="NUnit.Core.Tests.CombinatorialTests.TwoArguments_Sequential(2,20)" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                              <test-case name="NUnit.Core.Tests.CombinatorialTests.TwoArguments_Sequential(3,null)" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                            </results>
+                          </test-suite>
+                        </results>
+                      </test-suite>
+                      <test-suite type="TestFixture" name="CoreExtensionsTests" executed="True" result="Success" success="True" time="0.503" asserts="0">
+                        <results>
+                          <test-case name="NUnit.Core.Tests.CoreExtensionsTests.CanAddDecorator" executed="True" result="Success" success="True" time="0.350" asserts="0" />
+                          <test-case name="NUnit.Core.Tests.CoreExtensionsTests.CanAddEventListener" executed="True" result="Success" success="True" time="0.101" asserts="0" />
+                          <test-case name="NUnit.Core.Tests.CoreExtensionsTests.CanAddSuiteBuilder" executed="True" result="Success" success="True" time="0.016" asserts="0" />
+                          <test-case name="NUnit.Core.Tests.CoreExtensionsTests.CanAddTestCaseBuilder" executed="True" result="Success" success="True" time="0.005" asserts="0" />
+                          <test-case name="NUnit.Core.Tests.CoreExtensionsTests.CanAddTestCaseBuilder2" executed="True" result="Success" success="True" time="0.007" asserts="0" />
+                          <test-case name="NUnit.Core.Tests.CoreExtensionsTests.DecoratorsRunInOrderOfPriorities" executed="True" result="Success" success="True" time="0.002" asserts="2" />
+                          <test-case name="NUnit.Core.Tests.CoreExtensionsTests.HasEventListenerExtensionPoint" executed="True" result="Success" success="True" time="0.000" asserts="3" />
+                          <test-case name="NUnit.Core.Tests.CoreExtensionsTests.HasSuiteBuildersExtensionPoint" executed="True" result="Success" success="True" time="0.000" asserts="3" />
+                          <test-case name="NUnit.Core.Tests.CoreExtensionsTests.HasTestCaseBuildersExtensionPoint" executed="True" result="Success" success="True" time="0.000" asserts="3" />
+                          <test-case name="NUnit.Core.Tests.CoreExtensionsTests.HasTestDecoratorsExtensionPoint" executed="True" result="Success" success="True" time="0.000" asserts="3" />
+                          <test-case name="NUnit.Core.Tests.CoreExtensionsTests.HasTestFrameworkRegistry" executed="True" result="Success" success="True" time="0.000" asserts="3" />
+                        </results>
+                      </test-suite>
+                      <test-suite type="TestFixture" name="CultureSettingAndDetectionTests" executed="True" result="Success" success="True" time="0.042" asserts="0">
+                        <results>
+                          <test-case name="NUnit.Core.Tests.CultureSettingAndDetectionTests.CanMatchAttributeWithExclude" executed="True" result="Success" success="True" time="0.001" asserts="2" />
+                          <test-case name="NUnit.Core.Tests.CultureSettingAndDetectionTests.CanMatchAttributeWithInclude" executed="True" result="Success" success="True" time="0.000" asserts="2" />
+                          <test-case name="NUnit.Core.Tests.CultureSettingAndDetectionTests.CanMatchAttributeWithIncludeAndExclude" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Core.Tests.CultureSettingAndDetectionTests.CanMatchStrings" executed="True" result="Success" success="True" time="0.000" asserts="5" />
+                          <test-case name="NUnit.Core.Tests.CultureSettingAndDetectionTests.LoadWithFrenchCanadianCulture" executed="True" result="Success" success="True" time="0.003" asserts="5" />
+                          <test-case name="NUnit.Core.Tests.CultureSettingAndDetectionTests.LoadWithFrenchCulture" executed="True" result="Success" success="True" time="0.003" asserts="5" />
+                          <test-case name="NUnit.Core.Tests.CultureSettingAndDetectionTests.LoadWithRussianCulture" executed="True" result="Success" success="True" time="0.003" asserts="5" />
+                          <test-case name="NUnit.Core.Tests.CultureSettingAndDetectionTests.SettingInvalidCultureGivesError" executed="True" result="Success" success="True" time="0.014" asserts="3" />
+                          <test-suite type="ParameterizedTest" name="UseWithParameterizedTest" executed="True" result="Success" success="True" time="0.001" asserts="0">
+                            <results>
+                              <test-case name="NUnit.Core.Tests.CultureSettingAndDetectionTests.UseWithParameterizedTest()" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                            </results>
+                          </test-suite>
+                        </results>
+                      </test-suite>
+                      <test-suite type="TestFixture" name="CultureSettingAndDetectionTests+NestedFixture" executed="True" result="Success" success="True" time="0.002" asserts="0">
+                        <results>
+                          <test-case name="NUnit.Core.Tests.CultureSettingAndDetectionTests+NestedFixture.CanSetCultureOnFixture" executed="True" result="Success" success="True" time="0.001" asserts="1" />
+                        </results>
+                      </test-suite>
+                      <test-suite type="TestFixture" name="DatapointTests" executed="True" result="Success" success="True" time="0.053" asserts="0">
+                        <results>
+                          <test-case name="NUnit.Core.Tests.DatapointTests.WorksOnArray" executed="True" result="Success" success="True" time="0.007" asserts="3" />
+                          <test-case name="NUnit.Core.Tests.DatapointTests.WorksOnField" executed="True" result="Success" success="True" time="0.005" asserts="3" />
+                          <test-case name="NUnit.Core.Tests.DatapointTests.WorksOnIEnumerableOfT" executed="True" result="Success" success="True" time="0.005" asserts="3" />
+                          <test-case name="NUnit.Core.Tests.DatapointTests.WorksOnIteratorReturningIEnumerableOfT" executed="True" result="Success" success="True" time="0.005" asserts="3" />
+                          <test-case name="NUnit.Core.Tests.DatapointTests.WorksOnMethodReturningArray" executed="True" result="Success" success="True" time="0.004" asserts="3" />
+                          <test-case name="NUnit.Core.Tests.DatapointTests.WorksOnMethodReturningIEnumerableOfT" executed="True" result="Success" success="True" time="0.005" asserts="3" />
+                          <test-case name="NUnit.Core.Tests.DatapointTests.WorksOnPropertyReturningArray" executed="True" result="Success" success="True" time="0.004" asserts="3" />
+                          <test-case name="NUnit.Core.Tests.DatapointTests.WorksOnPropertyReturningIEnumerableOfT" executed="True" result="Success" success="True" time="0.004" asserts="3" />
+                        </results>
+                      </test-suite>
+                      <test-suite type="TestFixture" name="DirectoryChangeTests" executed="True" result="Success" success="True" time="0.002" asserts="0">
+                        <results>
+                          <test-case name="NUnit.Core.Tests.DirectoryChangeTests.ChangingCurrentDirectoryGivesWarning" executed="True" result="Success" success="True" time="0.001" asserts="2" />
+                        </results>
+                      </test-suite>
+                      <test-suite type="TestFixture" name="DirectorySwapperTests" executed="True" result="Success" success="True" time="0.003" asserts="0">
+                        <results>
+                          <test-case name="NUnit.Core.Tests.DirectorySwapperTests.ChangeAndRestore" executed="True" result="Success" success="True" time="0.001" asserts="3" />
+                          <test-case name="NUnit.Core.Tests.DirectorySwapperTests.SwapAndRestore" executed="True" result="Success" success="True" time="0.000" asserts="2" />
+                        </results>
+                      </test-suite>
+                      <test-suite type="TestFixture" name="EventQueueTests" executed="True" result="Success" success="True" time="0.439" asserts="0">
+                        <results>
+                          <test-case name="NUnit.Core.Tests.EventQueueTests.DequeueEmpty" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Core.Tests.EventQueueTests.PumpAutoStopsOnRunFinished" executed="True" result="Success" success="True" time="0.101" asserts="3" />
+                          <test-case name="NUnit.Core.Tests.EventQueueTests.PumpEvents" executed="True" result="Success" success="True" time="0.008" asserts="12">
+                            <properties>
+                              <property name="Timeout" value="3000" />
+                            </properties>
+                          </test-case>
+                          <test-case name="NUnit.Core.Tests.EventQueueTests.PumpEventsWithAutoStop" executed="True" result="Success" success="True" time="0.103" asserts="1">
+                            <properties>
+                              <property name="Timeout" value="2000" />
+                            </properties>
+                          </test-case>
+                          <test-case name="NUnit.Core.Tests.EventQueueTests.PumpPendingEventsAfterAutoStop" executed="True" result="Success" success="True" time="0.103" asserts="2">
+                            <properties>
+                              <property name="Timeout" value="2000" />
+                            </properties>
+                          </test-case>
+                          <test-case name="NUnit.Core.Tests.EventQueueTests.PumpSynchronousAndAsynchronousEvents" executed="True" result="Success" success="True" time="0.005" asserts="6">
+                            <properties>
+                              <property name="Timeout" value="1000" />
+                            </properties>
+                          </test-case>
+                          <test-case name="NUnit.Core.Tests.EventQueueTests.QueueEvents" executed="True" result="Success" success="True" time="0.000" asserts="9" />
+                          <test-case name="NUnit.Core.Tests.EventQueueTests.SendEvents" executed="True" result="Success" success="True" time="0.001" asserts="9" />
+                          <test-case name="NUnit.Core.Tests.EventQueueTests.StartAndStopPumpOnEmptyQueue" executed="True" result="Success" success="True" time="0.002" asserts="2" />
+                          <test-case name="NUnit.Core.Tests.EventQueueTests.TracingEventListenerDoesNotDeadlock" executed="True" result="Success" success="True" time="0.077" asserts="0">
+                            <properties>
+                              <property name="Timeout" value="1000" />
+                            </properties>
+                          </test-case>
+                        </results>
+                      </test-suite>
+                      <test-suite type="TestFixture" name="EventQueueTests+DequeueBlocking_StopTest" executed="True" result="Success" success="True" time="0.035" asserts="0">
+                        <results>
+                          <test-case name="NUnit.Core.Tests.EventQueueTests+DequeueBlocking_StopTest.DequeueBlocking_Stop" executed="True" result="Success" success="True" time="0.033" asserts="3">
+                            <properties>
+                              <property name="Timeout" value="1000" />
+                            </properties>
+                          </test-case>
+                        </results>
+                      </test-suite>
+                      <test-suite type="TestFixture" name="EventQueueTests+SetWaitHandle_Enqueue_AsynchronousTest" executed="True" result="Success" success="True" time="0.035" asserts="0">
+                        <results>
+                          <test-case name="NUnit.Core.Tests.EventQueueTests+SetWaitHandle_Enqueue_AsynchronousTest.SetWaitHandle_Enqueue_Asynchronous" executed="True" result="Success" success="True" time="0.032" asserts="4">
+                            <properties>
+                              <property name="Timeout" value="1000" />
+                            </properties>
+                          </test-case>
+                        </results>
+                      </test-suite>
+                      <test-suite type="TestFixture" name="EventQueueTests+SetWaitHandle_Enqueue_SynchronousTest" executed="True" result="Success" success="True" time="0.064" asserts="0">
+                        <results>
+                          <test-case name="NUnit.Core.Tests.EventQueueTests+SetWaitHandle_Enqueue_SynchronousTest.SetWaitHandle_Enqueue_Synchronous" executed="True" result="Success" success="True" time="0.061" asserts="5">
+                            <properties>
+                              <property name="Timeout" value="1000" />
+                            </properties>
+                          </test-case>
+                        </results>
+                      </test-suite>
+                      <test-suite type="TestFixture" name="EventTestFixture" description="Tests that proper events are generated when running  test" executed="True" result="Success" success="True" time="0.111" asserts="0">
+                        <results>
+                          <test-case name="NUnit.Core.Tests.EventTestFixture.CheckEventListening" executed="True" result="Success" success="True" time="0.043" asserts="4" />
+                        </results>
+                      </test-suite>
+                      <test-suite type="TestFixture" name="ExpectExceptionTest" executed="True" result="Success" success="True" time="0.131" asserts="0">
+                        <results>
+                          <test-case name="NUnit.Core.Tests.ExpectExceptionTest.AssertFailBeforeException" executed="True" result="Success" success="True" time="0.004" asserts="2" />
+                          <test-case name="NUnit.Core.Tests.ExpectExceptionTest.CanExpectUnspecifiedException" executed="True" result="Success" success="True" time="0.000" asserts="0" />
+                          <test-case name="NUnit.Core.Tests.ExpectExceptionTest.ExceptionHandlerIsCalledWhenExceptionMatches" executed="True" result="Success" success="True" time="0.002" asserts="2" />
+                          <test-case name="NUnit.Core.Tests.ExpectExceptionTest.ExceptionHandlerIsCalledWhenExceptionMatches_AlternateHandler" executed="True" result="Success" success="True" time="0.002" asserts="2" />
+                          <test-case name="NUnit.Core.Tests.ExpectExceptionTest.ExceptionHandlerIsNotCalledWhenExceptionDoesNotMatch" executed="True" result="Success" success="True" time="0.002" asserts="2" />
+                          <test-case name="NUnit.Core.Tests.ExpectExceptionTest.ExceptionHandlerIsNotCalledWhenExceptionDoesNotMatch_AlternateHandler" executed="True" result="Success" success="True" time="0.002" asserts="2" />
+                          <test-case name="NUnit.Core.Tests.ExpectExceptionTest.MethodThrowsArgumentOutOfRange" executed="True" result="Success" success="True" time="0.002" asserts="1" />
+                          <test-case name="NUnit.Core.Tests.ExpectExceptionTest.MethodThrowsException" executed="True" result="Success" success="True" time="0.003" asserts="1" />
+                          <test-case name="NUnit.Core.Tests.ExpectExceptionTest.MethodThrowsRightExceptionMessage" executed="True" result="Success" success="True" time="0.003" asserts="1" />
+                          <test-case name="NUnit.Core.Tests.ExpectExceptionTest.MethodThrowsWrongExceptionMessage" executed="True" result="Success" success="True" time="0.005" asserts="1" />
+                          <test-case name="NUnit.Core.Tests.ExpectExceptionTest.SetUpThrowsSameException" executed="True" result="Success" success="True" time="0.003" asserts="1" />
+                          <test-case name="NUnit.Core.Tests.ExpectExceptionTest.TearDownThrowsSameException" executed="True" result="Success" success="True" time="0.003" asserts="1" />
+                          <test-case name="NUnit.Core.Tests.ExpectExceptionTest.TestExceptionNameNotThrown" executed="True" result="Success" success="True" time="0.001" asserts="2" />
+                          <test-case name="NUnit.Core.Tests.ExpectExceptionTest.TestExceptionNameNotThrownWithUserMessage" executed="True" result="Success" success="True" time="0.001" asserts="2" />
+                          <test-case name="NUnit.Core.Tests.ExpectExceptionTest.TestExceptionTypeNotThrown" executed="True" result="Success" success="True" time="0.001" asserts="2" />
+                          <test-case name="NUnit.Core.Tests.ExpectExceptionTest.TestExceptionTypeNotThrownWithUserMessage" executed="True" result="Success" success="True" time="0.001" asserts="2" />
+                          <test-case name="NUnit.Core.Tests.ExpectExceptionTest.TestFailsWhenBaseExceptionIsThrown" executed="True" result="Success" success="True" time="0.002" asserts="2" />
+                          <test-case name="NUnit.Core.Tests.ExpectExceptionTest.TestFailsWhenDerivedExceptionIsThrown" executed="True" result="Success" success="True" time="0.002" asserts="2" />
+                          <test-case name="NUnit.Core.Tests.ExpectExceptionTest.TestIsNotRunnableWhenAlternateHandlerIsNotFound" executed="True" result="Success" success="True" time="0.001" asserts="2" />
+                          <test-case name="NUnit.Core.Tests.ExpectExceptionTest.TestMismatchedExceptionMessage" executed="True" result="Success" success="True" time="0.001" asserts="2" />
+                          <test-case name="NUnit.Core.Tests.ExpectExceptionTest.TestMismatchedExceptionMessageWithUserMessage" executed="True" result="Success" success="True" time="0.001" asserts="2" />
+                          <test-case name="NUnit.Core.Tests.ExpectExceptionTest.TestMismatchedExceptionName" executed="True" result="Success" success="True" time="0.002" asserts="2" />
+                          <test-case name="NUnit.Core.Tests.ExpectExceptionTest.TestMismatchedExceptionNameWithUserMessage" executed="True" result="Success" success="True" time="0.001" asserts="2" />
+                          <test-case name="NUnit.Core.Tests.ExpectExceptionTest.TestMismatchedExceptionType" executed="True" result="Success" success="True" time="0.001" asserts="2" />
+                          <test-case name="NUnit.Core.Tests.ExpectExceptionTest.TestMismatchedExceptionTypeAsNamedParameter" executed="True" result="Success" success="True" time="0.001" asserts="2" />
+                          <test-case name="NUnit.Core.Tests.ExpectExceptionTest.TestMismatchedExceptionTypeWithUserMessage" executed="True" result="Success" success="True" time="0.001" asserts="2" />
+                          <test-case name="NUnit.Core.Tests.ExpectExceptionTest.TestSucceedsWhenSpecifiedExceptionNameAndContainsMatch" executed="True" result="Success" success="True" time="0.001" asserts="0" />
+                          <test-case name="NUnit.Core.Tests.ExpectExceptionTest.TestSucceedsWhenSpecifiedExceptionNameAndRegexMatch" executed="True" result="Success" success="True" time="0.001" asserts="0" />
+                          <test-case name="NUnit.Core.Tests.ExpectExceptionTest.TestSucceedsWithSpecifiedExceptionName" executed="True" result="Success" success="True" time="0.001" asserts="0" />
+                          <test-case name="NUnit.Core.Tests.ExpectExceptionTest.TestSucceedsWithSpecifiedExceptionNameAndExactMatch" executed="True" result="Success" success="True" time="0.001" asserts="0" />
+                          <test-case name="NUnit.Core.Tests.ExpectExceptionTest.TestSucceedsWithSpecifiedExceptionNameAndMessage_NewFormat" executed="True" result="Success" success="True" time="0.000" asserts="0" />
+                          <test-case name="NUnit.Core.Tests.ExpectExceptionTest.TestSucceedsWithSpecifiedExceptionNameAsNamedParameter" executed="True" result="Success" success="True" time="0.001" asserts="0" />
+                          <test-case name="NUnit.Core.Tests.ExpectExceptionTest.TestSucceedsWithSpecifiedExceptionType" executed="True" result="Success" success="True" time="0.001" asserts="0" />
+                          <test-case name="NUnit.Core.Tests.ExpectExceptionTest.TestSucceedsWithSpecifiedExceptionTypeAndContainsMatch" executed="True" result="Success" success="True" time="0.001" asserts="0" />
+                          <test-case name="NUnit.Core.Tests.ExpectExceptionTest.TestSucceedsWithSpecifiedExceptionTypeAndExactMatch" executed="True" result="Success" success="True" time="0.000" asserts="0" />
+                          <test-case name="NUnit.Core.Tests.ExpectExceptionTest.TestSucceedsWithSpecifiedExceptionTypeAndMessage" executed="True" result="Success" success="True" time="0.000" asserts="0" />
+                          <test-case name="NUnit.Core.Tests.ExpectExceptionTest.TestSucceedsWithSpecifiedExceptionTypeAndRegexMatch" executed="True" result="Success" success="True" time="0.000" asserts="0" />
+                          <test-case name="NUnit.Core.Tests.ExpectExceptionTest.TestSucceedsWithSpecifiedExceptionTypeAndStartsWithMatch" executed="True" result="Success" success="True" time="0.001" asserts="0" />
+                          <test-case name="NUnit.Core.Tests.ExpectExceptionTest.TestSucceedsWithSpecifiedExceptionTypeAsNamedParameter" executed="True" result="Success" success="True" time="0.001" asserts="0" />
+                          <test-case name="NUnit.Core.Tests.ExpectExceptionTest.TestUnspecifiedExceptionNotThrown" executed="True" result="Success" success="True" time="0.001" asserts="2" />
+                          <test-case name="NUnit.Core.Tests.ExpectExceptionTest.TestUnspecifiedExceptionNotThrownWithUserMessage" executed="True" result="Success" success="True" time="0.001" asserts="2" />
+                          <test-case name="NUnit.Core.Tests.ExpectExceptionTest.ThrowingMyAppException" executed="True" result="Success" success="True" time="0.001" asserts="0" />
+                          <test-case name="NUnit.Core.Tests.ExpectExceptionTest.ThrowingMyAppExceptionWithMessage" executed="True" result="Success" success="True" time="0.000" asserts="0" />
+                          <test-case name="NUnit.Core.Tests.ExpectExceptionTest.ThrowNUnitException" executed="True" result="Success" success="True" time="0.000" asserts="0" />
+                        </results>
+                      </test-suite>
+                      <test-suite type="TestFixture" name="FailFixture" executed="True" result="Success" success="True" time="0.015" asserts="0">
+                        <results>
+                          <test-case name="NUnit.Core.Tests.FailFixture.BadStackTraceIsHandled" executed="True" result="Success" success="True" time="0.001" asserts="3" />
+                          <test-case name="NUnit.Core.Tests.FailFixture.CustomExceptionIsHandled" executed="True" result="Success" success="True" time="0.001" asserts="2" />
+                          <test-case name="NUnit.Core.Tests.FailFixture.FailInheritsFromSystemException" executed="True" result="Success" success="True" time="0.001" asserts="0" />
+                          <test-case name="NUnit.Core.Tests.FailFixture.FailRecordsInnerException" executed="True" result="Success" success="True" time="0.002" asserts="2" />
+                          <test-case name="NUnit.Core.Tests.FailFixture.FailThrowsAssertionException" executed="True" result="Success" success="True" time="0.001" asserts="0" />
+                          <test-case name="NUnit.Core.Tests.FailFixture.VerifyFailWorks" executed="True" result="Success" success="True" time="0.002" asserts="2" />
+                        </results>
+                      </test-suite>
+                      <test-suite type="TestFixture" name="FixtureSetupTearDownTest" executed="True" result="Success" success="True" time="0.088" asserts="0">
+                        <results>
+                          <test-case name="NUnit.Core.Tests.FixtureSetupTearDownTest.BaseSetUpCalledFirstAndTearDownCalledLast" executed="True" result="Success" success="True" time="0.004" asserts="6" />
+                          <test-case name="NUnit.Core.Tests.FixtureSetupTearDownTest.CheckInheritedSetUpAndTearDownAreCalled" executed="True" result="Success" success="True" time="0.003" asserts="2" />
+                          <test-case name="NUnit.Core.Tests.FixtureSetupTearDownTest.DisposeCalledWhenFixtureImplementsIDisposable" executed="True" result="Success" success="True" time="0.002" asserts="1" />
+                          <test-case name="NUnit.Core.Tests.FixtureSetupTearDownTest.FixtureWithNoTestsCallsFixtureSetUpAndTearDown" executed="True" result="Success" success="True" time="0.003" asserts="2" />
+                          <test-case name="NUnit.Core.Tests.FixtureSetupTearDownTest.HandleErrorInFixtureSetup" executed="True" result="Success" success="True" time="0.004" asserts="11" />
+                          <test-case name="NUnit.Core.Tests.FixtureSetupTearDownTest.HandleErrorInFixtureTearDown" executed="True" result="Success" success="True" time="0.003" asserts="9" />
+                          <test-case name="NUnit.Core.Tests.FixtureSetupTearDownTest.HandleExceptionInFixtureConstructor" executed="True" result="Success" success="True" time="0.003" asserts="9" />
+                          <test-case name="NUnit.Core.Tests.FixtureSetupTearDownTest.HandleIgnoreInFixtureSetup" executed="True" result="Success" success="True" time="0.004" asserts="7" />
+                          <test-case name="NUnit.Core.Tests.FixtureSetupTearDownTest.HandleSetUpAndTearDownWithTestInName" executed="True" result="Success" success="True" time="0.002" asserts="2" />
+                          <test-case name="NUnit.Core.Tests.FixtureSetupTearDownTest.IgnoredFixtureShouldNotCallFixtureSetUpOrTearDown" executed="True" result="Success" success="True" time="0.003" asserts="6" />
+                          <test-case name="NUnit.Core.Tests.FixtureSetupTearDownTest.MakeSureSetUpAndTearDownAreCalled" executed="True" result="Success" success="True" time="0.002" asserts="2" />
+                          <test-case name="NUnit.Core.Tests.FixtureSetupTearDownTest.MakeSureSetUpAndTearDownAreCalledOnExplicitFixture" executed="True" result="Success" success="True" time="0.002" asserts="2" />
+                          <test-case name="NUnit.Core.Tests.FixtureSetupTearDownTest.OverriddenSetUpAndTearDownAreNotCalled" executed="True" result="Success" success="True" time="0.003" asserts="4" />
+                          <test-case name="NUnit.Core.Tests.FixtureSetupTearDownTest.RerunFixtureAfterSetUpFixed" executed="True" result="Success" success="True" time="0.004" asserts="4" />
+                          <test-case name="NUnit.Core.Tests.FixtureSetupTearDownTest.RerunFixtureAfterTearDownFixed" executed="True" result="Success" success="True" time="0.004" asserts="4" />
+                          <test-case name="NUnit.Core.Tests.FixtureSetupTearDownTest.RunningSingleMethodCallsSetUpAndTearDown" executed="True" result="Success" success="True" time="0.002" asserts="2" />
+                          <test-case name="NUnit.Core.Tests.FixtureSetupTearDownTest.StaticBaseSetUpCalledFirstAndTearDownCalledLast" executed="True" result="Success" success="True" time="0.004" asserts="6" />
+                          <test-case name="NUnit.Core.Tests.FixtureSetupTearDownTest.StaticClassSetUpAndTearDownAreCalled" executed="True" result="Success" success="True" time="0.002" asserts="2" />
+                          <test-case name="NUnit.Core.Tests.FixtureSetupTearDownTest.StaticSetUpAndTearDownAreCalled" executed="True" result="Success" success="True" time="0.001" asserts="2" />
+                        </results>
+                      </test-suite>
+                      <test-suite type="TestFixture" name="FixtureSetupTearDownTest+ChangesMadeInFixtureSetUp" executed="True" result="Success" success="True" time="0.004" asserts="0">
+                        <results>
+                          <test-case name="NUnit.Core.Tests.FixtureSetupTearDownTest+ChangesMadeInFixtureSetUp.TestThatChangesPersistUsingSameThread" executed="True" result="Success" success="True" time="0.001" asserts="3" />
+                          <test-case name="NUnit.Core.Tests.FixtureSetupTearDownTest+ChangesMadeInFixtureSetUp.TestThatChangesPersistUsingSeparateThread" executed="True" result="Success" success="True" time="0.001" asserts="3">
+                            <properties>
+                              <property name="RequiresThread" value="True" />
+                            </properties>
+                          </test-case>
+                        </results>
+                      </test-suite>
+                      <test-suite type="Namespace" name="Generic" executed="True" result="Success" success="True" time="0.052" asserts="0">
+                        <results>
+                          <test-suite type="GenericFixture" name="DeduceTypeArgsFromArgs&lt;T1,T2&gt;" executed="True" result="Success" success="True" time="0.006" asserts="0">
+                            <results>
+                              <test-suite type="TestFixture" name="DeduceTypeArgsFromArgs&lt;Double,Int32&gt;(100.0d,42)" executed="True" result="Success" success="True" time="0.002" asserts="0">
+                                <categories>
+                                  <category name="Generics" />
+                                </categories>
+                                <results>
+                                  <test-suite type="ParameterizedTest" name="TestMyArgTypes" executed="True" result="Success" success="True" time="0.002" asserts="0">
+                                    <results>
+                                      <test-case name="NUnit.Core.Tests.Generic.DeduceTypeArgsFromArgs&lt;Double,Int32&gt;(100.0d,42).TestMyArgTypes(5,7)" executed="True" result="Success" success="True" time="0.001" asserts="2" />
+                                    </results>
+                                  </test-suite>
+                                </results>
+                              </test-suite>
+                              <test-suite type="TestFixture" name="DeduceTypeArgsFromArgs&lt;Int32,Double&gt;(42,100.0d)" executed="True" result="Success" success="True" time="0.001" asserts="0">
+                                <categories>
+                                  <category name="Generics" />
+                                </categories>
+                                <results>
+                                  <test-suite type="ParameterizedTest" name="TestMyArgTypes" executed="True" result="Success" success="True" time="0.001" asserts="0">
+                                    <results>
+                                      <test-case name="NUnit.Core.Tests.Generic.DeduceTypeArgsFromArgs&lt;Int32,Double&gt;(42,100.0d).TestMyArgTypes(5,7)" executed="True" result="Success" success="True" time="0.001" asserts="2" />
+                                    </results>
+                                  </test-suite>
+                                </results>
+                              </test-suite>
+                            </results>
+                          </test-suite>
+                          <test-suite type="GenericFixture" name="SimpleGenericFixture&lt;TList&gt;" executed="True" result="Success" success="True" time="0.005" asserts="0">
+                            <results>
+                              <test-suite type="TestFixture" name="SimpleGenericFixture&lt;ArrayList&gt;" executed="True" result="Success" success="True" time="0.002" asserts="0">
+                                <categories>
+                                  <category name="Generics" />
+                                </categories>
+                                <results>
+                                  <test-case name="NUnit.Core.Tests.Generic.SimpleGenericFixture&lt;ArrayList&gt;.TestCollectionCount" executed="True" result="Success" success="True" time="0.001" asserts="1" />
+                                </results>
+                              </test-suite>
+                              <test-suite type="TestFixture" name="SimpleGenericFixture&lt;List&lt;Int32&gt;&gt;" executed="True" result="Success" success="True" time="0.001" asserts="0">
+                                <categories>
+                                  <category name="Generics" />
+                                </categories>
+                                <results>
+                                  <test-case name="NUnit.Core.Tests.Generic.SimpleGenericFixture&lt;List&lt;Int32&gt;&gt;.TestCollectionCount" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                                </results>
+                              </test-suite>
+                            </results>
+                          </test-suite>
+                          <test-suite type="TestFixture" name="SimpleGenericMethods" executed="True" result="Success" success="True" time="0.026" asserts="0">
+                            <categories>
+                              <category name="Generics" />
+                            </categories>
+                            <results>
+                              <test-suite type="ParameterizedTest" name="GenericTestMethodWithOneTypeParameter" executed="True" result="Success" success="True" time="0.007" asserts="0">
+                                <results>
+                                  <test-case name="NUnit.Core.Tests.Generic.SimpleGenericMethods.GenericTestMethodWithOneTypeParameter&lt;Double&gt;(5.0d,2.0d,&quot;ABC&quot;)" executed="True" result="Success" success="True" time="0.001" asserts="3" />
+                                  <test-case name="NUnit.Core.Tests.Generic.SimpleGenericMethods.GenericTestMethodWithOneTypeParameter&lt;Double&gt;(5.0d,2.0d,&quot;ABC&quot;)" executed="True" result="Success" success="True" time="0.000" asserts="3" />
+                                  <test-case name="NUnit.Core.Tests.Generic.SimpleGenericMethods.GenericTestMethodWithOneTypeParameter&lt;Double&gt;(5.0d,2.0d,&quot;ABC&quot;)" executed="True" result="Success" success="True" time="0.000" asserts="3" />
+                                  <test-case name="NUnit.Core.Tests.Generic.SimpleGenericMethods.GenericTestMethodWithOneTypeParameter&lt;Int32&gt;(5,2,&quot;ABC&quot;)" executed="True" result="Success" success="True" time="0.000" asserts="3" />
+                                </results>
+                              </test-suite>
+                              <test-suite type="ParameterizedTest" name="GenericTestMethodWithTwoTypeParameters" executed="True" result="Success" success="True" time="0.007" asserts="0">
+                                <results>
+                                  <test-case name="NUnit.Core.Tests.Generic.SimpleGenericMethods.GenericTestMethodWithTwoTypeParameters&lt;Int32,Double&gt;(5,2.0d,&quot;ABC&quot;)" executed="True" result="Success" success="True" time="0.001" asserts="3" />
+                                  <test-case name="NUnit.Core.Tests.Generic.SimpleGenericMethods.GenericTestMethodWithTwoTypeParameters&lt;Int32,Int32&gt;(5,2,&quot;ABC&quot;)" executed="True" result="Success" success="True" time="0.001" asserts="3" />
+                                  <test-case name="NUnit.Core.Tests.Generic.SimpleGenericMethods.GenericTestMethodWithTwoTypeParameters&lt;Double,Double&gt;(5.0d,2.0d,&quot;ABC&quot;)" executed="True" result="Success" success="True" time="0.001" asserts="3" />
+                                  <test-case name="NUnit.Core.Tests.Generic.SimpleGenericMethods.GenericTestMethodWithTwoTypeParameters&lt;Double,Int64&gt;(5.0d,2L,&quot;ABC&quot;)" executed="True" result="Success" success="True" time="0.001" asserts="3" />
+                                </results>
+                              </test-suite>
+                              <test-suite type="ParameterizedTest" name="GenericTestMethodWithTwoTypeParameters_Reversed" executed="True" result="Success" success="True" time="0.007" asserts="0">
+                                <results>
+                                  <test-case name="NUnit.Core.Tests.Generic.SimpleGenericMethods.GenericTestMethodWithTwoTypeParameters_Reversed&lt;Int32,Int32&gt;(5,2,&quot;ABC&quot;)" executed="True" result="Success" success="True" time="0.000" asserts="3" />
+                                  <test-case name="NUnit.Core.Tests.Generic.SimpleGenericMethods.GenericTestMethodWithTwoTypeParameters_Reversed&lt;Int64,Double&gt;(5.0d,2L,&quot;ABC&quot;)" executed="True" result="Success" success="True" time="0.000" asserts="3" />
+                                  <test-case name="NUnit.Core.Tests.Generic.SimpleGenericMethods.GenericTestMethodWithTwoTypeParameters_Reversed&lt;Double,Double&gt;(5.0d,2.0d,&quot;ABC&quot;)" executed="True" result="Success" success="True" time="0.000" asserts="3" />
+                                  <test-case name="NUnit.Core.Tests.Generic.SimpleGenericMethods.GenericTestMethodWithTwoTypeParameters_Reversed&lt;Double,Int32&gt;(5,2.0d,&quot;ABC&quot;)" executed="True" result="Success" success="True" time="0.000" asserts="3" />
+                                </results>
+                              </test-suite>
+                            </results>
+                          </test-suite>
+                          <test-suite type="GenericFixture" name="TypeParameterUsedWithTestMethod&lt;T&gt;" executed="True" result="Success" success="True" time="0.005" asserts="0">
+                            <results>
+                              <test-suite type="TestFixture" name="TypeParameterUsedWithTestMethod&lt;Double&gt;" executed="True" result="Success" success="True" time="0.005" asserts="0">
+                                <categories>
+                                  <category name="Generics" />
+                                </categories>
+                                <results>
+                                  <test-suite type="ParameterizedTest" name="TestMyArgType" executed="True" result="Success" success="True" time="0.004" asserts="0">
+                                    <results>
+                                      <test-case name="NUnit.Core.Tests.Generic.TypeParameterUsedWithTestMethod&lt;Double&gt;.TestMyArgType(1.23d)" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                                      <test-case name="NUnit.Core.Tests.Generic.TypeParameterUsedWithTestMethod&lt;Double&gt;.TestMyArgType(5)" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                                    </results>
+                                  </test-suite>
+                                </results>
+                              </test-suite>
+                            </results>
+                          </test-suite>
+                        </results>
+                      </test-suite>
+                      <test-suite type="TestFixture" name="IgnoreFixture" executed="True" result="Success" success="True" time="0.026" asserts="0">
+                        <results>
+                          <test-case name="NUnit.Core.Tests.IgnoreFixture.IgnoreTakesPrecedenceOverExpectedException" executed="True" result="Success" success="True" time="0.002" asserts="2" />
+                          <test-case name="NUnit.Core.Tests.IgnoreFixture.IgnoreThrowsIgnoreException" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Core.Tests.IgnoreFixture.IgnoreWithUserMessage" executed="True" result="Success" success="True" time="0.001" asserts="1" />
+                          <test-case name="NUnit.Core.Tests.IgnoreFixture.IgnoreWithUserMessage_ArrayOfArgs" executed="True" result="Success" success="True" time="0.001" asserts="1" />
+                          <test-case name="NUnit.Core.Tests.IgnoreFixture.IgnoreWithUserMessage_OneArg" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Core.Tests.IgnoreFixture.IgnoreWithUserMessage_ThreeArgs" executed="True" result="Success" success="True" time="0.001" asserts="1" />
+                          <test-case name="NUnit.Core.Tests.IgnoreFixture.IgnoreWorksForTestCase" executed="True" result="Success" success="True" time="0.001" asserts="2" />
+                          <test-case name="NUnit.Core.Tests.IgnoreFixture.IgnoreWorksForTestSuite" executed="True" result="Success" success="True" time="0.003" asserts="3" />
+                          <test-case name="NUnit.Core.Tests.IgnoreFixture.IgnoreWorksFromSetUp" executed="True" result="Success" success="True" time="0.004" asserts="2" />
+                        </results>
+                      </test-suite>
+                      <test-suite type="TestFixture" name="LegacySuiteTests" executed="True" result="Success" success="True" time="0.086" asserts="0">
+                        <results>
+                          <test-case name="NUnit.Core.Tests.LegacySuiteTests.SetUpAndTearDownAreCalled" executed="True" result="Success" success="True" time="0.004" asserts="3" />
+                          <test-case name="NUnit.Core.Tests.LegacySuiteTests.SuitePropertyWithInvalidType" executed="True" result="Success" success="True" time="0.001" asserts="1" />
+                          <test-case name="NUnit.Core.Tests.LegacySuiteTests.SuiteReturningFixtures" executed="True" result="Success" success="True" time="0.058" asserts="3" />
+                          <test-case name="NUnit.Core.Tests.LegacySuiteTests.SuiteReturningFixtureWithArguments" executed="True" result="Success" success="True" time="0.002" asserts="3" />
+                          <test-case name="NUnit.Core.Tests.LegacySuiteTests.SuiteReturningTestSuite" executed="True" result="Success" success="True" time="0.006" asserts="3" />
+                          <test-case name="NUnit.Core.Tests.LegacySuiteTests.SuiteReturningTypes" executed="True" result="Success" success="True" time="0.005" asserts="3" />
+                        </results>
+                      </test-suite>
+                      <test-suite type="TestFixture" name="MaxTimeTests" executed="True" result="Success" success="True" time="0.081" asserts="0">
+                        <results>
+                          <test-case name="NUnit.Core.Tests.MaxTimeTests.ErrorReport" executed="True" result="Success" success="True" time="0.001" asserts="0">
+                            <properties>
+                              <property name="MaxTime" value="1000" />
+                            </properties>
+                          </test-case>
+                          <test-case name="NUnit.Core.Tests.MaxTimeTests.ErrorReportHasPriorityOverMaxTime" executed="True" result="Success" success="True" time="0.022" asserts="3" />
+                          <test-case name="NUnit.Core.Tests.MaxTimeTests.FailureReport" executed="True" result="Success" success="True" time="0.000" asserts="0">
+                            <properties>
+                              <property name="MaxTime" value="1000" />
+                            </properties>
+                          </test-case>
+                          <test-case name="NUnit.Core.Tests.MaxTimeTests.FailureReportHasPriorityOverMaxTime" executed="True" result="Success" success="True" time="0.022" asserts="3" />
+                          <test-case name="NUnit.Core.Tests.MaxTimeTests.MaxTimeExceeded" executed="True" result="Success" success="True" time="0.022" asserts="2" />
+                          <test-case name="NUnit.Core.Tests.MaxTimeTests.MaxTimeNotExceeded" executed="True" result="Success" success="True" time="0.000" asserts="0">
+                            <properties>
+                              <property name="MaxTime" value="1000" />
+                            </properties>
+                          </test-case>
+                        </results>
+                      </test-suite>
+                      <test-suite type="TestFixture" name="NameFilterTest" executed="True" result="Success" success="True" time="0.066" asserts="0">
+                        <results>
+                          <test-case name="NUnit.Core.Tests.NameFilterTest.ExplicitTestCaseDoesNotMatchWhenNotSelectedDirectly" executed="True" result="Success" success="True" time="0.009" asserts="1" />
+                          <test-case name="NUnit.Core.Tests.NameFilterTest.ExplicitTestCaseMatchesWhenSelectedDirectly" executed="True" result="Success" success="True" time="0.005" asserts="2" />
+                          <test-case name="NUnit.Core.Tests.NameFilterTest.ExplicitTestSuiteDoesNotMatchWhenNotSelectedDirectly" executed="True" result="Success" success="True" time="0.006" asserts="2" />
+                          <test-case name="NUnit.Core.Tests.NameFilterTest.ExplicitTestSuiteMatchesWhenSelectedDirectly" executed="True" result="Success" success="True" time="0.006" asserts="3" />
+                          <test-case name="NUnit.Core.Tests.NameFilterTest.HighLevelSuite" executed="True" result="Success" success="True" time="0.004" asserts="3" />
+                          <test-case name="NUnit.Core.Tests.NameFilterTest.MultipleNameMatch" executed="True" result="Success" success="True" time="0.004" asserts="3" />
+                          <test-case name="NUnit.Core.Tests.NameFilterTest.SingleNameMatch" executed="True" result="Success" success="True" time="0.003" asserts="4" />
+                          <test-case name="NUnit.Core.Tests.NameFilterTest.SuiteNameMatch" executed="True" result="Success" success="True" time="0.004" asserts="3" />
+                          <test-case name="NUnit.Core.Tests.NameFilterTest.TestDoesNotMatch" executed="True" result="Success" success="True" time="0.004" asserts="2" />
+                        </results>
+                      </test-suite>
+                      <test-suite type="TestFixture" name="NamespaceAssemblyTests" executed="True" result="Success" success="True" time="0.086" asserts="0">
+                        <results>
+                          <test-case name="NUnit.Core.Tests.NamespaceAssemblyTests.Hierarchy" executed="True" result="Success" success="True" time="0.028" asserts="17" />
+                          <test-case name="NUnit.Core.Tests.NamespaceAssemblyTests.LoadTestFixtureFromAssembly" executed="True" result="Success" success="True" time="0.013" asserts="1" />
+                          <test-case name="NUnit.Core.Tests.NamespaceAssemblyTests.NoNamespaceInAssembly" executed="True" result="Success" success="True" time="0.009" asserts="5" />
+                          <test-case name="NUnit.Core.Tests.NamespaceAssemblyTests.TestRoot" executed="True" result="Success" success="True" time="0.028" asserts="1" />
+                        </results>
+                      </test-suite>
+                      <test-suite type="TestFixture" name="PairwiseTest" executed="True" result="Success" success="True" time="0.021" asserts="0">
+                        <results>
+                          <test-suite type="ParameterizedTest" name="Test" executed="True" result="Success" success="True" time="0.021" asserts="0">
+                            <results>
+                              <test-case name="NUnit.Core.Tests.PairwiseTest.Test 2x4" executed="True" result="Success" success="True" time="0.002" asserts="2" />
+                              <test-case name="NUnit.Core.Tests.PairwiseTest.Test 2x2x2" executed="True" result="Success" success="True" time="0.001" asserts="2" />
+                              <test-case name="NUnit.Core.Tests.PairwiseTest.Test 3x2x2" executed="True" result="Success" success="True" time="0.000" asserts="2" />
+                              <test-case name="NUnit.Core.Tests.PairwiseTest.Test 3x2x2x2" executed="True" result="Success" success="True" time="0.000" asserts="2" />
+                              <test-case name="NUnit.Core.Tests.PairwiseTest.Test 3x2x2x2x2" executed="True" result="Success" success="True" time="0.001" asserts="2" />
+                              <test-case name="NUnit.Core.Tests.PairwiseTest.Test 3x2x2x2x2x2" executed="True" result="Success" success="True" time="0.001" asserts="2" />
+                              <test-case name="NUnit.Core.Tests.PairwiseTest.Test 3x3x3" executed="True" result="Success" success="True" time="0.001" asserts="2" />
+                              <test-case name="NUnit.Core.Tests.PairwiseTest.Test 4x4x4" executed="True" result="Success" success="True" time="0.001" asserts="2" />
+                              <test-case name="NUnit.Core.Tests.PairwiseTest.Test 5x5x5" executed="True" result="Success" success="True" time="0.001" asserts="2" />
+                            </results>
+                          </test-suite>
+                        </results>
+                      </test-suite>
+                      <test-suite type="TestFixture" name="PairwiseTest+LiveTest" executed="True" result="Success" success="True" time="0.013" asserts="1">
+                        <results>
+                          <test-suite type="ParameterizedTest" name="Test" executed="True" result="Success" success="True" time="0.013" asserts="0">
+                            <results>
+                              <test-case name="NUnit.Core.Tests.PairwiseTest+LiveTest.Test(&quot;a&quot;,&quot;-&quot;,&quot;x&quot;)" executed="True" result="Success" success="True" time="0.000" asserts="0" />
+                              <test-case name="NUnit.Core.Tests.PairwiseTest+LiveTest.Test(&quot;b&quot;,&quot;+&quot;,&quot;y&quot;)" executed="True" result="Success" success="True" time="0.000" asserts="0" />
+                              <test-case name="NUnit.Core.Tests.PairwiseTest+LiveTest.Test(&quot;c&quot;,&quot;+&quot;,&quot;x&quot;)" executed="True" result="Success" success="True" time="0.000" asserts="0" />
+                              <test-case name="NUnit.Core.Tests.PairwiseTest+LiveTest.Test(&quot;b&quot;,&quot;-&quot;,&quot;x&quot;)" executed="True" result="Success" success="True" time="0.000" asserts="0" />
+                              <test-case name="NUnit.Core.Tests.PairwiseTest+LiveTest.Test(&quot;a&quot;,&quot;-&quot;,&quot;y&quot;)" executed="True" result="Success" success="True" time="0.001" asserts="0" />
+                              <test-case name="NUnit.Core.Tests.PairwiseTest+LiveTest.Test(&quot;c&quot;,&quot;-&quot;,&quot;y&quot;)" executed="True" result="Success" success="True" time="0.000" asserts="0" />
+                              <test-case name="NUnit.Core.Tests.PairwiseTest+LiveTest.Test(&quot;a&quot;,&quot;+&quot;,&quot;x&quot;)" executed="True" result="Success" success="True" time="0.000" asserts="0" />
+                            </results>
+                          </test-suite>
+                        </results>
+                      </test-suite>
+                      <test-suite type="ParameterizedFixture" name="ParameterizedTestFixture" executed="True" result="Success" success="True" time="0.015" asserts="0">
+                        <results>
+                          <test-suite type="TestFixture" name="ParameterizedTestFixture(&quot;hello&quot;,&quot;hello&quot;,&quot;goodbye&quot;)" executed="True" result="Success" success="True" time="0.003" asserts="0">
+                            <results>
+                              <test-case name="NUnit.Core.Tests.ParameterizedTestFixture(&quot;hello&quot;,&quot;hello&quot;,&quot;goodbye&quot;).TestEquality" executed="True" result="Success" success="True" time="0.000" asserts="2" />
+                              <test-case name="NUnit.Core.Tests.ParameterizedTestFixture(&quot;hello&quot;,&quot;hello&quot;,&quot;goodbye&quot;).TestInequality" executed="True" result="Success" success="True" time="0.001" asserts="2" />
+                            </results>
+                          </test-suite>
+                          <test-suite type="TestFixture" name="ParameterizedTestFixture(&quot;zip&quot;,&quot;zip&quot;)" executed="True" result="Success" success="True" time="0.004" asserts="0">
+                            <results>
+                              <test-case name="NUnit.Core.Tests.ParameterizedTestFixture(&quot;zip&quot;,&quot;zip&quot;).TestEquality" executed="True" result="Success" success="True" time="0.000" asserts="2" />
+                              <test-case name="NUnit.Core.Tests.ParameterizedTestFixture(&quot;zip&quot;,&quot;zip&quot;).TestInequality" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                            </results>
+                          </test-suite>
+                          <test-suite type="TestFixture" name="ParameterizedTestFixture(42,42,99)" executed="True" result="Success" success="True" time="0.004" asserts="0">
+                            <results>
+                              <test-case name="NUnit.Core.Tests.ParameterizedTestFixture(42,42,99).TestEquality" executed="True" result="Success" success="True" time="0.000" asserts="2" />
+                              <test-case name="NUnit.Core.Tests.ParameterizedTestFixture(42,42,99).TestInequality" executed="True" result="Success" success="True" time="0.000" asserts="2" />
+                            </results>
+                          </test-suite>
+                        </results>
+                      </test-suite>
+                      <test-suite type="TestFixture" name="ParameterizedTestFixtureNamingTests" executed="True" result="Success" success="True" time="0.025" asserts="0">
+                        <results>
+                          <test-case name="NUnit.Core.Tests.ParameterizedTestFixtureNamingTests.FixtureInstancesAreNamedCorrectly" executed="True" result="Success" success="True" time="0.004" asserts="2" />
+                          <test-case name="NUnit.Core.Tests.ParameterizedTestFixtureNamingTests.MethodWithoutParamsIsNamedCorrectly" executed="True" result="Success" success="True" time="0.003" asserts="2" />
+                          <test-case name="NUnit.Core.Tests.ParameterizedTestFixtureNamingTests.MethodWithParamsIsNamedCorrectly" executed="True" result="Success" success="True" time="0.003" asserts="3" />
+                          <test-case name="NUnit.Core.Tests.ParameterizedTestFixtureNamingTests.SuiteHasCorrectNumberOfInstances" executed="True" result="Success" success="True" time="0.003" asserts="1" />
+                          <test-case name="NUnit.Core.Tests.ParameterizedTestFixtureNamingTests.TopLevelSuiteIsNamedCorrectly" executed="True" result="Success" success="True" time="0.003" asserts="2" />
+                        </results>
+                      </test-suite>
+                      <test-suite type="TestFixture" name="ParameterizedTestFixtureTests" executed="True" result="Success" success="True" time="0.005" asserts="0">
+                        <results>
+                          <test-case name="NUnit.Core.Tests.ParameterizedTestFixtureTests.CanSpecifyCategory" executed="True" result="Success" success="True" time="0.002" asserts="1" />
+                          <test-case name="NUnit.Core.Tests.ParameterizedTestFixtureTests.CanSpecifyMultipleCategories" executed="True" result="Success" success="True" time="0.001" asserts="1" />
+                        </results>
+                      </test-suite>
+                      <test-suite type="ParameterizedFixture" name="ParameterizedTestFixtureWithDataSources" executed="True" result="Success" success="True" time="0.024" asserts="0">
+                        <results>
+                          <test-suite type="TestFixture" name="ParameterizedTestFixtureWithDataSources(42)" executed="True" result="Success" success="True" time="0.024" asserts="0">
+                            <results>
+                              <test-suite type="ParameterizedTest" name="CanAccessTestCaseSource" executed="True" result="Success" success="True" time="0.003" asserts="0">
+                                <results>
+                                  <test-case name="NUnit.Core.Tests.ParameterizedTestFixtureWithDataSources(42).CanAccessTestCaseSource(6,7)" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                                  <test-case name="NUnit.Core.Tests.ParameterizedTestFixtureWithDataSources(42).CanAccessTestCaseSource(3,14)" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                                </results>
+                              </test-suite>
+                              <test-suite type="ParameterizedTest" name="CanAccessValueSource" executed="True" result="Success" success="True" time="0.004" asserts="0">
+                                <results>
+                                  <test-case name="NUnit.Core.Tests.ParameterizedTestFixtureWithDataSources(42).CanAccessValueSource(1)" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                                  <test-case name="NUnit.Core.Tests.ParameterizedTestFixtureWithDataSources(42).CanAccessValueSource(2)" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                                  <test-case name="NUnit.Core.Tests.ParameterizedTestFixtureWithDataSources(42).CanAccessValueSource(3)" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                                </results>
+                              </test-suite>
+                              <test-suite type="ParameterizedTest" name="CanGenerateDataFromParameter" executed="True" result="Success" success="True" time="0.012" asserts="0">
+                                <results>
+                                  <test-case name="NUnit.Core.Tests.ParameterizedTestFixtureWithDataSources(42).CanGenerateDataFromParameter(1,42)" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                                  <test-case name="NUnit.Core.Tests.ParameterizedTestFixtureWithDataSources(42).CanGenerateDataFromParameter(2,21)" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                                  <test-case name="NUnit.Core.Tests.ParameterizedTestFixtureWithDataSources(42).CanGenerateDataFromParameter(3,14)" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                                  <test-case name="NUnit.Core.Tests.ParameterizedTestFixtureWithDataSources(42).CanGenerateDataFromParameter(6,7)" executed="True" result="Success" success="True" time="0.001" asserts="1" />
+                                  <test-case name="NUnit.Core.Tests.ParameterizedTestFixtureWithDataSources(42).CanGenerateDataFromParameter(7,6)" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                                  <test-case name="NUnit.Core.Tests.ParameterizedTestFixtureWithDataSources(42).CanGenerateDataFromParameter(14,3)" executed="True" result="Success" success="True" time="0.001" asserts="1" />
+                                  <test-case name="NUnit.Core.Tests.ParameterizedTestFixtureWithDataSources(42).CanGenerateDataFromParameter(21,2)" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                                  <test-case name="NUnit.Core.Tests.ParameterizedTestFixtureWithDataSources(42).CanGenerateDataFromParameter(42,1)" executed="True" result="Success" success="True" time="0.001" asserts="1" />
+                                </results>
+                              </test-suite>
+                            </results>
+                          </test-suite>
+                        </results>
+                      </test-suite>
+                      <test-suite type="ParameterizedFixture" name="ParameterizedTestFixtureWithNullArguments" executed="True" result="Success" success="True" time="0.006" asserts="0">
+                        <results>
+                          <test-suite type="TestFixture" name="ParameterizedTestFixtureWithNullArguments(&quot;A&quot;,null)" executed="True" result="Success" success="True" time="0.001" asserts="0">
+                            <results>
+                              <test-case name="NUnit.Core.Tests.ParameterizedTestFixtureWithNullArguments(&quot;A&quot;,null).TestMethod" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                            </results>
+                          </test-suite>
+                          <test-suite type="TestFixture" name="ParameterizedTestFixtureWithNullArguments(null,&quot;A&quot;)" executed="True" result="Success" success="True" time="0.001" asserts="0">
+                            <results>
+                              <test-case name="NUnit.Core.Tests.ParameterizedTestFixtureWithNullArguments(null,&quot;A&quot;).TestMethod" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                            </results>
+                          </test-suite>
+                          <test-suite type="TestFixture" name="ParameterizedTestFixtureWithNullArguments(null,null)" executed="True" result="Success" success="True" time="0.001" asserts="0">
+                            <results>
+                              <test-case name="NUnit.Core.Tests.ParameterizedTestFixtureWithNullArguments(null,null).TestMethod" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                            </results>
+                          </test-suite>
+                        </results>
+                      </test-suite>
+                      <test-suite type="TestFixture" name="PlatformDetectionTests" executed="True" result="Success" success="True" time="0.069" asserts="0">
+                        <results>
+                          <test-case name="NUnit.Core.Tests.PlatformDetectionTests.ArrayOfPlatforms" executed="True" result="Success" success="True" time="0.001" asserts="2" />
+                          <test-case name="NUnit.Core.Tests.PlatformDetectionTests.DetectExactVersion" executed="True" result="Success" success="True" time="0.000" asserts="4" />
+                          <test-case name="NUnit.Core.Tests.PlatformDetectionTests.DetectMono10" executed="True" result="Success" success="True" time="0.001" asserts="14" />
+                          <test-case name="NUnit.Core.Tests.PlatformDetectionTests.DetectMono20" executed="True" result="Success" success="True" time="0.000" asserts="14" />
+                          <test-case name="NUnit.Core.Tests.PlatformDetectionTests.DetectMono30" executed="True" result="Success" success="True" time="0.001" asserts="13" />
+                          <test-case name="NUnit.Core.Tests.PlatformDetectionTests.DetectMono35" executed="True" result="Success" success="True" time="0.001" asserts="12" />
+                          <test-case name="NUnit.Core.Tests.PlatformDetectionTests.DetectMono40" executed="True" result="Success" success="True" time="0.000" asserts="14" />
+                          <test-case name="NUnit.Core.Tests.PlatformDetectionTests.DetectNet10" executed="True" result="Success" success="True" time="0.000" asserts="14" />
+                          <test-case name="NUnit.Core.Tests.PlatformDetectionTests.DetectNet11" executed="True" result="Success" success="True" time="0.001" asserts="14" />
+                          <test-case name="NUnit.Core.Tests.PlatformDetectionTests.DetectNet20" executed="True" result="Success" success="True" time="0.001" asserts="14" />
+                          <test-case name="NUnit.Core.Tests.PlatformDetectionTests.DetectNet30" executed="True" result="Success" success="True" time="0.001" asserts="13" />
+                          <test-case name="NUnit.Core.Tests.PlatformDetectionTests.DetectNet35" executed="True" result="Success" success="True" time="0.001" asserts="12" />
+                          <test-case name="NUnit.Core.Tests.PlatformDetectionTests.DetectNet40" executed="True" result="Success" success="True" time="0.001" asserts="14" />
+                          <test-case name="NUnit.Core.Tests.PlatformDetectionTests.DetectNetCF" executed="True" result="Success" success="True" time="0.000" asserts="15" />
+                          <test-case name="NUnit.Core.Tests.PlatformDetectionTests.DetectNT3" executed="True" result="Success" success="True" time="0.001" asserts="20" />
+                          <test-case name="NUnit.Core.Tests.PlatformDetectionTests.DetectNT4" executed="True" result="Success" success="True" time="0.000" asserts="20" />
+                          <test-case name="NUnit.Core.Tests.PlatformDetectionTests.DetectSSCLI" executed="True" result="Success" success="True" time="0.001" asserts="14" />
+                          <test-case name="NUnit.Core.Tests.PlatformDetectionTests.DetectUnixUnderMicrosoftDotNet" executed="True" result="Success" success="True" time="0.001" asserts="22" />
+                          <test-case name="NUnit.Core.Tests.PlatformDetectionTests.DetectUnixUnderMono" executed="False" result="Skipped">
+                            <reason>
+                              <message><![CDATA[Not supported on Net]]></message>
+                            </reason>
+                          </test-case>
+                          <test-case name="NUnit.Core.Tests.PlatformDetectionTests.DetectVista" executed="True" result="Success" success="True" time="0.001" asserts="19" />
+                          <test-case name="NUnit.Core.Tests.PlatformDetectionTests.DetectWin2003Server" executed="True" result="Success" success="True" time="0.000" asserts="19" />
+                          <test-case name="NUnit.Core.Tests.PlatformDetectionTests.DetectWin2008ServerOriginal" executed="True" result="Success" success="True" time="0.000" asserts="19" />
+                          <test-case name="NUnit.Core.Tests.PlatformDetectionTests.DetectWin2008ServerR2" executed="True" result="Success" success="True" time="0.000" asserts="18" />
+                          <test-case name="NUnit.Core.Tests.PlatformDetectionTests.DetectWin2K" executed="True" result="Success" success="True" time="0.000" asserts="19" />
+                          <test-case name="NUnit.Core.Tests.PlatformDetectionTests.DetectWin95" executed="True" result="Success" success="True" time="0.001" asserts="20" />
+                          <test-case name="NUnit.Core.Tests.PlatformDetectionTests.DetectWin98" executed="True" result="Success" success="True" time="0.000" asserts="20" />
+                          <test-case name="NUnit.Core.Tests.PlatformDetectionTests.DetectWinCE" executed="True" result="Success" success="True" time="0.000" asserts="21" />
+                          <test-case name="NUnit.Core.Tests.PlatformDetectionTests.DetectWindows7" executed="True" result="Success" success="True" time="0.000" asserts="19" />
+                          <test-case name="NUnit.Core.Tests.PlatformDetectionTests.DetectWinMe" executed="True" result="Success" success="True" time="0.000" asserts="20" />
+                          <test-case name="NUnit.Core.Tests.PlatformDetectionTests.DetectWinXP" executed="True" result="Success" success="True" time="0.000" asserts="19" />
+                          <test-case name="NUnit.Core.Tests.PlatformDetectionTests.DetectWinXPProfessionalX64" executed="True" result="Success" success="True" time="0.001" asserts="19" />
+                          <test-case name="NUnit.Core.Tests.PlatformDetectionTests.PlatformAttribute_Exclude" executed="True" result="Success" success="True" time="0.001" asserts="3" />
+                          <test-case name="NUnit.Core.Tests.PlatformDetectionTests.PlatformAttribute_Include" executed="True" result="Success" success="True" time="0.001" asserts="3" />
+                          <test-case name="NUnit.Core.Tests.PlatformDetectionTests.PlatformAttribute_IncludeAndExclude" executed="True" result="Success" success="True" time="0.000" asserts="7" />
+                          <test-case name="NUnit.Core.Tests.PlatformDetectionTests.PlatformAttribute_InvalidPlatform" executed="True" result="Success" success="True" time="0.000" asserts="2" />
+                        </results>
+                      </test-suite>
+                      <test-suite type="TestFixture" name="PropertyAttributeTests" executed="True" result="Success" success="True" time="0.014" asserts="0">
+                        <results>
+                          <test-case name="NUnit.Core.Tests.PropertyAttributeTests.CanDeriveFromPropertyAttribute" executed="True" result="Success" success="True" time="0.003" asserts="1" />
+                          <test-case name="NUnit.Core.Tests.PropertyAttributeTests.PropertiesWithNumericValues" executed="True" result="Success" success="True" time="0.002" asserts="2" />
+                          <test-case name="NUnit.Core.Tests.PropertyAttributeTests.PropertyWithStringValue" executed="True" result="Success" success="True" time="0.002" asserts="1" />
+                          <test-case name="NUnit.Core.Tests.PropertyAttributeTests.PropertyWorksOnFixtures" executed="True" result="Success" success="True" time="0.003" asserts="1" />
+                        </results>
+                      </test-suite>
+                      <test-suite type="TestFixture" name="ReflectTests" executed="True" result="Success" success="True" time="0.033" asserts="0">
+                        <results>
+                          <test-case name="NUnit.Core.Tests.ReflectTests.CanDetectAttributes" executed="True" result="Success" success="True" time="0.000" asserts="3" />
+                          <test-case name="NUnit.Core.Tests.ReflectTests.CanDetectInheritedAttributes" executed="True" result="Success" success="True" time="0.000" asserts="3" />
+                          <test-case name="NUnit.Core.Tests.ReflectTests.Construct" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Core.Tests.ReflectTests.GetAttribute" executed="True" result="Success" success="True" time="0.001" asserts="3" />
+                          <test-case name="NUnit.Core.Tests.ReflectTests.GetAttributes" executed="True" result="Success" success="True" time="0.001" asserts="4" />
+                          <test-case name="NUnit.Core.Tests.ReflectTests.GetConstructor" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Core.Tests.ReflectTests.GetInheritedAttribute" executed="True" result="Success" success="True" time="0.001" asserts="3" />
+                          <test-case name="NUnit.Core.Tests.ReflectTests.GetInheritedAttributes" executed="True" result="Success" success="True" time="0.000" asserts="4" />
+                          <test-case name="NUnit.Core.Tests.ReflectTests.GetMethodsWithAttribute" executed="True" result="Success" success="True" time="0.002" asserts="1" />
+                          <test-case name="NUnit.Core.Tests.ReflectTests.GetNamedMethod" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Core.Tests.ReflectTests.GetNamedMethodWithArgs" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Core.Tests.ReflectTests.GetNamedProperty" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Core.Tests.ReflectTests.GetPropertyValue" executed="True" result="Success" success="True" time="0.001" asserts="1" />
+                          <test-case name="NUnit.Core.Tests.ReflectTests.GetPropertyWithAttribute" executed="True" result="Success" success="True" time="0.001" asserts="1" />
+                          <test-case name="NUnit.Core.Tests.ReflectTests.HasInterface" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Core.Tests.ReflectTests.InheritsFrom" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Core.Tests.ReflectTests.InvokeMethod" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                        </results>
+                      </test-suite>
+                      <test-suite type="TestFixture" name="RemoteRunnerTests" executed="True" result="Success" success="True" time="0.435" asserts="1">
+                        <results>
+                          <test-case name="NUnit.Core.Tests.RemoteRunnerTests.BasicRunnerTests.CheckRunnerID" executed="True" result="Success" success="True" time="0.001" asserts="1" />
+                          <test-case name="NUnit.Core.Tests.RemoteRunnerTests.BasicRunnerTests.CountTestCases" executed="True" result="Success" success="True" time="0.030" asserts="1" />
+                          <test-case name="NUnit.Core.Tests.RemoteRunnerTests.BasicRunnerTests.CountTestCasesAcrossMultipleAssemblies" executed="True" result="Success" success="True" time="0.036" asserts="1" />
+                          <test-case name="NUnit.Core.Tests.RemoteRunnerTests.BasicRunnerTests.LoadAndReloadAssembly" executed="True" result="Success" success="True" time="0.058" asserts="2" />
+                          <test-case name="NUnit.Core.Tests.RemoteRunnerTests.BasicRunnerTests.LoadAssemblyWithFixture" executed="True" result="Success" success="True" time="0.013" asserts="1" />
+                          <test-case name="NUnit.Core.Tests.RemoteRunnerTests.BasicRunnerTests.LoadAssemblyWithoutNamespaces" executed="True" result="Success" success="True" time="0.027" asserts="4" />
+                          <test-case name="NUnit.Core.Tests.RemoteRunnerTests.BasicRunnerTests.LoadAssemblyWithSuite" executed="True" result="Success" success="True" time="0.010" asserts="1" />
+                          <test-case name="NUnit.Core.Tests.RemoteRunnerTests.BasicRunnerTests.LoadMultipleAssemblies" executed="True" result="Success" success="True" time="0.035" asserts="1" />
+                          <test-case name="NUnit.Core.Tests.RemoteRunnerTests.BasicRunnerTests.LoadMultipleAssembliesWithFixture" executed="True" result="Success" success="True" time="0.020" asserts="1" />
+                          <test-case name="NUnit.Core.Tests.RemoteRunnerTests.BasicRunnerTests.LoadMultipleAssembliesWithSuite" executed="True" result="Success" success="True" time="0.017" asserts="1" />
+                          <test-case name="NUnit.Core.Tests.RemoteRunnerTests.BasicRunnerTests.RunAssembly" executed="True" result="Success" success="True" time="0.036" asserts="1" />
+                          <test-case name="NUnit.Core.Tests.RemoteRunnerTests.BasicRunnerTests.RunAssemblyUsingBeginAndEndRun" executed="True" result="Success" success="True" time="0.035" asserts="2" />
+                          <test-case name="NUnit.Core.Tests.RemoteRunnerTests.BasicRunnerTests.RunMultipleAssemblies" executed="True" result="Success" success="True" time="0.046" asserts="1" />
+                          <test-case name="NUnit.Core.Tests.RemoteRunnerTests.BasicRunnerTests.RunMultipleAssembliesUsingBeginAndEndRun" executed="True" result="Success" success="True" time="0.045" asserts="2" />
+                        </results>
+                      </test-suite>
+                      <test-suite type="TestFixture" name="RepeatedTestFixture" executed="True" result="Success" success="True" time="0.024" asserts="0">
+                        <results>
+                          <test-case name="NUnit.Core.Tests.RepeatedTestFixture.CategoryWorksWithRepeatedTest" executed="True" result="Success" success="True" time="0.003" asserts="3" />
+                          <test-case name="NUnit.Core.Tests.RepeatedTestFixture.IgnoreWorksWithRepeatedTest" executed="True" result="Success" success="True" time="0.003" asserts="3" />
+                          <test-case name="NUnit.Core.Tests.RepeatedTestFixture.RepeatFailOnFirst" executed="True" result="Success" success="True" time="0.003" asserts="4" />
+                          <test-case name="NUnit.Core.Tests.RepeatedTestFixture.RepeatFailOnThird" executed="True" result="Success" success="True" time="0.003" asserts="4" />
+                          <test-case name="NUnit.Core.Tests.RepeatedTestFixture.RepeatSuccess" executed="True" result="Success" success="True" time="0.003" asserts="6" />
+                        </results>
+                      </test-suite>
+                      <test-suite type="TestFixture" name="RuntimeFrameworkTests" executed="True" result="Success" success="True" time="0.172" asserts="0">
+                        <results>
+                          <test-suite type="ParameterizedTest" name="CanCreateUsingClrVersion" executed="True" result="Success" success="True" time="0.030" asserts="0">
+                            <results>
+                              <test-case name="NUnit.Core.Tests.RuntimeFrameworkTests.CanCreateUsingClrVersion(&lt;Net,1.0,1.0.3705&gt;)" executed="True" result="Success" success="True" time="0.000" asserts="3" />
+                              <test-case name="NUnit.Core.Tests.RuntimeFrameworkTests.CanCreateUsingClrVersion(&lt;Net,1.1,1.1.4322&gt;)" executed="True" result="Success" success="True" time="0.000" asserts="3" />
+                              <test-case name="NUnit.Core.Tests.RuntimeFrameworkTests.CanCreateUsingClrVersion(&lt;Net,2.0,2.0.50727&gt;)" executed="True" result="Success" success="True" time="0.000" asserts="3" />
+                              <test-case name="NUnit.Core.Tests.RuntimeFrameworkTests.CanCreateUsingClrVersion(&lt;Net,3.0,2.0.50727&gt;)" executed="True" result="Inconclusive" success="False" time="0.001" asserts="0">
+                                <reason>
+                                  <message><![CDATA[  Expected: True
+  But was:  False
+]]></message>
+                                </reason>
+                              </test-case>
+                              <test-case name="NUnit.Core.Tests.RuntimeFrameworkTests.CanCreateUsingClrVersion(&lt;Net,3.5,2.0.50727&gt;)" executed="True" result="Inconclusive" success="False" time="0.001" asserts="0">
+                                <reason>
+                                  <message><![CDATA[  Expected: True
+  But was:  False
+]]></message>
+                                </reason>
+                              </test-case>
+                              <test-case name="NUnit.Core.Tests.RuntimeFrameworkTests.CanCreateUsingClrVersion(&lt;Net,4.0,4.0.30319&gt;)" executed="True" result="Success" success="True" time="0.000" asserts="3" />
+                              <test-case name="NUnit.Core.Tests.RuntimeFrameworkTests.CanCreateUsingClrVersion(&lt;Net,0.0,0.0&gt;)" executed="True" result="Success" success="True" time="0.000" asserts="3" />
+                              <test-case name="NUnit.Core.Tests.RuntimeFrameworkTests.CanCreateUsingClrVersion(&lt;Mono,1.0,1.1.4322&gt;)" executed="True" result="Success" success="True" time="0.000" asserts="3" />
+                              <test-case name="NUnit.Core.Tests.RuntimeFrameworkTests.CanCreateUsingClrVersion(&lt;Mono,2.0,2.0.50727&gt;)" executed="True" result="Success" success="True" time="0.001" asserts="3" />
+                              <test-case name="NUnit.Core.Tests.RuntimeFrameworkTests.CanCreateUsingClrVersion(&lt;Mono,3.5,2.0.50727&gt;)" executed="True" result="Inconclusive" success="False" time="0.001" asserts="0">
+                                <reason>
+                                  <message><![CDATA[  Expected: True
+  But was:  False
+]]></message>
+                                </reason>
+                              </test-case>
+                              <test-case name="NUnit.Core.Tests.RuntimeFrameworkTests.CanCreateUsingClrVersion(&lt;Mono,4.0,4.0.30319&gt;)" executed="True" result="Success" success="True" time="0.001" asserts="3" />
+                              <test-case name="NUnit.Core.Tests.RuntimeFrameworkTests.CanCreateUsingClrVersion(&lt;Mono,0.0,0.0&gt;)" executed="True" result="Success" success="True" time="0.000" asserts="3" />
+                              <test-case name="NUnit.Core.Tests.RuntimeFrameworkTests.CanCreateUsingClrVersion(&lt;Any,1.1,1.1.4322&gt;)" executed="True" result="Success" success="True" time="0.000" asserts="3" />
+                              <test-case name="NUnit.Core.Tests.RuntimeFrameworkTests.CanCreateUsingClrVersion(&lt;Any,2.0,2.0.50727&gt;)" executed="True" result="Success" success="True" time="0.000" asserts="3" />
+                              <test-case name="NUnit.Core.Tests.RuntimeFrameworkTests.CanCreateUsingClrVersion(&lt;Any,3.5,2.0.50727&gt;)" executed="True" result="Inconclusive" success="False" time="0.001" asserts="0">
+                                <reason>
+                                  <message><![CDATA[  Expected: True
+  But was:  False
+]]></message>
+                                </reason>
+                              </test-case>
+                              <test-case name="NUnit.Core.Tests.RuntimeFrameworkTests.CanCreateUsingClrVersion(&lt;Any,4.0,4.0.30319&gt;)" executed="True" result="Success" success="True" time="0.000" asserts="3" />
+                              <test-case name="NUnit.Core.Tests.RuntimeFrameworkTests.CanCreateUsingClrVersion(&lt;Any,0.0,0.0&gt;)" executed="True" result="Success" success="True" time="0.000" asserts="3" />
+                            </results>
+                          </test-suite>
+                          <test-suite type="ParameterizedTest" name="CanCreateUsingFrameworkVersion" executed="True" result="Success" success="True" time="0.028" asserts="0">
+                            <results>
+                              <test-case name="NUnit.Core.Tests.RuntimeFrameworkTests.CanCreateUsingFrameworkVersion(&lt;Net,1.0,1.0.3705&gt;)" executed="True" result="Success" success="True" time="0.000" asserts="3" />
+                              <test-case name="NUnit.Core.Tests.RuntimeFrameworkTests.CanCreateUsingFrameworkVersion(&lt;Net,1.1,1.1.4322&gt;)" executed="True" result="Success" success="True" time="0.000" asserts="3" />
+                              <test-case name="NUnit.Core.Tests.RuntimeFrameworkTests.CanCreateUsingFrameworkVersion(&lt;Net,2.0,2.0.50727&gt;)" executed="True" result="Success" success="True" time="0.000" asserts="3" />
+                              <test-case name="NUnit.Core.Tests.RuntimeFrameworkTests.CanCreateUsingFrameworkVersion(&lt;Net,3.0,2.0.50727&gt;)" executed="True" result="Success" success="True" time="0.000" asserts="3" />
+                              <test-case name="NUnit.Core.Tests.RuntimeFrameworkTests.CanCreateUsingFrameworkVersion(&lt;Net,3.5,2.0.50727&gt;)" executed="True" result="Success" success="True" time="0.000" asserts="3" />
+                              <test-case name="NUnit.Core.Tests.RuntimeFrameworkTests.CanCreateUsingFrameworkVersion(&lt;Net,4.0,4.0.30319&gt;)" executed="True" result="Success" success="True" time="0.000" asserts="3" />
+                              <test-case name="NUnit.Core.Tests.RuntimeFrameworkTests.CanCreateUsingFrameworkVersion(&lt;Net,0.0,0.0&gt;)" executed="True" result="Success" success="True" time="0.000" asserts="3" />
+                              <test-case name="NUnit.Core.Tests.RuntimeFrameworkTests.CanCreateUsingFrameworkVersion(&lt;Mono,1.0,1.1.4322&gt;)" executed="True" result="Success" success="True" time="0.000" asserts="3" />
+                              <test-case name="NUnit.Core.Tests.RuntimeFrameworkTests.CanCreateUsingFrameworkVersion(&lt;Mono,2.0,2.0.50727&gt;)" executed="True" result="Success" success="True" time="0.001" asserts="3" />
+                              <test-case name="NUnit.Core.Tests.RuntimeFrameworkTests.CanCreateUsingFrameworkVersion(&lt;Mono,3.5,2.0.50727&gt;)" executed="True" result="Success" success="True" time="0.000" asserts="3" />
+                              <test-case name="NUnit.Core.Tests.RuntimeFrameworkTests.CanCreateUsingFrameworkVersion(&lt;Mono,4.0,4.0.30319&gt;)" executed="True" result="Success" success="True" time="0.000" asserts="3" />
+                              <test-case name="NUnit.Core.Tests.RuntimeFrameworkTests.CanCreateUsingFrameworkVersion(&lt;Mono,0.0,0.0&gt;)" executed="True" result="Success" success="True" time="0.000" asserts="3" />
+                              <test-case name="NUnit.Core.Tests.RuntimeFrameworkTests.CanCreateUsingFrameworkVersion(&lt;Any,1.1,1.1.4322&gt;)" executed="True" result="Success" success="True" time="0.000" asserts="3" />
+                              <test-case name="NUnit.Core.Tests.RuntimeFrameworkTests.CanCreateUsingFrameworkVersion(&lt;Any,2.0,2.0.50727&gt;)" executed="True" result="Success" success="True" time="0.000" asserts="3" />
+                              <test-case name="NUnit.Core.Tests.RuntimeFrameworkTests.CanCreateUsingFrameworkVersion(&lt;Any,3.5,2.0.50727&gt;)" executed="True" result="Success" success="True" time="0.000" asserts="3" />
+                              <test-case name="NUnit.Core.Tests.RuntimeFrameworkTests.CanCreateUsingFrameworkVersion(&lt;Any,4.0,4.0.30319&gt;)" executed="True" result="Success" success="True" time="0.000" asserts="3" />
+                              <test-case name="NUnit.Core.Tests.RuntimeFrameworkTests.CanCreateUsingFrameworkVersion(&lt;Any,0.0,0.0&gt;)" executed="True" result="Success" success="True" time="0.000" asserts="3" />
+                            </results>
+                          </test-suite>
+                          <test-suite type="ParameterizedTest" name="CanDisplayFrameworkAsString" executed="True" result="Success" success="True" time="0.027" asserts="0">
+                            <results>
+                              <test-case name="NUnit.Core.Tests.RuntimeFrameworkTests.CanDisplayFrameworkAsString(&lt;Net,1.0,1.0.3705&gt;)" executed="True" result="Success" success="True" time="0.001" asserts="2" />
+                              <test-case name="NUnit.Core.Tests.RuntimeFrameworkTests.CanDisplayFrameworkAsString(&lt;Net,1.1,1.1.4322&gt;)" executed="True" result="Success" success="True" time="0.000" asserts="2" />
+                              <test-case name="NUnit.Core.Tests.RuntimeFrameworkTests.CanDisplayFrameworkAsString(&lt;Net,2.0,2.0.50727&gt;)" executed="True" result="Success" success="True" time="0.000" asserts="2" />
+                              <test-case name="NUnit.Core.Tests.RuntimeFrameworkTests.CanDisplayFrameworkAsString(&lt;Net,3.0,2.0.50727&gt;)" executed="True" result="Success" success="True" time="0.001" asserts="2" />
+                              <test-case name="NUnit.Core.Tests.RuntimeFrameworkTests.CanDisplayFrameworkAsString(&lt;Net,3.5,2.0.50727&gt;)" executed="True" result="Success" success="True" time="0.000" asserts="2" />
+                              <test-case name="NUnit.Core.Tests.RuntimeFrameworkTests.CanDisplayFrameworkAsString(&lt;Net,4.0,4.0.30319&gt;)" executed="True" result="Success" success="True" time="0.001" asserts="2" />
+                              <test-case name="NUnit.Core.Tests.RuntimeFrameworkTests.CanDisplayFrameworkAsString(&lt;Net,0.0,0.0&gt;)" executed="True" result="Success" success="True" time="0.000" asserts="2" />
+                              <test-case name="NUnit.Core.Tests.RuntimeFrameworkTests.CanDisplayFrameworkAsString(&lt;Mono,1.0,1.1.4322&gt;)" executed="True" result="Success" success="True" time="0.000" asserts="2" />
+                              <test-case name="NUnit.Core.Tests.RuntimeFrameworkTests.CanDisplayFrameworkAsString(&lt;Mono,2.0,2.0.50727&gt;)" executed="True" result="Success" success="True" time="0.000" asserts="2" />
+                              <test-case name="NUnit.Core.Tests.RuntimeFrameworkTests.CanDisplayFrameworkAsString(&lt;Mono,3.5,2.0.50727&gt;)" executed="True" result="Success" success="True" time="0.000" asserts="2" />
+                              <test-case name="NUnit.Core.Tests.RuntimeFrameworkTests.CanDisplayFrameworkAsString(&lt;Mono,4.0,4.0.30319&gt;)" executed="True" result="Success" success="True" time="0.000" asserts="2" />
+                              <test-case name="NUnit.Core.Tests.RuntimeFrameworkTests.CanDisplayFrameworkAsString(&lt;Mono,0.0,0.0&gt;)" executed="True" result="Success" success="True" time="0.000" asserts="2" />
+                              <test-case name="NUnit.Core.Tests.RuntimeFrameworkTests.CanDisplayFrameworkAsString(&lt;Any,1.1,1.1.4322&gt;)" executed="True" result="Success" success="True" time="0.000" asserts="2" />
+                              <test-case name="NUnit.Core.Tests.RuntimeFrameworkTests.CanDisplayFrameworkAsString(&lt;Any,2.0,2.0.50727&gt;)" executed="True" result="Success" success="True" time="0.000" asserts="2" />
+                              <test-case name="NUnit.Core.Tests.RuntimeFrameworkTests.CanDisplayFrameworkAsString(&lt;Any,3.5,2.0.50727&gt;)" executed="True" result="Success" success="True" time="0.000" asserts="2" />
+                              <test-case name="NUnit.Core.Tests.RuntimeFrameworkTests.CanDisplayFrameworkAsString(&lt;Any,4.0,4.0.30319&gt;)" executed="True" result="Success" success="True" time="0.000" asserts="2" />
+                              <test-case name="NUnit.Core.Tests.RuntimeFrameworkTests.CanDisplayFrameworkAsString(&lt;Any,0.0,0.0&gt;)" executed="True" result="Success" success="True" time="0.000" asserts="2" />
+                            </results>
+                          </test-suite>
+                          <test-case name="NUnit.Core.Tests.RuntimeFrameworkTests.CanGetCurrentFramework" executed="True" result="Success" success="True" time="0.001" asserts="2" />
+                          <test-case name="NUnit.Core.Tests.RuntimeFrameworkTests.CanListAvailableFrameworks" executed="True" result="Success" success="True" time="0.004" asserts="2" />
+                          <test-suite type="ParameterizedTest" name="CanMatchRuntimes" executed="True" result="Success" success="True" time="0.031" asserts="0">
+                            <results>
+                              <test-case name="NUnit.Core.Tests.RuntimeFrameworkTests.CanMatchRuntimes(net-3.5,net-2.0)" executed="True" result="Success" success="True" time="0.001" asserts="1" />
+                              <test-case name="NUnit.Core.Tests.RuntimeFrameworkTests.CanMatchRuntimes(net-2.0,net-3.5)" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                              <test-case name="NUnit.Core.Tests.RuntimeFrameworkTests.CanMatchRuntimes(net-3.5,net-3.5)" executed="True" result="Success" success="True" time="0.001" asserts="1" />
+                              <test-case name="NUnit.Core.Tests.RuntimeFrameworkTests.CanMatchRuntimes(net-2.0,net-2.0)" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                              <test-case name="NUnit.Core.Tests.RuntimeFrameworkTests.CanMatchRuntimes(net-2.0,net-2.0)" executed="True" result="Success" success="True" time="0.001" asserts="1" />
+                              <test-case name="NUnit.Core.Tests.RuntimeFrameworkTests.CanMatchRuntimes(net-2.0,net-2.0)" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                              <test-case name="NUnit.Core.Tests.RuntimeFrameworkTests.CanMatchRuntimes(net-2.0,net-2.0)" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                              <test-case name="NUnit.Core.Tests.RuntimeFrameworkTests.CanMatchRuntimes(net-2.0,mono-2.0)" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                              <test-case name="NUnit.Core.Tests.RuntimeFrameworkTests.CanMatchRuntimes(net-2.0,net-1.1)" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                              <test-case name="NUnit.Core.Tests.RuntimeFrameworkTests.CanMatchRuntimes(net-2.0,net-2.0)" executed="True" result="Success" success="True" time="0.001" asserts="1" />
+                              <test-case name="NUnit.Core.Tests.RuntimeFrameworkTests.CanMatchRuntimes(mono-1.0,mono-1.0)" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                              <test-case name="NUnit.Core.Tests.RuntimeFrameworkTests.CanMatchRuntimes(mono-2.0,v2.0)" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                              <test-case name="NUnit.Core.Tests.RuntimeFrameworkTests.CanMatchRuntimes(v2.0,mono-2.0)" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                              <test-case name="NUnit.Core.Tests.RuntimeFrameworkTests.CanMatchRuntimes(v2.0,v2.0)" executed="True" result="Success" success="True" time="0.001" asserts="1" />
+                              <test-case name="NUnit.Core.Tests.RuntimeFrameworkTests.CanMatchRuntimes(v2.0,v4.0)" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                              <test-case name="NUnit.Core.Tests.RuntimeFrameworkTests.CanMatchRuntimes(net,net-2.0)" executed="True" result="Success" success="True" time="0.001" asserts="1" />
+                              <test-case name="NUnit.Core.Tests.RuntimeFrameworkTests.CanMatchRuntimes(net-2.0,net)" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                              <test-case name="NUnit.Core.Tests.RuntimeFrameworkTests.CanMatchRuntimes(any,net-2.0)" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                              <test-case name="NUnit.Core.Tests.RuntimeFrameworkTests.CanMatchRuntimes(net-2.0,any)" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                            </results>
+                          </test-suite>
+                          <test-suite type="ParameterizedTest" name="CanParseRuntimeFramework" executed="True" result="Success" success="True" time="0.027" asserts="0">
+                            <results>
+                              <test-case name="NUnit.Core.Tests.RuntimeFrameworkTests.CanParseRuntimeFramework(&lt;Net,1.0,1.0.3705&gt;)" executed="True" result="Success" success="True" time="0.001" asserts="2" />
+                              <test-case name="NUnit.Core.Tests.RuntimeFrameworkTests.CanParseRuntimeFramework(&lt;Net,1.1,1.1.4322&gt;)" executed="True" result="Success" success="True" time="0.001" asserts="2" />
+                              <test-case name="NUnit.Core.Tests.RuntimeFrameworkTests.CanParseRuntimeFramework(&lt;Net,2.0,2.0.50727&gt;)" executed="True" result="Success" success="True" time="0.000" asserts="2" />
+                              <test-case name="NUnit.Core.Tests.RuntimeFrameworkTests.CanParseRuntimeFramework(&lt;Net,3.0,2.0.50727&gt;)" executed="True" result="Success" success="True" time="0.001" asserts="2" />
+                              <test-case name="NUnit.Core.Tests.RuntimeFrameworkTests.CanParseRuntimeFramework(&lt;Net,3.5,2.0.50727&gt;)" executed="True" result="Success" success="True" time="0.000" asserts="2" />
+                              <test-case name="NUnit.Core.Tests.RuntimeFrameworkTests.CanParseRuntimeFramework(&lt;Net,4.0,4.0.30319&gt;)" executed="True" result="Success" success="True" time="0.000" asserts="2" />
+                              <test-case name="NUnit.Core.Tests.RuntimeFrameworkTests.CanParseRuntimeFramework(&lt;Net,0.0,0.0&gt;)" executed="True" result="Success" success="True" time="0.000" asserts="2" />
+                              <test-case name="NUnit.Core.Tests.RuntimeFrameworkTests.CanParseRuntimeFramework(&lt;Mono,1.0,1.1.4322&gt;)" executed="True" result="Success" success="True" time="0.000" asserts="2" />
+                              <test-case name="NUnit.Core.Tests.RuntimeFrameworkTests.CanParseRuntimeFramework(&lt;Mono,2.0,2.0.50727&gt;)" executed="True" result="Success" success="True" time="0.000" asserts="2" />
+                              <test-case name="NUnit.Core.Tests.RuntimeFrameworkTests.CanParseRuntimeFramework(&lt;Mono,3.5,2.0.50727&gt;)" executed="True" result="Success" success="True" time="0.000" asserts="2" />
+                              <test-case name="NUnit.Core.Tests.RuntimeFrameworkTests.CanParseRuntimeFramework(&lt;Mono,4.0,4.0.30319&gt;)" executed="True" result="Success" success="True" time="0.000" asserts="2" />
+                              <test-case name="NUnit.Core.Tests.RuntimeFrameworkTests.CanParseRuntimeFramework(&lt;Mono,0.0,0.0&gt;)" executed="True" result="Success" success="True" time="0.000" asserts="2" />
+                              <test-case name="NUnit.Core.Tests.RuntimeFrameworkTests.CanParseRuntimeFramework(&lt;Any,1.1,1.1.4322&gt;)" executed="True" result="Success" success="True" time="0.001" asserts="2" />
+                              <test-case name="NUnit.Core.Tests.RuntimeFrameworkTests.CanParseRuntimeFramework(&lt;Any,2.0,2.0.50727&gt;)" executed="True" result="Success" success="True" time="0.000" asserts="2" />
+                              <test-case name="NUnit.Core.Tests.RuntimeFrameworkTests.CanParseRuntimeFramework(&lt;Any,3.5,2.0.50727&gt;)" executed="True" result="Success" success="True" time="0.000" asserts="2" />
+                              <test-case name="NUnit.Core.Tests.RuntimeFrameworkTests.CanParseRuntimeFramework(&lt;Any,4.0,4.0.30319&gt;)" executed="True" result="Success" success="True" time="0.001" asserts="2" />
+                              <test-case name="NUnit.Core.Tests.RuntimeFrameworkTests.CanParseRuntimeFramework(&lt;Any,0.0,0.0&gt;)" executed="True" result="Success" success="True" time="0.000" asserts="2" />
+                            </results>
+                          </test-suite>
+                          <test-case name="NUnit.Core.Tests.RuntimeFrameworkTests.CurrentFrameworkHasBuildSpecified" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Core.Tests.RuntimeFrameworkTests.CurrentFrameworkMustBeAvailable" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                        </results>
+                      </test-suite>
+                      <test-suite type="TestFixture" name="SerializationBug" executed="True" result="Success" success="True" time="0.006" asserts="0">
+                        <results>
+                          <test-case name="NUnit.Core.Tests.SerializationBug.SaveAndLoad" executed="True" result="Success" success="True" time="0.002" asserts="3" />
+                        </results>
+                      </test-suite>
+                      <test-suite type="TestFixture" name="SetCultureAttributeTests" executed="True" result="Success" success="True" time="0.014" asserts="0">
+                        <results>
+                          <test-case name="NUnit.Core.Tests.SetCultureAttributeTests.SetBothCulturesToFrench" executed="True" result="Success" success="True" time="0.001" asserts="2" />
+                          <test-case name="NUnit.Core.Tests.SetCultureAttributeTests.SetBothCulturesToFrenchCanadian" executed="True" result="Success" success="True" time="0.001" asserts="2" />
+                          <test-case name="NUnit.Core.Tests.SetCultureAttributeTests.SetBothCulturesToRussian" executed="True" result="Success" success="True" time="0.000" asserts="2" />
+                          <test-case name="NUnit.Core.Tests.SetCultureAttributeTests.SetMixedCulturesToFrenchAndUIFrenchCanadian" executed="True" result="Success" success="True" time="0.000" asserts="2" />
+                          <test-case name="NUnit.Core.Tests.SetCultureAttributeTests.SetMixedCulturesToRussianAndUIEnglishUS" executed="True" result="Success" success="True" time="0.000" asserts="2" />
+                          <test-case name="NUnit.Core.Tests.SetCultureAttributeTests.SetUICultureOnlyToFrench" executed="True" result="Success" success="True" time="0.000" asserts="2" />
+                          <test-case name="NUnit.Core.Tests.SetCultureAttributeTests.SetUICultureOnlyToFrenchCanadian" executed="True" result="Success" success="True" time="0.000" asserts="2" />
+                          <test-case name="NUnit.Core.Tests.SetCultureAttributeTests.SetUICultureOnlyToRussian" executed="True" result="Success" success="True" time="0.000" asserts="2" />
+                        </results>
+                      </test-suite>
+                      <test-suite type="TestFixture" name="SetCultureAttributeTests+NestedBehavior" executed="True" result="Success" success="True" time="0.003" asserts="0">
+                        <results>
+                          <test-case name="NUnit.Core.Tests.SetCultureAttributeTests+NestedBehavior.InheritedRussian" executed="True" result="Success" success="True" time="0.000" asserts="2" />
+                          <test-case name="NUnit.Core.Tests.SetCultureAttributeTests+NestedBehavior.InheritedRussianWithUIFrench" executed="True" result="Success" success="True" time="0.001" asserts="2" />
+                        </results>
+                      </test-suite>
+                      <test-suite type="TestFixture" name="SetUpFixtureTests" executed="True" result="Success" success="True" time="0.707" asserts="0">
+                        <results>
+                          <test-case name="NUnit.Core.Tests.SetUpFixtureTests.AssemblySetUpFixtureReplacesAssemblyNodeInTree" executed="True" result="Success" success="True" time="0.303" asserts="4" />
+                          <test-case name="NUnit.Core.Tests.SetUpFixtureTests.AssemblySetupFixtureWrapsExecutionOfTest" executed="True" result="Success" success="True" time="0.296" asserts="5" />
+                          <test-case name="NUnit.Core.Tests.SetUpFixtureTests.NamespaceSetUpFixtureReplacesNamespaceNodeInTree" executed="True" result="Success" success="True" time="0.013" asserts="14" />
+                          <test-case name="NUnit.Core.Tests.SetUpFixtureTests.NamespaceSetUpFixtureWrapsExecutionOfSingleTest" executed="True" result="Success" success="True" time="0.013" asserts="8" />
+                          <test-case name="NUnit.Core.Tests.SetUpFixtureTests.NamespaceSetUpFixtureWrapsExecutionOfTwoTests" executed="True" result="Success" success="True" time="0.015" asserts="13" />
+                          <test-case name="NUnit.Core.Tests.SetUpFixtureTests.NamespaceSetUpFixtureWrapsNestedNamespaceSetUpFixture" executed="True" result="Success" success="True" time="0.019" asserts="15" />
+                          <test-case name="NUnit.Core.Tests.SetUpFixtureTests.NamespaceSetUpMethodsMayBeStatic" executed="True" result="Success" success="True" time="0.017" asserts="8" />
+                          <test-case name="NUnit.Core.Tests.SetUpFixtureTests.WithTwoSetUpFixtuesOnlyOneIsUsed" executed="True" result="Success" success="True" time="0.015" asserts="8" />
+                        </results>
+                      </test-suite>
+                      <test-suite type="TestFixture" name="SetUpTest" executed="True" result="Success" success="True" time="0.033" asserts="0">
+                        <results>
+                          <test-case name="NUnit.Core.Tests.SetUpTest.BaseSetUpIsCalledFirstTearDownLast" executed="True" result="Success" success="True" time="0.003" asserts="6" />
+                          <test-case name="NUnit.Core.Tests.SetUpTest.CheckInheritedSetUpAndTearDownAreCalled" executed="True" result="Success" success="True" time="0.002" asserts="2" />
+                          <test-case name="NUnit.Core.Tests.SetUpTest.CheckOverriddenSetUpAndTearDownAreNotCalled" executed="True" result="Success" success="True" time="0.002" asserts="4" />
+                          <test-case name="NUnit.Core.Tests.SetUpTest.MakeSureSetUpAndTearDownAreCalled" executed="True" result="Success" success="True" time="0.002" asserts="2" />
+                          <test-case name="NUnit.Core.Tests.SetUpTest.MultipleSetUpAndTearDownMethodsAreCalled" executed="True" result="Success" success="True" time="0.002" asserts="5" />
+                          <test-case name="NUnit.Core.Tests.SetUpTest.SetUpAndTearDownCounter" executed="True" result="Success" success="True" time="0.002" asserts="2" />
+                          <test-case name="NUnit.Core.Tests.SetUpTest.SetupRecordsOriginalExceptionThownByTestCase" executed="True" result="Success" success="True" time="0.003" asserts="4" />
+                          <test-case name="NUnit.Core.Tests.SetUpTest.TearDownRecordsOriginalExceptionThownByTestCase" executed="True" result="Success" success="True" time="0.003" asserts="4" />
+                        </results>
+                      </test-suite>
+                      <test-suite type="TestFixture" name="SetUpTest+SetupCallDerived" executed="True" result="Success" success="True" time="0.002" asserts="0">
+                        <results>
+                          <test-case name="NUnit.Core.Tests.SetUpTest+SetupCallDerived.AssertCount" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                        </results>
+                      </test-suite>
+                      <test-suite type="TestFixture" name="SimpleNameFilterTests" executed="True" result="Success" success="True" time="0.052" asserts="0">
+                        <results>
+                          <test-case name="NUnit.Core.Tests.SimpleNameFilterTests.ExplicitTestCaseDoesNotMatchWhenNotSelectedDirectly" executed="True" result="Success" success="True" time="0.004" asserts="1" />
+                          <test-case name="NUnit.Core.Tests.SimpleNameFilterTests.ExplicitTestCaseMatchesWhenSelectedDirectly" executed="True" result="Success" success="True" time="0.004" asserts="2" />
+                          <test-case name="NUnit.Core.Tests.SimpleNameFilterTests.ExplicitTestSuiteDoesNotMatchWhenNotSelectedDirectly" executed="True" result="Success" success="True" time="0.005" asserts="2" />
+                          <test-case name="NUnit.Core.Tests.SimpleNameFilterTests.ExplicitTestSuiteMatchesWhenSelectedDirectly" executed="True" result="Success" success="True" time="0.003" asserts="3" />
+                          <test-case name="NUnit.Core.Tests.SimpleNameFilterTests.HighLevelSuite" executed="True" result="Success" success="True" time="0.004" asserts="3" />
+                          <test-case name="NUnit.Core.Tests.SimpleNameFilterTests.MultipleNameMatch" executed="True" result="Success" success="True" time="0.004" asserts="3" />
+                          <test-case name="NUnit.Core.Tests.SimpleNameFilterTests.SingleNameMatch" executed="True" result="Success" success="True" time="0.004" asserts="4" />
+                          <test-case name="NUnit.Core.Tests.SimpleNameFilterTests.SuiteNameMatch" executed="True" result="Success" success="True" time="0.004" asserts="3" />
+                          <test-case name="NUnit.Core.Tests.SimpleNameFilterTests.TestDoesNotMatch" executed="True" result="Success" success="True" time="0.004" asserts="2" />
+                        </results>
+                      </test-suite>
+                      <test-suite type="TestFixture" name="SimpleTestRunnerTests" executed="True" result="Success" success="True" time="0.398" asserts="1">
+                        <results>
+                          <test-case name="NUnit.Core.Tests.SimpleTestRunnerTests.BasicRunnerTests.CheckRunnerID" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Core.Tests.SimpleTestRunnerTests.BasicRunnerTests.CountTestCases" executed="True" result="Success" success="True" time="0.028" asserts="1" />
+                          <test-case name="NUnit.Core.Tests.SimpleTestRunnerTests.BasicRunnerTests.CountTestCasesAcrossMultipleAssemblies" executed="True" result="Success" success="True" time="0.032" asserts="1" />
+                          <test-case name="NUnit.Core.Tests.SimpleTestRunnerTests.BasicRunnerTests.LoadAndReloadAssembly" executed="True" result="Success" success="True" time="0.050" asserts="2" />
+                          <test-case name="NUnit.Core.Tests.SimpleTestRunnerTests.BasicRunnerTests.LoadAssemblyWithFixture" executed="True" result="Success" success="True" time="0.013" asserts="1" />
+                          <test-case name="NUnit.Core.Tests.SimpleTestRunnerTests.BasicRunnerTests.LoadAssemblyWithoutNamespaces" executed="True" result="Success" success="True" time="0.026" asserts="4" />
+                          <test-case name="NUnit.Core.Tests.SimpleTestRunnerTests.BasicRunnerTests.LoadAssemblyWithSuite" executed="True" result="Success" success="True" time="0.009" asserts="1" />
+                          <test-case name="NUnit.Core.Tests.SimpleTestRunnerTests.BasicRunnerTests.LoadMultipleAssemblies" executed="True" result="Success" success="True" time="0.032" asserts="1" />
+                          <test-case name="NUnit.Core.Tests.SimpleTestRunnerTests.BasicRunnerTests.LoadMultipleAssembliesWithFixture" executed="True" result="Success" success="True" time="0.019" asserts="1" />
+                          <test-case name="NUnit.Core.Tests.SimpleTestRunnerTests.BasicRunnerTests.LoadMultipleAssembliesWithSuite" executed="True" result="Success" success="True" time="0.015" asserts="1" />
+                          <test-case name="NUnit.Core.Tests.SimpleTestRunnerTests.BasicRunnerTests.RunAssembly" executed="True" result="Success" success="True" time="0.033" asserts="1" />
+                          <test-case name="NUnit.Core.Tests.SimpleTestRunnerTests.BasicRunnerTests.RunAssemblyUsingBeginAndEndRun" executed="True" result="Success" success="True" time="0.033" asserts="2" />
+                          <test-case name="NUnit.Core.Tests.SimpleTestRunnerTests.BasicRunnerTests.RunMultipleAssemblies" executed="True" result="Success" success="True" time="0.040" asserts="1" />
+                          <test-case name="NUnit.Core.Tests.SimpleTestRunnerTests.BasicRunnerTests.RunMultipleAssembliesUsingBeginAndEndRun" executed="True" result="Success" success="True" time="0.040" asserts="2" />
+                        </results>
+                      </test-suite>
+                      <test-suite type="TestFixture" name="StackOverflowTestFixture" executed="False" result="Skipped">
+                        <reason>
+                          <message><![CDATA[Cannot handle StackOverflowException in managed code]]></message>
+                        </reason>
+                        <results>
+                          <test-case name="NUnit.Core.Tests.StackOverflowTestFixture.SimpleOverflow" executed="False" result="Skipped">
+                            <reason>
+                              <message><![CDATA[Cannot handle StackOverflowException in managed code]]></message>
+                            </reason>
+                          </test-case>
+                        </results>
+                      </test-suite>
+                      <test-suite type="TestFixture" name="SuiteBuilderTests" executed="True" result="Success" success="True" time="1.069" asserts="0">
+                        <results>
+                          <test-case name="NUnit.Core.Tests.SuiteBuilderTests.DiscoverSuite" executed="True" result="Success" success="True" time="0.011" asserts="1" />
+                          <test-case name="NUnit.Core.Tests.SuiteBuilderTests.FileNotFound" executed="True" result="Success" success="True" time="0.012" asserts="0" />
+                          <test-case name="NUnit.Core.Tests.SuiteBuilderTests.FixtureNotFound" executed="True" result="Success" success="True" time="0.011" asserts="1" />
+                          <test-case name="NUnit.Core.Tests.SuiteBuilderTests.InvalidAssembly" executed="True" result="Success" success="True" time="0.013" asserts="0" />
+                          <test-case name="NUnit.Core.Tests.SuiteBuilderTests.LoadAssembly" executed="True" result="Success" success="True" time="0.324" asserts="3" />
+                          <test-case name="NUnit.Core.Tests.SuiteBuilderTests.LoadAssemblyWithoutNamespaces" executed="True" result="Success" success="True" time="0.324" asserts="3" />
+                          <test-case name="NUnit.Core.Tests.SuiteBuilderTests.LoadFixture" executed="True" result="Success" success="True" time="0.014" asserts="1" />
+                          <test-case name="NUnit.Core.Tests.SuiteBuilderTests.LoadNamespaceAsSuite" executed="True" result="Success" success="True" time="0.312" asserts="3" />
+                          <test-case name="NUnit.Core.Tests.SuiteBuilderTests.LoadSuite" executed="True" result="Success" success="True" time="0.016" asserts="2" />
+                          <test-case name="NUnit.Core.Tests.SuiteBuilderTests.WrongReturnTypeSuite" executed="True" result="Success" success="True" time="0.011" asserts="2" />
+                        </results>
+                      </test-suite>
+                      <test-suite type="TestFixture" name="SuiteBuilderTests_Multiple" executed="True" result="Success" success="True" time="0.159" asserts="0">
+                        <results>
+                          <test-case name="NUnit.Core.Tests.SuiteBuilderTests_Multiple.BuildSuite" executed="True" result="Success" success="True" time="0.034" asserts="1" />
+                          <test-case name="NUnit.Core.Tests.SuiteBuilderTests_Multiple.LoadFixture" executed="True" result="Success" success="True" time="0.050" asserts="2" />
+                          <test-case name="NUnit.Core.Tests.SuiteBuilderTests_Multiple.RootNode" executed="True" result="Success" success="True" time="0.035" asserts="1" />
+                          <test-case name="NUnit.Core.Tests.SuiteBuilderTests_Multiple.TestCaseCount" executed="True" result="Success" success="True" time="0.033" asserts="1" />
+                        </results>
+                      </test-suite>
+                      <test-suite type="TestFixture" name="TestAttributeFixture" executed="True" result="Success" success="True" time="0.023" asserts="0">
+                        <results>
+                          <test-case name="NUnit.Core.Tests.TestAttributeFixture.Description" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Core.Tests.TestAttributeFixture.DescriptionInResult" executed="True" result="Success" success="True" time="0.003" asserts="2" />
+                          <test-case name="NUnit.Core.Tests.TestAttributeFixture.FixtureDescription" executed="True" result="Success" success="True" time="0.002" asserts="1" />
+                          <test-case name="NUnit.Core.Tests.TestAttributeFixture.FixtureDescriptionInResult" executed="True" result="Success" success="True" time="0.002" asserts="1" />
+                          <test-case name="NUnit.Core.Tests.TestAttributeFixture.NoDescription" executed="True" result="Success" success="True" time="0.001" asserts="1" />
+                          <test-case name="NUnit.Core.Tests.TestAttributeFixture.ReflectionTest" executed="True" result="Success" success="True" time="0.001" asserts="1" />
+                          <test-case name="NUnit.Core.Tests.TestAttributeFixture.SeparateDescriptionAttribute" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Core.Tests.TestAttributeFixture.SeparateDescriptionInResult" executed="True" result="Success" success="True" time="0.002" asserts="1" />
+                        </results>
+                      </test-suite>
+                      <test-suite type="TestFixture" name="TestCaseAttributeTests" executed="True" result="Success" success="True" time="0.117" asserts="0">
+                        <results>
+                          <test-suite type="ParameterizedTest" name="ArgumentsAreCoalescedInObjectArray" executed="True" result="Success" success="True" time="0.001" asserts="0">
+                            <results>
+                              <test-case name="NUnit.Core.Tests.TestCaseAttributeTests.ArgumentsAreCoalescedInObjectArray(&quot;a&quot;,&quot;b&quot;)" executed="True" result="Success" success="True" time="0.000" asserts="2" />
+                            </results>
+                          </test-suite>
+                          <test-suite type="ParameterizedTest" name="ArgumentsOfDifferentTypeAreCoalescedInObjectArray" executed="True" result="Success" success="True" time="0.001" asserts="0">
+                            <results>
+                              <test-case name="NUnit.Core.Tests.TestCaseAttributeTests.ArgumentsOfDifferentTypeAreCoalescedInObjectArray(1,&quot;b&quot;)" executed="True" result="Success" success="True" time="0.000" asserts="2" />
+                            </results>
+                          </test-suite>
+                          <test-suite type="ParameterizedTest" name="CanConvertDoubleToDecimal" executed="True" result="Success" success="True" time="0.001" asserts="0">
+                            <results>
+                              <test-case name="NUnit.Core.Tests.TestCaseAttributeTests.CanConvertDoubleToDecimal(2.2m,3.3m)" executed="True" result="Success" success="True" time="0.001" asserts="1" />
+                            </results>
+                          </test-suite>
+                          <test-suite type="ParameterizedTest" name="CanConvertIntToDecimal" executed="True" result="Success" success="True" time="0.001" asserts="0">
+                            <results>
+                              <test-case name="NUnit.Core.Tests.TestCaseAttributeTests.CanConvertIntToDecimal(5m,2m)" executed="True" result="Success" success="True" time="0.001" asserts="1" />
+                            </results>
+                          </test-suite>
+                          <test-suite type="ParameterizedTest" name="CanConvertIntToDouble" executed="True" result="Success" success="True" time="0.001" asserts="0">
+                            <results>
+                              <test-case name="NUnit.Core.Tests.TestCaseAttributeTests.CanConvertIntToDouble(2,2)" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                            </results>
+                          </test-suite>
+                          <test-suite type="ParameterizedTest" name="CanConvertSmallIntsToByte" executed="True" result="Success" success="True" time="0.001" asserts="0">
+                            <results>
+                              <test-case name="NUnit.Core.Tests.TestCaseAttributeTests.CanConvertSmallIntsToByte(5,2)" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                            </results>
+                          </test-suite>
+                          <test-suite type="ParameterizedTest" name="CanConvertSmallIntsToSByte" executed="True" result="Success" success="True" time="0.000" asserts="0">
+                            <results>
+                              <test-case name="NUnit.Core.Tests.TestCaseAttributeTests.CanConvertSmallIntsToSByte(5,2)" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                            </results>
+                          </test-suite>
+                          <test-suite type="ParameterizedTest" name="CanConvertSmallIntsToShort" executed="True" result="Success" success="True" time="0.001" asserts="0">
+                            <results>
+                              <test-case name="NUnit.Core.Tests.TestCaseAttributeTests.CanConvertSmallIntsToShort(5,2)" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                            </results>
+                          </test-suite>
+                          <test-suite type="ParameterizedTest" name="CanConvertStringToDateTime" executed="True" result="Success" success="True" time="0.001" asserts="0">
+                            <results>
+                              <test-case name="NUnit.Core.Tests.TestCaseAttributeTests.CanConvertStringToDateTime(10/12/1942 00:00:00)" executed="True" result="Success" success="True" time="0.001" asserts="1" />
+                            </results>
+                          </test-suite>
+                          <test-suite type="ParameterizedTest" name="CanConvertStringToDecimal" executed="True" result="Success" success="True" time="0.001" asserts="0">
+                            <results>
+                              <test-case name="NUnit.Core.Tests.TestCaseAttributeTests.CanConvertStringToDecimal(2.2m,3.3m)" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                            </results>
+                          </test-suite>
+                          <test-case name="NUnit.Core.Tests.TestCaseAttributeTests.CanIgnoreIndividualTestCases" executed="True" result="Success" success="True" time="0.002" asserts="4" />
+                          <test-case name="NUnit.Core.Tests.TestCaseAttributeTests.CanMarkIndividualTestCasesExplicit" executed="True" result="Success" success="True" time="0.001" asserts="4" />
+                          <test-suite type="ParameterizedTest" name="CanPassArrayAsArgument" executed="True" result="Success" success="True" time="0.000" asserts="0">
+                            <results>
+                              <test-case name="NUnit.Core.Tests.TestCaseAttributeTests.CanPassArrayAsArgument(&quot;a&quot;,&quot;b&quot;)" executed="True" result="Success" success="True" time="0.000" asserts="2" />
+                            </results>
+                          </test-suite>
+                          <test-suite type="ParameterizedTest" name="CanPassNullAsArgument" executed="True" result="Success" success="True" time="0.001" asserts="0">
+                            <results>
+                              <test-case name="NUnit.Core.Tests.TestCaseAttributeTests.CanPassNullAsArgument(null,null)" executed="True" result="Success" success="True" time="0.001" asserts="2" />
+                            </results>
+                          </test-suite>
+                          <test-suite type="ParameterizedTest" name="CanPassNullAsSoleArgument" executed="True" result="Success" success="True" time="0.001" asserts="0">
+                            <results>
+                              <test-case name="NUnit.Core.Tests.TestCaseAttributeTests.CanPassNullAsSoleArgument(null)" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                            </results>
+                          </test-suite>
+                          <test-suite type="ParameterizedTest" name="CanPassObjectArrayAsFirstArgument" executed="True" result="Success" success="True" time="0.003" asserts="0">
+                            <results>
+                              <test-case name="NUnit.Core.Tests.TestCaseAttributeTests.CanPassObjectArrayAsFirstArgument(1,&quot;two&quot;,3.0d)" executed="True" result="Success" success="True" time="0.000" asserts="0" />
+                              <test-case name="NUnit.Core.Tests.TestCaseAttributeTests.CanPassObjectArrayAsFirstArgument(&quot;zip&quot;)" executed="True" result="Success" success="True" time="0.000" asserts="0" />
+                            </results>
+                          </test-suite>
+                          <test-case name="NUnit.Core.Tests.TestCaseAttributeTests.CanSpecifyCategory" executed="True" result="Success" success="True" time="0.001" asserts="1" />
+                          <test-case name="NUnit.Core.Tests.TestCaseAttributeTests.CanSpecifyDescription" executed="True" result="Success" success="True" time="0.001" asserts="1" />
+                          <test-suite type="ParameterizedTest" name="CanSpecifyExceptionMessage" executed="True" result="Success" success="True" time="0.002" asserts="0">
+                            <results>
+                              <test-case name="NUnit.Core.Tests.TestCaseAttributeTests.CanSpecifyExceptionMessage(42)" executed="True" result="Success" success="True" time="0.000" asserts="0" />
+                            </results>
+                          </test-suite>
+                          <test-suite type="ParameterizedTest" name="CanSpecifyExceptionMessageAndMatchType" executed="True" result="Success" success="True" time="0.001" asserts="0">
+                            <results>
+                              <test-case name="NUnit.Core.Tests.TestCaseAttributeTests.CanSpecifyExceptionMessageAndMatchType(42)" executed="True" result="Success" success="True" time="0.000" asserts="0" />
+                            </results>
+                          </test-suite>
+                          <test-case name="NUnit.Core.Tests.TestCaseAttributeTests.CanSpecifyExpectedException" executed="True" result="Success" success="True" time="0.002" asserts="1" />
+                          <test-case name="NUnit.Core.Tests.TestCaseAttributeTests.CanSpecifyExpectedException_NoneThrown" executed="True" result="Success" success="True" time="0.002" asserts="2" />
+                          <test-case name="NUnit.Core.Tests.TestCaseAttributeTests.CanSpecifyExpectedException_WrongException" executed="True" result="Success" success="True" time="0.002" asserts="2" />
+                          <test-case name="NUnit.Core.Tests.TestCaseAttributeTests.CanSpecifyExpectedException_WrongMessage" executed="True" result="Success" success="True" time="0.002" asserts="2" />
+                          <test-case name="NUnit.Core.Tests.TestCaseAttributeTests.CanSpecifyMultipleCategories" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Core.Tests.TestCaseAttributeTests.CanSpecifyTestName" executed="True" result="Success" success="True" time="0.000" asserts="2" />
+                          <test-case name="NUnit.Core.Tests.TestCaseAttributeTests.ConversionOverflowMakesTestNonRunnable" executed="True" result="Success" success="True" time="0.001" asserts="1" />
+                          <test-suite type="ParameterizedTest" name="ExpectedResultCanBeNull" executed="True" result="Success" success="True" time="0.001" asserts="0">
+                            <results>
+                              <test-case name="NUnit.Core.Tests.TestCaseAttributeTests.ExpectedResultCanBeNull()" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                            </results>
+                          </test-suite>
+                          <test-suite type="ParameterizedTest" name="HandlesParamsArrayAsLastArgument" executed="True" result="Success" success="True" time="0.001" asserts="0">
+                            <results>
+                              <test-case name="NUnit.Core.Tests.TestCaseAttributeTests.HandlesParamsArrayAsLastArgument(&quot;a&quot;,&quot;b&quot;,&quot;c&quot;,&quot;d&quot;)" executed="True" result="Success" success="True" time="0.001" asserts="4" />
+                            </results>
+                          </test-suite>
+                          <test-suite type="ParameterizedTest" name="HandlesParamsArrayAsLastArgumentWithNoValues" executed="True" result="Success" success="True" time="0.001" asserts="0">
+                            <results>
+                              <test-case name="NUnit.Core.Tests.TestCaseAttributeTests.HandlesParamsArrayAsLastArgumentWithNoValues(&quot;a&quot;,&quot;b&quot;)" executed="True" result="Success" success="True" time="0.000" asserts="3" />
+                            </results>
+                          </test-suite>
+                          <test-suite type="ParameterizedTest" name="HandlesParamsArrayAsSoleArgument" executed="True" result="Success" success="True" time="0.000" asserts="0">
+                            <results>
+                              <test-case name="NUnit.Core.Tests.TestCaseAttributeTests.HandlesParamsArrayAsSoleArgument(&quot;a&quot;,&quot;b&quot;)" executed="True" result="Success" success="True" time="0.000" asserts="2" />
+                            </results>
+                          </test-suite>
+                          <test-suite type="ParameterizedTest" name="HandlesParamsArrayWithOneItemAsLastArgument" executed="True" result="Success" success="True" time="0.001" asserts="0">
+                            <results>
+                              <test-case name="NUnit.Core.Tests.TestCaseAttributeTests.HandlesParamsArrayWithOneItemAsLastArgument(&quot;a&quot;,&quot;b&quot;,System.Object[])" executed="True" result="Success" success="True" time="0.000" asserts="3" />
+                            </results>
+                          </test-suite>
+                          <test-suite type="ParameterizedTest" name="HandlesParamsArrayWithOneItemAsSoleArgument" executed="True" result="Success" success="True" time="0.001" asserts="0">
+                            <results>
+                              <test-case name="NUnit.Core.Tests.TestCaseAttributeTests.HandlesParamsArrayWithOneItemAsSoleArgument(System.String[])" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                            </results>
+                          </test-suite>
+                          <test-case name="NUnit.Core.Tests.TestCaseAttributeTests.IgnoreTakesPrecedenceOverExpectedException" executed="True" result="Success" success="True" time="0.002" asserts="2" />
+                          <test-suite type="ParameterizedTest" name="IntegerDivisionWithResultCheckedByNUnit" executed="True" result="Success" success="True" time="0.008" asserts="0">
+                            <results>
+                              <test-case name="NUnit.Core.Tests.TestCaseAttributeTests.IntegerDivisionWithResultCheckedByNUnit(12,3)" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                              <test-case name="NUnit.Core.Tests.TestCaseAttributeTests.IntegerDivisionWithResultCheckedByNUnit(12,2)" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                              <test-case name="NUnit.Core.Tests.TestCaseAttributeTests.IntegerDivisionWithResultCheckedByNUnit(12,4)" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                              <test-case name="NUnit.Core.Tests.TestCaseAttributeTests.IntegerDivisionWithResultCheckedByNUnit(12,0)" executed="True" result="Success" success="True" time="0.000" asserts="0" />
+                              <test-case name="NUnit.Core.Tests.TestCaseAttributeTests.DivisionByZeroThrowsException" executed="True" result="Success" success="True" time="0.000" asserts="0" />
+                            </results>
+                          </test-suite>
+                          <test-suite type="ParameterizedTest" name="IntegerDivisionWithResultPassedToTest" executed="True" result="Success" success="True" time="0.009" asserts="0">
+                            <results>
+                              <test-case name="NUnit.Core.Tests.TestCaseAttributeTests.IntegerDivisionWithResultPassedToTest(12,3,4)" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                              <test-case name="NUnit.Core.Tests.TestCaseAttributeTests.IntegerDivisionWithResultPassedToTest(12,2,6)" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                              <test-case name="NUnit.Core.Tests.TestCaseAttributeTests.IntegerDivisionWithResultPassedToTest(12,4,3)" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                              <test-case name="NUnit.Core.Tests.TestCaseAttributeTests.IntegerDivisionWithResultPassedToTest(12,0,0)" executed="True" result="Success" success="True" time="0.001" asserts="0" />
+                              <test-case name="NUnit.Core.Tests.TestCaseAttributeTests.IntegerDivisionWithResultPassedToTest(12,0,0)" executed="True" result="Success" success="True" time="0.001" asserts="0" />
+                            </results>
+                          </test-suite>
+                        </results>
+                      </test-suite>
+                      <test-suite type="TestFixture" name="TestCaseResultFixture" executed="True" result="Success" success="True" time="0.007" asserts="0">
+                        <results>
+                          <test-case name="NUnit.Core.Tests.TestCaseResultFixture.TestCaseDefault" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Core.Tests.TestCaseResultFixture.TestCaseFailure" executed="True" result="Success" success="True" time="0.000" asserts="4" />
+                          <test-case name="NUnit.Core.Tests.TestCaseResultFixture.TestCaseNotRun" executed="True" result="Success" success="True" time="0.000" asserts="2" />
+                          <test-case name="NUnit.Core.Tests.TestCaseResultFixture.TestCaseSuccess" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                        </results>
+                      </test-suite>
+                      <test-suite type="TestFixture" name="TestCaseSourceTests" executed="True" result="Success" success="True" time="0.111" asserts="0">
+                        <results>
+                          <test-case name="NUnit.Core.Tests.TestCaseSourceTests.CanIgnoreIndividualTestCases" executed="True" result="Success" success="True" time="0.002" asserts="4" />
+                          <test-case name="NUnit.Core.Tests.TestCaseSourceTests.CanMarkIndividualTestCasesExplicit" executed="True" result="Success" success="True" time="0.001" asserts="4" />
+                          <test-case name="NUnit.Core.Tests.TestCaseSourceTests.CanSpecifyExpectedException" executed="True" result="Success" success="True" time="0.002" asserts="1" />
+                          <test-case name="NUnit.Core.Tests.TestCaseSourceTests.CanSpecifyExpectedException_NoneThrown" executed="True" result="Success" success="True" time="0.001" asserts="2" />
+                          <test-case name="NUnit.Core.Tests.TestCaseSourceTests.CanSpecifyExpectedException_NoneThrown_ExpectedResultReturned" executed="True" result="Success" success="True" time="0.001" asserts="2" />
+                          <test-case name="NUnit.Core.Tests.TestCaseSourceTests.CanSpecifyExpectedException_WrongException" executed="True" result="Success" success="True" time="0.001" asserts="2" />
+                          <test-suite type="ParameterizedTest" name="ExpectedResultCanBeNull" executed="True" result="Success" success="True" time="0.000" asserts="0">
+                            <results>
+                              <test-case name="NUnit.Core.Tests.TestCaseSourceTests.ExpectedResultCanBeNull()" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                            </results>
+                          </test-suite>
+                          <test-case name="NUnit.Core.Tests.TestCaseSourceTests.HandlesExceptionInTestCaseSource" executed="True" result="Success" success="True" time="0.002" asserts="3" />
+                          <test-case name="NUnit.Core.Tests.TestCaseSourceTests.IgnoreTakesPrecedenceOverExpectedException" executed="True" result="Success" success="True" time="0.002" asserts="2" />
+                          <test-suite type="ParameterizedTest" name="MethodTakingTwoStringArrays" executed="True" result="Success" success="True" time="0.001" asserts="0">
+                            <results>
+                              <test-case name="NUnit.Core.Tests.TestCaseSourceTests.MethodTakingTwoStringArrays(System.String[],System.String[])" executed="True" result="Success" success="True" time="0.001" asserts="2" />
+                            </results>
+                          </test-suite>
+                          <test-suite type="ParameterizedTest" name="SourceCanBeInstanceField" executed="True" result="Success" success="True" time="0.000" asserts="0">
+                            <results>
+                              <test-case name="NUnit.Core.Tests.TestCaseSourceTests.SourceCanBeInstanceField(&quot;InstanceField&quot;)" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                            </results>
+                          </test-suite>
+                          <test-suite type="ParameterizedTest" name="SourceCanBeInstanceMethod" executed="True" result="Success" success="True" time="0.001" asserts="0">
+                            <results>
+                              <test-case name="NUnit.Core.Tests.TestCaseSourceTests.SourceCanBeInstanceMethod(&quot;InstanceMethod&quot;)" executed="True" result="Success" success="True" time="0.001" asserts="1" />
+                            </results>
+                          </test-suite>
+                          <test-suite type="ParameterizedTest" name="SourceCanBeInstanceProperty" executed="True" result="Success" success="True" time="0.001" asserts="0">
+                            <results>
+                              <test-case name="NUnit.Core.Tests.TestCaseSourceTests.SourceCanBeInstanceProperty(&quot;InstanceProperty&quot;)" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                            </results>
+                          </test-suite>
+                          <test-suite type="ParameterizedTest" name="SourceCanBeStaticField" executed="True" result="Success" success="True" time="0.000" asserts="0">
+                            <results>
+                              <test-case name="NUnit.Core.Tests.TestCaseSourceTests.SourceCanBeStaticField(&quot;StaticField&quot;)" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                            </results>
+                          </test-suite>
+                          <test-suite type="ParameterizedTest" name="SourceCanBeStaticMethod" executed="True" result="Success" success="True" time="0.001" asserts="0">
+                            <results>
+                              <test-case name="NUnit.Core.Tests.TestCaseSourceTests.SourceCanBeStaticMethod(&quot;StaticMethod&quot;)" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                            </results>
+                          </test-suite>
+                          <test-suite type="ParameterizedTest" name="SourceCanBeStaticProperty" executed="True" result="Success" success="True" time="0.001" asserts="0">
+                            <results>
+                              <test-case name="NUnit.Core.Tests.TestCaseSourceTests.SourceCanBeStaticProperty(&quot;StaticProperty&quot;)" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                            </results>
+                          </test-suite>
+                          <test-suite type="ParameterizedTest" name="SourceIsInvokedWithCorrectCurrentDirectory" executed="True" result="Success" success="True" time="0.001" asserts="0">
+                            <results>
+                              <test-case name="NUnit.Core.Tests.TestCaseSourceTests.SourceIsInvokedWithCorrectCurrentDirectory(True)" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                            </results>
+                          </test-suite>
+                          <test-suite type="ParameterizedTest" name="SourceMayBeInAnotherClass" executed="True" result="Success" success="True" time="0.004" asserts="0">
+                            <categories>
+                              <category name="Top" />
+                            </categories>
+                            <results>
+                              <test-case name="NUnit.Core.Tests.TestCaseSourceTests.ThisOneShouldThrow" description="Demonstrates use of ExpectedException" executed="True" result="Success" success="True" time="0.001" asserts="0">
+                                <categories>
+                                  <category name="Junk" />
+                                </categories>
+                                <properties>
+                                  <property name="MyProp" value="zip" />
+                                </properties>
+                              </test-case>
+                              <test-case name="NUnit.Core.Tests.TestCaseSourceTests.SourceMayBeInAnotherClass(100,20,5)" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                              <test-case name="NUnit.Core.Tests.TestCaseSourceTests.SourceMayBeInAnotherClass(100,4,25)" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                            </results>
+                          </test-suite>
+                          <test-suite type="ParameterizedTest" name="SourceMayBeInAnotherClassWithExpectedResult" executed="True" result="Success" success="True" time="0.007" asserts="0">
+                            <results>
+                              <test-case name="NUnit.Core.Tests.TestCaseSourceTests.SourceMayBeInAnotherClassWithExpectedResult(12,0)" executed="True" result="Success" success="True" time="0.000" asserts="0" />
+                              <test-case name="NUnit.Core.Tests.TestCaseSourceTests.TC1" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                              <test-case name="NUnit.Core.Tests.TestCaseSourceTests.TC2" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                              <test-case name="NUnit.Core.Tests.TestCaseSourceTests.TC3" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                            </results>
+                          </test-suite>
+                          <test-suite type="ParameterizedTest" name="SourceMayReturnArgumentsAsIntArray" executed="True" result="Success" success="True" time="0.004" asserts="0">
+                            <results>
+                              <test-case name="NUnit.Core.Tests.TestCaseSourceTests.SourceMayReturnArgumentsAsIntArray(12,3,4)" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                              <test-case name="NUnit.Core.Tests.TestCaseSourceTests.SourceMayReturnArgumentsAsIntArray(12,4,3)" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                              <test-case name="NUnit.Core.Tests.TestCaseSourceTests.SourceMayReturnArgumentsAsIntArray(12,6,2)" executed="True" result="Success" success="True" time="0.001" asserts="1" />
+                            </results>
+                          </test-suite>
+                          <test-suite type="ParameterizedTest" name="SourceMayReturnArgumentsAsObjectArray" executed="True" result="Success" success="True" time="0.004" asserts="0">
+                            <results>
+                              <test-case name="NUnit.Core.Tests.TestCaseSourceTests.SourceMayReturnArgumentsAsObjectArray(12,3,4)" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                              <test-case name="NUnit.Core.Tests.TestCaseSourceTests.SourceMayReturnArgumentsAsObjectArray(12,4,3)" executed="True" result="Success" success="True" time="0.001" asserts="1" />
+                              <test-case name="NUnit.Core.Tests.TestCaseSourceTests.SourceMayReturnArgumentsAsObjectArray(12,6,2)" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                            </results>
+                          </test-suite>
+                          <test-suite type="ParameterizedTest" name="SourceMayReturnArgumentsAsParamSet" executed="True" result="Success" success="True" time="0.003" asserts="0">
+                            <results>
+                              <test-case name="NUnit.Core.Tests.TestCaseSourceTests.SourceMayReturnArgumentsAsParamSet(24,3)" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                              <test-case name="NUnit.Core.Tests.TestCaseSourceTests.SourceMayReturnArgumentsAsParamSet(24,2)" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                            </results>
+                          </test-suite>
+                          <test-suite type="ParameterizedTest" name="SourceMayReturnSinglePrimitiveArgumentAlone" executed="True" result="Success" success="True" time="0.005" asserts="0">
+                            <results>
+                              <test-case name="NUnit.Core.Tests.TestCaseSourceTests.SourceMayReturnSinglePrimitiveArgumentAlone(2)" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                              <test-case name="NUnit.Core.Tests.TestCaseSourceTests.SourceMayReturnSinglePrimitiveArgumentAlone(4)" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                              <test-case name="NUnit.Core.Tests.TestCaseSourceTests.SourceMayReturnSinglePrimitiveArgumentAlone(6)" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                              <test-case name="NUnit.Core.Tests.TestCaseSourceTests.SourceMayReturnSinglePrimitiveArgumentAlone(8)" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                            </results>
+                          </test-suite>
+                          <test-suite type="ParameterizedTest" name="TestAttributeIsOptional" executed="True" result="Success" success="True" time="0.006" asserts="0">
+                            <results>
+                              <test-case name="NUnit.Core.Tests.TestCaseSourceTests.TestAttributeIsOptional(12,3,4)" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                              <test-case name="NUnit.Core.Tests.TestCaseSourceTests.TestAttributeIsOptional(12,4,3)" executed="True" result="Success" success="True" time="0.001" asserts="1" />
+                              <test-case name="NUnit.Core.Tests.TestCaseSourceTests.TestAttributeIsOptional(12,6,2)" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                            </results>
+                          </test-suite>
+                          <test-suite type="ParameterizedTest" name="TestMayUseMultipleSourceAttributes" executed="True" result="Success" success="True" time="0.010" asserts="0">
+                            <results>
+                              <test-case name="NUnit.Core.Tests.TestCaseSourceTests.TestMayUseMultipleSourceAttributes(12,1,12)" executed="True" result="Success" success="True" time="0.000" asserts="1">
+                                <categories>
+                                  <category name="Extra" />
+                                </categories>
+                              </test-case>
+                              <test-case name="NUnit.Core.Tests.TestCaseSourceTests.TestMayUseMultipleSourceAttributes(12,2,6)" executed="True" result="Success" success="True" time="0.000" asserts="1">
+                                <categories>
+                                  <category name="Extra" />
+                                </categories>
+                              </test-case>
+                              <test-case name="NUnit.Core.Tests.TestCaseSourceTests.TestMayUseMultipleSourceAttributes(12,3,4)" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                              <test-case name="NUnit.Core.Tests.TestCaseSourceTests.TestMayUseMultipleSourceAttributes(12,4,3)" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                              <test-case name="NUnit.Core.Tests.TestCaseSourceTests.TestMayUseMultipleSourceAttributes(12,6,2)" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                              <test-case name="NUnit.Core.Tests.TestCaseSourceTests.TestMayUseMultipleSourceAttributes(12,0,0)" executed="True" result="Success" success="True" time="0.001" asserts="0" />
+                            </results>
+                          </test-suite>
+                          <test-suite type="ParameterizedTest" name="TestWithFourArguments" executed="True" result="Success" success="True" time="0.004" asserts="0">
+                            <results>
+                              <test-case name="NUnit.Core.Tests.TestCaseSourceTests.TestWithFourArguments(12,3,4,0)" executed="True" result="Success" success="True" time="0.000" asserts="2" />
+                              <test-case name="NUnit.Core.Tests.TestCaseSourceTests.TestWithFourArguments(12,4,3,0)" executed="True" result="Success" success="True" time="0.000" asserts="2" />
+                              <test-case name="NUnit.Core.Tests.TestCaseSourceTests.TestWithFourArguments(12,5,2,2)" executed="True" result="Success" success="True" time="0.000" asserts="2" />
+                            </results>
+                          </test-suite>
+                        </results>
+                      </test-suite>
+                      <test-suite type="TestFixture" name="TestCaseTest" executed="True" result="Success" success="True" time="0.008" asserts="0">
+                        <results>
+                          <test-case name="NUnit.Core.Tests.TestCaseTest.CreateIgnoredTestCase" executed="True" result="Success" success="True" time="0.001" asserts="3" />
+                          <test-case name="NUnit.Core.Tests.TestCaseTest.LoadMethodCategories" executed="True" result="Success" success="True" time="0.000" asserts="3" />
+                          <test-case name="NUnit.Core.Tests.TestCaseTest.RunIgnoredTestCase" executed="True" result="Success" success="True" time="0.001" asserts="3" />
+                        </results>
+                      </test-suite>
+                      <test-suite type="TestFixture" name="TestConsole" executed="True" result="Success" success="True" time="0.008" asserts="0">
+                        <results>
+                          <test-case name="NUnit.Core.Tests.TestConsole.ConsoleWrite" executed="True" result="Success" success="True" time="0.001" asserts="0" />
+                          <test-case name="NUnit.Core.Tests.TestConsole.ConsoleWriteLine" executed="True" result="Success" success="True" time="0.001" asserts="0" />
+                        </results>
+                      </test-suite>
+                      <test-suite type="TestFixture" name="TestContextTests" executed="True" result="Success" success="True" time="0.032" asserts="0">
+                        <results>
+                          <test-case name="NUnit.Core.Tests.TestContextTests.CanAccessTestContextOnSeparateThread" executed="True" result="Success" success="True" time="0.003" asserts="1">
+                            <properties>
+                              <property name="RequiresThread" value="True" />
+                            </properties>
+                          </test-case>
+                          <test-case name="NUnit.Core.Tests.TestContextTests.TestCanAccessItsOwnFullName" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Core.Tests.TestContextTests.TestCanAccessItsOwnName" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Core.Tests.TestContextTests.TestCanAccessItsOwnProperties" executed="True" result="Success" success="True" time="0.001" asserts="1">
+                            <properties>
+                              <property name="Answer" value="42" />
+                            </properties>
+                          </test-case>
+                          <test-case name="NUnit.Core.Tests.TestContextTests.TestCanAccessTestDirectory" executed="True" result="Success" success="True" time="0.001" asserts="3" />
+                          <test-case name="NUnit.Core.Tests.TestContextTests.TestCanAccessTestState_FailingTest" executed="True" result="Success" success="True" time="0.004" asserts="2" />
+                          <test-case name="NUnit.Core.Tests.TestContextTests.TestCanAccessTestState_FailureInSetUp" executed="True" result="Success" success="True" time="0.003" asserts="2" />
+                          <test-case name="NUnit.Core.Tests.TestContextTests.TestCanAccessTestState_IgnoredInSetUp" executed="True" result="Success" success="True" time="0.002" asserts="2" />
+                          <test-case name="NUnit.Core.Tests.TestContextTests.TestCanAccessTestState_PassingTest" executed="True" result="Success" success="True" time="0.002" asserts="2" />
+                          <test-case name="NUnit.Core.Tests.TestContextTests.TestCanAccessWorkDirectory" executed="True" result="Success" success="True" time="0.001" asserts="2" />
+                        </results>
+                      </test-suite>
+                      <test-suite type="TestFixture" name="TestDelegateFixture" executed="True" result="Success" success="True" time="0.002" asserts="0">
+                        <results>
+                          <test-case name="NUnit.Core.Tests.TestDelegateFixture.DelegateTest" executed="True" result="Success" success="True" time="0.001" asserts="1" />
+                        </results>
+                      </test-suite>
+                      <test-suite type="TestFixture" name="TestExecutionContextTests" executed="True" result="Success" success="True" time="0.011" asserts="0">
+                        <results>
+                          <test-case name="NUnit.Core.Tests.TestExecutionContextTests.SetAndRestoreCurrentCulture" executed="True" result="Success" success="True" time="0.001" asserts="5" />
+                          <test-case name="NUnit.Core.Tests.TestExecutionContextTests.SetAndRestoreCurrentDirectory" executed="True" result="Success" success="True" time="0.002" asserts="5" />
+                          <test-case name="NUnit.Core.Tests.TestExecutionContextTests.SetAndRestoreCurrentPrincipal" executed="True" result="Success" success="True" time="0.001" asserts="5" />
+                          <test-case name="NUnit.Core.Tests.TestExecutionContextTests.SetAndRestoreCurrentUICulture" executed="True" result="Success" success="True" time="0.000" asserts="5" />
+                        </results>
+                      </test-suite>
+                      <test-suite type="TestFixture" name="TestFixtureBuilderTests" executed="True" result="Success" success="True" time="0.007" asserts="0">
+                        <results>
+                          <test-case name="NUnit.Core.Tests.TestFixtureBuilderTests.GoodSignature" executed="True" result="Success" success="True" time="0.002" asserts="2" />
+                          <test-case name="NUnit.Core.Tests.TestFixtureBuilderTests.LoadCategories" executed="True" result="Success" success="True" time="0.001" asserts="2" />
+                        </results>
+                      </test-suite>
+                      <test-suite type="TestFixture" name="TestFixtureExtension" executed="True" result="Success" success="True" time="0.059" asserts="0">
+                        <results>
+                          <test-case name="NUnit.Core.Tests.TestFixtureExtension.CheckMultipleSetUp" executed="True" result="Success" success="True" time="0.013" asserts="1" />
+                          <test-case name="NUnit.Core.Tests.TestFixtureExtension.DerivedTest" executed="True" result="Success" success="True" time="0.012" asserts="1" />
+                          <test-case name="NUnit.Core.Tests.TestFixtureExtension.InheritSetup" executed="True" result="Success" success="True" time="0.013" asserts="1" />
+                          <test-case name="NUnit.Core.Tests.TestFixtureExtension.InheritTearDown" executed="True" result="Success" success="True" time="0.014" asserts="1" />
+                        </results>
+                      </test-suite>
+                      <test-suite type="TestFixture" name="TestFixtureTests" executed="True" result="Success" success="True" time="0.163" asserts="0">
+                        <results>
+                          <test-case name="NUnit.Core.Tests.TestFixtureTests.CannotRunBadConstructor" executed="True" result="Success" success="True" time="0.002" asserts="3" />
+                          <test-case name="NUnit.Core.Tests.TestFixtureTests.CannotRunConstructorWithArgsNotSupplied" executed="True" result="Success" success="True" time="0.001" asserts="3" />
+                          <test-case name="NUnit.Core.Tests.TestFixtureTests.CannotRunFixtureSetupWithParameters" executed="True" result="Success" success="True" time="0.001" asserts="3" />
+                          <test-case name="NUnit.Core.Tests.TestFixtureTests.CannotRunFixtureSetupWithReturnValue" executed="True" result="Success" success="True" time="0.002" asserts="3" />
+                          <test-case name="NUnit.Core.Tests.TestFixtureTests.CannotRunFixtureTearDownWithParameters" executed="True" result="Success" success="True" time="0.001" asserts="3" />
+                          <test-case name="NUnit.Core.Tests.TestFixtureTests.CannotRunFixtureTearDownWithReturnValue" executed="True" result="Success" success="True" time="0.001" asserts="3" />
+                          <test-case name="NUnit.Core.Tests.TestFixtureTests.CannotRunGenericFixtureDerivedFromAbstractFixtureWithNoArgsProvided" executed="True" result="Success" success="True" time="0.004" asserts="2" />
+                          <test-case name="NUnit.Core.Tests.TestFixtureTests.CannotRunGenericFixtureWithNoArgsProvided" executed="True" result="Success" success="True" time="0.002" asserts="2" />
+                          <test-case name="NUnit.Core.Tests.TestFixtureTests.CannotRunGenericFixtureWithNoTestFixtureAttribute" executed="True" result="Success" success="True" time="0.000" asserts="3" />
+                          <test-case name="NUnit.Core.Tests.TestFixtureTests.CannotRunIgnoredFixture" executed="True" result="Success" success="True" time="0.001" asserts="2" />
+                          <test-case name="NUnit.Core.Tests.TestFixtureTests.CannotRunPrivateFixtureSetUp" executed="True" result="Success" success="True" time="0.002" asserts="3" />
+                          <test-case name="NUnit.Core.Tests.TestFixtureTests.CannotRunPrivateFixtureTearDown" executed="True" result="Success" success="True" time="0.002" asserts="3" />
+                          <test-case name="NUnit.Core.Tests.TestFixtureTests.CannotRunPrivateSetUp" executed="True" result="Success" success="True" time="0.002" asserts="3" />
+                          <test-case name="NUnit.Core.Tests.TestFixtureTests.CannotRunPrivateTearDown" executed="True" result="Success" success="True" time="0.001" asserts="3" />
+                          <test-case name="NUnit.Core.Tests.TestFixtureTests.CannotRunSetupWithParameters" executed="True" result="Success" success="True" time="0.001" asserts="3" />
+                          <test-case name="NUnit.Core.Tests.TestFixtureTests.CannotRunSetupWithReturnValue" executed="True" result="Success" success="True" time="0.002" asserts="3" />
+                          <test-case name="NUnit.Core.Tests.TestFixtureTests.CannotRunTearDownWithParameters" executed="True" result="Success" success="True" time="0.003" asserts="3" />
+                          <test-case name="NUnit.Core.Tests.TestFixtureTests.CannotRunTearDownWithReturnValue" executed="True" result="Success" success="True" time="0.002" asserts="3" />
+                          <test-case name="NUnit.Core.Tests.TestFixtureTests.CanRunConstructorWithArgsSupplied" executed="True" result="Success" success="True" time="0.002" asserts="1" />
+                          <test-case name="NUnit.Core.Tests.TestFixtureTests.CanRunFixtureDerivedFromAbstractDerivedTestFixture" executed="True" result="Success" success="True" time="0.002" asserts="1" />
+                          <test-case name="NUnit.Core.Tests.TestFixtureTests.CanRunFixtureDerivedFromAbstractFixture" executed="True" result="Success" success="True" time="0.002" asserts="1" />
+                          <test-case name="NUnit.Core.Tests.TestFixtureTests.CanRunGenericFixtureDerivedFromAbstractFixtureWithArgsProvided" executed="True" result="Success" success="True" time="0.004" asserts="3" />
+                          <test-case name="NUnit.Core.Tests.TestFixtureTests.CanRunGenericFixtureWithProperArgsProvided" executed="True" result="Success" success="True" time="0.003" asserts="3" />
+                          <test-case name="NUnit.Core.Tests.TestFixtureTests.CanRunMultipleSetUp" executed="True" result="Success" success="True" time="0.002" asserts="1" />
+                          <test-case name="NUnit.Core.Tests.TestFixtureTests.CanRunMultipleTearDown" executed="True" result="Success" success="True" time="0.002" asserts="1" />
+                          <test-case name="NUnit.Core.Tests.TestFixtureTests.CanRunMultipleTestFixtureSetUp" executed="True" result="Success" success="True" time="0.002" asserts="1" />
+                          <test-case name="NUnit.Core.Tests.TestFixtureTests.CanRunMultipleTestFixtureTearDown" executed="True" result="Success" success="True" time="0.002" asserts="1" />
+                          <test-case name="NUnit.Core.Tests.TestFixtureTests.CanRunProtectedFixtureSetUp" executed="True" result="Success" success="True" time="0.002" asserts="1" />
+                          <test-case name="NUnit.Core.Tests.TestFixtureTests.CanRunProtectedFixtureTearDown" executed="True" result="Success" success="True" time="0.001" asserts="1" />
+                          <test-case name="NUnit.Core.Tests.TestFixtureTests.CanRunProtectedSetUp" executed="True" result="Success" success="True" time="0.002" asserts="1" />
+                          <test-case name="NUnit.Core.Tests.TestFixtureTests.CanRunProtectedTearDown" executed="True" result="Success" success="True" time="0.001" asserts="1" />
+                          <test-case name="NUnit.Core.Tests.TestFixtureTests.CanRunStaticFixture" executed="True" result="Success" success="True" time="0.002" asserts="1" />
+                          <test-case name="NUnit.Core.Tests.TestFixtureTests.CanRunStaticFixtureSetUp" executed="True" result="Success" success="True" time="0.002" asserts="1" />
+                          <test-case name="NUnit.Core.Tests.TestFixtureTests.CanRunStaticFixtureTearDown" executed="True" result="Success" success="True" time="0.002" asserts="1" />
+                          <test-case name="NUnit.Core.Tests.TestFixtureTests.CanRunStaticSetUp" executed="True" result="Success" success="True" time="0.001" asserts="1" />
+                          <test-case name="NUnit.Core.Tests.TestFixtureTests.CanRunStaticTearDown" executed="True" result="Success" success="True" time="0.002" asserts="1" />
+                          <test-case name="NUnit.Core.Tests.TestFixtureTests.ConstructFromDoublyNestedType" executed="True" result="Success" success="True" time="0.003" asserts="2" />
+                          <test-case name="NUnit.Core.Tests.TestFixtureTests.ConstructFromNestedType" executed="True" result="Success" success="True" time="0.002" asserts="2" />
+                          <test-case name="NUnit.Core.Tests.TestFixtureTests.ConstructFromStaticTypeWithoutTestFixtureAttribute" executed="True" result="Success" success="True" time="0.002" asserts="3" />
+                          <test-case name="NUnit.Core.Tests.TestFixtureTests.ConstructFromType" executed="True" result="Success" success="True" time="0.003" asserts="2" />
+                          <test-case name="NUnit.Core.Tests.TestFixtureTests.ConstructFromTypeWithoutNamespace" executed="True" result="Success" success="True" time="0.002" asserts="2" />
+                          <test-case name="NUnit.Core.Tests.TestFixtureTests.ConstructFromTypeWithoutTestFixtureAttributeContainingTest" executed="True" result="Success" success="True" time="0.001" asserts="3" />
+                          <test-case name="NUnit.Core.Tests.TestFixtureTests.ConstructFromTypeWithoutTestFixtureAttributeContainingTestCase" executed="True" result="Success" success="True" time="0.002" asserts="3" />
+                          <test-case name="NUnit.Core.Tests.TestFixtureTests.ConstructFromTypeWithoutTestFixtureAttributeContainingTestCaseSource" executed="True" result="Success" success="True" time="0.002" asserts="3" />
+                          <test-case name="NUnit.Core.Tests.TestFixtureTests.ConstructFromTypeWithoutTestFixtureAttributeContainingTheory" executed="True" result="Success" success="True" time="0.002" asserts="3" />
+                          <test-case name="NUnit.Core.Tests.TestFixtureTests.FixtureInheritingTwoTestFixtureAttributesIsLoadedOnlyOnce" executed="True" result="Success" success="True" time="0.002" asserts="2" />
+                        </results>
+                      </test-suite>
+                      <test-suite type="TestFixture" name="TestFixtureTests+InternalTestFixture" executed="True" result="Success" success="True" time="0.002" asserts="0">
+                        <results>
+                          <test-case name="NUnit.Core.Tests.TestFixtureTests+InternalTestFixture.CanRunTestInInternalTestFixture" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                        </results>
+                      </test-suite>
+                      <test-suite type="TestFixture" name="TestFixtureTests+PrivateTestFixture" executed="True" result="Success" success="True" time="0.001" asserts="0">
+                        <results>
+                          <test-case name="NUnit.Core.Tests.TestFixtureTests+PrivateTestFixture.CanRunTestInPrivateTestFixture" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                        </results>
+                      </test-suite>
+                      <test-suite type="TestFixture" name="TestFixtureTests+ProtectedTestFixture" executed="True" result="Success" success="True" time="0.003" asserts="0">
+                        <results>
+                          <test-case name="NUnit.Core.Tests.TestFixtureTests+ProtectedTestFixture.CanRunTestInProtectedTestFixture" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                        </results>
+                      </test-suite>
+                      <test-suite type="TestFixture" name="TestFrameworkTests" executed="True" result="Success" success="True" time="0.002" asserts="0">
+                        <results>
+                          <test-case name="NUnit.Core.Tests.TestFrameworkTests.NUnitFrameworkIsKnownAndReferenced" executed="True" result="Success" success="True" time="0.001" asserts="0" />
+                        </results>
+                      </test-suite>
+                      <test-suite type="TestFixture" name="TestIDTests" executed="True" result="Success" success="True" time="0.006" asserts="0">
+                        <results>
+                          <test-case name="NUnit.Core.Tests.TestIDTests.ClonedTestIDsAreEqual" executed="True" result="Success" success="True" time="0.001" asserts="3" />
+                          <test-case name="NUnit.Core.Tests.TestIDTests.DifferentTestIDsAreNotEqual" executed="True" result="Success" success="True" time="0.000" asserts="3" />
+                          <test-case name="NUnit.Core.Tests.TestIDTests.DifferentTestIDsDisplayDifferentStrings" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                        </results>
+                      </test-suite>
+                      <test-suite type="TestFixture" name="TestInfoTests" executed="True" result="Success" success="True" time="0.016" asserts="0">
+                        <results>
+                          <test-case name="NUnit.Core.Tests.TestInfoTests.ConstructFromFixture" executed="True" result="Success" success="True" time="0.005" asserts="8" />
+                          <test-case name="NUnit.Core.Tests.TestInfoTests.ConstructFromSuite" executed="True" result="Success" success="True" time="0.003" asserts="7" />
+                          <test-case name="NUnit.Core.Tests.TestInfoTests.ConstructFromTestCase" executed="True" result="Success" success="True" time="0.003" asserts="7" />
+                        </results>
+                      </test-suite>
+                      <test-suite type="TestFixture" name="TestMethodSignatureTests" executed="True" result="Success" success="True" time="0.165" asserts="0">
+                        <results>
+                          <test-case name="NUnit.Core.Tests.TestMethodSignatureTests.InstanceTestMethodIsRunnable" executed="True" result="Success" success="True" time="0.007" asserts="1" />
+                          <test-case name="NUnit.Core.Tests.TestMethodSignatureTests.PrivateTestMethodIsNotRunnable" executed="True" result="Success" success="True" time="0.006" asserts="2" />
+                          <test-case name="NUnit.Core.Tests.TestMethodSignatureTests.ProtectedTestMethodIsNotRunnable" executed="True" result="Success" success="True" time="0.007" asserts="2" />
+                          <test-case name="NUnit.Core.Tests.TestMethodSignatureTests.RunningTestsThroughFixtureGivesCorrectResults" executed="True" result="Success" success="True" time="0.010" asserts="6" />
+                          <test-case name="NUnit.Core.Tests.TestMethodSignatureTests.StaticTestMethodIsRunnable" executed="True" result="Success" success="True" time="0.005" asserts="1" />
+                          <test-case name="NUnit.Core.Tests.TestMethodSignatureTests.StaticTestMethodWithArgumentsNotProvidedIsNotRunnable" executed="True" result="Success" success="True" time="0.005" asserts="2" />
+                          <test-case name="NUnit.Core.Tests.TestMethodSignatureTests.StaticTestMethodWithArgumentsProvidedIsRunnable" executed="True" result="Success" success="True" time="0.006" asserts="1" />
+                          <test-case name="NUnit.Core.Tests.TestMethodSignatureTests.StaticTestMethodWithWrongArgumentTypesProvidedGivesError" executed="True" result="Success" success="True" time="0.006" asserts="1" />
+                          <test-case name="NUnit.Core.Tests.TestMethodSignatureTests.StaticTestMethodWithWrongNumberOfArgumentsProvidedIsNotRunnable" executed="True" result="Success" success="True" time="0.006" asserts="2" />
+                          <test-case name="NUnit.Core.Tests.TestMethodSignatureTests.TestMethodWithArgumentsNotProvidedIsNotRunnable" executed="True" result="Success" success="True" time="0.005" asserts="2" />
+                          <test-case name="NUnit.Core.Tests.TestMethodSignatureTests.TestMethodWithArgumentsProvidedIsRunnable" executed="True" result="Success" success="True" time="0.006" asserts="1" />
+                          <test-case name="NUnit.Core.Tests.TestMethodSignatureTests.TestMethodWithConvertibleArgumentsIsRunnable" executed="True" result="Success" success="True" time="0.006" asserts="1" />
+                          <test-case name="NUnit.Core.Tests.TestMethodSignatureTests.TestMethodWithMultipleTestCasesExecutesMultipleTimes" executed="True" result="Success" success="True" time="0.007" asserts="2" />
+                          <test-case name="NUnit.Core.Tests.TestMethodSignatureTests.TestMethodWithMultipleTestCasesUsesCorrectNames" executed="True" result="Success" success="True" time="0.007" asserts="7" />
+                          <test-case name="NUnit.Core.Tests.TestMethodSignatureTests.TestMethodWithNonConvertibleArgumentsGivesError" executed="True" result="Success" success="True" time="0.007" asserts="1" />
+                          <test-case name="NUnit.Core.Tests.TestMethodSignatureTests.TestMethodWithoutParametersWithArgumentsProvidedIsNotRunnable" executed="True" result="Success" success="True" time="0.007" asserts="2" />
+                          <test-case name="NUnit.Core.Tests.TestMethodSignatureTests.TestMethodWithParamsArgumentIsRunnable" executed="True" result="Success" success="True" time="0.006" asserts="1" />
+                          <test-case name="NUnit.Core.Tests.TestMethodSignatureTests.TestMethodWithReturnTypeIsNotRunnable" executed="True" result="Success" success="True" time="0.006" asserts="2" />
+                          <test-case name="NUnit.Core.Tests.TestMethodSignatureTests.TestMethodWithWrongArgumentTypesProvidedGivesError" executed="True" result="Success" success="True" time="0.007" asserts="1" />
+                          <test-case name="NUnit.Core.Tests.TestMethodSignatureTests.TestMethodWithWrongNumberOfArgumentsProvidedIsNotRunnable" executed="True" result="Success" success="True" time="0.006" asserts="2" />
+                        </results>
+                      </test-suite>
+                      <test-suite type="TestFixture" name="TestNameTests" executed="True" result="Success" success="True" time="0.019" asserts="0">
+                        <results>
+                          <test-case name="NUnit.Core.Tests.TestNameTests.CanCompareStrongTestNames" executed="True" result="Success" success="True" time="0.001" asserts="9" />
+                          <test-case name="NUnit.Core.Tests.TestNameTests.CanCompareWeakAndStrongTestNames" executed="True" result="Success" success="True" time="0.000" asserts="3" />
+                          <test-case name="NUnit.Core.Tests.TestNameTests.CanCompareWeakTestNames" executed="True" result="Success" success="True" time="0.000" asserts="6" />
+                          <test-case name="NUnit.Core.Tests.TestNameTests.CanDisplayUniqueNames" executed="True" result="Success" success="True" time="0.000" asserts="2" />
+                          <test-case name="NUnit.Core.Tests.TestNameTests.CanParseSimpleTestNames" executed="True" result="Success" success="True" time="0.001" asserts="1" />
+                          <test-case name="NUnit.Core.Tests.TestNameTests.CanParseStrongTestNames" executed="True" result="Success" success="True" time="0.000" asserts="2" />
+                          <test-case name="NUnit.Core.Tests.TestNameTests.CanParseWeakTestNames" executed="True" result="Success" success="True" time="0.000" asserts="2" />
+                          <test-case name="NUnit.Core.Tests.TestNameTests.ClonedTestNamesAreEqual" executed="True" result="Success" success="True" time="0.001" asserts="6" />
+                          <test-case name="NUnit.Core.Tests.TestNameTests.TestNamesWithDifferentRunnerIDsAreNotEqual" executed="True" result="Success" success="True" time="0.001" asserts="7" />
+                        </results>
+                      </test-suite>
+                      <test-suite type="TestFixture" name="TestNodeTests" executed="True" result="Success" success="True" time="0.017" asserts="0">
+                        <results>
+                          <test-case name="NUnit.Core.Tests.TestNodeTests.ConstructFromMultipleTests" executed="True" result="Success" success="True" time="0.005" asserts="8" />
+                          <test-case name="NUnit.Core.Tests.TestNodeTests.ConstructFromSuite" executed="True" result="Success" success="True" time="0.004" asserts="3" />
+                          <test-case name="NUnit.Core.Tests.TestNodeTests.ConstructFromTestCase" executed="True" result="Success" success="True" time="0.003" asserts="1" />
+                        </results>
+                      </test-suite>
+                      <test-suite type="TestFixture" name="TestRunnerThreadTests" executed="True" result="Success" success="True" time="0.025" asserts="0">
+                        <results>
+                          <test-case name="NUnit.Core.Tests.TestRunnerThreadTests.RunMultipleTests" executed="True" result="Success" success="True" time="0.018" asserts="0" />
+                          <test-case name="NUnit.Core.Tests.TestRunnerThreadTests.RunNamedTest" executed="True" result="Success" success="True" time="0.002" asserts="0" />
+                          <test-case name="NUnit.Core.Tests.TestRunnerThreadTests.RunTestSuite" executed="True" result="Success" success="True" time="0.001" asserts="0" />
+                        </results>
+                      </test-suite>
+                      <test-suite type="TestFixture" name="TestSuiteTest" executed="True" result="Success" success="True" time="0.173" asserts="0">
+                        <results>
+                          <test-case name="NUnit.Core.Tests.TestSuiteTest.CanSortUsingExternalComparer" executed="True" result="Success" success="True" time="0.005" asserts="1" />
+                          <test-case name="NUnit.Core.Tests.TestSuiteTest.CountTestCasesFilteredByName" executed="True" result="Success" success="True" time="0.005" asserts="4" />
+                          <test-case name="NUnit.Core.Tests.TestSuiteTest.DefaultSortIsByName" executed="True" result="Success" success="True" time="0.004" asserts="1" />
+                          <test-case name="NUnit.Core.Tests.TestSuiteTest.ExcludingCategoryDoesNotRunExplicitTestCases" executed="True" result="Success" success="True" time="0.008" asserts="1" />
+                          <test-case name="NUnit.Core.Tests.TestSuiteTest.ExcludingCategoryDoesNotRunExplicitTestFixtures" executed="True" result="Success" success="True" time="0.037" asserts="1" />
+                          <test-case name="NUnit.Core.Tests.TestSuiteTest.InheritedTestCount" executed="True" result="Success" success="True" time="0.006" asserts="1" />
+                          <test-case name="NUnit.Core.Tests.TestSuiteTest.RunExplicitTestByCategory" executed="True" result="Success" success="True" time="0.004" asserts="1" />
+                          <test-case name="NUnit.Core.Tests.TestSuiteTest.RunExplicitTestByName" executed="True" result="Success" success="True" time="0.004" asserts="1" />
+                          <test-case name="NUnit.Core.Tests.TestSuiteTest.RunExplicitTestDirectly" executed="True" result="Success" success="True" time="0.005" asserts="1" />
+                          <test-case name="NUnit.Core.Tests.TestSuiteTest.RunNoTestSuite" executed="True" result="Success" success="True" time="0.005" asserts="2" />
+                          <test-case name="NUnit.Core.Tests.TestSuiteTest.RunSingleTest" executed="True" result="Success" success="True" time="0.007" asserts="1" />
+                          <test-case name="NUnit.Core.Tests.TestSuiteTest.RunSuiteByCategory" executed="True" result="Success" success="True" time="0.007" asserts="1" />
+                          <test-case name="NUnit.Core.Tests.TestSuiteTest.RunSuiteByName" executed="True" result="Success" success="True" time="0.009" asserts="2" />
+                          <test-case name="NUnit.Core.Tests.TestSuiteTest.RunTestByCategory" executed="True" result="Success" success="True" time="0.005" asserts="1" />
+                          <test-case name="NUnit.Core.Tests.TestSuiteTest.RunTestByName" executed="True" result="Success" success="True" time="0.006" asserts="2" />
+                          <test-case name="NUnit.Core.Tests.TestSuiteTest.RunTestExcludingCategory" executed="True" result="Success" success="True" time="0.006" asserts="1" />
+                          <test-case name="NUnit.Core.Tests.TestSuiteTest.RunTestsInFixture" executed="True" result="Success" success="True" time="0.007" asserts="6" />
+                          <test-case name="NUnit.Core.Tests.TestSuiteTest.SuiteRunInitialized" executed="True" result="Success" success="True" time="0.005" asserts="1" />
+                          <test-case name="NUnit.Core.Tests.TestSuiteTest.SuiteWithNoTests" executed="True" result="Success" success="True" time="0.004" asserts="2" />
+                        </results>
+                      </test-suite>
+                      <test-suite type="TestFixture" name="TheoryTests" executed="True" result="Success" success="True" time="0.085" asserts="0">
+                        <results>
+                          <test-suite type="Theory" name="ArrayWithDatapointsAttributeIsUsed" executed="True" result="Success" success="True" time="0.006" asserts="0">
+                            <results>
+                              <test-case name="NUnit.Core.Tests.TheoryTests.ArrayWithDatapointsAttributeIsUsed(&quot;xyz1&quot;)" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                              <test-case name="NUnit.Core.Tests.TheoryTests.ArrayWithDatapointsAttributeIsUsed(&quot;xyz2&quot;)" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                              <test-case name="NUnit.Core.Tests.TheoryTests.ArrayWithDatapointsAttributeIsUsed(&quot;xyz3&quot;)" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                            </results>
+                          </test-suite>
+                          <test-case name="NUnit.Core.Tests.TheoryTests.BooleanArgumentsAreSuppliedAutomatically" executed="True" result="Success" success="True" time="0.002" asserts="2" />
+                          <test-case name="NUnit.Core.Tests.TheoryTests.EnumArgumentsAreSuppliedAutomatically" executed="True" result="Success" success="True" time="0.000" asserts="2" />
+                          <test-suite type="Theory" name="NullDatapointIsOK" executed="True" result="Success" success="True" time="0.001" asserts="0">
+                            <results>
+                              <test-case name="NUnit.Core.Tests.TheoryTests.NullDatapointIsOK(null)" executed="True" result="Success" success="True" time="0.000" asserts="0" />
+                            </results>
+                          </test-suite>
+                          <test-case name="NUnit.Core.Tests.TheoryTests.SimpleTestIgnoresDataPoints" executed="True" result="Success" success="True" time="0.001" asserts="1" />
+                          <test-suite type="Theory" name="SquareRootWithAllGoodValues" executed="True" result="Success" success="True" time="0.004" asserts="0">
+                            <results>
+                              <test-case name="NUnit.Core.Tests.TheoryTests.SquareRootWithAllGoodValues(12.0d)" executed="True" result="Success" success="True" time="0.001" asserts="2" />
+                              <test-case name="NUnit.Core.Tests.TheoryTests.SquareRootWithAllGoodValues(4.0d)" executed="True" result="Success" success="True" time="0.000" asserts="2" />
+                              <test-case name="NUnit.Core.Tests.TheoryTests.SquareRootWithAllGoodValues(9.0d)" executed="True" result="Success" success="True" time="0.000" asserts="2" />
+                            </results>
+                          </test-suite>
+                          <test-suite type="Theory" name="SquareRootWithOneBadValue" executed="True" result="Success" success="True" time="0.007" asserts="0">
+                            <results>
+                              <test-case name="NUnit.Core.Tests.TheoryTests.SquareRootWithOneBadValue(12.0d)" executed="True" result="Success" success="True" time="0.000" asserts="2" />
+                              <test-case name="NUnit.Core.Tests.TheoryTests.SquareRootWithOneBadValue(-4.0d)" executed="True" result="Inconclusive" success="False" time="0.001" asserts="0">
+                                <reason>
+                                  <message><![CDATA[  Expected: True
+  But was:  False
+]]></message>
+                                </reason>
+                              </test-case>
+                              <test-case name="NUnit.Core.Tests.TheoryTests.SquareRootWithOneBadValue(9.0d)" executed="True" result="Success" success="True" time="0.000" asserts="2" />
+                            </results>
+                          </test-suite>
+                          <test-case name="NUnit.Core.Tests.TheoryTests.TheoryFailsIfAllTestsAreInconclusive" executed="True" result="Success" success="True" time="0.004" asserts="2" />
+                          <test-case name="NUnit.Core.Tests.TheoryTests.TheoryWithDatapointsIsRunnable" executed="True" result="Success" success="True" time="0.003" asserts="2" />
+                          <test-case name="NUnit.Core.Tests.TheoryTests.TheoryWithNoArgumentsIsTreatedAsTest" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Core.Tests.TheoryTests.TheoryWithNoDatapointsIsNotRunnable" executed="True" result="Success" success="True" time="0.001" asserts="2" />
+                        </results>
+                      </test-suite>
+                      <test-suite type="TestFixture" name="TheoryTests+SqrtTests_DisplayResults" executed="True" result="Success" success="True" time="0.011" asserts="0">
+                        <results>
+                          <test-suite type="Theory" name="SqrtTimesItselfGivesOriginal" executed="True" result="Success" success="True" time="0.010" asserts="0">
+                            <results>
+                              <test-case name="NUnit.Core.Tests.TheoryTests+SqrtTests_DisplayResults.SqrtTimesItselfGivesOriginal(0.0d)" executed="True" result="Success" success="True" time="0.000" asserts="2" />
+                              <test-case name="NUnit.Core.Tests.TheoryTests+SqrtTests_DisplayResults.SqrtTimesItselfGivesOriginal(1.0d)" executed="True" result="Success" success="True" time="0.000" asserts="2" />
+                              <test-case name="NUnit.Core.Tests.TheoryTests+SqrtTests_DisplayResults.SqrtTimesItselfGivesOriginal(-1.0d)" executed="True" result="Inconclusive" success="False" time="0.000" asserts="0">
+                                <reason>
+                                  <message><![CDATA[  Expected: True
+  But was:  False
+]]></message>
+                                </reason>
+                              </test-case>
+                              <test-case name="NUnit.Core.Tests.TheoryTests+SqrtTests_DisplayResults.SqrtTimesItselfGivesOriginal(double.MaxValue)" executed="True" result="Inconclusive" success="False" time="0.001" asserts="0">
+                                <reason>
+                                  <message><![CDATA[  Expected: True
+  But was:  False
+]]></message>
+                                </reason>
+                              </test-case>
+                              <test-case name="NUnit.Core.Tests.TheoryTests+SqrtTests_DisplayResults.SqrtTimesItselfGivesOriginal(double.PositiveInfinity)" executed="True" result="Inconclusive" success="False" time="0.000" asserts="0">
+                                <reason>
+                                  <message><![CDATA[  Expected: True
+  But was:  False
+]]></message>
+                                </reason>
+                              </test-case>
+                            </results>
+                          </test-suite>
+                        </results>
+                      </test-suite>
+                      <test-suite type="TestFixture" name="ThreadedTestRunnerTests" executed="True" result="Success" success="True" time="0.400" asserts="1">
+                        <results>
+                          <test-case name="NUnit.Core.Tests.ThreadedTestRunnerTests.BasicRunnerTests.CheckRunnerID" executed="True" result="Success" success="True" time="0.001" asserts="1" />
+                          <test-case name="NUnit.Core.Tests.ThreadedTestRunnerTests.BasicRunnerTests.CountTestCases" executed="True" result="Success" success="True" time="0.027" asserts="1" />
+                          <test-case name="NUnit.Core.Tests.ThreadedTestRunnerTests.BasicRunnerTests.CountTestCasesAcrossMultipleAssemblies" executed="True" result="Success" success="True" time="0.033" asserts="1" />
+                          <test-case name="NUnit.Core.Tests.ThreadedTestRunnerTests.BasicRunnerTests.LoadAndReloadAssembly" executed="True" result="Success" success="True" time="0.053" asserts="2" />
+                          <test-case name="NUnit.Core.Tests.ThreadedTestRunnerTests.BasicRunnerTests.LoadAssemblyWithFixture" executed="True" result="Success" success="True" time="0.012" asserts="1" />
+                          <test-case name="NUnit.Core.Tests.ThreadedTestRunnerTests.BasicRunnerTests.LoadAssemblyWithoutNamespaces" executed="True" result="Success" success="True" time="0.026" asserts="4" />
+                          <test-case name="NUnit.Core.Tests.ThreadedTestRunnerTests.BasicRunnerTests.LoadAssemblyWithSuite" executed="True" result="Success" success="True" time="0.009" asserts="1" />
+                          <test-case name="NUnit.Core.Tests.ThreadedTestRunnerTests.BasicRunnerTests.LoadMultipleAssemblies" executed="True" result="Success" success="True" time="0.034" asserts="1" />
+                          <test-case name="NUnit.Core.Tests.ThreadedTestRunnerTests.BasicRunnerTests.LoadMultipleAssembliesWithFixture" executed="True" result="Success" success="True" time="0.017" asserts="1" />
+                          <test-case name="NUnit.Core.Tests.ThreadedTestRunnerTests.BasicRunnerTests.LoadMultipleAssembliesWithSuite" executed="True" result="Success" success="True" time="0.015" asserts="1" />
+                          <test-case name="NUnit.Core.Tests.ThreadedTestRunnerTests.BasicRunnerTests.RunAssembly" executed="True" result="Success" success="True" time="0.033" asserts="1" />
+                          <test-case name="NUnit.Core.Tests.ThreadedTestRunnerTests.BasicRunnerTests.RunAssemblyUsingBeginAndEndRun" executed="True" result="Success" success="True" time="0.033" asserts="2" />
+                          <test-case name="NUnit.Core.Tests.ThreadedTestRunnerTests.BasicRunnerTests.RunMultipleAssemblies" executed="True" result="Success" success="True" time="0.043" asserts="1" />
+                          <test-case name="NUnit.Core.Tests.ThreadedTestRunnerTests.BasicRunnerTests.RunMultipleAssembliesUsingBeginAndEndRun" executed="True" result="Success" success="True" time="0.040" asserts="2" />
+                        </results>
+                      </test-suite>
+                      <test-suite type="TestFixture" name="ThreadingTests" executed="True" result="Success" success="True" time="0.159" asserts="0">
+                        <results>
+                          <test-case name="NUnit.Core.Tests.ThreadingTests.TestOnSeparateThreadReportsAssertCountCorrectly" executed="True" result="Success" success="True" time="0.002" asserts="1" />
+                          <test-case name="NUnit.Core.Tests.ThreadingTests.TestWithInfiniteLoopTimesOut" executed="True" result="Success" success="True" time="0.063" asserts="3" />
+                          <test-case name="NUnit.Core.Tests.ThreadingTests.TestWithMTAThreadRunsInMTA" executed="True" result="Success" success="True" time="0.000" asserts="2">
+                            <properties>
+                              <property name="APARTMENT_STATE" value="MTA" />
+                            </properties>
+                          </test-case>
+                          <test-case name="NUnit.Core.Tests.ThreadingTests.TestWithRequiresMTARunsInMTA" executed="True" result="Success" success="True" time="0.000" asserts="2">
+                            <properties>
+                              <property name="APARTMENT_STATE" value="MTA" />
+                            </properties>
+                          </test-case>
+                          <test-case name="NUnit.Core.Tests.ThreadingTests.TestWithRequiresSTARunsInSTA" executed="True" result="Success" success="True" time="0.001" asserts="1">
+                            <properties>
+                              <property name="APARTMENT_STATE" value="STA" />
+                            </properties>
+                          </test-case>
+                          <test-case name="NUnit.Core.Tests.ThreadingTests.TestWithRequiresThreadRunsInSeparateThread" executed="True" result="Success" success="True" time="0.001" asserts="1">
+                            <properties>
+                              <property name="RequiresThread" value="True" />
+                            </properties>
+                          </test-case>
+                          <test-case name="NUnit.Core.Tests.ThreadingTests.TestWithRequiresThreadRunsSetUpAndTestOnSameThread" executed="True" result="Success" success="True" time="0.000" asserts="1">
+                            <properties>
+                              <property name="RequiresThread" value="True" />
+                            </properties>
+                          </test-case>
+                          <test-case name="NUnit.Core.Tests.ThreadingTests.TestWithRequiresThreadWithMTAArgRunsOnSeparateThreadInMTA" executed="True" result="Success" success="True" time="0.001" asserts="2">
+                            <properties>
+                              <property name="RequiresThread" value="True" />
+                              <property name="APARTMENT_STATE" value="MTA" />
+                            </properties>
+                          </test-case>
+                          <test-case name="NUnit.Core.Tests.ThreadingTests.TestWithRequiresThreadWithSTAArgRunsOnSeparateThreadInSTA" executed="True" result="Success" success="True" time="0.001" asserts="2">
+                            <properties>
+                              <property name="RequiresThread" value="True" />
+                              <property name="APARTMENT_STATE" value="STA" />
+                            </properties>
+                          </test-case>
+                          <test-case name="NUnit.Core.Tests.ThreadingTests.TestWithSTAThreadRunsInSTA" executed="True" result="Success" success="True" time="0.001" asserts="1">
+                            <properties>
+                              <property name="APARTMENT_STATE" value="STA" />
+                            </properties>
+                          </test-case>
+                          <test-case name="NUnit.Core.Tests.ThreadingTests.TestWithTimeoutRunsOnSeparateThread" executed="True" result="Success" success="True" time="0.001" asserts="1">
+                            <properties>
+                              <property name="Timeout" value="50" />
+                            </properties>
+                          </test-case>
+                          <test-case name="NUnit.Core.Tests.ThreadingTests.TestWithTimeoutRunsSetUpAndTestOnSameThread" executed="True" result="Success" success="True" time="0.000" asserts="1">
+                            <properties>
+                              <property name="Timeout" value="50" />
+                            </properties>
+                          </test-case>
+                          <test-case name="NUnit.Core.Tests.ThreadingTests.TimeoutCanBeSetOnTestFixture" executed="True" result="Success" success="True" time="0.064" asserts="3" />
+                        </results>
+                      </test-suite>
+                      <test-suite type="TestFixture" name="ThreadingTests+FixtureRequiresMTA" executed="True" result="Success" success="True" time="0.001" asserts="0">
+                        <properties>
+                          <property name="APARTMENT_STATE" value="MTA" />
+                        </properties>
+                        <results>
+                          <test-case name="NUnit.Core.Tests.ThreadingTests+FixtureRequiresMTA.RequiresMTACanBeSetOnTestFixture" executed="True" result="Success" success="True" time="0.001" asserts="1" />
+                        </results>
+                      </test-suite>
+                      <test-suite type="TestFixture" name="ThreadingTests+FixtureRequiresSTA" executed="True" result="Success" success="True" time="0.003" asserts="0">
+                        <properties>
+                          <property name="APARTMENT_STATE" value="STA" />
+                        </properties>
+                        <results>
+                          <test-case name="NUnit.Core.Tests.ThreadingTests+FixtureRequiresSTA.RequiresSTACanBeSetOnTestFixture" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                        </results>
+                      </test-suite>
+                      <test-suite type="TestFixture" name="ThreadingTests+FixtureRequiresThread" executed="True" result="Success" success="True" time="0.003" asserts="0">
+                        <properties>
+                          <property name="RequiresThread" value="True" />
+                        </properties>
+                        <results>
+                          <test-case name="NUnit.Core.Tests.ThreadingTests+FixtureRequiresThread.RequiresThreadCanBeSetOnTestFixture" executed="True" result="Success" success="True" time="0.001" asserts="1" />
+                        </results>
+                      </test-suite>
+                      <test-suite type="TestFixture" name="TypeHelperTests" executed="True" result="Success" success="True" time="0.040" asserts="0">
+                        <results>
+                          <test-suite type="ParameterizedTest" name="GetDisplayName" executed="True" result="Success" success="True" time="0.039" asserts="0">
+                            <results>
+                              <test-case name="NUnit.Core.Tests.TypeHelperTests.GetDisplayName(NUnit.TestData.TypeHelperFixture.GenericContainerClass`1+NestedGeneric`1+DoublyNestedClass[System.String,System.Int32],&quot;GenericContainerClass+NestedGeneric+DoublyNestedClass&lt;String,Int32&gt;&quot;)" executed="True" result="Success" success="True" time="0.001" asserts="1" />
+                              <test-case name="NUnit.Core.Tests.TypeHelperTests.GetDisplayName(NUnit.TestData.TypeHelperFixture.ContainerClass+NestedGeneric`1+DoublyNestedGeneric`1[System.String,System.Int32],&quot;ContainerClass+NestedGeneric+DoublyNestedGeneric&lt;String,Int32&gt;&quot;)" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                              <test-case name="NUnit.Core.Tests.TypeHelperTests.GetDisplayName(System.Int32,&quot;Int32&quot;)" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                              <test-case name="NUnit.Core.Tests.TypeHelperTests.GetDisplayName(NUnit.TestData.TypeHelperFixture.SimpleClass,&quot;SimpleClass&quot;)" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                              <test-case name="NUnit.Core.Tests.TypeHelperTests.GetDisplayName(MyNoNamespaceClass,&quot;MyNoNamespaceClass&quot;)" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                              <test-case name="NUnit.Core.Tests.TypeHelperTests.GetDisplayName(NUnit.TestData.TypeHelperFixture.GenericClass`3[System.Int32,System.Decimal,System.String],&quot;GenericClass&lt;Int32,Decimal,String&gt;&quot;)" executed="True" result="Success" success="True" time="0.001" asserts="1" />
+                              <test-case name="NUnit.Core.Tests.TypeHelperTests.GetDisplayName(NUnit.TestData.TypeHelperFixture.ListTester`1[System.Collections.Generic.List`1[System.Collections.Generic.List`1[System.Int32]]],&quot;ListTester&lt;List&lt;List&lt;Int32&gt;&gt;&gt;&quot;)" executed="True" result="Success" success="True" time="0.001" asserts="1" />
+                              <test-case name="NUnit.Core.Tests.TypeHelperTests.GetDisplayName(NUnit.TestData.TypeHelperFixture.ContainerClass+NestedClass,&quot;ContainerClass+NestedClass&quot;)" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                              <test-case name="NUnit.Core.Tests.TypeHelperTests.GetDisplayName(NUnit.TestData.TypeHelperFixture.ContainerClass+NestedClass+DoublyNestedClass,&quot;ContainerClass+NestedClass+DoublyNestedClass&quot;)" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                              <test-case name="NUnit.Core.Tests.TypeHelperTests.GetDisplayName(NUnit.TestData.TypeHelperFixture.ContainerClass+NestedClass+DoublyNestedGeneric`1[System.Int32],&quot;ContainerClass+NestedClass+DoublyNestedGeneric&lt;Int32&gt;&quot;)" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                              <test-case name="NUnit.Core.Tests.TypeHelperTests.GetDisplayName(NUnit.TestData.TypeHelperFixture.ContainerClass+NestedGeneric`1[System.Int32],&quot;ContainerClass+NestedGeneric&lt;Int32&gt;&quot;)" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                              <test-case name="NUnit.Core.Tests.TypeHelperTests.GetDisplayName(NUnit.TestData.TypeHelperFixture.ContainerClass+NestedGeneric`1+DoublyNestedClass[System.Int32],&quot;ContainerClass+NestedGeneric+DoublyNestedClass&lt;Int32&gt;&quot;)" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                              <test-case name="NUnit.Core.Tests.TypeHelperTests.GetDisplayName(NUnit.TestData.TypeHelperFixture.GenericClass`3[System.Int32[],System.Decimal[],System.String[]],&quot;GenericClass&lt;Int32[],Decimal[],String[]&gt;&quot;)" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                              <test-case name="NUnit.Core.Tests.TypeHelperTests.GetDisplayName(NUnit.TestData.TypeHelperFixture.GenericContainerClass`1+NestedClass[System.String],&quot;GenericContainerClass+NestedClass&lt;String&gt;&quot;)" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                              <test-case name="NUnit.Core.Tests.TypeHelperTests.GetDisplayName(NUnit.TestData.TypeHelperFixture.GenericContainerClass`1+NestedClass+DoublyNestedClass[System.String],&quot;GenericContainerClass+NestedClass+DoublyNestedClass&lt;String&gt;&quot;)" executed="True" result="Success" success="True" time="0.001" asserts="1" />
+                              <test-case name="NUnit.Core.Tests.TypeHelperTests.GetDisplayName(NUnit.TestData.TypeHelperFixture.GenericContainerClass`1+NestedClass+DoublyNestedGeneric`1[System.String,System.Boolean],&quot;GenericContainerClass+NestedClass+DoublyNestedGeneric&lt;String,Boolean&gt;&quot;)" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                              <test-case name="NUnit.Core.Tests.TypeHelperTests.GetDisplayName(NUnit.TestData.TypeHelperFixture.GenericContainerClass`1+NestedGeneric`1[System.String,System.Int32],&quot;GenericContainerClass+NestedGeneric&lt;String,Int32&gt;&quot;)" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                              <test-case name="NUnit.Core.Tests.TypeHelperTests.GetDisplayName(NUnit.TestData.TypeHelperFixture.GenericContainerClass`1+NestedGeneric`1+DoublyNestedGeneric`1[System.String,System.Int32,System.Boolean],&quot;GenericContainerClass+NestedGeneric+DoublyNestedGeneric&lt;String,Int32,Boolean&gt;&quot;)" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                              <test-case name="NUnit.Core.Tests.TypeHelperTests.GetDisplayName(NUnit.TestData.TypeHelperFixture.ListTester`1[System.Collections.Generic.List`1[System.Int32]],&quot;ListTester&lt;List&lt;Int32&gt;&gt;&quot;)" executed="True" result="Success" success="True" time="0.001" asserts="1" />
+                            </results>
+                          </test-suite>
+                        </results>
+                      </test-suite>
+                      <test-suite type="TestFixture" name="ValueSourceTests" executed="True" result="Success" success="True" time="0.036" asserts="0">
+                        <results>
+                          <test-suite type="ParameterizedTest" name="MultipleArguments" executed="True" result="Success" success="True" time="0.004" asserts="0">
+                            <results>
+                              <test-case name="NUnit.Core.Tests.ValueSourceTests.MultipleArguments(12,3,4)" executed="True" result="Success" success="True" time="0.001" asserts="1" />
+                              <test-case name="NUnit.Core.Tests.ValueSourceTests.MultipleArguments(12,4,3)" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                              <test-case name="NUnit.Core.Tests.ValueSourceTests.MultipleArguments(12,6,2)" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                            </results>
+                          </test-suite>
+                          <test-suite type="ParameterizedTest" name="ValueSourceCanBeInstanceField" executed="True" result="Success" success="True" time="0.001" asserts="0">
+                            <results>
+                              <test-case name="NUnit.Core.Tests.ValueSourceTests.ValueSourceCanBeInstanceField(&quot;InstanceField&quot;)" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                            </results>
+                          </test-suite>
+                          <test-suite type="ParameterizedTest" name="ValueSourceCanBeInstanceMethod" executed="True" result="Success" success="True" time="0.001" asserts="0">
+                            <results>
+                              <test-case name="NUnit.Core.Tests.ValueSourceTests.ValueSourceCanBeInstanceMethod(&quot;InstanceMethod&quot;)" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                            </results>
+                          </test-suite>
+                          <test-suite type="ParameterizedTest" name="ValueSourceCanBeInstanceProperty" executed="True" result="Success" success="True" time="0.000" asserts="0">
+                            <results>
+                              <test-case name="NUnit.Core.Tests.ValueSourceTests.ValueSourceCanBeInstanceProperty(&quot;InstanceProperty&quot;)" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                            </results>
+                          </test-suite>
+                          <test-suite type="ParameterizedTest" name="ValueSourceCanBeStaticField" executed="True" result="Success" success="True" time="0.000" asserts="0">
+                            <results>
+                              <test-case name="NUnit.Core.Tests.ValueSourceTests.ValueSourceCanBeStaticField(&quot;StaticField&quot;)" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                            </results>
+                          </test-suite>
+                          <test-suite type="ParameterizedTest" name="ValueSourceCanBeStaticMethod" executed="True" result="Success" success="True" time="0.002" asserts="0">
+                            <results>
+                              <test-case name="NUnit.Core.Tests.ValueSourceTests.ValueSourceCanBeStaticMethod(&quot;StaticMethod&quot;)" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                            </results>
+                          </test-suite>
+                          <test-suite type="ParameterizedTest" name="ValueSourceCanBeStaticProperty" executed="True" result="Success" success="True" time="0.001" asserts="0">
+                            <results>
+                              <test-case name="NUnit.Core.Tests.ValueSourceTests.ValueSourceCanBeStaticProperty(&quot;StaticProperty&quot;)" executed="True" result="Success" success="True" time="0.001" asserts="1" />
+                            </results>
+                          </test-suite>
+                          <test-suite type="ParameterizedTest" name="ValueSourceIsInvokedWithCorrectCurrentDirectory" executed="True" result="Success" success="True" time="0.001" asserts="0">
+                            <results>
+                              <test-case name="NUnit.Core.Tests.ValueSourceTests.ValueSourceIsInvokedWithCorrectCurrentDirectory(True)" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                            </results>
+                          </test-suite>
+                          <test-suite type="ParameterizedTest" name="ValueSourceMayBeGeneric" executed="True" result="Success" success="True" time="0.005" asserts="0">
+                            <results>
+                              <test-case name="NUnit.Core.Tests.ValueSourceTests.ValueSourceMayBeGeneric(1)" executed="True" result="Success" success="True" time="0.001" asserts="1" />
+                              <test-case name="NUnit.Core.Tests.ValueSourceTests.ValueSourceMayBeGeneric(2)" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                              <test-case name="NUnit.Core.Tests.ValueSourceTests.ValueSourceMayBeGeneric(4)" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                              <test-case name="NUnit.Core.Tests.ValueSourceTests.ValueSourceMayBeGeneric(8)" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                            </results>
+                          </test-suite>
+                          <test-suite type="ParameterizedTest" name="ValueSourceMayBeInAnotherClass" executed="True" result="Success" success="True" time="0.004" asserts="0">
+                            <results>
+                              <test-case name="NUnit.Core.Tests.ValueSourceTests.ValueSourceMayBeInAnotherClass(12,3,4)" executed="True" result="Success" success="True" time="0.001" asserts="1" />
+                              <test-case name="NUnit.Core.Tests.ValueSourceTests.ValueSourceMayBeInAnotherClass(12,4,3)" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                              <test-case name="NUnit.Core.Tests.ValueSourceTests.ValueSourceMayBeInAnotherClass(12,6,2)" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                            </results>
+                          </test-suite>
+                        </results>
+                      </test-suite>
+                      <test-suite type="TestFixture" name="XmlTest" executed="True" result="Success" success="True" time="1.650" asserts="0">
+                        <results>
+                          <test-case name="NUnit.Core.Tests.XmlTest.removeTime" executed="True" result="Success" success="True" time="1.167" asserts="1" />
+                          <test-case name="NUnit.Core.Tests.XmlTest.TestSchemaValidatorFrenchCulture" executed="True" result="Success" success="True" time="0.301" asserts="1" />
+                          <test-case name="NUnit.Core.Tests.XmlTest.TestSchemaValidatorInvariantCulture" executed="True" result="Success" success="True" time="0.041" asserts="1" />
+                          <test-case name="NUnit.Core.Tests.XmlTest.TestSchemaValidatorUnitedStatesCulture" executed="True" result="Success" success="True" time="0.043" asserts="1" />
+                          <test-case name="NUnit.Core.Tests.XmlTest.TestStream" executed="True" result="Success" success="True" time="0.086" asserts="1" />
+                        </results>
+                      </test-suite>
+                    </results>
+                  </test-suite>
+                </results>
+              </test-suite>
+            </results>
+          </test-suite>
+        </results>
+      </test-suite>
+      <test-suite type="Assembly" name="C:\Program Files\NUnit 2.6\bin\tests/nunit.util.tests.dll" executed="True" result="Success" success="True" time="20.305" asserts="0">
+        <results>
+          <test-suite type="Namespace" name="NUnit" executed="True" result="Success" success="True" time="20.304" asserts="0">
+            <results>
+              <test-suite type="Namespace" name="Util" executed="True" result="Success" success="True" time="20.304" asserts="0">
+                <results>
+                  <test-suite type="SetUpFixture" name="Tests" executed="True" result="Success" success="True" time="20.303" asserts="0">
+                    <results>
+                      <test-suite type="TestFixture" name="AssemblyListTests" executed="True" result="Success" success="True" time="0.018" asserts="0">
+                        <results>
+                          <test-case name="NUnit.Util.Tests.AssemblyListTests.AddFiresChangedEvent" executed="True" result="Success" success="True" time="0.001" asserts="1" />
+                          <test-case name="NUnit.Util.Tests.AssemblyListTests.CanAddAssemblies" executed="True" result="Success" success="True" time="0.000" asserts="3" />
+                          <test-case name="NUnit.Util.Tests.AssemblyListTests.CanRemoveAssemblies" executed="True" result="Success" success="True" time="0.000" asserts="3" />
+                          <test-case name="NUnit.Util.Tests.AssemblyListTests.EmptyList" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Util.Tests.AssemblyListTests.MustAddAbsolutePath" executed="True" result="Success" success="True" time="0.001" asserts="0" />
+                          <test-case name="NUnit.Util.Tests.AssemblyListTests.RemoveAtFiresChangedEvent" executed="True" result="Success" success="True" time="0.001" asserts="1" />
+                          <test-case name="NUnit.Util.Tests.AssemblyListTests.RemoveFiresChangedEvent" executed="True" result="Success" success="True" time="0.001" asserts="1" />
+                          <test-case name="NUnit.Util.Tests.AssemblyListTests.SettingFullPathFiresChangedEvent" executed="True" result="Success" success="True" time="0.001" asserts="1" />
+                        </results>
+                      </test-suite>
+                      <test-suite type="TestFixture" name="AssemblyWatcherTests" executed="True" result="Success" success="True" time="0.911" asserts="0">
+                        <results>
+                          <test-case name="NUnit.Util.Tests.AssemblyWatcherTests.ChangingAttributesDoesNotTriggerWatcher" executed="True" result="Success" success="True" time="0.211" asserts="1" />
+                          <test-case name="NUnit.Util.Tests.AssemblyWatcherTests.ChangingFileTriggersWatcher" executed="True" result="Success" success="True" time="0.205" asserts="2" />
+                          <test-case name="NUnit.Util.Tests.AssemblyWatcherTests.CopyingFileDoesNotTriggerWatcher" executed="True" result="Success" success="True" time="0.217" asserts="1" />
+                          <test-case name="NUnit.Util.Tests.AssemblyWatcherTests.MultipleCloselySpacedChangesTriggerWatcherOnlyOnce" executed="True" result="Success" success="True" time="0.265" asserts="2" />
+                        </results>
+                      </test-suite>
+                      <test-suite type="TestFixture" name="CategoryManagerTest" executed="True" result="Success" success="True" time="0.091" asserts="0">
+                        <results>
+                          <test-case name="NUnit.Util.Tests.CategoryManagerTest.CanAddAllAvailableCategoriesInTestTree" executed="True" result="Success" success="True" time="0.045" asserts="1" />
+                          <test-case name="NUnit.Util.Tests.CategoryManagerTest.CanAddStrings" executed="True" result="Success" success="True" time="0.001" asserts="1" />
+                          <test-case name="NUnit.Util.Tests.CategoryManagerTest.CanAddStringsWithoutDuplicating" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Util.Tests.CategoryManagerTest.CanAddTestCategories" executed="True" result="Success" success="True" time="0.035" asserts="1" />
+                          <test-case name="NUnit.Util.Tests.CategoryManagerTest.CanClearEntries" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                        </results>
+                      </test-suite>
+                      <test-suite type="TestFixture" name="CategoryParseTests" executed="True" result="Success" success="True" time="0.026" asserts="0">
+                        <results>
+                          <test-case name="NUnit.Util.Tests.CategoryParseTests.CanParseCompoundCategory" executed="True" result="Success" success="True" time="0.003" asserts="1" />
+                          <test-case name="NUnit.Util.Tests.CategoryParseTests.CanParseExcludedCategories" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Util.Tests.CategoryParseTests.CanParseMultipleAlternatives" executed="True" result="Success" success="True" time="0.001" asserts="4" />
+                          <test-case name="NUnit.Util.Tests.CategoryParseTests.CanParseMultipleCategoriesWithAnd" executed="True" result="Success" success="True" time="0.000" asserts="4" />
+                          <test-case name="NUnit.Util.Tests.CategoryParseTests.CanParseSimpleCategory" executed="True" result="Success" success="True" time="0.001" asserts="1" />
+                          <test-case name="NUnit.Util.Tests.CategoryParseTests.EmptyStringReturnsEmptyFilter" executed="True" result="Success" success="True" time="0.001" asserts="1" />
+                          <test-case name="NUnit.Util.Tests.CategoryParseTests.OrAndMinusCombined" executed="True" result="Success" success="True" time="0.000" asserts="5" />
+                          <test-case name="NUnit.Util.Tests.CategoryParseTests.PlusAndMinusCombined" executed="True" result="Success" success="True" time="0.000" asserts="6" />
+                          <test-case name="NUnit.Util.Tests.CategoryParseTests.PrecedenceTest" executed="True" result="Success" success="True" time="0.001" asserts="4" />
+                          <test-case name="NUnit.Util.Tests.CategoryParseTests.PrecedenceTestWithParentheses" executed="True" result="Success" success="True" time="0.001" asserts="5" />
+                        </results>
+                      </test-suite>
+                      <test-suite type="TestFixture" name="DomainManagerTests" executed="True" result="Success" success="True" time="0.019" asserts="0">
+                        <results>
+                          <test-case name="NUnit.Util.Tests.DomainManagerTests.GetCommonAppBase_OneElement" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Util.Tests.DomainManagerTests.GetCommonAppBase_ThreeElements_DiferentDirectories" executed="True" result="Success" success="True" time="0.002" asserts="1" />
+                          <test-case name="NUnit.Util.Tests.DomainManagerTests.GetCommonAppBase_TwoElements_DifferentDirectories" executed="True" result="Success" success="True" time="0.001" asserts="1" />
+                          <test-case name="NUnit.Util.Tests.DomainManagerTests.GetCommonAppBase_TwoElements_SameDirectory" executed="True" result="Success" success="True" time="0.001" asserts="1" />
+                          <test-case name="NUnit.Util.Tests.DomainManagerTests.GetPrivateBinPath" executed="True" result="Success" success="True" time="0.003" asserts="1" />
+                          <test-case name="NUnit.Util.Tests.DomainManagerTests.UnloadUnloadedDomain" executed="True" result="Success" success="True" time="0.004" asserts="0" />
+                        </results>
+                      </test-suite>
+                      <test-suite type="TestFixture" name="EventDispatcherTests" executed="True" result="Success" success="True" time="0.053" asserts="0">
+                        <results>
+                          <test-case name="NUnit.Util.Tests.EventDispatcherTests.ProjectLoaded" executed="True" result="Success" success="True" time="0.006" asserts="3" />
+                          <test-case name="NUnit.Util.Tests.EventDispatcherTests.ProjectLoadFailed" executed="True" result="Success" success="True" time="0.001" asserts="4" />
+                          <test-case name="NUnit.Util.Tests.EventDispatcherTests.ProjectLoading" executed="True" result="Success" success="True" time="0.001" asserts="3" />
+                          <test-case name="NUnit.Util.Tests.EventDispatcherTests.ProjectUnloaded" executed="True" result="Success" success="True" time="0.000" asserts="3" />
+                          <test-case name="NUnit.Util.Tests.EventDispatcherTests.ProjectUnloadFailed" executed="True" result="Success" success="True" time="0.000" asserts="4" />
+                          <test-case name="NUnit.Util.Tests.EventDispatcherTests.ProjectUnloading" executed="True" result="Success" success="True" time="0.000" asserts="3" />
+                          <test-case name="NUnit.Util.Tests.EventDispatcherTests.RunFailed" executed="True" result="Success" success="True" time="0.000" asserts="3" />
+                          <test-case name="NUnit.Util.Tests.EventDispatcherTests.RunFinished" executed="True" result="Success" success="True" time="0.001" asserts="3" />
+                          <test-case name="NUnit.Util.Tests.EventDispatcherTests.RunStarting" executed="True" result="Success" success="True" time="0.001" asserts="4" />
+                          <test-case name="NUnit.Util.Tests.EventDispatcherTests.SuiteFinished" executed="True" result="Success" success="True" time="0.000" asserts="3" />
+                          <test-case name="NUnit.Util.Tests.EventDispatcherTests.SuiteStarting" executed="True" result="Success" success="True" time="0.001" asserts="3" />
+                          <test-case name="NUnit.Util.Tests.EventDispatcherTests.TestFinished" executed="True" result="Success" success="True" time="0.000" asserts="3" />
+                          <test-case name="NUnit.Util.Tests.EventDispatcherTests.TestLoaded" executed="True" result="Success" success="True" time="0.000" asserts="4" />
+                          <test-case name="NUnit.Util.Tests.EventDispatcherTests.TestLoadFailed" executed="True" result="Success" success="True" time="0.000" asserts="4" />
+                          <test-case name="NUnit.Util.Tests.EventDispatcherTests.TestLoading" executed="True" result="Success" success="True" time="0.000" asserts="3" />
+                          <test-case name="NUnit.Util.Tests.EventDispatcherTests.TestReloaded" executed="True" result="Success" success="True" time="0.001" asserts="4" />
+                          <test-case name="NUnit.Util.Tests.EventDispatcherTests.TestReloadFailed" executed="True" result="Success" success="True" time="0.001" asserts="4" />
+                          <test-case name="NUnit.Util.Tests.EventDispatcherTests.TestReloading" executed="True" result="Success" success="True" time="0.001" asserts="3" />
+                          <test-case name="NUnit.Util.Tests.EventDispatcherTests.TestStarting" executed="True" result="Success" success="True" time="0.000" asserts="3" />
+                          <test-case name="NUnit.Util.Tests.EventDispatcherTests.TestUnloaded" executed="True" result="Success" success="True" time="0.000" asserts="3" />
+                          <test-case name="NUnit.Util.Tests.EventDispatcherTests.TestUnloadFailed" executed="True" result="Success" success="True" time="0.000" asserts="4" />
+                          <test-case name="NUnit.Util.Tests.EventDispatcherTests.TestUnloading" executed="True" result="Success" success="True" time="0.000" asserts="3" />
+                        </results>
+                      </test-suite>
+                      <test-suite type="TestFixture" name="FileWatcherTests" executed="True" result="Success" success="True" time="0.891" asserts="0">
+                        <results>
+                          <test-case name="NUnit.Util.Tests.FileWatcherTests.ChangingAttributesDoesNotTriggerWatcher" executed="True" result="Success" success="True" time="0.205" asserts="1" />
+                          <test-case name="NUnit.Util.Tests.FileWatcherTests.ChangingFileTriggersWatcher" executed="True" result="Success" success="True" time="0.204" asserts="2" />
+                          <test-case name="NUnit.Util.Tests.FileWatcherTests.CopyingFileDoesNotTriggerWatcher" executed="True" result="Success" success="True" time="0.206" asserts="1" />
+                          <test-case name="NUnit.Util.Tests.FileWatcherTests.MultipleCloselySpacedChangesTriggerWatcherOnlyOnce" executed="True" result="Success" success="True" time="0.264" asserts="2" />
+                        </results>
+                      </test-suite>
+                      <test-suite type="TestFixture" name="MemorySettingsStorageTests" executed="True" result="Success" success="True" time="0.026" asserts="0">
+                        <results>
+                          <test-case name="NUnit.Util.Tests.MemorySettingsStorageTests.MakeStorage" executed="True" result="Success" success="True" time="0.001" asserts="1" />
+                          <test-case name="NUnit.Util.Tests.MemorySettingsStorageTests.MakeSubStorages" executed="True" result="Success" success="True" time="0.001" asserts="2" />
+                          <test-case name="NUnit.Util.Tests.MemorySettingsStorageTests.RemoveSettings" executed="True" result="Success" success="True" time="0.002" asserts="3" />
+                          <test-case name="NUnit.Util.Tests.MemorySettingsStorageTests.SaveAndLoadSettings" executed="True" result="Success" success="True" time="0.001" asserts="4" />
+                          <test-case name="NUnit.Util.Tests.MemorySettingsStorageTests.SubstorageSettings" executed="True" result="Success" success="True" time="0.001" asserts="5" />
+                          <test-case name="NUnit.Util.Tests.MemorySettingsStorageTests.TypeSafeSettings" executed="True" result="Success" success="True" time="0.000" asserts="3" />
+                        </results>
+                      </test-suite>
+                      <test-suite type="TestFixture" name="NUnitProjectLoad" executed="True" result="Success" success="True" time="0.037" asserts="0">
+                        <results>
+                          <test-case name="NUnit.Util.Tests.NUnitProjectLoad.FromAssembly" executed="True" result="Success" success="True" time="0.005" asserts="5" />
+                          <test-case name="NUnit.Util.Tests.NUnitProjectLoad.LoadEmptyConfigs" executed="True" result="Success" success="True" time="0.008" asserts="3" />
+                          <test-case name="NUnit.Util.Tests.NUnitProjectLoad.LoadEmptyProject" executed="True" result="Success" success="True" time="0.002" asserts="1" />
+                          <test-case name="NUnit.Util.Tests.NUnitProjectLoad.LoadNormalProject" executed="True" result="Success" success="True" time="0.003" asserts="7" />
+                          <test-case name="NUnit.Util.Tests.NUnitProjectLoad.LoadProjectWithManualBinPath" executed="True" result="Success" success="True" time="0.002" asserts="2" />
+                          <test-case name="NUnit.Util.Tests.NUnitProjectLoad.SaveClearsAssemblyWrapper" executed="True" result="Success" success="True" time="0.004" asserts="1" />
+                        </results>
+                      </test-suite>
+                      <test-suite type="TestFixture" name="NUnitProjectSave" executed="True" result="Success" success="True" time="0.011" asserts="0">
+                        <results>
+                          <test-case name="NUnit.Util.Tests.NUnitProjectSave.SaveEmptyConfigs" executed="True" result="Success" success="True" time="0.003" asserts="1" />
+                          <test-case name="NUnit.Util.Tests.NUnitProjectSave.SaveEmptyProject" executed="True" result="Success" success="True" time="0.002" asserts="1" />
+                          <test-case name="NUnit.Util.Tests.NUnitProjectSave.SaveNormalProject" executed="True" result="Success" success="True" time="0.003" asserts="1" />
+                        </results>
+                      </test-suite>
+                      <test-suite type="TestFixture" name="NUnitProjectTests" executed="True" result="Success" success="True" time="0.083" asserts="0">
+                        <results>
+                          <test-case name="NUnit.Util.Tests.NUnitProjectTests.AddConfigMakesProjectDirty" executed="True" result="Success" success="True" time="0.001" asserts="1" />
+                          <test-case name="NUnit.Util.Tests.NUnitProjectTests.CanAddAssemblies" executed="True" result="Success" success="True" time="0.001" asserts="3" />
+                          <test-case name="NUnit.Util.Tests.NUnitProjectTests.CanAddConfigs" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Util.Tests.NUnitProjectTests.CanSetActiveConfig" executed="True" result="Success" success="True" time="0.001" asserts="1" />
+                          <test-case name="NUnit.Util.Tests.NUnitProjectTests.CanSetAppBase" executed="True" result="Success" success="True" time="0.001" asserts="1" />
+                          <test-case name="NUnit.Util.Tests.NUnitProjectTests.ConfigurationFileFromAssemblies" executed="True" result="Success" success="True" time="0.002" asserts="1" />
+                          <test-case name="NUnit.Util.Tests.NUnitProjectTests.ConfigurationFileFromAssembly" executed="True" result="Success" success="True" time="0.001" asserts="1" />
+                          <test-case name="NUnit.Util.Tests.NUnitProjectTests.DefaultActiveConfig" executed="True" result="Success" success="True" time="0.001" asserts="1" />
+                          <test-case name="NUnit.Util.Tests.NUnitProjectTests.DefaultApplicationBase" executed="True" result="Success" success="True" time="0.002" asserts="1" />
+                          <test-case name="NUnit.Util.Tests.NUnitProjectTests.DefaultConfigurationFile" executed="True" result="Success" success="True" time="0.001" asserts="2" />
+                          <test-case name="NUnit.Util.Tests.NUnitProjectTests.DefaultProjectName" executed="True" result="Success" success="True" time="0.002" asserts="1" />
+                          <test-case name="NUnit.Util.Tests.NUnitProjectTests.IsProjectFile" executed="True" result="Success" success="True" time="0.001" asserts="2" />
+                          <test-case name="NUnit.Util.Tests.NUnitProjectTests.LoadMakesProjectNotDirty" executed="True" result="Success" success="True" time="0.002" asserts="1" />
+                          <test-case name="NUnit.Util.Tests.NUnitProjectTests.NewProjectDefaultPath" executed="True" result="Success" success="True" time="0.001" asserts="3" />
+                          <test-case name="NUnit.Util.Tests.NUnitProjectTests.NewProjectIsEmpty" executed="True" result="Success" success="True" time="0.001" asserts="2" />
+                          <test-case name="NUnit.Util.Tests.NUnitProjectTests.NewProjectIsNotDirty" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Util.Tests.NUnitProjectTests.NewProjectNotLoadable" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Util.Tests.NUnitProjectTests.RemoveActiveConfig" executed="True" result="Success" success="True" time="0.001" asserts="1" />
+                          <test-case name="NUnit.Util.Tests.NUnitProjectTests.RemoveConfigMakesProjectDirty" executed="True" result="Success" success="True" time="0.001" asserts="1" />
+                          <test-case name="NUnit.Util.Tests.NUnitProjectTests.RenameActiveConfig" executed="True" result="Success" success="True" time="0.001" asserts="1" />
+                          <test-case name="NUnit.Util.Tests.NUnitProjectTests.RenameConfigMakesProjectDirty" executed="True" result="Success" success="True" time="0.001" asserts="1" />
+                          <test-case name="NUnit.Util.Tests.NUnitProjectTests.SaveAndLoadConfigsWithAssemblies" executed="True" result="Success" success="True" time="0.003" asserts="8" />
+                          <test-case name="NUnit.Util.Tests.NUnitProjectTests.SaveAndLoadEmptyConfigs" executed="True" result="Success" success="True" time="0.002" asserts="4" />
+                          <test-case name="NUnit.Util.Tests.NUnitProjectTests.SaveAndLoadEmptyProject" executed="True" result="Success" success="True" time="0.002" asserts="2" />
+                          <test-case name="NUnit.Util.Tests.NUnitProjectTests.SaveMakesProjectNotDirty" executed="True" result="Success" success="True" time="0.002" asserts="1" />
+                          <test-case name="NUnit.Util.Tests.NUnitProjectTests.SaveSetsProjectPath" executed="True" result="Success" success="True" time="0.002" asserts="2" />
+                          <test-case name="NUnit.Util.Tests.NUnitProjectTests.SettingActiveConfigMakesProjectDirty" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                        </results>
+                      </test-suite>
+                      <test-suite type="TestFixture" name="NUnitRegistryTests" executed="True" result="Success" success="True" time="0.009" asserts="0">
+                        <results>
+                          <test-case name="NUnit.Util.Tests.NUnitRegistryTests.CurrentUser" executed="True" result="Success" success="True" time="0.002" asserts="2" />
+                          <test-case name="NUnit.Util.Tests.NUnitRegistryTests.CurrentUserTestMode" executed="True" result="Success" success="True" time="0.001" asserts="2" />
+                          <test-case name="NUnit.Util.Tests.NUnitRegistryTests.TestClearRoutines" executed="True" result="Success" success="True" time="0.004" asserts="2" />
+                        </results>
+                      </test-suite>
+                      <test-suite type="TestFixture" name="PathUtilTests" executed="True" result="Success" success="True" time="0.001" asserts="0">
+                        <results>
+                          <test-case name="NUnit.Util.Tests.PathUtilTests.CheckDefaults" executed="True" result="Success" success="True" time="0.000" asserts="2" />
+                        </results>
+                      </test-suite>
+                      <test-suite type="TestFixture" name="PathUtilTests_Unix" executed="True" result="Success" success="True" time="0.011" asserts="0">
+                        <results>
+                          <test-case name="NUnit.Util.Tests.PathUtilTests_Unix.Canonicalize" executed="True" result="Success" success="True" time="0.001" asserts="5" />
+                          <test-case name="NUnit.Util.Tests.PathUtilTests_Unix.IsAssemblyFileType" executed="True" result="Success" success="True" time="0.001" asserts="3" />
+                          <test-case name="NUnit.Util.Tests.PathUtilTests_Unix.PathFromUri" executed="True" result="Success" success="True" time="0.000" asserts="2" />
+                          <test-case name="NUnit.Util.Tests.PathUtilTests_Unix.RelativePath" executed="True" result="Success" success="True" time="0.000" asserts="10" />
+                          <test-case name="NUnit.Util.Tests.PathUtilTests_Unix.SamePath" executed="True" result="Success" success="True" time="0.000" asserts="4" />
+                          <test-case name="NUnit.Util.Tests.PathUtilTests_Unix.SamePathOrUnder" executed="True" result="Success" success="True" time="0.000" asserts="7" />
+                        </results>
+                      </test-suite>
+                      <test-suite type="TestFixture" name="PathUtilTests_Windows" executed="True" result="Success" success="True" time="0.013" asserts="0">
+                        <results>
+                          <test-case name="NUnit.Util.Tests.PathUtilTests_Windows.Canonicalize" executed="True" result="Success" success="True" time="0.000" asserts="5" />
+                          <test-case name="NUnit.Util.Tests.PathUtilTests_Windows.IsAssemblyFileType" executed="True" result="Success" success="True" time="0.000" asserts="3" />
+                          <test-case name="NUnit.Util.Tests.PathUtilTests_Windows.PathFromUri" executed="True" result="Success" success="True" time="0.001" asserts="2" />
+                          <test-case name="NUnit.Util.Tests.PathUtilTests_Windows.RelativePath" executed="True" result="Success" success="True" time="0.000" asserts="12" />
+                          <test-case name="NUnit.Util.Tests.PathUtilTests_Windows.SamePath" executed="True" result="Success" success="True" time="0.000" asserts="4" />
+                          <test-case name="NUnit.Util.Tests.PathUtilTests_Windows.SamePathOrUnder" executed="True" result="Success" success="True" time="0.001" asserts="9" />
+                        </results>
+                      </test-suite>
+                      <test-suite type="TestFixture" name="ProcessRunnerTests" executed="True" result="Success" success="True" time="5.493" asserts="1">
+                        <properties>
+                          <property name="Timeout" value="30000" />
+                        </properties>
+                        <results>
+                          <test-case name="NUnit.Util.Tests.ProcessRunnerTests.BasicRunnerTests.CheckRunnerID" executed="True" result="Success" success="True" time="0.001" asserts="1" />
+                          <test-case name="NUnit.Util.Tests.ProcessRunnerTests.BasicRunnerTests.CountTestCases" executed="True" result="Success" success="True" time="0.871" asserts="1" />
+                          <test-case name="NUnit.Util.Tests.ProcessRunnerTests.BasicRunnerTests.CountTestCasesAcrossMultipleAssemblies" executed="True" result="Success" success="True" time="0.336" asserts="1" />
+                          <test-case name="NUnit.Util.Tests.ProcessRunnerTests.BasicRunnerTests.LoadAndReloadAssembly" executed="True" result="Success" success="True" time="0.552" asserts="2" />
+                          <test-case name="NUnit.Util.Tests.ProcessRunnerTests.BasicRunnerTests.LoadAssemblyWithFixture" executed="True" result="Success" success="True" time="0.251" asserts="1" />
+                          <test-case name="NUnit.Util.Tests.ProcessRunnerTests.BasicRunnerTests.LoadAssemblyWithoutNamespaces" executed="True" result="Success" success="True" time="0.272" asserts="4" />
+                          <test-case name="NUnit.Util.Tests.ProcessRunnerTests.BasicRunnerTests.LoadAssemblyWithSuite" executed="True" result="Success" success="True" time="0.221" asserts="1" />
+                          <test-case name="NUnit.Util.Tests.ProcessRunnerTests.BasicRunnerTests.LoadMultipleAssemblies" executed="True" result="Success" success="True" time="0.306" asserts="1" />
+                          <test-case name="NUnit.Util.Tests.ProcessRunnerTests.BasicRunnerTests.LoadMultipleAssembliesWithFixture" executed="True" result="Success" success="True" time="0.300" asserts="1" />
+                          <test-case name="NUnit.Util.Tests.ProcessRunnerTests.BasicRunnerTests.LoadMultipleAssembliesWithSuite" executed="True" result="Success" success="True" time="0.246" asserts="1" />
+                          <test-case name="NUnit.Util.Tests.ProcessRunnerTests.BasicRunnerTests.RunAssembly" executed="True" result="Success" success="True" time="0.327" asserts="1" />
+                          <test-case name="NUnit.Util.Tests.ProcessRunnerTests.BasicRunnerTests.RunAssemblyUsingBeginAndEndRun" executed="True" result="Success" success="True" time="0.351" asserts="2" />
+                          <test-case name="NUnit.Util.Tests.ProcessRunnerTests.BasicRunnerTests.RunMultipleAssemblies" executed="True" result="Success" success="True" time="0.382" asserts="1" />
+                          <test-case name="NUnit.Util.Tests.ProcessRunnerTests.BasicRunnerTests.RunMultipleAssembliesUsingBeginAndEndRun" executed="True" result="Success" success="True" time="0.398" asserts="2" />
+                          <test-case name="NUnit.Util.Tests.ProcessRunnerTests.TestProcessIsReused" executed="True" result="Success" success="True" time="0.608" asserts="2" />
+                        </results>
+                      </test-suite>
+                      <test-suite type="TestFixture" name="ProjectConfigTests" executed="True" result="Success" success="True" time="0.094" asserts="0">
+                        <results>
+                          <test-case name="NUnit.Util.Tests.ProjectConfigTests.AbsoluteBasePath" executed="True" result="Success" success="True" time="0.001" asserts="1" />
+                          <test-case name="NUnit.Util.Tests.ProjectConfigTests.AbsoluteConfigurationFile" executed="True" result="Success" success="True" time="0.001" asserts="1" />
+                          <test-case name="NUnit.Util.Tests.ProjectConfigTests.AddingConfigMarksProjectDirty" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Util.Tests.ProjectConfigTests.AddingInitialConfigRequiresReload" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Util.Tests.ProjectConfigTests.AddingSubsequentConfigDoesNotRequireReload" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Util.Tests.ProjectConfigTests.AddToActiveConfigMarksProjectDirty" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Util.Tests.ProjectConfigTests.AddToActiveConfigRequiresReload" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Util.Tests.ProjectConfigTests.AddToInactiveConfigDoesNotRequireReload" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Util.Tests.ProjectConfigTests.AddToInactiveConfigMarksProjectDirty" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Util.Tests.ProjectConfigTests.CanAddAssemblies" executed="True" result="Success" success="True" time="0.000" asserts="3" />
+                          <test-case name="NUnit.Util.Tests.ProjectConfigTests.DefaultConfigurationFile" executed="True" result="Success" success="True" time="0.001" asserts="2" />
+                          <test-case name="NUnit.Util.Tests.ProjectConfigTests.EmptyConfig" executed="True" result="Success" success="True" time="0.000" asserts="2" />
+                          <test-case name="NUnit.Util.Tests.ProjectConfigTests.ManualPrivateBinPath" executed="True" result="Success" success="True" time="0.001" asserts="1" />
+                          <test-case name="NUnit.Util.Tests.ProjectConfigTests.NoBasePathSet" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Util.Tests.ProjectConfigTests.NoPrivateBinPath" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Util.Tests.ProjectConfigTests.RelativeBasePath" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Util.Tests.ProjectConfigTests.RelativeConfigurationFile" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Util.Tests.ProjectConfigTests.RemoveActiveConfigMarksProjectDirty" executed="True" result="Success" success="True" time="0.001" asserts="1" />
+                          <test-case name="NUnit.Util.Tests.ProjectConfigTests.RemoveActiveConfigRequiresReload" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Util.Tests.ProjectConfigTests.RemoveInactiveConfigDoesNotRequireReload" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Util.Tests.ProjectConfigTests.RemoveInactiveConfigMarksProjectDirty" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Util.Tests.ProjectConfigTests.RenameActiveConfigMarksProjectDirty" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Util.Tests.ProjectConfigTests.RenameActiveConfigRequiresReload" executed="True" result="Success" success="True" time="0.001" asserts="1" />
+                          <test-case name="NUnit.Util.Tests.ProjectConfigTests.RenameInactiveConfigDoesNotRequireReload" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Util.Tests.ProjectConfigTests.RenameInctiveConfigMarksProjectDirty" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Util.Tests.ProjectConfigTests.SettingActiveConfigApplicationBaseMarksProjectDirty" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Util.Tests.ProjectConfigTests.SettingActiveConfigApplicationBaseRequiresReload" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Util.Tests.ProjectConfigTests.SettingActiveConfigBinPathTypeMarksProjectDirty" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Util.Tests.ProjectConfigTests.SettingActiveConfigBinPathTypeRequiresReload" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Util.Tests.ProjectConfigTests.SettingActiveConfigConfigurationFileMarksProjectDirty" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Util.Tests.ProjectConfigTests.SettingActiveConfigConfigurationFileRequiresReload" executed="True" result="Success" success="True" time="0.001" asserts="1" />
+                          <test-case name="NUnit.Util.Tests.ProjectConfigTests.SettingActiveConfigPrivateBinPathMarksProjectDirty" executed="True" result="Success" success="True" time="0.001" asserts="1" />
+                          <test-case name="NUnit.Util.Tests.ProjectConfigTests.SettingActiveConfigPrivateBinPathRequiresReload" executed="True" result="Success" success="True" time="0.001" asserts="1" />
+                          <test-case name="NUnit.Util.Tests.ProjectConfigTests.SettingInactiveConfigApplicationBaseDoesNotRequireReload" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Util.Tests.ProjectConfigTests.SettingInactiveConfigApplicationBaseMarksProjectDirty" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Util.Tests.ProjectConfigTests.SettingInactiveConfigBinPathTypeDoesNotRequireReload" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Util.Tests.ProjectConfigTests.SettingInactiveConfigBinPathTypeMarksProjectDirty" executed="True" result="Success" success="True" time="0.001" asserts="1" />
+                          <test-case name="NUnit.Util.Tests.ProjectConfigTests.SettingInactiveConfigConfigurationFileDoesNotRequireReload" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Util.Tests.ProjectConfigTests.SettingInactiveConfigConfigurationFileMarksProjectDirty" executed="True" result="Success" success="True" time="0.001" asserts="1" />
+                          <test-case name="NUnit.Util.Tests.ProjectConfigTests.SettingInactiveConfigPrivateBinPathDoesNotRequireReload" executed="True" result="Success" success="True" time="0.001" asserts="1" />
+                          <test-case name="NUnit.Util.Tests.ProjectConfigTests.SettingInactiveConfigPrivateBinPathMarksProjectDirty" executed="True" result="Success" success="True" time="0.001" asserts="1" />
+                          <test-case name="NUnit.Util.Tests.ProjectConfigTests.ToArray" executed="True" result="Success" success="True" time="0.001" asserts="2" />
+                        </results>
+                      </test-suite>
+                      <test-suite type="TestFixture" name="RecentFileEntryTests" executed="True" result="Success" success="True" time="0.015" asserts="0">
+                        <results>
+                          <test-case name="NUnit.Util.Tests.RecentFileEntryTests.CanCreateFromFileNameAndVersion" executed="True" result="Success" success="True" time="0.000" asserts="2" />
+                          <test-case name="NUnit.Util.Tests.RecentFileEntryTests.CanCreateFromSimpleFileName" executed="True" result="Success" success="True" time="0.000" asserts="2" />
+                          <test-case name="NUnit.Util.Tests.RecentFileEntryTests.CanParseFileNamePlusVersionString" executed="True" result="Success" success="True" time="0.001" asserts="2" />
+                          <test-case name="NUnit.Util.Tests.RecentFileEntryTests.CanParseFileNameWithCommaPlusVersionString" executed="True" result="Success" success="True" time="0.001" asserts="2" />
+                          <test-case name="NUnit.Util.Tests.RecentFileEntryTests.CanParseSimpleFileName" executed="True" result="Success" success="True" time="0.001" asserts="2" />
+                          <test-case name="NUnit.Util.Tests.RecentFileEntryTests.CanParseSimpleFileNameWithComma" executed="True" result="Success" success="True" time="0.001" asserts="2" />
+                          <test-case name="NUnit.Util.Tests.RecentFileEntryTests.EntryCanDisplayItself" executed="True" result="Success" success="True" time="0.001" asserts="1" />
+                        </results>
+                      </test-suite>
+                      <test-suite type="TestFixture" name="RecentFilesTests" executed="True" result="Success" success="True" time="0.047" asserts="0">
+                        <results>
+                          <test-case name="NUnit.Util.Tests.RecentFilesTests.AddMaxItems" executed="True" result="Success" success="True" time="0.003" asserts="7" />
+                          <test-case name="NUnit.Util.Tests.RecentFilesTests.AddSingleItem" executed="True" result="Success" success="True" time="0.000" asserts="3" />
+                          <test-case name="NUnit.Util.Tests.RecentFilesTests.AddTooManyItems" executed="True" result="Success" success="True" time="0.001" asserts="7" />
+                          <test-case name="NUnit.Util.Tests.RecentFilesTests.CountAtMax" executed="True" result="Success" success="True" time="0.001" asserts="1" />
+                          <test-case name="NUnit.Util.Tests.RecentFilesTests.CountAtMin" executed="True" result="Success" success="True" time="0.001" asserts="1" />
+                          <test-case name="NUnit.Util.Tests.RecentFilesTests.CountDefault" executed="True" result="Success" success="True" time="0.001" asserts="1" />
+                          <test-case name="NUnit.Util.Tests.RecentFilesTests.CountOverMax" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Util.Tests.RecentFilesTests.CountUnderMin" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Util.Tests.RecentFilesTests.EmptyList" executed="True" result="Success" success="True" time="0.000" asserts="3" />
+                          <test-case name="NUnit.Util.Tests.RecentFilesTests.IncreaseSize" executed="True" result="Success" success="True" time="0.000" asserts="12" />
+                          <test-case name="NUnit.Util.Tests.RecentFilesTests.IncreaseSizeAfterAdd" executed="True" result="Success" success="True" time="0.000" asserts="8" />
+                          <test-case name="NUnit.Util.Tests.RecentFilesTests.ReduceSize" executed="True" result="Success" success="True" time="0.000" asserts="5" />
+                          <test-case name="NUnit.Util.Tests.RecentFilesTests.ReduceSizeAfterAdd" executed="True" result="Success" success="True" time="0.001" asserts="4" />
+                          <test-case name="NUnit.Util.Tests.RecentFilesTests.RemoveFirstProject" executed="True" result="Success" success="True" time="0.001" asserts="3" />
+                          <test-case name="NUnit.Util.Tests.RecentFilesTests.RemoveLastProject" executed="True" result="Success" success="True" time="0.000" asserts="5" />
+                          <test-case name="NUnit.Util.Tests.RecentFilesTests.RemoveMultipleProjects" executed="True" result="Success" success="True" time="0.000" asserts="3" />
+                          <test-case name="NUnit.Util.Tests.RecentFilesTests.RemoveOneProject" executed="True" result="Success" success="True" time="0.000" asserts="4" />
+                          <test-case name="NUnit.Util.Tests.RecentFilesTests.ReorderLastProject" executed="True" result="Success" success="True" time="0.000" asserts="6" />
+                          <test-case name="NUnit.Util.Tests.RecentFilesTests.ReorderMultipleProjects" executed="True" result="Success" success="True" time="0.000" asserts="6" />
+                          <test-case name="NUnit.Util.Tests.RecentFilesTests.ReorderSameProject" executed="True" result="Success" success="True" time="0.000" asserts="6" />
+                          <test-case name="NUnit.Util.Tests.RecentFilesTests.ReorderSingleProject" executed="True" result="Success" success="True" time="0.000" asserts="6" />
+                          <test-case name="NUnit.Util.Tests.RecentFilesTests.ReorderWithListNotFull" executed="True" result="Success" success="True" time="0.000" asserts="4" />
+                        </results>
+                      </test-suite>
+                      <test-suite type="TestFixture" name="RegistrySettingsStorageTests" executed="True" result="Success" success="True" time="0.023" asserts="0">
+                        <results>
+                          <test-case name="NUnit.Util.Tests.RegistrySettingsStorageTests.MakeSubStorages" executed="True" result="Success" success="True" time="0.003" asserts="4" />
+                          <test-case name="NUnit.Util.Tests.RegistrySettingsStorageTests.RemoveSettings" executed="True" result="Success" success="True" time="0.003" asserts="3" />
+                          <test-case name="NUnit.Util.Tests.RegistrySettingsStorageTests.SaveAndLoadSettings" executed="True" result="Success" success="True" time="0.002" asserts="6" />
+                          <test-case name="NUnit.Util.Tests.RegistrySettingsStorageTests.StorageHasCorrectKey" executed="True" result="Success" success="True" time="0.001" asserts="1" />
+                          <test-case name="NUnit.Util.Tests.RegistrySettingsStorageTests.SubstorageSettings" executed="True" result="Success" success="True" time="0.001" asserts="5" />
+                          <test-case name="NUnit.Util.Tests.RegistrySettingsStorageTests.TypeSafeSettings" executed="True" result="Success" success="True" time="0.001" asserts="3" />
+                        </results>
+                      </test-suite>
+                      <test-suite type="TestFixture" name="RemoteTestAgentTests" executed="True" result="Success" success="True" time="0.002" asserts="0">
+                        <results>
+                          <test-case name="NUnit.Util.Tests.RemoteTestAgentTests.AgentReturnsProcessId" executed="True" result="Success" success="True" time="0.001" asserts="1" />
+                        </results>
+                      </test-suite>
+                      <test-suite type="TestFixture" name="RemoteTestResultTest" executed="True" result="Success" success="True" time="0.331" asserts="0">
+                        <results>
+                          <test-case name="NUnit.Util.Tests.RemoteTestResultTest.ResultStillValidAfterDomainUnload" executed="True" result="Success" success="True" time="0.330" asserts="2" />
+                        </results>
+                      </test-suite>
+                      <test-suite type="TestFixture" name="RuntimeFrameworkSelectorTests" executed="True" result="Success" success="True" time="0.051" asserts="0">
+                        <results>
+                          <test-suite type="Theory" name="RequestForSpecificFrameworkIsHonored" executed="True" result="Success" success="True" time="0.023" asserts="0">
+                            <results>
+                              <test-case name="NUnit.Util.Tests.RuntimeFrameworkSelectorTests.RequestForSpecificFrameworkIsHonored(net-1.0)" executed="True" result="Success" success="True" time="0.003" asserts="2" />
+                              <test-case name="NUnit.Util.Tests.RuntimeFrameworkSelectorTests.RequestForSpecificFrameworkIsHonored(net-1.1)" executed="True" result="Success" success="True" time="0.000" asserts="2" />
+                              <test-case name="NUnit.Util.Tests.RuntimeFrameworkSelectorTests.RequestForSpecificFrameworkIsHonored(net-2.0)" executed="True" result="Success" success="True" time="0.000" asserts="2" />
+                              <test-case name="NUnit.Util.Tests.RuntimeFrameworkSelectorTests.RequestForSpecificFrameworkIsHonored(net-4.0)" executed="True" result="Success" success="True" time="0.000" asserts="2" />
+                              <test-case name="NUnit.Util.Tests.RuntimeFrameworkSelectorTests.RequestForSpecificFrameworkIsHonored(mono-1.0)" executed="True" result="Success" success="True" time="0.000" asserts="2" />
+                              <test-case name="NUnit.Util.Tests.RuntimeFrameworkSelectorTests.RequestForSpecificFrameworkIsHonored(mono-2.0)" executed="True" result="Success" success="True" time="0.000" asserts="2" />
+                              <test-case name="NUnit.Util.Tests.RuntimeFrameworkSelectorTests.RequestForSpecificFrameworkIsHonored(v1.1)" executed="True" result="Inconclusive" success="False" time="0.003" asserts="0">
+                                <reason>
+                                  <message><![CDATA[  Expected: not Any
+  But was:  Any
+]]></message>
+                                </reason>
+                              </test-case>
+                              <test-case name="NUnit.Util.Tests.RuntimeFrameworkSelectorTests.RequestForSpecificFrameworkIsHonored(v2.0)" executed="True" result="Inconclusive" success="False" time="0.001" asserts="0">
+                                <reason>
+                                  <message><![CDATA[  Expected: not Any
+  But was:  Any
+]]></message>
+                                </reason>
+                              </test-case>
+                              <test-case name="NUnit.Util.Tests.RuntimeFrameworkSelectorTests.RequestForSpecificFrameworkIsHonored(v4.0)" executed="True" result="Inconclusive" success="False" time="0.001" asserts="0">
+                                <reason>
+                                  <message><![CDATA[  Expected: not Any
+  But was:  Any
+]]></message>
+                                </reason>
+                              </test-case>
+                            </results>
+                          </test-suite>
+                          <test-suite type="Theory" name="RequestForSpecificVersionIsHonored" executed="True" result="Success" success="True" time="0.021" asserts="0">
+                            <results>
+                              <test-case name="NUnit.Util.Tests.RuntimeFrameworkSelectorTests.RequestForSpecificVersionIsHonored(net-1.0)" executed="True" result="Inconclusive" success="False" time="0.002" asserts="0">
+                                <reason>
+                                  <message><![CDATA[  Expected: Any
+  But was:  Net
+]]></message>
+                                </reason>
+                              </test-case>
+                              <test-case name="NUnit.Util.Tests.RuntimeFrameworkSelectorTests.RequestForSpecificVersionIsHonored(net-1.1)" executed="True" result="Inconclusive" success="False" time="0.001" asserts="0">
+                                <reason>
+                                  <message><![CDATA[  Expected: Any
+  But was:  Net
+]]></message>
+                                </reason>
+                              </test-case>
+                              <test-case name="NUnit.Util.Tests.RuntimeFrameworkSelectorTests.RequestForSpecificVersionIsHonored(net-2.0)" executed="True" result="Inconclusive" success="False" time="0.001" asserts="0">
+                                <reason>
+                                  <message><![CDATA[  Expected: Any
+  But was:  Net
+]]></message>
+                                </reason>
+                              </test-case>
+                              <test-case name="NUnit.Util.Tests.RuntimeFrameworkSelectorTests.RequestForSpecificVersionIsHonored(net-4.0)" executed="True" result="Inconclusive" success="False" time="0.001" asserts="0">
+                                <reason>
+                                  <message><![CDATA[  Expected: Any
+  But was:  Net
+]]></message>
+                                </reason>
+                              </test-case>
+                              <test-case name="NUnit.Util.Tests.RuntimeFrameworkSelectorTests.RequestForSpecificVersionIsHonored(mono-1.0)" executed="True" result="Inconclusive" success="False" time="0.001" asserts="0">
+                                <reason>
+                                  <message><![CDATA[  Expected: Any
+  But was:  Mono
+]]></message>
+                                </reason>
+                              </test-case>
+                              <test-case name="NUnit.Util.Tests.RuntimeFrameworkSelectorTests.RequestForSpecificVersionIsHonored(mono-2.0)" executed="True" result="Inconclusive" success="False" time="0.001" asserts="0">
+                                <reason>
+                                  <message><![CDATA[  Expected: Any
+  But was:  Mono
+]]></message>
+                                </reason>
+                              </test-case>
+                              <test-case name="NUnit.Util.Tests.RuntimeFrameworkSelectorTests.RequestForSpecificVersionIsHonored(v1.1)" executed="True" result="Success" success="True" time="0.001" asserts="2" />
+                              <test-case name="NUnit.Util.Tests.RuntimeFrameworkSelectorTests.RequestForSpecificVersionIsHonored(v2.0)" executed="True" result="Success" success="True" time="0.000" asserts="2" />
+                              <test-case name="NUnit.Util.Tests.RuntimeFrameworkSelectorTests.RequestForSpecificVersionIsHonored(v4.0)" executed="True" result="Success" success="True" time="0.000" asserts="2" />
+                            </results>
+                          </test-suite>
+                        </results>
+                      </test-suite>
+                      <test-suite type="TestFixture" name="ServerUtilityTests" executed="True" result="Success" success="True" time="0.006" asserts="0">
+                        <results>
+                          <test-case name="NUnit.Util.Tests.ServerUtilityTests.CanGetTcpChannelOnSpecifiedPort" executed="True" result="Success" success="True" time="0.003" asserts="5" />
+                          <test-case name="NUnit.Util.Tests.ServerUtilityTests.CanGetTcpChannelOnUnpecifiedPort" executed="True" result="Success" success="True" time="0.001" asserts="4" />
+                        </results>
+                      </test-suite>
+                      <test-suite type="TestFixture" name="SettingsGroupTests" executed="True" result="Success" success="True" time="0.010" asserts="0">
+                        <results>
+                          <test-case name="NUnit.Util.Tests.SettingsGroupTests.BadSetting" executed="True" result="Success" success="True" time="0.001" asserts="1" />
+                          <test-case name="NUnit.Util.Tests.SettingsGroupTests.DefaultSettings" executed="True" result="Success" success="True" time="0.000" asserts="7" />
+                          <test-case name="NUnit.Util.Tests.SettingsGroupTests.SubGroupSettings" executed="True" result="Success" success="True" time="0.000" asserts="7" />
+                          <test-case name="NUnit.Util.Tests.SettingsGroupTests.TopLevelSettings" executed="True" result="Success" success="True" time="0.000" asserts="5" />
+                          <test-case name="NUnit.Util.Tests.SettingsGroupTests.TypeSafeSettings" executed="True" result="Success" success="True" time="0.001" asserts="3" />
+                        </results>
+                      </test-suite>
+                      <test-suite type="TestFixture" name="SummaryResultFixture" executed="True" result="Success" success="True" time="0.009" asserts="0">
+                        <results>
+                          <test-case name="NUnit.Util.Tests.SummaryResultFixture.SummaryMatchesResult" executed="True" result="Success" success="True" time="0.008" asserts="9" />
+                        </results>
+                      </test-suite>
+                      <test-suite type="TestFixture" name="TestAgencyTests" executed="True" result="Success" success="True" time="0.536" asserts="0">
+                        <results>
+                          <test-case name="NUnit.Util.Tests.TestAgencyTests.CanConnectToAgency" executed="True" result="Success" success="True" time="0.002" asserts="2" />
+                          <test-case name="NUnit.Util.Tests.TestAgencyTests.CanLaunchAndConnectToAgent" executed="True" result="Success" success="True" time="0.525" asserts="1" />
+                        </results>
+                      </test-suite>
+                      <test-suite type="TestFixture" name="TestDomainFixture" executed="True" result="Success" success="True" time="0.329" asserts="0">
+                        <results>
+                          <test-case name="NUnit.Util.Tests.TestDomainFixture.AppDomainIsSetUpCorrectly" executed="True" result="Success" success="True" time="0.001" asserts="8" />
+                          <test-case name="NUnit.Util.Tests.TestDomainFixture.AssemblyIsLoadedCorrectly" executed="True" result="Success" success="True" time="0.000" asserts="2" />
+                          <test-case name="NUnit.Util.Tests.TestDomainFixture.CanRunMockAssemblyTests" executed="True" result="Success" success="True" time="0.066" asserts="5" />
+                        </results>
+                      </test-suite>
+                      <test-suite type="TestFixture" name="TestDomainRunnerTests" executed="True" result="Success" success="True" time="3.917" asserts="1">
+                        <results>
+                          <test-case name="NUnit.Util.Tests.TestDomainRunnerTests.BasicRunnerTests.CheckRunnerID" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Util.Tests.TestDomainRunnerTests.BasicRunnerTests.CountTestCases" executed="True" result="Success" success="True" time="0.243" asserts="1" />
+                          <test-case name="NUnit.Util.Tests.TestDomainRunnerTests.BasicRunnerTests.CountTestCasesAcrossMultipleAssemblies" executed="True" result="Success" success="True" time="0.291" asserts="1" />
+                          <test-case name="NUnit.Util.Tests.TestDomainRunnerTests.BasicRunnerTests.LoadAndReloadAssembly" executed="True" result="Success" success="True" time="0.499" asserts="2" />
+                          <test-case name="NUnit.Util.Tests.TestDomainRunnerTests.BasicRunnerTests.LoadAssemblyWithFixture" executed="True" result="Success" success="True" time="0.217" asserts="1" />
+                          <test-case name="NUnit.Util.Tests.TestDomainRunnerTests.BasicRunnerTests.LoadAssemblyWithoutNamespaces" executed="True" result="Success" success="True" time="0.267" asserts="4" />
+                          <test-case name="NUnit.Util.Tests.TestDomainRunnerTests.BasicRunnerTests.LoadAssemblyWithSuite" executed="True" result="Success" success="True" time="0.193" asserts="1" />
+                          <test-case name="NUnit.Util.Tests.TestDomainRunnerTests.BasicRunnerTests.LoadMultipleAssemblies" executed="True" result="Success" success="True" time="0.305" asserts="1" />
+                          <test-case name="NUnit.Util.Tests.TestDomainRunnerTests.BasicRunnerTests.LoadMultipleAssembliesWithFixture" executed="True" result="Success" success="True" time="0.271" asserts="1" />
+                          <test-case name="NUnit.Util.Tests.TestDomainRunnerTests.BasicRunnerTests.LoadMultipleAssembliesWithSuite" executed="True" result="Success" success="True" time="0.233" asserts="1" />
+                          <test-case name="NUnit.Util.Tests.TestDomainRunnerTests.BasicRunnerTests.RunAssembly" executed="True" result="Success" success="True" time="0.308" asserts="1" />
+                          <test-case name="NUnit.Util.Tests.TestDomainRunnerTests.BasicRunnerTests.RunAssemblyUsingBeginAndEndRun" executed="True" result="Success" success="True" time="0.313" asserts="2" />
+                          <test-case name="NUnit.Util.Tests.TestDomainRunnerTests.BasicRunnerTests.RunMultipleAssemblies" executed="True" result="Success" success="True" time="0.364" asserts="1" />
+                          <test-case name="NUnit.Util.Tests.TestDomainRunnerTests.BasicRunnerTests.RunMultipleAssembliesUsingBeginAndEndRun" executed="True" result="Success" success="True" time="0.358" asserts="2" />
+                        </results>
+                      </test-suite>
+                      <test-suite type="TestFixture" name="TestDomainTests" executed="True" result="Success" success="True" time="2.124" asserts="0">
+                        <results>
+                          <test-case name="NUnit.Util.Tests.TestDomainTests.BasePathOverrideIsHonored" executed="True" result="Success" success="True" time="0.569" asserts="1" />
+                          <test-case name="NUnit.Util.Tests.TestDomainTests.BinPathOverrideIsHonored" executed="True" result="Success" success="True" time="0.245" asserts="1" />
+                          <test-case name="NUnit.Util.Tests.TestDomainTests.ConfigFileOverrideIsHonored" executed="True" result="Success" success="True" time="0.250" asserts="1" />
+                          <test-case name="NUnit.Util.Tests.TestDomainTests.FileNotFound" executed="True" result="Success" success="True" time="0.408" asserts="0" />
+                          <test-case name="NUnit.Util.Tests.TestDomainTests.InvalidTestFixture" executed="True" result="Success" success="True" time="0.185" asserts="1" />
+                          <test-case name="NUnit.Util.Tests.TestDomainTests.SpecificTestFixture" executed="True" result="Success" success="True" time="0.263" asserts="4" />
+                          <test-case name="NUnit.Util.Tests.TestDomainTests.TurnOffShadowCopy" executed="True" result="Success" success="True" time="0.189" asserts="1" />
+                        </results>
+                      </test-suite>
+                      <test-suite type="TestFixture" name="TestDomainTests_Multiple" executed="True" result="Success" success="True" time="0.380" asserts="0">
+                        <results>
+                          <test-case name="NUnit.Util.Tests.TestDomainTests_Multiple.AssemblyNodes" executed="True" result="Success" success="True" time="0.000" asserts="2" />
+                          <test-case name="NUnit.Util.Tests.TestDomainTests_Multiple.BuildSuite" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Util.Tests.TestDomainTests_Multiple.RootNode" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Util.Tests.TestDomainTests_Multiple.RunMultipleAssemblies" executed="True" result="Success" success="True" time="0.061" asserts="1" />
+                          <test-case name="NUnit.Util.Tests.TestDomainTests_Multiple.TestCaseCount" executed="True" result="Success" success="True" time="0.001" asserts="1" />
+                        </results>
+                      </test-suite>
+                      <test-suite type="TestFixture" name="TestDomainTests_MultipleFixture" executed="True" result="Success" success="True" time="0.333" asserts="0">
+                        <results>
+                          <test-case name="NUnit.Util.Tests.TestDomainTests_MultipleFixture.LoadFixture" executed="True" result="Success" success="True" time="0.332" asserts="1" />
+                        </results>
+                      </test-suite>
+                      <test-suite type="TestFixture" name="TestLoaderAssemblyTests" executed="True" result="Success" success="True" time="1.885" asserts="0">
+                        <results>
+                          <test-case name="NUnit.Util.Tests.TestLoaderAssemblyTests.AssemblyWithNoTests" executed="True" result="Success" success="True" time="0.348" asserts="4" />
+                          <test-case name="NUnit.Util.Tests.TestLoaderAssemblyTests.FileNotFound" executed="True" result="Success" success="True" time="0.004" asserts="5" />
+                          <test-case name="NUnit.Util.Tests.TestLoaderAssemblyTests.LoadProject" executed="True" result="Success" success="True" time="0.001" asserts="5" />
+                          <test-case name="NUnit.Util.Tests.TestLoaderAssemblyTests.LoadTest" executed="True" result="Success" success="True" time="0.383" asserts="6" />
+                          <test-case name="NUnit.Util.Tests.TestLoaderAssemblyTests.RunTest" executed="True" result="Success" success="True" time="0.867" asserts="9" />
+                          <test-case name="NUnit.Util.Tests.TestLoaderAssemblyTests.UnloadProject" executed="True" result="Success" success="True" time="0.001" asserts="5" />
+                          <test-case name="NUnit.Util.Tests.TestLoaderAssemblyTests.UnloadTest" executed="True" result="Success" success="True" time="0.266" asserts="3" />
+                        </results>
+                      </test-suite>
+                      <test-suite type="TestFixture" name="TestLoaderWatcherTests" executed="True" result="Success" success="True" time="1.774" asserts="0">
+                        <results>
+                          <test-case name="NUnit.Util.Tests.TestLoaderWatcherTests.LoadShouldStartWatcher" executed="True" result="Success" success="True" time="0.243" asserts="3" />
+                          <test-case name="NUnit.Util.Tests.TestLoaderWatcherTests.LoadShouldStartWatcherDependingOnSettings" executed="True" result="Success" success="True" time="0.247" asserts="2" />
+                          <test-case name="NUnit.Util.Tests.TestLoaderWatcherTests.ReloadShouldStartWatcher" executed="True" result="Success" success="True" time="0.506" asserts="3" />
+                          <test-case name="NUnit.Util.Tests.TestLoaderWatcherTests.ReloadShouldStartWatcherDependingOnSettings" executed="True" result="Success" success="True" time="0.504" asserts="2" />
+                          <test-case name="NUnit.Util.Tests.TestLoaderWatcherTests.UnloadShouldStopWatcherAndFreeResources" executed="True" result="Success" success="True" time="0.264" asserts="3" />
+                        </results>
+                      </test-suite>
+                      <test-suite type="TestFixture" name="TestRunnerFactoryTests" executed="True" result="Success" success="True" time="0.006" asserts="0">
+                        <results>
+                          <test-case name="NUnit.Util.Tests.TestRunnerFactoryTests.DifferentRuntimeUsesProcessRunner" executed="True" result="Success" success="True" time="0.001" asserts="1" />
+                          <test-case name="NUnit.Util.Tests.TestRunnerFactoryTests.DifferentVersionUsesProcessRunner" executed="True" result="Success" success="True" time="0.001" asserts="1" />
+                          <test-case name="NUnit.Util.Tests.TestRunnerFactoryTests.SameFrameworkUsesTestDomain" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                        </results>
+                      </test-suite>
+                      <test-suite type="TestFixture" name="VisualStudioConverterTests" executed="True" result="Success" success="True" time="0.296" asserts="0">
+                        <results>
+                          <test-case name="NUnit.Util.Tests.VisualStudioConverterTests.FromCppProject" executed="True" result="Success" success="True" time="0.057" asserts="5" />
+                          <test-case name="NUnit.Util.Tests.VisualStudioConverterTests.FromCSharpProject" executed="True" result="Success" success="True" time="0.008" asserts="5" />
+                          <test-case name="NUnit.Util.Tests.VisualStudioConverterTests.FromJsharpProject" executed="True" result="Success" success="True" time="0.006" asserts="5" />
+                          <test-case name="NUnit.Util.Tests.VisualStudioConverterTests.FromMakefileProject" executed="True" result="Success" success="True" time="0.007" asserts="3" />
+                          <test-case name="NUnit.Util.Tests.VisualStudioConverterTests.FromProjectWithHebrewFileIncluded" executed="True" result="Success" success="True" time="0.012" asserts="5" />
+                          <test-case name="NUnit.Util.Tests.VisualStudioConverterTests.FromSolutionWithDisabledProject" executed="True" result="Success" success="True" time="0.040" asserts="3" />
+                          <test-case name="NUnit.Util.Tests.VisualStudioConverterTests.FromVBProject" executed="True" result="Success" success="True" time="0.009" asserts="5" />
+                          <test-case name="NUnit.Util.Tests.VisualStudioConverterTests.FromVSSolution2003" executed="True" result="Success" success="True" time="0.043" asserts="5" />
+                          <test-case name="NUnit.Util.Tests.VisualStudioConverterTests.FromVSSolution2005" executed="True" result="Success" success="True" time="0.047" asserts="5" />
+                          <test-case name="NUnit.Util.Tests.VisualStudioConverterTests.FromWebApplication" executed="True" result="Success" success="True" time="0.016" asserts="3" />
+                          <test-case name="NUnit.Util.Tests.VisualStudioConverterTests.WithUnmanagedCpp" executed="True" result="Success" success="True" time="0.022" asserts="3" />
+                        </results>
+                      </test-suite>
+                      <test-suite type="TestFixture" name="VSProjectTests" executed="True" result="Success" success="True" time="0.173" asserts="0">
+                        <results>
+                          <test-case name="NUnit.Util.Tests.VSProjectTests.FileNotFoundError" executed="True" result="Success" success="True" time="0.002" asserts="0" />
+                          <test-case name="NUnit.Util.Tests.VSProjectTests.GenerateCorrectExtensionsFromVCProjectVS2005" executed="True" result="Success" success="True" time="0.010" asserts="4" />
+                          <test-case name="NUnit.Util.Tests.VSProjectTests.InvalidProjectFormat" executed="True" result="Success" success="True" time="0.003" asserts="0" />
+                          <test-case name="NUnit.Util.Tests.VSProjectTests.InvalidXmlFormat" executed="True" result="Success" success="True" time="0.004" asserts="0" />
+                          <test-case name="NUnit.Util.Tests.VSProjectTests.LoadCppProject" executed="True" result="Success" success="True" time="0.009" asserts="3" />
+                          <test-case name="NUnit.Util.Tests.VSProjectTests.LoadCppProjectVS2005" executed="True" result="Success" success="True" time="0.008" asserts="3" />
+                          <test-case name="NUnit.Util.Tests.VSProjectTests.LoadCppProjectWithMacros" executed="True" result="Success" success="True" time="0.009" asserts="4" />
+                          <test-case name="NUnit.Util.Tests.VSProjectTests.LoadCsharpProject" executed="True" result="Success" success="True" time="0.010" asserts="3" />
+                          <test-case name="NUnit.Util.Tests.VSProjectTests.LoadCsharpProjectVS2005" executed="True" result="Success" success="True" time="0.009" asserts="3" />
+                          <test-case name="NUnit.Util.Tests.VSProjectTests.LoadInvalidFileType" executed="True" result="Success" success="True" time="0.002" asserts="0" />
+                          <test-case name="NUnit.Util.Tests.VSProjectTests.LoadJsharpProject" executed="True" result="Success" success="True" time="0.009" asserts="3" />
+                          <test-case name="NUnit.Util.Tests.VSProjectTests.LoadJsharpProjectVS2005" executed="True" result="Success" success="True" time="0.008" asserts="3" />
+                          <test-case name="NUnit.Util.Tests.VSProjectTests.LoadProjectWithHebrewFileIncluded" executed="True" result="Success" success="True" time="0.010" asserts="3" />
+                          <test-case name="NUnit.Util.Tests.VSProjectTests.LoadProjectWithMissingOutputPath" executed="True" result="Success" success="True" time="0.010" asserts="3" />
+                          <test-case name="NUnit.Util.Tests.VSProjectTests.LoadVbProject" executed="True" result="Success" success="True" time="0.008" asserts="3" />
+                          <test-case name="NUnit.Util.Tests.VSProjectTests.LoadVbProjectVS2005" executed="True" result="Success" success="True" time="0.008" asserts="3" />
+                          <test-case name="NUnit.Util.Tests.VSProjectTests.MissingAttributes" executed="True" result="Success" success="True" time="0.003" asserts="0" />
+                          <test-case name="NUnit.Util.Tests.VSProjectTests.NoConfigurations" executed="True" result="Success" success="True" time="0.002" asserts="1" />
+                          <test-case name="NUnit.Util.Tests.VSProjectTests.NotWebProject" executed="True" result="Success" success="True" time="0.000" asserts="2" />
+                          <test-case name="NUnit.Util.Tests.VSProjectTests.ProjectExtensions" executed="True" result="Success" success="True" time="0.001" asserts="4" />
+                          <test-case name="NUnit.Util.Tests.VSProjectTests.SolutionExtension" executed="True" result="Success" success="True" time="0.001" asserts="2" />
+                        </results>
+                      </test-suite>
+                      <test-suite type="TestFixture" name="XmlResultWriterTest" executed="True" result="Success" success="True" time="0.071" asserts="0">
+                        <results>
+                          <test-case name="NUnit.Util.Tests.XmlResultWriterTest.FailingTestHasCorrectInformation" executed="True" result="Success" success="True" time="0.003" asserts="7" />
+                          <test-case name="NUnit.Util.Tests.XmlResultWriterTest.HasMultipleCategories" executed="True" result="Success" success="True" time="0.001" asserts="2" />
+                          <test-case name="NUnit.Util.Tests.XmlResultWriterTest.HasMultipleProperties" executed="True" result="Success" success="True" time="0.002" asserts="2" />
+                          <test-case name="NUnit.Util.Tests.XmlResultWriterTest.HasSingleCategory" executed="True" result="Success" success="True" time="0.001" asserts="3" />
+                          <test-case name="NUnit.Util.Tests.XmlResultWriterTest.HasSingleProperty" executed="True" result="Success" success="True" time="0.001" asserts="3" />
+                          <test-case name="NUnit.Util.Tests.XmlResultWriterTest.IgnoredTestHasCorrectInformation" executed="True" result="Success" success="True" time="0.001" asserts="5" />
+                          <test-case name="NUnit.Util.Tests.XmlResultWriterTest.InconclusiveTestHasCorrectInformation" executed="True" result="Success" success="True" time="0.001" asserts="6" />
+                          <test-case name="NUnit.Util.Tests.XmlResultWriterTest.PassingTestHasCorrectInformation" executed="True" result="Success" success="True" time="0.001" asserts="6" />
+                          <test-case name="NUnit.Util.Tests.XmlResultWriterTest.SuiteResultHasCategories" executed="True" result="Success" success="True" time="0.002" asserts="3" />
+                          <test-case name="NUnit.Util.Tests.XmlResultWriterTest.TestHasCultureInfo" executed="True" result="Success" success="True" time="0.000" asserts="5" />
+                          <test-case name="NUnit.Util.Tests.XmlResultWriterTest.TestHasEnvironmentInfo" executed="True" result="Success" success="True" time="0.000" asserts="9" />
+                        </results>
+                      </test-suite>
+                    </results>
+                  </test-suite>
+                </results>
+              </test-suite>
+            </results>
+          </test-suite>
+        </results>
+      </test-suite>
+      <test-suite type="Assembly" name="C:\Program Files\NUnit 2.6\bin\tests/nunit.mocks.tests.dll" executed="True" result="Success" success="True" time="0.139" asserts="0">
+        <results>
+          <test-suite type="Namespace" name="NUnit" executed="True" result="Success" success="True" time="0.138" asserts="0">
+            <results>
+              <test-suite type="Namespace" name="Mocks" executed="True" result="Success" success="True" time="0.138" asserts="0">
+                <results>
+                  <test-suite type="Namespace" name="Tests" executed="True" result="Success" success="True" time="0.137" asserts="0">
+                    <results>
+                      <test-suite type="TestFixture" name="DynamicMockTests" executed="True" result="Success" success="True" time="0.033" asserts="0">
+                        <results>
+                          <test-case name="NUnit.Mocks.Tests.DynamicMockTests.CallMethod" executed="True" result="Success" success="True" time="0.003" asserts="0" />
+                          <test-case name="NUnit.Mocks.Tests.DynamicMockTests.CallMethodWithArgs" executed="True" result="Success" success="True" time="0.001" asserts="0" />
+                          <test-case name="NUnit.Mocks.Tests.DynamicMockTests.CreateMockForMBRClass" executed="True" result="Success" success="True" time="0.003" asserts="13" />
+                          <test-case name="NUnit.Mocks.Tests.DynamicMockTests.CreateMockForNonMBRClassFails" executed="True" result="Success" success="True" time="0.001" asserts="0" />
+                          <test-case name="NUnit.Mocks.Tests.DynamicMockTests.DefaultReturnValues" executed="True" result="Success" success="True" time="0.001" asserts="5" />
+                          <test-case name="NUnit.Mocks.Tests.DynamicMockTests.ExpectedMethod" executed="True" result="Success" success="True" time="0.001" asserts="2" />
+                          <test-case name="NUnit.Mocks.Tests.DynamicMockTests.ExpectedMethodNotCalled" executed="True" result="Success" success="True" time="0.001" asserts="1" />
+                          <test-case name="NUnit.Mocks.Tests.DynamicMockTests.MethodWithReturnValue" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Mocks.Tests.DynamicMockTests.MockHasDefaultName" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Mocks.Tests.DynamicMockTests.MockHasNonDefaultName" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Mocks.Tests.DynamicMockTests.OverrideMethodOnDynamicMock" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Mocks.Tests.DynamicMockTests.RefParameter" executed="True" result="Success" success="True" time="0.000" asserts="2" />
+                          <test-case name="NUnit.Mocks.Tests.DynamicMockTests.WrongReturnType" executed="True" result="Success" success="True" time="0.001" asserts="0" />
+                        </results>
+                      </test-suite>
+                      <test-suite type="TestFixture" name="MockTests" executed="True" result="Success" success="True" time="0.101" asserts="0">
+                        <results>
+                          <test-case name="NUnit.Mocks.Tests.MockTests.CallMultipleMethodsInDifferentOrder" executed="True" result="Success" success="True" time="0.001" asserts="6" />
+                          <test-case name="NUnit.Mocks.Tests.MockTests.CallMultipleMethodsSomeWithoutExpectations" executed="True" result="Success" success="True" time="0.001" asserts="5" />
+                          <test-case name="NUnit.Mocks.Tests.MockTests.ChangeExpectAndReturnToFixedReturn" executed="True" result="Success" success="True" time="0.001" asserts="8" />
+                          <test-case name="NUnit.Mocks.Tests.MockTests.ChangeFixedReturnToExpectAndReturn" executed="True" result="Success" success="True" time="0.000" asserts="9" />
+                          <test-case name="NUnit.Mocks.Tests.MockTests.ConstraintArgumentSucceeds" executed="True" result="Success" success="True" time="0.000" asserts="3" />
+                          <test-case name="NUnit.Mocks.Tests.MockTests.ConstraintArgumentThatFails" executed="True" result="Success" success="True" time="0.001" asserts="3" />
+                          <test-case name="NUnit.Mocks.Tests.MockTests.ExpectAndReturn" executed="True" result="Success" success="True" time="0.000" asserts="4" />
+                          <test-case name="NUnit.Mocks.Tests.MockTests.ExpectAndReturnNull" executed="True" result="Success" success="True" time="0.000" asserts="4" />
+                          <test-case name="NUnit.Mocks.Tests.MockTests.ExpectAndReturnWithArgument" executed="True" result="Success" success="True" time="0.000" asserts="5" />
+                          <test-case name="NUnit.Mocks.Tests.MockTests.ExpectAndReturnWithWrongArgument" executed="True" result="Success" success="True" time="0.001" asserts="3" />
+                          <test-case name="NUnit.Mocks.Tests.MockTests.ExpectAndThrowException" executed="True" result="Success" success="True" time="0.001" asserts="2" />
+                          <test-case name="NUnit.Mocks.Tests.MockTests.ExpectNoCallFails" executed="True" result="Success" success="True" time="0.001" asserts="0" />
+                          <test-case name="NUnit.Mocks.Tests.MockTests.ExpectNoCallSucceeds" executed="True" result="Success" success="True" time="0.000" asserts="0" />
+                          <test-case name="NUnit.Mocks.Tests.MockTests.FailWithParametersSpecified" executed="True" result="Success" success="True" time="0.001" asserts="2" />
+                          <test-case name="NUnit.Mocks.Tests.MockTests.IgnoreArguments" executed="True" result="Success" success="True" time="0.000" asserts="2" />
+                          <test-case name="NUnit.Mocks.Tests.MockTests.MethodNotCalled" executed="True" result="Success" success="True" time="0.001" asserts="1" />
+                          <test-case name="NUnit.Mocks.Tests.MockTests.MockHasName" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Mocks.Tests.MockTests.MultipleCallsToSameMethod" executed="True" result="Success" success="True" time="0.000" asserts="4" />
+                          <test-case name="NUnit.Mocks.Tests.MockTests.MultipleExpectAndReturn" executed="True" result="Success" success="True" time="0.003" asserts="10" />
+                          <test-case name="NUnit.Mocks.Tests.MockTests.MultipleExpectations" executed="True" result="Success" success="True" time="0.000" asserts="12" />
+                          <test-case name="NUnit.Mocks.Tests.MockTests.NotEnoughCalls" executed="True" result="Success" success="True" time="0.002" asserts="3" />
+                          <test-case name="NUnit.Mocks.Tests.MockTests.OneExpectation" executed="True" result="Success" success="True" time="0.001" asserts="2" />
+                          <test-case name="NUnit.Mocks.Tests.MockTests.RequireArguments" executed="True" result="Success" success="True" time="0.001" asserts="2" />
+                          <test-case name="NUnit.Mocks.Tests.MockTests.SetReturnValue" executed="True" result="Success" success="True" time="0.001" asserts="1" />
+                          <test-case name="NUnit.Mocks.Tests.MockTests.SetReturnValueMultipleTimesOnMultipleMethods" executed="True" result="Success" success="True" time="0.001" asserts="7" />
+                          <test-case name="NUnit.Mocks.Tests.MockTests.SetReturnValueRepeatedCalls" executed="True" result="Success" success="True" time="0.001" asserts="3" />
+                          <test-case name="NUnit.Mocks.Tests.MockTests.SetReturnValueWithoutCalling" executed="True" result="Success" success="True" time="0.000" asserts="0" />
+                          <test-case name="NUnit.Mocks.Tests.MockTests.StrictDefaultsToFalse" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Mocks.Tests.MockTests.StrictMode" executed="True" result="Success" success="True" time="0.002" asserts="2" />
+                          <test-case name="NUnit.Mocks.Tests.MockTests.StrictMode_ExceptionsCaught" executed="True" result="Success" success="True" time="0.002" asserts="4" />
+                          <test-case name="NUnit.Mocks.Tests.MockTests.TooManyCalls" executed="True" result="Success" success="True" time="0.001" asserts="3" />
+                          <test-case name="NUnit.Mocks.Tests.MockTests.UnexpectedCallsIgnored" executed="True" result="Success" success="True" time="0.001" asserts="0" />
+                          <test-case name="NUnit.Mocks.Tests.MockTests.VerifyNewMock" executed="True" result="Success" success="True" time="0.000" asserts="0" />
+                        </results>
+                      </test-suite>
+                    </results>
+                  </test-suite>
+                </results>
+              </test-suite>
+            </results>
+          </test-suite>
+        </results>
+      </test-suite>
+      <test-suite type="Assembly" name="C:\Program Files\NUnit 2.6\bin\tests/nunit-console.tests.dll" executed="True" result="Success" success="True" time="5.207" asserts="0">
+        <results>
+          <test-suite type="Namespace" name="NUnit" executed="True" result="Success" success="True" time="5.206" asserts="0">
+            <results>
+              <test-suite type="Namespace" name="ConsoleRunner" executed="True" result="Success" success="True" time="5.206" asserts="0">
+                <results>
+                  <test-suite type="Namespace" name="Tests" executed="True" result="Success" success="True" time="5.206" asserts="0">
+                    <results>
+                      <test-suite type="TestFixture" name="CommandLineTests" executed="True" result="Success" success="True" time="0.127" asserts="0">
+                        <results>
+                          <test-case name="NUnit.ConsoleRunner.Tests.CommandLineTests.AllowForwardSlashDefaultsCorrectly" executed="True" result="Success" success="True" time="0.023" asserts="1" />
+                          <test-case name="NUnit.ConsoleRunner.Tests.CommandLineTests.AssemblyAloneIsValid" executed="True" result="Success" success="True" time="0.001" asserts="1" />
+                          <test-case name="NUnit.ConsoleRunner.Tests.CommandLineTests.AssemblyName" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                          <test-suite type="ParameterizedTest" name="BooleanOptionAreRecognized" executed="True" result="Success" success="True" time="0.031" asserts="0">
+                            <results>
+                              <test-case name="NUnit.ConsoleRunner.Tests.CommandLineTests.BooleanOptionAreRecognized(&quot;labels&quot;,&quot;labels&quot;)" executed="True" result="Success" success="True" time="0.006" asserts="6" />
+                              <test-case name="NUnit.ConsoleRunner.Tests.CommandLineTests.BooleanOptionAreRecognized(&quot;help&quot;,&quot;help&quot;)" executed="True" result="Success" success="True" time="0.002" asserts="6" />
+                              <test-case name="NUnit.ConsoleRunner.Tests.CommandLineTests.BooleanOptionAreRecognized(&quot;help&quot;,&quot;?&quot;)" executed="True" result="Success" success="True" time="0.002" asserts="6" />
+                              <test-case name="NUnit.ConsoleRunner.Tests.CommandLineTests.BooleanOptionAreRecognized(&quot;xmlConsole&quot;,&quot;xmlConsole&quot;)" executed="True" result="Success" success="True" time="0.001" asserts="6" />
+                              <test-case name="NUnit.ConsoleRunner.Tests.CommandLineTests.BooleanOptionAreRecognized(&quot;wait&quot;,&quot;wait&quot;)" executed="True" result="Success" success="True" time="0.001" asserts="6" />
+                              <test-case name="NUnit.ConsoleRunner.Tests.CommandLineTests.BooleanOptionAreRecognized(&quot;nologo&quot;,&quot;nologo&quot;)" executed="True" result="Success" success="True" time="0.002" asserts="6" />
+                              <test-case name="NUnit.ConsoleRunner.Tests.CommandLineTests.BooleanOptionAreRecognized(&quot;noshadow&quot;,&quot;noshadow&quot;)" executed="True" result="Success" success="True" time="0.001" asserts="6" />
+                              <test-case name="NUnit.ConsoleRunner.Tests.CommandLineTests.BooleanOptionAreRecognized(&quot;nothread&quot;,&quot;nothread&quot;)" executed="True" result="Success" success="True" time="0.001" asserts="6" />
+                            </results>
+                          </test-suite>
+                          <test-suite type="ParameterizedTest" name="EnumOptionsAreRecognized" executed="True" result="Success" success="True" time="0.003" asserts="0">
+                            <results>
+                              <test-case name="NUnit.ConsoleRunner.Tests.CommandLineTests.EnumOptionsAreRecognized(&quot;trace&quot;)" executed="True" result="Success" success="True" time="0.000" asserts="2" />
+                              <test-case name="NUnit.ConsoleRunner.Tests.CommandLineTests.EnumOptionsAreRecognized(&quot;domain&quot;)" executed="True" result="Success" success="True" time="0.000" asserts="2" />
+                            </results>
+                          </test-suite>
+                          <test-case name="NUnit.ConsoleRunner.Tests.CommandLineTests.FileNameWithoutXmlParameterLooksLikeParameter" executed="True" result="Success" success="True" time="0.000" asserts="2" />
+                          <test-case name="NUnit.ConsoleRunner.Tests.CommandLineTests.FixtureNamePlusAssemblyIsValid" executed="True" result="Success" success="True" time="0.000" asserts="3" />
+                          <test-case name="NUnit.ConsoleRunner.Tests.CommandLineTests.HelpTextUsesCorrectDelimiterForPlatform" executed="True" result="Success" success="True" time="0.001" asserts="2" />
+                          <test-case name="NUnit.ConsoleRunner.Tests.CommandLineTests.InvalidCommandLineParms" executed="True" result="Success" success="True" time="0.001" asserts="1" />
+                          <test-case name="NUnit.ConsoleRunner.Tests.CommandLineTests.InvalidOption" executed="True" result="Success" success="True" time="0.001" asserts="1" />
+                          <test-case name="NUnit.ConsoleRunner.Tests.CommandLineTests.NoFixtureNameProvided" executed="True" result="Success" success="True" time="0.001" asserts="1" />
+                          <test-case name="NUnit.ConsoleRunner.Tests.CommandLineTests.NoParametersCount" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                          <test-suite type="ParameterizedTest" name="StringOptionsAreRecognized" executed="True" result="Success" success="True" time="0.028" asserts="0">
+                            <results>
+                              <test-case name="NUnit.ConsoleRunner.Tests.CommandLineTests.StringOptionsAreRecognized(&quot;result&quot;,&quot;xml&quot;)" executed="True" result="Success" success="True" time="0.001" asserts="6" />
+                              <test-case name="NUnit.ConsoleRunner.Tests.CommandLineTests.StringOptionsAreRecognized(&quot;run&quot;,&quot;run&quot;)" executed="True" result="Success" success="True" time="0.000" asserts="6" />
+                              <test-case name="NUnit.ConsoleRunner.Tests.CommandLineTests.StringOptionsAreRecognized(&quot;runlist&quot;,&quot;runlist&quot;)" executed="True" result="Success" success="True" time="0.000" asserts="6" />
+                              <test-case name="NUnit.ConsoleRunner.Tests.CommandLineTests.StringOptionsAreRecognized(&quot;config&quot;,&quot;config&quot;)" executed="True" result="Success" success="True" time="0.001" asserts="6" />
+                              <test-case name="NUnit.ConsoleRunner.Tests.CommandLineTests.StringOptionsAreRecognized(&quot;result&quot;,&quot;result&quot;)" executed="True" result="Success" success="True" time="0.000" asserts="6" />
+                              <test-case name="NUnit.ConsoleRunner.Tests.CommandLineTests.StringOptionsAreRecognized(&quot;output&quot;,&quot;out&quot;)" executed="True" result="Success" success="True" time="0.000" asserts="6" />
+                              <test-case name="NUnit.ConsoleRunner.Tests.CommandLineTests.StringOptionsAreRecognized(&quot;exclude&quot;,&quot;exclude&quot;)" executed="True" result="Success" success="True" time="0.001" asserts="6" />
+                              <test-case name="NUnit.ConsoleRunner.Tests.CommandLineTests.StringOptionsAreRecognized(&quot;output&quot;,&quot;output&quot;)" executed="True" result="Success" success="True" time="0.000" asserts="6" />
+                              <test-case name="NUnit.ConsoleRunner.Tests.CommandLineTests.StringOptionsAreRecognized(&quot;fixture&quot;,&quot;fixture&quot;)" executed="True" result="Success" success="True" time="0.001" asserts="6" />
+                              <test-case name="NUnit.ConsoleRunner.Tests.CommandLineTests.StringOptionsAreRecognized(&quot;err&quot;,&quot;err&quot;)" executed="True" result="Success" success="True" time="0.000" asserts="6" />
+                              <test-case name="NUnit.ConsoleRunner.Tests.CommandLineTests.StringOptionsAreRecognized(&quot;include&quot;,&quot;include&quot;)" executed="True" result="Success" success="True" time="0.000" asserts="6" />
+                            </results>
+                          </test-suite>
+                          <test-case name="NUnit.ConsoleRunner.Tests.CommandLineTests.XmlParameter" executed="True" result="Success" success="True" time="0.001" asserts="3" />
+                          <test-case name="NUnit.ConsoleRunner.Tests.CommandLineTests.XmlParameterWithFullPath" executed="True" result="Success" success="True" time="0.001" asserts="3" />
+                          <test-case name="NUnit.ConsoleRunner.Tests.CommandLineTests.XmlParameterWithFullPathUsingEqualSign" executed="True" result="Success" success="True" time="0.000" asserts="3" />
+                          <test-case name="NUnit.ConsoleRunner.Tests.CommandLineTests.XmlParameterWithoutFileNameIsInvalid" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                        </results>
+                      </test-suite>
+                      <test-suite type="TestFixture" name="CommandLineTests_MultipleAssemblies" executed="True" result="Success" success="True" time="0.010" asserts="0">
+                        <results>
+                          <test-case name="NUnit.ConsoleRunner.Tests.CommandLineTests_MultipleAssemblies.CheckParameters" executed="True" result="Success" success="True" time="0.000" asserts="2" />
+                          <test-case name="NUnit.ConsoleRunner.Tests.CommandLineTests_MultipleAssemblies.FixtureParameters" executed="True" result="Success" success="True" time="0.000" asserts="3" />
+                          <test-case name="NUnit.ConsoleRunner.Tests.CommandLineTests_MultipleAssemblies.FixtureValidate" executed="True" result="Success" success="True" time="0.001" asserts="1" />
+                          <test-case name="NUnit.ConsoleRunner.Tests.CommandLineTests_MultipleAssemblies.MultipleAssemblyValidate" executed="True" result="Success" success="True" time="0.001" asserts="1" />
+                          <test-case name="NUnit.ConsoleRunner.Tests.CommandLineTests_MultipleAssemblies.ParameterCount" executed="True" result="Success" success="True" time="0.001" asserts="1" />
+                        </results>
+                      </test-suite>
+                      <test-suite type="TestFixture" name="ConsoleRunnerTest" executed="True" result="Success" success="True" time="5.027" asserts="0">
+                        <results>
+                          <test-case name="NUnit.ConsoleRunner.Tests.ConsoleRunnerTest.AssemblyNotFound" executed="True" result="Success" success="True" time="0.026" asserts="1" />
+                          <test-case name="NUnit.ConsoleRunner.Tests.ConsoleRunnerTest.Bug1073539Test" executed="True" result="Success" success="True" time="0.336" asserts="1" />
+                          <test-case name="NUnit.ConsoleRunner.Tests.ConsoleRunnerTest.Bug1311644Test" executed="True" result="Success" success="True" time="0.359" asserts="1" />
+                          <test-case name="NUnit.ConsoleRunner.Tests.ConsoleRunnerTest.CanRunWithMultipleTestDomains" executed="True" result="Success" success="True" time="0.760" asserts="2" />
+                          <test-case name="NUnit.ConsoleRunner.Tests.ConsoleRunnerTest.CanRunWithMultipleTestDomains_NoThread" executed="True" result="Success" success="True" time="0.729" asserts="2" />
+                          <test-case name="NUnit.ConsoleRunner.Tests.ConsoleRunnerTest.CanRunWithoutTestDomain" executed="True" result="Success" success="True" time="0.053" asserts="2" />
+                          <test-case name="NUnit.ConsoleRunner.Tests.ConsoleRunnerTest.CanRunWithoutTestDomain_NoThread" executed="True" result="Success" success="True" time="0.052" asserts="2" />
+                          <test-case name="NUnit.ConsoleRunner.Tests.ConsoleRunnerTest.CanRunWithSingleTestDomain" executed="True" result="Success" success="True" time="0.435" asserts="2" />
+                          <test-case name="NUnit.ConsoleRunner.Tests.ConsoleRunnerTest.CanRunWithSingleTestDomain_NoThread" executed="True" result="Success" success="True" time="0.452" asserts="2" />
+                          <test-case name="NUnit.ConsoleRunner.Tests.ConsoleRunnerTest.FailureFixture" executed="True" result="Success" success="True" time="0.304" asserts="1" />
+                          <test-case name="NUnit.ConsoleRunner.Tests.ConsoleRunnerTest.InvalidFixture" executed="True" result="Success" success="True" time="0.254" asserts="1" />
+                          <test-case name="NUnit.ConsoleRunner.Tests.ConsoleRunnerTest.MultiFailureFixture" executed="True" result="Success" success="True" time="0.354" asserts="1" />
+                          <test-case name="NUnit.ConsoleRunner.Tests.ConsoleRunnerTest.OneOfTwoAssembliesNotFound" executed="True" result="Success" success="True" time="0.015" asserts="1" />
+                          <test-case name="NUnit.ConsoleRunner.Tests.ConsoleRunnerTest.SuccessFixture" executed="True" result="Success" success="True" time="0.286" asserts="1" />
+                          <test-case name="NUnit.ConsoleRunner.Tests.ConsoleRunnerTest.XmlResult" executed="True" result="Success" success="True" time="0.292" asserts="2" />
+                          <test-case name="NUnit.ConsoleRunner.Tests.ConsoleRunnerTest.XmlToConsole" executed="True" result="Success" success="True" time="0.284" asserts="2" />
+                        </results>
+                      </test-suite>
+                      <test-suite type="TestFixture" name="TestNameParserTests" executed="True" result="Success" success="True" time="0.028" asserts="0">
+                        <results>
+                          <test-suite type="ParameterizedTest" name="SingleName" executed="True" result="Success" success="True" time="0.018" asserts="0">
+                            <results>
+                              <test-case name="NUnit.ConsoleRunner.Tests.TestNameParserTests.SingleName(&quot;Test.Namespace.Fixture.Method()&quot;)" executed="True" result="Success" success="True" time="0.001" asserts="2" />
+                              <test-case name="NUnit.ConsoleRunner.Tests.TestNameParserTests.SingleName(&quot;  Test.Namespace.Fixture.Method  &quot;)" executed="True" result="Success" success="True" time="0.000" asserts="2" />
+                              <test-case name="NUnit.ConsoleRunner.Tests.TestNameParserTests.SingleName(&quot;  Test.Namespace.Fixture.Method  ,&quot;)" executed="True" result="Success" success="True" time="0.000" asserts="2" />
+                              <test-case name="NUnit.ConsoleRunner.Tests.TestNameParserTests.SingleName(&quot;Test.Namespace.Fixture.Method(\&quot;)\&quot;)&quot;)" executed="True" result="Success" success="True" time="0.000" asserts="2" />
+                              <test-case name="NUnit.ConsoleRunner.Tests.TestNameParserTests.SingleName(&quot;Test.Namespace.Fixture.Method,&quot;)" executed="True" result="Success" success="True" time="0.000" asserts="2" />
+                              <test-case name="NUnit.ConsoleRunner.Tests.TestNameParserTests.SingleName(&quot;Test.Namespace.Fixture.Method&quot;)" executed="True" result="Success" success="True" time="0.000" asserts="2" />
+                              <test-case name="NUnit.ConsoleRunner.Tests.TestNameParserTests.SingleName(&quot;Test.Namespace.Fixture.Method(\&quot;string,argument\&quot;)&quot;)" executed="True" result="Success" success="True" time="0.000" asserts="2" />
+                              <test-case name="NUnit.ConsoleRunner.Tests.TestNameParserTests.SingleName(&quot;Test.Namespace.Fixture.Method(1,2,3)&quot;)" executed="True" result="Success" success="True" time="0.001" asserts="2" />
+                              <test-case name="NUnit.ConsoleRunner.Tests.TestNameParserTests.SingleName(&quot;Test.Namespace.Fixture.Method&lt;int,int&gt;()&quot;)" executed="True" result="Success" success="True" time="0.000" asserts="2" />
+                            </results>
+                          </test-suite>
+                          <test-suite type="ParameterizedTest" name="TwoNames" executed="True" result="Success" success="True" time="0.007" asserts="0">
+                            <results>
+                              <test-case name="NUnit.ConsoleRunner.Tests.TestNameParserTests.TwoNames(&quot;Test.Namespace.Fixture.Method1(1,2)&quot;,&quot;Test.Namespace.Fixture.Method2(3,4)&quot;)" executed="True" result="Success" success="True" time="0.000" asserts="3" />
+                              <test-case name="NUnit.ConsoleRunner.Tests.TestNameParserTests.TwoNames(&quot;Test.Namespace.Fixture.Method1&quot;,&quot;Test.Namespace.Fixture.Method2,&quot;)" executed="True" result="Success" success="True" time="0.000" asserts="3" />
+                              <test-case name="NUnit.ConsoleRunner.Tests.TestNameParserTests.TwoNames(&quot;Test.Namespace.Fixture.Method1(\&quot;(\&quot;)&quot;,&quot;Test.Namespace.Fixture.Method2(\&quot;&lt;\&quot;)&quot;)" executed="True" result="Success" success="True" time="0.000" asserts="3" />
+                              <test-case name="NUnit.ConsoleRunner.Tests.TestNameParserTests.TwoNames(&quot;Test.Namespace.Fixture.Method1&quot;,&quot;Test.Namespace.Fixture.Method2&quot;)" executed="True" result="Success" success="True" time="0.000" asserts="3" />
+                            </results>
+                          </test-suite>
+                        </results>
+                      </test-suite>
+                    </results>
+                  </test-suite>
+                </results>
+              </test-suite>
+            </results>
+          </test-suite>
+        </results>
+      </test-suite>
+      <test-suite type="Assembly" name="C:\Program Files\NUnit 2.6\bin\tests/nunit.uiexception.tests.dll" executed="True" result="Success" success="True" time="1.340" asserts="0">
+        <results>
+          <test-suite type="Namespace" name="NUnit" executed="True" result="Success" success="True" time="1.340" asserts="0">
+            <results>
+              <test-suite type="Namespace" name="UiException" executed="True" result="Success" success="True" time="1.340" asserts="0">
+                <results>
+                  <test-suite type="Namespace" name="Tests" executed="True" result="Success" success="True" time="1.339" asserts="0">
+                    <results>
+                      <test-suite type="Namespace" name="CodeFormatters" executed="True" result="Success" success="True" time="0.346" asserts="0">
+                        <results>
+                          <test-suite type="TestFixture" name="TestCodeFormatterCollection" executed="True" result="Success" success="True" time="0.040" asserts="0">
+                            <results>
+                              <test-case name="NUnit.UiException.Tests.CodeFormatters.TestCodeFormatterCollection.Clear" executed="True" result="Success" success="True" time="0.003" asserts="1" />
+                              <test-case name="NUnit.UiException.Tests.CodeFormatters.TestCodeFormatterCollection.ContainsFormatterFromExtension" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                              <test-case name="NUnit.UiException.Tests.CodeFormatters.TestCodeFormatterCollection.Indexer_Can_Throw_UnknownExtensionException" executed="True" result="Success" success="True" time="0.002" asserts="0" />
+                              <test-case name="NUnit.UiException.Tests.CodeFormatters.TestCodeFormatterCollection.ItemIndexer_Can_Throw_NullExtensionException" executed="True" result="Success" success="True" time="0.000" asserts="0" />
+                              <test-case name="NUnit.UiException.Tests.CodeFormatters.TestCodeFormatterCollection.Register_Can_Throw_NullExtensionException" executed="True" result="Success" success="True" time="0.001" asserts="0" />
+                              <test-case name="NUnit.UiException.Tests.CodeFormatters.TestCodeFormatterCollection.Register_Can_Throw_NullFormatterException" executed="True" result="Success" success="True" time="0.001" asserts="0" />
+                              <test-case name="NUnit.UiException.Tests.CodeFormatters.TestCodeFormatterCollection.Register_Check_Extension_Case" executed="True" result="Success" success="True" time="0.001" asserts="0" />
+                              <test-case name="NUnit.UiException.Tests.CodeFormatters.TestCodeFormatterCollection.Register_Check_Extension_Is_Not_Empty" executed="True" result="Success" success="True" time="0.001" asserts="0" />
+                              <test-case name="NUnit.UiException.Tests.CodeFormatters.TestCodeFormatterCollection.Register_Check_Extension_Not_Contain_Dot_Character" executed="True" result="Success" success="True" time="0.001" asserts="0" />
+                              <test-case name="NUnit.UiException.Tests.CodeFormatters.TestCodeFormatterCollection.Register_Check_Multiple_Extension_Definition" executed="True" result="Success" success="True" time="0.001" asserts="0" />
+                              <test-case name="NUnit.UiException.Tests.CodeFormatters.TestCodeFormatterCollection.Remove" executed="True" result="Success" success="True" time="0.002" asserts="4" />
+                              <test-case name="NUnit.UiException.Tests.CodeFormatters.TestCodeFormatterCollection.Remove_Is_Not_Case_Sensitive" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                              <test-case name="NUnit.UiException.Tests.CodeFormatters.TestCodeFormatterCollection.StringIndexer_Can_Throw_NullExtensionException" executed="True" result="Success" success="True" time="0.001" asserts="0" />
+                              <test-case name="NUnit.UiException.Tests.CodeFormatters.TestCodeFormatterCollection.Test_Default" executed="True" result="Success" success="True" time="0.002" asserts="10" />
+                            </results>
+                          </test-suite>
+                          <test-suite type="TestFixture" name="TestCSharpCodeFormatter" executed="True" result="Success" success="True" time="0.039" asserts="0">
+                            <results>
+                              <test-case name="NUnit.UiException.Tests.CodeFormatters.TestCSharpCodeFormatter.Format_Can_Throw_CSharpNullException" executed="True" result="Success" success="True" time="0.001" asserts="0" />
+                              <test-case name="NUnit.UiException.Tests.CodeFormatters.TestCSharpCodeFormatter.Test_Conserve_Intermediary_Spaces" executed="True" result="Success" success="True" time="0.021" asserts="9" />
+                              <test-case name="NUnit.UiException.Tests.CodeFormatters.TestCSharpCodeFormatter.Test_Default" executed="True" result="Success" success="True" time="0.001" asserts="4" />
+                              <test-case name="NUnit.UiException.Tests.CodeFormatters.TestCSharpCodeFormatter.Test_Format" executed="True" result="Success" success="True" time="0.004" asserts="1" />
+                              <test-case name="NUnit.UiException.Tests.CodeFormatters.TestCSharpCodeFormatter.Test_Format_2" executed="True" result="Success" success="True" time="0.001" asserts="1" />
+                              <test-case name="NUnit.UiException.Tests.CodeFormatters.TestCSharpCodeFormatter.Test_Format_3" executed="True" result="Success" success="True" time="0.001" asserts="2" />
+                              <test-case name="NUnit.UiException.Tests.CodeFormatters.TestCSharpCodeFormatter.Test_PreProcess" executed="True" result="Success" success="True" time="0.000" asserts="3" />
+                            </results>
+                          </test-suite>
+                          <test-suite type="TestFixture" name="TestFormattedCode" executed="True" result="Success" success="True" time="0.028" asserts="0">
+                            <results>
+                              <test-case name="NUnit.UiException.Tests.CodeFormatters.TestFormattedCode.CheckData_Can_Throw_NullDataException" executed="True" result="Success" success="True" time="0.002" asserts="0" />
+                              <test-case name="NUnit.UiException.Tests.CodeFormatters.TestFormattedCode.CheckData_IndexArray_And_TagArray_Count_Must_Match" executed="True" result="Success" success="True" time="0.001" asserts="0" />
+                              <test-case name="NUnit.UiException.Tests.CodeFormatters.TestFormattedCode.CheckData_LineArray_Values_Must_Always_Grow_Up" executed="True" result="Success" success="True" time="0.001" asserts="0" />
+                              <test-case name="NUnit.UiException.Tests.CodeFormatters.TestFormattedCode.CheckData_LineArray_Values_Must_Be_In_IndexArray_Count" executed="True" result="Success" success="True" time="0.001" asserts="0" />
+                              <test-case name="NUnit.UiException.Tests.CodeFormatters.TestFormattedCode.Empty" executed="True" result="Success" success="True" time="0.000" asserts="2" />
+                              <test-case name="NUnit.UiException.Tests.CodeFormatters.TestFormattedCode.Test_ComplexCollection" executed="True" result="Success" success="True" time="0.004" asserts="22" />
+                              <test-case name="NUnit.UiException.Tests.CodeFormatters.TestFormattedCode.Test_Equals" executed="True" result="Success" success="True" time="0.001" asserts="10" />
+                              <test-case name="NUnit.UiException.Tests.CodeFormatters.TestFormattedCode.Test_MaxLength" executed="True" result="Success" success="True" time="0.002" asserts="3" />
+                              <test-case name="NUnit.UiException.Tests.CodeFormatters.TestFormattedCode.Test_SimpleCollection" executed="True" result="Success" success="True" time="0.002" asserts="17" />
+                            </results>
+                          </test-suite>
+                          <test-suite type="TestFixture" name="TestGeneralCodeFormatter" executed="True" result="Success" success="True" time="0.093" asserts="0">
+                            <results>
+                              <test-case name="NUnit.UiException.Tests.CodeFormatters.TestGeneralCodeFormatter.All_Formatters_Have_Unique_Language_Value" executed="True" result="Success" success="True" time="0.003" asserts="2" />
+                              <test-case name="NUnit.UiException.Tests.CodeFormatters.TestGeneralCodeFormatter.All_Formatters_Should_Have_Overwrite_Behavior" executed="True" result="Success" success="True" time="0.003" asserts="2" />
+                              <test-case name="NUnit.UiException.Tests.CodeFormatters.TestGeneralCodeFormatter.All_Formatters_Should_PreProcess_Tab_Character" executed="True" result="Success" success="True" time="0.001" asserts="2" />
+                              <test-case name="NUnit.UiException.Tests.CodeFormatters.TestGeneralCodeFormatter.Any_Formatter_Should_Format_Any_Text" executed="True" result="Success" success="True" time="0.032" asserts="6" />
+                              <test-case name="NUnit.UiException.Tests.CodeFormatters.TestGeneralCodeFormatter.DefaultFormatter" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                              <test-case name="NUnit.UiException.Tests.CodeFormatters.TestGeneralCodeFormatter.DefaultFormatter_Can_Throw_FormatterNullException" executed="True" result="Success" success="True" time="0.001" asserts="0" />
+                              <test-case name="NUnit.UiException.Tests.CodeFormatters.TestGeneralCodeFormatter.Format" executed="True" result="Success" success="True" time="0.000" asserts="2" />
+                              <test-case name="NUnit.UiException.Tests.CodeFormatters.TestGeneralCodeFormatter.Format_Can_Throw_CodeNullException" executed="True" result="Success" success="True" time="0.001" asserts="0" />
+                              <test-case name="NUnit.UiException.Tests.CodeFormatters.TestGeneralCodeFormatter.Format_Can_Throw_LanguageNameNullException" executed="True" result="Success" success="True" time="0.001" asserts="0" />
+                              <test-case name="NUnit.UiException.Tests.CodeFormatters.TestGeneralCodeFormatter.Format_Pick_Best_Formatter" executed="True" result="Success" success="True" time="0.017" asserts="2" />
+                              <test-case name="NUnit.UiException.Tests.CodeFormatters.TestGeneralCodeFormatter.FormatFromExtension_Can_Throw_CodeNullException" executed="True" result="Success" success="True" time="0.001" asserts="0" />
+                              <test-case name="NUnit.UiException.Tests.CodeFormatters.TestGeneralCodeFormatter.FormatFromExtension_Can_Throw_ExtensionNullException" executed="True" result="Success" success="True" time="0.001" asserts="0" />
+                              <test-case name="NUnit.UiException.Tests.CodeFormatters.TestGeneralCodeFormatter.GetFormatterFromExtension_Can_Throw_ExtensionNullException" executed="True" result="Success" success="True" time="0.001" asserts="0" />
+                              <test-case name="NUnit.UiException.Tests.CodeFormatters.TestGeneralCodeFormatter.GetFormatterFromLanguage_Can_Throw_LanguageNullException" executed="True" result="Success" success="True" time="0.001" asserts="0" />
+                              <test-case name="NUnit.UiException.Tests.CodeFormatters.TestGeneralCodeFormatter.GetFormatterFroms" executed="True" result="Success" success="True" time="0.000" asserts="4" />
+                              <test-case name="NUnit.UiException.Tests.CodeFormatters.TestGeneralCodeFormatter.LanguageFromExtension" executed="True" result="Success" success="True" time="0.000" asserts="3" />
+                              <test-case name="NUnit.UiException.Tests.CodeFormatters.TestGeneralCodeFormatter.Test_Default" executed="True" result="Success" success="True" time="0.000" asserts="3" />
+                            </results>
+                          </test-suite>
+                          <test-suite type="TestFixture" name="TestLexer" executed="True" result="Success" success="True" time="0.035" asserts="0">
+                            <results>
+                              <test-case name="NUnit.UiException.Tests.CodeFormatters.TestLexer.Test_Default" executed="True" result="Success" success="True" time="0.001" asserts="3" />
+                              <test-case name="NUnit.UiException.Tests.CodeFormatters.TestLexer.Test_Dot_Character" executed="True" result="Success" success="True" time="0.003" asserts="5" />
+                              <test-case name="NUnit.UiException.Tests.CodeFormatters.TestLexer.Test_SetText_Throws_NullArgumentException" executed="True" result="Success" success="True" time="0.001" asserts="0" />
+                              <test-case name="NUnit.UiException.Tests.CodeFormatters.TestLexer.Test_Split_ColonCharacter" executed="True" result="Success" success="True" time="0.001" asserts="20" />
+                              <test-case name="NUnit.UiException.Tests.CodeFormatters.TestLexer.Test_Split_CommentC" executed="True" result="Success" success="True" time="0.001" asserts="10" />
+                              <test-case name="NUnit.UiException.Tests.CodeFormatters.TestLexer.Test_Split_CommentCpp" executed="True" result="Success" success="True" time="0.000" asserts="5" />
+                              <test-case name="NUnit.UiException.Tests.CodeFormatters.TestLexer.Test_Split_DoubleQuote" executed="True" result="Success" success="True" time="0.001" asserts="19" />
+                              <test-case name="NUnit.UiException.Tests.CodeFormatters.TestLexer.Test_Split_Equals" executed="True" result="Success" success="True" time="0.000" asserts="5" />
+                              <test-case name="NUnit.UiException.Tests.CodeFormatters.TestLexer.Test_Split_New_Line" executed="True" result="Success" success="True" time="0.000" asserts="5" />
+                              <test-case name="NUnit.UiException.Tests.CodeFormatters.TestLexer.Test_Split_NumberSign" executed="True" result="Success" success="True" time="0.000" asserts="5" />
+                              <test-case name="NUnit.UiException.Tests.CodeFormatters.TestLexer.Test_Split_SingleQuote" executed="True" result="Success" success="True" time="0.000" asserts="5" />
+                              <test-case name="NUnit.UiException.Tests.CodeFormatters.TestLexer.Test_Split_WhiteSpaces" executed="True" result="Success" success="True" time="0.002" asserts="35" />
+                              <test-case name="NUnit.UiException.Tests.CodeFormatters.TestLexer.Test_Split_Words" executed="True" result="Success" success="True" time="0.001" asserts="10" />
+                            </results>
+                          </test-suite>
+                          <test-suite type="TestFixture" name="TestPlainTextCodeFormatter" executed="True" result="Success" success="True" time="0.010" asserts="0">
+                            <results>
+                              <test-case name="NUnit.UiException.Tests.CodeFormatters.TestPlainTextCodeFormatter.Format_Can_Throw_CodeNullException" executed="True" result="Success" success="True" time="0.001" asserts="0" />
+                              <test-case name="NUnit.UiException.Tests.CodeFormatters.TestPlainTextCodeFormatter.Format_HelloWorld" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                              <test-case name="NUnit.UiException.Tests.CodeFormatters.TestPlainTextCodeFormatter.Format_Lines" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                              <test-case name="NUnit.UiException.Tests.CodeFormatters.TestPlainTextCodeFormatter.Test_Language" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                              <test-case name="NUnit.UiException.Tests.CodeFormatters.TestPlainTextCodeFormatter.Test_PreProcess" executed="True" result="Success" success="True" time="0.001" asserts="3" />
+                            </results>
+                          </test-suite>
+                          <test-suite type="TestFixture" name="TestToken" executed="True" result="Success" success="True" time="0.001" asserts="0">
+                            <results>
+                              <test-case name="NUnit.UiException.Tests.CodeFormatters.TestToken.Test_Equals" executed="True" result="Success" success="True" time="0.001" asserts="6" />
+                            </results>
+                          </test-suite>
+                          <test-suite type="TestFixture" name="TestTokenClassifier" executed="True" result="Success" success="True" time="0.041" asserts="0">
+                            <results>
+                              <test-case name="NUnit.UiException.Tests.CodeFormatters.TestTokenClassifier.test_AcceptToken" executed="True" result="Success" success="True" time="0.004" asserts="60" />
+                              <test-case name="NUnit.UiException.Tests.CodeFormatters.TestTokenClassifier.Test_Classification_Cases" executed="True" result="Success" success="True" time="0.003" asserts="32" />
+                              <test-case name="NUnit.UiException.Tests.CodeFormatters.TestTokenClassifier.Test_Classify" executed="True" result="Success" success="True" time="0.003" asserts="60" />
+                              <test-case name="NUnit.UiException.Tests.CodeFormatters.TestTokenClassifier.Test_Classify_As_Keyword" executed="True" result="Success" success="True" time="0.004" asserts="81" />
+                              <test-case name="NUnit.UiException.Tests.CodeFormatters.TestTokenClassifier.Test_Classify_Can_Throw_ArgumentNullException" executed="True" result="Success" success="True" time="0.001" asserts="0" />
+                              <test-case name="NUnit.UiException.Tests.CodeFormatters.TestTokenClassifier.Test_Classify_Throw_NullArgException" executed="True" result="Success" success="True" time="0.001" asserts="0" />
+                              <test-case name="NUnit.UiException.Tests.CodeFormatters.TestTokenClassifier.Test_Escaping_sequence" executed="True" result="Success" success="True" time="0.005" asserts="61" />
+                              <test-case name="NUnit.UiException.Tests.CodeFormatters.TestTokenClassifier.Test_NewState" executed="True" result="Success" success="True" time="0.005" asserts="40" />
+                              <test-case name="NUnit.UiException.Tests.CodeFormatters.TestTokenClassifier.Test_Reset" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                            </results>
+                          </test-suite>
+                          <test-suite type="TestFixture" name="TestTokenDictionary" executed="True" result="Success" success="True" time="0.035" asserts="0">
+                            <results>
+                              <test-case name="NUnit.UiException.Tests.CodeFormatters.TestTokenDictionary.Add_can_throw_AlreadyDefinedException" executed="True" result="Success" success="True" time="0.002" asserts="2" />
+                              <test-case name="NUnit.UiException.Tests.CodeFormatters.TestTokenDictionary.Add_can_throw_EmptySequenceException" executed="True" result="Success" success="True" time="0.001" asserts="2" />
+                              <test-case name="NUnit.UiException.Tests.CodeFormatters.TestTokenDictionary.Add_can_throw_InvalidSortException" executed="True" result="Success" success="True" time="0.001" asserts="2" />
+                              <test-case name="NUnit.UiException.Tests.CodeFormatters.TestTokenDictionary.Add_can_throw_NullValueException" executed="True" result="Success" success="True" time="0.000" asserts="2" />
+                              <test-case name="NUnit.UiException.Tests.CodeFormatters.TestTokenDictionary.add_token" executed="True" result="Success" success="True" time="0.000" asserts="3" />
+                              <test-case name="NUnit.UiException.Tests.CodeFormatters.TestTokenDictionary.PopulateTokenStartingWith" executed="True" result="Success" success="True" time="0.002" asserts="14" />
+                              <test-case name="NUnit.UiException.Tests.CodeFormatters.TestTokenDictionary.PopulateTokenStartingWith_can_throw_NullOutputException" executed="True" result="Success" success="True" time="0.001" asserts="2" />
+                              <test-case name="NUnit.UiException.Tests.CodeFormatters.TestTokenDictionary.PopulateTokenStartingWith_can_throw_NullStarterException" executed="True" result="Success" success="True" time="0.001" asserts="2" />
+                              <test-case name="NUnit.UiException.Tests.CodeFormatters.TestTokenDictionary.test_default" executed="True" result="Success" success="True" time="0.001" asserts="3" />
+                              <test-case name="NUnit.UiException.Tests.CodeFormatters.TestTokenDictionary.TryMatch_can_throw_NullPredictionException" executed="True" result="Success" success="True" time="0.001" asserts="2" />
+                              <test-case name="NUnit.UiException.Tests.CodeFormatters.TestTokenDictionary.TryMatch_can_throw_NullTextException" executed="True" result="Success" success="True" time="0.001" asserts="2" />
+                              <test-case name="NUnit.UiException.Tests.CodeFormatters.TestTokenDictionary.TryMatch_no_prediction" executed="True" result="Success" success="True" time="0.002" asserts="146" />
+                              <test-case name="NUnit.UiException.Tests.CodeFormatters.TestTokenDictionary.TryMatch_prediction" executed="True" result="Success" success="True" time="0.002" asserts="19" />
+                            </results>
+                          </test-suite>
+                        </results>
+                      </test-suite>
+                      <test-suite type="Namespace" name="Controls" executed="True" result="Success" success="True" time="0.767" asserts="0">
+                        <results>
+                          <test-suite type="TestFixture" name="TestCodeBox" executed="True" result="Success" success="True" time="0.185" asserts="0">
+                            <results>
+                              <test-case name="NUnit.UiException.Tests.Controls.TestCodeBox.Can_Disable_ShowCurrentLine" executed="True" result="Success" success="True" time="0.134" asserts="3" />
+                              <test-case name="NUnit.UiException.Tests.Controls.TestCodeBox.Can_Set_Back_And_Fore_Colors" executed="True" result="Success" success="True" time="0.006" asserts="2" />
+                              <test-case name="NUnit.UiException.Tests.Controls.TestCodeBox.Changing_Font_Causes_Reformatting" executed="True" result="Success" success="True" time="0.007" asserts="2" />
+                              <test-case name="NUnit.UiException.Tests.Controls.TestCodeBox.Changing_Language_Causes_Reformatting" executed="True" result="Success" success="True" time="0.005" asserts="3" />
+                              <test-case name="NUnit.UiException.Tests.Controls.TestCodeBox.CurrentLine" executed="True" result="Success" success="True" time="0.007" asserts="5" />
+                              <test-case name="NUnit.UiException.Tests.Controls.TestCodeBox.DefaultState" executed="True" result="Success" success="True" time="0.002" asserts="11" />
+                              <test-case name="NUnit.UiException.Tests.Controls.TestCodeBox.Format_Text_With_Language" executed="True" result="Success" success="True" time="0.003" asserts="3" />
+                              <test-case name="NUnit.UiException.Tests.Controls.TestCodeBox.OnPaint" executed="True" result="Success" success="True" time="0.003" asserts="1" />
+                            </results>
+                          </test-suite>
+                          <test-suite type="TestFixture" name="TestCodeRenderingContext" executed="True" result="Success" success="True" time="0.011" asserts="0">
+                            <results>
+                              <test-case name="NUnit.UiException.Tests.Controls.TestCodeRenderingContext.Can_Change_Colors" executed="True" result="Success" success="True" time="0.006" asserts="43" />
+                              <test-case name="NUnit.UiException.Tests.Controls.TestCodeRenderingContext.DefaultState" executed="True" result="Success" success="True" time="0.003" asserts="38" />
+                            </results>
+                          </test-suite>
+                          <test-suite type="TestFixture" name="TestDefaultCodeRenderer" executed="True" result="Success" success="True" time="0.023" asserts="0">
+                            <results>
+                              <test-case name="NUnit.UiException.Tests.Controls.TestDefaultCodeRenderer.DrawToGraphics_Can_Raise_ArgumentNullException" executed="True" result="Success" success="True" time="0.003" asserts="2" />
+                              <test-case name="NUnit.UiException.Tests.Controls.TestDefaultCodeRenderer.GetDocumentSize" executed="True" result="Success" success="True" time="0.001" asserts="4" />
+                              <test-case name="NUnit.UiException.Tests.Controls.TestDefaultCodeRenderer.GetDocumentSize_Can_Raise_ArgumentNullException" executed="True" result="Success" success="True" time="0.001" asserts="3" />
+                              <test-case name="NUnit.UiException.Tests.Controls.TestDefaultCodeRenderer.LineIndexToYCoordinate" executed="True" result="Success" success="True" time="0.001" asserts="4" />
+                              <test-case name="NUnit.UiException.Tests.Controls.TestDefaultCodeRenderer.LineIndexToYCoordinate_Can_Raise_ArgumentNullException" executed="True" result="Success" success="True" time="0.001" asserts="2" />
+                              <test-case name="NUnit.UiException.Tests.Controls.TestDefaultCodeRenderer.ViewportLines" executed="True" result="Success" success="True" time="0.006" asserts="32" />
+                            </results>
+                          </test-suite>
+                          <test-suite type="TestFixture" name="TestDefaultErrorListRenderer" executed="True" result="Success" success="True" time="0.081" asserts="0">
+                            <results>
+                              <test-case name="NUnit.UiException.Tests.Controls.TestDefaultErrorListRenderer.DefaultState" executed="True" result="Success" success="True" time="0.013" asserts="2" />
+                              <test-case name="NUnit.UiException.Tests.Controls.TestDefaultErrorListRenderer.DrawToGraphics_Can_Throw_ArgumentNullException" executed="True" result="Success" success="True" time="0.003" asserts="2" />
+                              <test-case name="NUnit.UiException.Tests.Controls.TestDefaultErrorListRenderer.GetDocumentSize" executed="True" result="Success" success="True" time="0.003" asserts="5" />
+                              <test-case name="NUnit.UiException.Tests.Controls.TestDefaultErrorListRenderer.IsDirty" executed="True" result="Success" success="True" time="0.044" asserts="7" />
+                              <test-case name="NUnit.UiException.Tests.Controls.TestDefaultErrorListRenderer.ItemAt" executed="True" result="Success" success="True" time="0.004" asserts="7" />
+                              <test-case name="NUnit.UiException.Tests.Controls.TestDefaultErrorListRenderer.MeasureItem" executed="True" result="Success" success="True" time="0.003" asserts="6" />
+                            </results>
+                          </test-suite>
+                          <test-suite type="TestFixture" name="TestErrorBrowser" executed="True" result="Success" success="True" time="0.137" asserts="0">
+                            <results>
+                              <test-case name="NUnit.UiException.Tests.Controls.TestErrorBrowser.Can_Raise_ErrorSourceChanged" executed="True" result="Success" success="True" time="0.089" asserts="3" />
+                              <test-case name="NUnit.UiException.Tests.Controls.TestErrorBrowser.Cannot_Register_Null_Display" executed="True" result="Success" success="True" time="0.001" asserts="0" />
+                              <test-case name="NUnit.UiException.Tests.Controls.TestErrorBrowser.DefaultState" executed="True" result="Success" success="True" time="0.003" asserts="10" />
+                              <test-case name="NUnit.UiException.Tests.Controls.TestErrorBrowser.ErrorDisplay_Plugins_life_cycle_events" executed="True" result="Success" success="True" time="0.031" asserts="13" />
+                              <test-case name="NUnit.UiException.Tests.Controls.TestErrorBrowser.LayoutPanel_Auto_Resizes_When_Parent_Sizes_Change" executed="True" result="Success" success="True" time="0.004" asserts="4" />
+                            </results>
+                          </test-suite>
+                          <test-suite type="TestFixture" name="TestErrorList" executed="True" result="Success" success="True" time="0.062" asserts="0">
+                            <results>
+                              <test-case name="NUnit.UiException.Tests.Controls.TestErrorList.AutoSelectFirstItem" executed="True" result="Success" success="True" time="0.010" asserts="4" />
+                              <test-case name="NUnit.UiException.Tests.Controls.TestErrorList.CanReportInvalidItems" executed="True" result="Success" success="True" time="0.001" asserts="3" />
+                              <test-case name="NUnit.UiException.Tests.Controls.TestErrorList.Click_Can_Select_Item" executed="True" result="Success" success="True" time="0.004" asserts="4" />
+                              <test-case name="NUnit.UiException.Tests.Controls.TestErrorList.CurrentSelection" executed="True" result="Success" success="True" time="0.002" asserts="10" />
+                              <test-case name="NUnit.UiException.Tests.Controls.TestErrorList.DefaultState" executed="True" result="Success" success="True" time="0.002" asserts="7" />
+                              <test-case name="NUnit.UiException.Tests.Controls.TestErrorList.DrawItem" executed="True" result="Success" success="True" time="0.014" asserts="9" />
+                              <test-case name="NUnit.UiException.Tests.Controls.TestErrorList.Invoking_DrawToGraphics" executed="True" result="Success" success="True" time="0.004" asserts="0" />
+                              <test-case name="NUnit.UiException.Tests.Controls.TestErrorList.ListOrderPolicy" executed="True" result="Success" success="True" time="0.004" asserts="22" />
+                              <test-case name="NUnit.UiException.Tests.Controls.TestErrorList.Populate_StackTraceSource" executed="True" result="Success" success="True" time="0.003" asserts="6" />
+                            </results>
+                          </test-suite>
+                          <test-suite type="TestFixture" name="TestErrorPanelLayout" executed="True" result="Success" success="True" time="0.009" asserts="0">
+                            <results>
+                              <test-case name="NUnit.UiException.Tests.Controls.TestErrorPanelLayout.Can_Layout_Child_Controls_When_Size_Changed" executed="True" result="Success" success="True" time="0.001" asserts="16" />
+                              <test-case name="NUnit.UiException.Tests.Controls.TestErrorPanelLayout.DefaultState" executed="True" result="Success" success="True" time="0.000" asserts="13" />
+                              <test-case name="NUnit.UiException.Tests.Controls.TestErrorPanelLayout.Setting_Content" executed="True" result="Success" success="True" time="0.001" asserts="21" />
+                              <test-case name="NUnit.UiException.Tests.Controls.TestErrorPanelLayout.Setting_Toolbar" executed="True" result="Success" success="True" time="0.001" asserts="14" />
+                            </results>
+                          </test-suite>
+                          <test-suite type="TestFixture" name="TestErrorToolbar" executed="True" result="Success" success="True" time="0.093" asserts="0">
+                            <results>
+                              <test-case name="NUnit.UiException.Tests.Controls.TestErrorToolbar.Cannot_Register_Null_Display" executed="True" result="Success" success="True" time="0.003" asserts="2" />
+                              <test-case name="NUnit.UiException.Tests.Controls.TestErrorToolbar.Cannot_Select_UnRegistered_Display" executed="True" result="Success" success="True" time="0.002" asserts="0" />
+                              <test-case name="NUnit.UiException.Tests.Controls.TestErrorToolbar.DefaultState" executed="True" result="Success" success="True" time="0.003" asserts="8" />
+                              <test-case name="NUnit.UiException.Tests.Controls.TestErrorToolbar.NewStripButton" executed="True" result="Success" success="True" time="0.005" asserts="1" />
+                              <test-case name="NUnit.UiException.Tests.Controls.TestErrorToolbar.PluginItem_Click_Raises_SelectedRenderedChanged" executed="True" result="Success" success="True" time="0.020" asserts="4" />
+                              <test-case name="NUnit.UiException.Tests.Controls.TestErrorToolbar.Registering_displays_adds_ToolStripItem" executed="True" result="Success" success="True" time="0.036" asserts="8" />
+                              <test-case name="NUnit.UiException.Tests.Controls.TestErrorToolbar.SelectedDisplay" executed="True" result="Success" success="True" time="0.004" asserts="9" />
+                              <test-case name="NUnit.UiException.Tests.Controls.TestErrorToolbar.Set_Or_Unset_Check_Flag_On_Selection" executed="True" result="Success" success="True" time="0.004" asserts="6" />
+                            </results>
+                          </test-suite>
+                          <test-suite type="TestFixture" name="TestSourceCodeDisplay" executed="True" result="Success" success="True" time="0.072" asserts="0">
+                            <results>
+                              <test-case name="NUnit.UiException.Tests.Controls.TestSourceCodeDisplay.CanReportFileException" executed="True" result="Success" success="True" time="0.023" asserts="2" />
+                              <test-case name="NUnit.UiException.Tests.Controls.TestSourceCodeDisplay.DefaultState" executed="True" result="Success" success="True" time="0.005" asserts="15" />
+                              <test-case name="NUnit.UiException.Tests.Controls.TestSourceCodeDisplay.ListOrderPolicy" executed="True" result="Success" success="True" time="0.004" asserts="2" />
+                              <test-case name="NUnit.UiException.Tests.Controls.TestSourceCodeDisplay.SelectedItemChanged" executed="True" result="Success" success="True" time="0.021" asserts="5" />
+                              <test-case name="NUnit.UiException.Tests.Controls.TestSourceCodeDisplay.SplitOrientation" executed="True" result="Success" success="True" time="0.004" asserts="4" />
+                              <test-case name="NUnit.UiException.Tests.Controls.TestSourceCodeDisplay.SplitterDistance" executed="True" result="Success" success="True" time="0.003" asserts="2" />
+                            </results>
+                          </test-suite>
+                          <test-suite type="TestFixture" name="TestSplitterBox" executed="True" result="Success" success="True" time="0.031" asserts="0">
+                            <results>
+                              <test-case name="NUnit.UiException.Tests.Controls.TestSplitterBox.CanChangeDefaultControl1" executed="True" result="Success" success="True" time="0.003" asserts="48" />
+                              <test-case name="NUnit.UiException.Tests.Controls.TestSplitterBox.CanChangeDefaultControl2" executed="True" result="Success" success="True" time="0.001" asserts="48" />
+                              <test-case name="NUnit.UiException.Tests.Controls.TestSplitterBox.ChangingSizeInvokeDoLayout" executed="True" result="Success" success="True" time="0.000" asserts="28" />
+                              <test-case name="NUnit.UiException.Tests.Controls.TestSplitterBox.CollapseControl" executed="True" result="Success" success="True" time="0.005" asserts="82" />
+                              <test-case name="NUnit.UiException.Tests.Controls.TestSplitterBox.DefaultState" executed="True" result="Success" success="True" time="0.001" asserts="51" />
+                              <test-case name="NUnit.UiException.Tests.Controls.TestSplitterBox.MouseActions" executed="True" result="Success" success="True" time="0.004" asserts="6" />
+                              <test-case name="NUnit.UiException.Tests.Controls.TestSplitterBox.OrientationAffectsLayout" executed="True" result="Success" success="True" time="0.000" asserts="25" />
+                              <test-case name="NUnit.UiException.Tests.Controls.TestSplitterBox.PointToSplit" executed="True" result="Success" success="True" time="0.001" asserts="75" />
+                              <test-case name="NUnit.UiException.Tests.Controls.TestSplitterBox.SplitterDistance" executed="True" result="Success" success="True" time="0.001" asserts="81" />
+                            </results>
+                          </test-suite>
+                          <test-suite type="TestFixture" name="TestStackTraceDisplay" executed="True" result="Success" success="True" time="0.039" asserts="0">
+                            <results>
+                              <test-case name="NUnit.UiException.Tests.Controls.TestStackTraceDisplay.CopyToClipBoard" executed="True" result="Success" success="True" time="0.028" asserts="4">
+                                <properties>
+                                  <property name="APARTMENT_STATE" value="STA" />
+                                </properties>
+                              </test-case>
+                              <test-case name="NUnit.UiException.Tests.Controls.TestStackTraceDisplay.DefaultState" executed="True" result="Success" success="True" time="0.002" asserts="10" />
+                              <test-case name="NUnit.UiException.Tests.Controls.TestStackTraceDisplay.FeedingDisplayWithGarbageDoesNotMakeItCrash" executed="True" result="Success" success="True" time="0.001" asserts="1" />
+                              <test-case name="NUnit.UiException.Tests.Controls.TestStackTraceDisplay.OnStackTraceChanged" executed="True" result="Success" success="True" time="0.000" asserts="3" />
+                            </results>
+                          </test-suite>
+                        </results>
+                      </test-suite>
+                      <test-suite type="Namespace" name="StackTraceAnalyzers" executed="True" result="Success" success="True" time="0.062" asserts="0">
+                        <results>
+                          <test-suite type="TestFixture" name="TestFunctionParser" executed="True" result="Success" success="True" time="0.012" asserts="0">
+                            <results>
+                              <test-case name="NUnit.UiException.Tests.StackTraceAnalyzers.TestFunctionParser.Test_Ability_To_Parse_Mono_Stack_Trace" executed="True" result="Success" success="True" time="0.001" asserts="2" />
+                              <test-case name="NUnit.UiException.Tests.StackTraceAnalyzers.TestFunctionParser.Test_Ability_To_Parse_Regular_Function_Values" executed="True" result="Success" success="True" time="0.001" asserts="7" />
+                              <test-case name="NUnit.UiException.Tests.StackTraceAnalyzers.TestFunctionParser.Test_Fail_To_Parse_Odd_Function_Values" executed="True" result="Success" success="True" time="0.001" asserts="5" />
+                              <test-case name="NUnit.UiException.Tests.StackTraceAnalyzers.TestFunctionParser.TestIErrorParser.Test_IErrorParser_Can_Throw_ArgsNullException" executed="True" result="Success" success="True" time="0.001" asserts="10" />
+                              <test-case name="NUnit.UiException.Tests.StackTraceAnalyzers.TestFunctionParser.TestIErrorParser.Test_IErrorParser_Can_Throw_ParserNullException" executed="True" result="Success" success="True" time="0.001" asserts="10" />
+                            </results>
+                          </test-suite>
+                          <test-suite type="TestFixture" name="TestIErrorParser" executed="True" result="Success" success="True" time="0.003" asserts="0">
+                            <results>
+                              <test-case name="NUnit.UiException.Tests.StackTraceAnalyzers.TestIErrorParser.Test_IErrorParser_Can_Throw_ArgsNullException" executed="True" result="Success" success="True" time="0.000" asserts="10" />
+                              <test-case name="NUnit.UiException.Tests.StackTraceAnalyzers.TestIErrorParser.Test_IErrorParser_Can_Throw_ParserNullException" executed="True" result="Success" success="True" time="0.000" asserts="10" />
+                            </results>
+                          </test-suite>
+                          <test-suite type="TestFixture" name="TestLineNumberParser" executed="True" result="Success" success="True" time="0.008" asserts="0">
+                            <results>
+                              <test-case name="NUnit.UiException.Tests.StackTraceAnalyzers.TestLineNumberParser.Test_Ability_To_Parse_Regular_Line_Number_Values" executed="True" result="Success" success="True" time="0.000" asserts="10" />
+                              <test-case name="NUnit.UiException.Tests.StackTraceAnalyzers.TestLineNumberParser.Test_Ability_To_Reject_Odd_Line_Number_Values" executed="True" result="Success" success="True" time="0.000" asserts="5" />
+                              <test-case name="NUnit.UiException.Tests.StackTraceAnalyzers.TestLineNumberParser.TestIErrorParser.Test_IErrorParser_Can_Throw_ArgsNullException" executed="True" result="Success" success="True" time="0.000" asserts="10" />
+                              <test-case name="NUnit.UiException.Tests.StackTraceAnalyzers.TestLineNumberParser.TestIErrorParser.Test_IErrorParser_Can_Throw_ParserNullException" executed="True" result="Success" success="True" time="0.000" asserts="10" />
+                            </results>
+                          </test-suite>
+                          <test-suite type="TestFixture" name="TestPathParser" executed="True" result="Success" success="True" time="0.008" asserts="0">
+                            <results>
+                              <test-case name="NUnit.UiException.Tests.StackTraceAnalyzers.TestPathParser.Test_Ability_To_Handle_Unix_Path_Like_Values" executed="True" result="Success" success="True" time="0.001" asserts="4" />
+                              <test-case name="NUnit.UiException.Tests.StackTraceAnalyzers.TestPathParser.Test_Ability_To_Handle_Windows_Path_Like_Values" executed="True" result="Success" success="True" time="0.000" asserts="4" />
+                              <test-case name="NUnit.UiException.Tests.StackTraceAnalyzers.TestPathParser.TestIErrorParser.Test_IErrorParser_Can_Throw_ArgsNullException" executed="True" result="Success" success="True" time="0.001" asserts="12" />
+                              <test-case name="NUnit.UiException.Tests.StackTraceAnalyzers.TestPathParser.TestIErrorParser.Test_IErrorParser_Can_Throw_ParserNullException" executed="True" result="Success" success="True" time="0.000" asserts="12" />
+                            </results>
+                          </test-suite>
+                          <test-suite type="TestFixture" name="TestUnixPathParser" executed="True" result="Success" success="True" time="0.012" asserts="0">
+                            <results>
+                              <test-case name="NUnit.UiException.Tests.StackTraceAnalyzers.TestUnixPathParser.Test_Ability_To_Parse_Regular_Unix_Like_Path_Values" executed="True" result="Success" success="True" time="0.001" asserts="21" />
+                              <test-case name="NUnit.UiException.Tests.StackTraceAnalyzers.TestUnixPathParser.Test_Inability_To_Parse_Non_Unix_Like_Path_Values" executed="True" result="Success" success="True" time="0.000" asserts="6" />
+                              <test-case name="NUnit.UiException.Tests.StackTraceAnalyzers.TestUnixPathParser.TestIErrorParser.Test_IErrorParser_Can_Throw_ArgsNullException" executed="True" result="Success" success="True" time="0.000" asserts="11" />
+                              <test-case name="NUnit.UiException.Tests.StackTraceAnalyzers.TestUnixPathParser.TestIErrorParser.Test_IErrorParser_Can_Throw_ParserNullException" executed="True" result="Success" success="True" time="0.003" asserts="11" />
+                            </results>
+                          </test-suite>
+                          <test-suite type="TestFixture" name="TestWindowsPathParser" executed="True" result="Success" success="True" time="0.008" asserts="0">
+                            <results>
+                              <test-case name="NUnit.UiException.Tests.StackTraceAnalyzers.TestWindowsPathParser.Test_Ability_To_Parse_Regular_Windows_Path" executed="True" result="Success" success="True" time="0.001" asserts="21" />
+                              <test-case name="NUnit.UiException.Tests.StackTraceAnalyzers.TestWindowsPathParser.Test_Inability_To_Parse_Non_Windows_Like_Path_Values" executed="True" result="Success" success="True" time="0.000" asserts="6" />
+                              <test-case name="NUnit.UiException.Tests.StackTraceAnalyzers.TestWindowsPathParser.TestIErrorParser.Test_IErrorParser_Can_Throw_ArgsNullException" executed="True" result="Success" success="True" time="0.001" asserts="11" />
+                              <test-case name="NUnit.UiException.Tests.StackTraceAnalyzers.TestWindowsPathParser.TestIErrorParser.Test_IErrorParser_Can_Throw_ParserNullException" executed="True" result="Success" success="True" time="0.001" asserts="11" />
+                            </results>
+                          </test-suite>
+                        </results>
+                      </test-suite>
+                      <test-suite type="TestFixture" name="TestDefaultTextManager" executed="True" result="Success" success="True" time="0.007" asserts="0">
+                        <results>
+                          <test-case name="NUnit.UiException.Tests.TestDefaultTextManager.Test_CodeBlockCollection" executed="True" result="Success" success="True" time="0.002" asserts="15" />
+                          <test-case name="NUnit.UiException.Tests.TestDefaultTextManager.Test_Default" executed="True" result="Success" success="True" time="0.001" asserts="3" />
+                          <test-case name="NUnit.UiException.Tests.TestDefaultTextManager.Test_MaxLength" executed="True" result="Success" success="True" time="0.001" asserts="3" />
+                        </results>
+                      </test-suite>
+                      <test-suite type="TestFixture" name="TestErrorItem" executed="True" result="Success" success="True" time="0.030" asserts="0">
+                        <results>
+                          <test-case name="NUnit.UiException.Tests.TestErrorItem.Can_Set_Properties" executed="True" result="Success" success="True" time="0.001" asserts="10" />
+                          <test-case name="NUnit.UiException.Tests.TestErrorItem.Ctor_2" executed="True" result="Success" success="True" time="0.001" asserts="10" />
+                          <test-case name="NUnit.UiException.Tests.TestErrorItem.Ctor_Throws_NullPathException" executed="True" result="Success" success="True" time="0.001" asserts="0" />
+                          <test-case name="NUnit.UiException.Tests.TestErrorItem.Ctor_With_Line_0" executed="True" result="Success" success="True" time="0.000" asserts="0" />
+                          <test-case name="NUnit.UiException.Tests.TestErrorItem.ReadFile" executed="True" result="Success" success="True" time="0.008" asserts="2" />
+                          <test-case name="NUnit.UiException.Tests.TestErrorItem.ReadFile_Throws_FileNotExistException" executed="True" result="Success" success="True" time="0.001" asserts="0" />
+                          <test-case name="NUnit.UiException.Tests.TestErrorItem.Test_Equals" executed="True" result="Success" success="True" time="0.001" asserts="8" />
+                          <test-case name="NUnit.UiException.Tests.TestErrorItem.Test_FileExtension" executed="True" result="Success" success="True" time="0.000" asserts="5" />
+                          <test-case name="NUnit.UiException.Tests.TestErrorItem.Test_MethodName" executed="True" result="Success" success="True" time="0.001" asserts="15" />
+                        </results>
+                      </test-suite>
+                      <test-suite type="TestFixture" name="TestErrorItemCollection" executed="True" result="Success" success="True" time="0.060" asserts="0">
+                        <results>
+                          <test-case name="NUnit.UiException.Tests.TestErrorItemCollection.Test_Add_Throws_NullItemException" executed="True" result="Success" success="True" time="0.015" asserts="0" />
+                          <test-case name="NUnit.UiException.Tests.TestErrorItemCollection.Test_Clear" executed="True" result="Success" success="True" time="0.012" asserts="2" />
+                          <test-case name="NUnit.UiException.Tests.TestErrorItemCollection.Test_Contains" executed="True" result="Success" success="True" time="0.012" asserts="3" />
+                          <test-case name="NUnit.UiException.Tests.TestErrorItemCollection.Test_TraceItems" executed="True" result="Success" success="True" time="0.014" asserts="7" />
+                        </results>
+                      </test-suite>
+                      <test-suite type="TestFixture" name="TestPaintLineLocation" executed="True" result="Success" success="True" time="0.008" asserts="0">
+                        <results>
+                          <test-case name="NUnit.UiException.Tests.TestPaintLineLocation.Test_Equals" executed="True" result="Success" success="True" time="0.002" asserts="8" />
+                          <test-case name="NUnit.UiException.Tests.TestPaintLineLocation.Test_PaintLineLocation" executed="True" result="Success" success="True" time="0.001" asserts="3" />
+                          <test-case name="NUnit.UiException.Tests.TestPaintLineLocation.Test_SetText_Throws_NullTextException" executed="True" result="Success" success="True" time="0.001" asserts="0" />
+                        </results>
+                      </test-suite>
+                      <test-suite type="TestFixture" name="TestStackTraceParser" executed="True" result="Success" success="True" time="0.025" asserts="0">
+                        <results>
+                          <test-case name="NUnit.UiException.Tests.TestStackTraceParser.Test_Ability_To_Handle_Different_Path_System_Syntaxes" executed="True" result="Success" success="True" time="0.001" asserts="3" />
+                          <test-case name="NUnit.UiException.Tests.TestStackTraceParser.Test_Ability_To_Handle_Files_With_Unknown_Extension" executed="True" result="Success" success="True" time="0.000" asserts="2" />
+                          <test-case name="NUnit.UiException.Tests.TestStackTraceParser.Test_Analysis_Does_Not_Depend_Upon_File_Extension" executed="True" result="Success" success="True" time="0.001" asserts="2" />
+                          <test-case name="NUnit.UiException.Tests.TestStackTraceParser.Test_Default" executed="True" result="Success" success="True" time="0.001" asserts="2" />
+                          <test-case name="NUnit.UiException.Tests.TestStackTraceParser.Test_English_Stack" executed="True" result="Success" success="True" time="0.001" asserts="2" />
+                          <test-case name="NUnit.UiException.Tests.TestStackTraceParser.Test_Missing_Line_Number" executed="True" result="Success" success="True" time="0.000" asserts="2" />
+                          <test-case name="NUnit.UiException.Tests.TestStackTraceParser.Test_Parse" executed="True" result="Success" success="True" time="0.000" asserts="3" />
+                          <test-case name="NUnit.UiException.Tests.TestStackTraceParser.Test_Parse_MultipleExtension" executed="True" result="Success" success="True" time="0.001" asserts="6" />
+                          <test-case name="NUnit.UiException.Tests.TestStackTraceParser.Test_Parse_Null" executed="True" result="Success" success="True" time="0.000" asserts="0" />
+                          <test-case name="NUnit.UiException.Tests.TestStackTraceParser.Test_Parse_With_Real_Life_Samples" executed="True" result="Success" success="True" time="0.000" asserts="5" />
+                          <test-case name="NUnit.UiException.Tests.TestStackTraceParser.Test_Trace_When_Missing_File" executed="True" result="Success" success="True" time="0.001" asserts="5" />
+                        </results>
+                      </test-suite>
+                    </results>
+                  </test-suite>
+                </results>
+              </test-suite>
+            </results>
+          </test-suite>
+        </results>
+      </test-suite>
+      <test-suite type="Assembly" name="C:\Program Files\NUnit 2.6\bin\tests/nunit.uikit.tests.dll" executed="True" result="Success" success="True" time="1.607" asserts="0">
+        <results>
+          <test-suite type="Namespace" name="NUnit" executed="True" result="Success" success="True" time="1.607" asserts="0">
+            <results>
+              <test-suite type="Namespace" name="UiKit" executed="True" result="Success" success="True" time="1.606" asserts="0">
+                <results>
+                  <test-suite type="Namespace" name="Tests" executed="True" result="Success" success="True" time="1.606" asserts="0">
+                    <results>
+                      <test-suite type="TestFixture" name="AddConfigurationDialogTests" executed="True" result="Success" success="True" time="0.242" asserts="0">
+                        <results>
+                          <test-case name="NUnit.UiKit.Tests.AddConfigurationDialogTests.CheckComboBox" executed="True" result="Success" success="True" time="0.160" asserts="5" />
+                          <test-case name="NUnit.UiKit.Tests.AddConfigurationDialogTests.CheckForControls" executed="True" result="Success" success="True" time="0.001" asserts="0" />
+                          <test-case name="NUnit.UiKit.Tests.AddConfigurationDialogTests.CheckTextBox" executed="True" result="Success" success="True" time="0.001" asserts="1" />
+                          <test-case name="NUnit.UiKit.Tests.AddConfigurationDialogTests.TestComplexEntry" executed="True" result="Success" success="True" time="0.054" asserts="2" />
+                          <test-case name="NUnit.UiKit.Tests.AddConfigurationDialogTests.TestSimpleEntry" executed="True" result="Success" success="True" time="0.015" asserts="2" />
+                        </results>
+                      </test-suite>
+                      <test-suite type="TestFixture" name="ErrorDisplayTests" executed="True" result="Success" success="True" time="0.028" asserts="0">
+                        <results>
+                          <test-case name="NUnit.UiKit.Tests.ErrorDisplayTests.ControlsArePositionedCorrectly" executed="True" result="Success" success="True" time="0.001" asserts="0" />
+                          <test-case name="NUnit.UiKit.Tests.ErrorDisplayTests.ControlsExist" executed="True" result="Success" success="True" time="0.000" asserts="0" />
+                        </results>
+                      </test-suite>
+                      <test-suite type="TestFixture" name="LongRunningOperationDisplayTests" executed="True" result="Success" success="True" time="0.019" asserts="0">
+                        <results>
+                          <test-case name="NUnit.UiKit.Tests.LongRunningOperationDisplayTests.CreateDisplay" executed="True" result="Success" success="True" time="0.017" asserts="2" />
+                        </results>
+                      </test-suite>
+                      <test-suite type="TestFixture" name="ProgressBarTests" executed="True" result="Success" success="True" time="0.048" asserts="0">
+                        <results>
+                          <test-case name="NUnit.UiKit.Tests.ProgressBarTests.TestProgressDisplay" executed="True" result="Success" success="True" time="0.047" asserts="5" />
+                        </results>
+                      </test-suite>
+                      <test-suite type="TestFixture" name="StatusBarTests" executed="True" result="Success" success="True" time="0.155" asserts="0">
+                        <results>
+                          <test-case name="NUnit.UiKit.Tests.StatusBarTests.TestConstruction" executed="True" result="Success" success="True" time="0.040" asserts="5" />
+                          <test-case name="NUnit.UiKit.Tests.StatusBarTests.TestFinalDisplay" executed="True" result="Success" success="True" time="0.042" asserts="5" />
+                          <test-case name="NUnit.UiKit.Tests.StatusBarTests.TestInitialization" executed="True" result="Success" success="True" time="0.027" asserts="10" />
+                          <test-case name="NUnit.UiKit.Tests.StatusBarTests.TestProgressDisplay" executed="True" result="Success" success="True" time="0.039" asserts="5" />
+                        </results>
+                      </test-suite>
+                      <test-suite type="TestFixture" name="TestSuiteTreeNodeTests" executed="True" result="Success" success="True" time="0.057" asserts="0">
+                        <results>
+                          <test-case name="NUnit.UiKit.Tests.TestSuiteTreeNodeTests.ClearNestedResults" executed="True" result="Success" success="True" time="0.013" asserts="8" />
+                          <test-case name="NUnit.UiKit.Tests.TestSuiteTreeNodeTests.ClearResult" executed="True" result="Success" success="True" time="0.003" asserts="5" />
+                          <test-case name="NUnit.UiKit.Tests.TestSuiteTreeNodeTests.ConstructFromTestInfo" executed="True" result="Success" success="True" time="0.004" asserts="6" />
+                          <test-case name="NUnit.UiKit.Tests.TestSuiteTreeNodeTests.ResultNotSet" executed="True" result="Success" success="True" time="0.003" asserts="2" />
+                          <test-case name="NUnit.UiKit.Tests.TestSuiteTreeNodeTests.SetResult_Failure" executed="True" result="Success" success="True" time="0.004" asserts="3" />
+                          <test-case name="NUnit.UiKit.Tests.TestSuiteTreeNodeTests.SetResult_Ignore" executed="True" result="Success" success="True" time="0.003" asserts="4" />
+                          <test-case name="NUnit.UiKit.Tests.TestSuiteTreeNodeTests.SetResult_Inconclusive" executed="True" result="Success" success="True" time="0.004" asserts="4" />
+                          <test-case name="NUnit.UiKit.Tests.TestSuiteTreeNodeTests.SetResult_Skipped" executed="True" result="Success" success="True" time="0.004" asserts="3" />
+                          <test-case name="NUnit.UiKit.Tests.TestSuiteTreeNodeTests.SetResult_Success" executed="True" result="Success" success="True" time="0.004" asserts="3" />
+                        </results>
+                      </test-suite>
+                      <test-suite type="TestFixture" name="TestSuiteTreeViewReloadTests" executed="True" result="Success" success="True" time="0.514" asserts="0">
+                        <results>
+                          <test-case name="NUnit.UiKit.Tests.TestSuiteTreeViewReloadTests.CanReloadAfterChangingOrder" executed="True" result="Success" success="True" time="0.090" asserts="178" />
+                          <test-case name="NUnit.UiKit.Tests.TestSuiteTreeViewReloadTests.CanReloadAfterDeletingBranch" executed="True" result="Success" success="True" time="0.035" asserts="137" />
+                          <test-case name="NUnit.UiKit.Tests.TestSuiteTreeViewReloadTests.CanReloadAfterDeletingOneTestCase" executed="True" result="Success" success="True" time="0.037" asserts="175" />
+                          <test-case name="NUnit.UiKit.Tests.TestSuiteTreeViewReloadTests.CanReloadAfterDeletingThreeTestCases" executed="True" result="Success" success="True" time="0.038" asserts="169" />
+                          <test-case name="NUnit.UiKit.Tests.TestSuiteTreeViewReloadTests.CanReloadAfterInsertingTestCase" executed="True" result="Success" success="True" time="0.040" asserts="181" />
+                          <test-case name="NUnit.UiKit.Tests.TestSuiteTreeViewReloadTests.CanReloadAfterInsertingTestFixture" executed="True" result="Success" success="True" time="0.039" asserts="182" />
+                          <test-case name="NUnit.UiKit.Tests.TestSuiteTreeViewReloadTests.CanReloadAfterMultipleChanges" executed="True" result="Success" success="True" time="0.037" asserts="179" />
+                          <test-case name="NUnit.UiKit.Tests.TestSuiteTreeViewReloadTests.CanReloadAfterTurningOffAutoNamespaces" executed="True" result="Success" success="True" time="0.064" asserts="159" />
+                          <test-case name="NUnit.UiKit.Tests.TestSuiteTreeViewReloadTests.CanReloadWithoutChange" executed="True" result="Success" success="True" time="0.037" asserts="177" />
+                          <test-case name="NUnit.UiKit.Tests.TestSuiteTreeViewReloadTests.ReloadTreeWithWrongTest" executed="True" result="Success" success="True" time="0.035" asserts="0" />
+                          <test-case name="NUnit.UiKit.Tests.TestSuiteTreeViewReloadTests.VerifyCheckTreeWorks" executed="True" result="Success" success="True" time="0.035" asserts="177" />
+                        </results>
+                      </test-suite>
+                      <test-suite type="TestFixture" name="TestSuiteTreeViewTests" executed="True" result="Success" success="True" time="0.196" asserts="0">
+                        <results>
+                          <test-case name="NUnit.UiKit.Tests.TestSuiteTreeViewTests.BuildFromResult" executed="True" result="Success" success="True" time="0.045" asserts="15" />
+                          <test-case name="NUnit.UiKit.Tests.TestSuiteTreeViewTests.BuildTreeView" executed="True" result="Success" success="True" time="0.035" asserts="5" />
+                          <test-case name="NUnit.UiKit.Tests.TestSuiteTreeViewTests.ClearTree" executed="True" result="Success" success="True" time="0.033" asserts="1" />
+                          <test-case name="NUnit.UiKit.Tests.TestSuiteTreeViewTests.ProcessChecks" executed="True" result="Success" success="True" time="0.039" asserts="7" />
+                          <test-case name="NUnit.UiKit.Tests.TestSuiteTreeViewTests.SetTestResult" executed="True" result="Success" success="True" time="0.036" asserts="3" />
+                        </results>
+                      </test-suite>
+                      <test-suite type="TestFixture" name="TestTreeTests" executed="True" result="Success" success="True" time="0.034" asserts="0">
+                        <results>
+                          <test-case name="NUnit.UiKit.Tests.TestTreeTests.SameCategoryShouldNotBeSelectedMoreThanOnce" executed="True" result="Success" success="True" time="0.032" asserts="4" />
+                        </results>
+                      </test-suite>
+                      <test-suite type="TestFixture" name="VisualStateTests" executed="True" result="Success" success="True" time="0.290" asserts="0">
+                        <results>
+                          <test-case name="NUnit.UiKit.Tests.VisualStateTests.SaveAndRestoreVisualState" executed="True" result="Success" success="True" time="0.289" asserts="5" />
+                        </results>
+                      </test-suite>
+                    </results>
+                  </test-suite>
+                </results>
+              </test-suite>
+            </results>
+          </test-suite>
+        </results>
+      </test-suite>
+      <test-suite type="Assembly" name="C:\Program Files\NUnit 2.6\bin\tests/nunit-gui.tests.dll" executed="True" result="Success" success="True" time="0.093" asserts="0">
+        <results>
+          <test-suite type="Namespace" name="NUnit" executed="True" result="Success" success="True" time="0.092" asserts="0">
+            <results>
+              <test-suite type="Namespace" name="Gui" executed="True" result="Success" success="True" time="0.092" asserts="0">
+                <results>
+                  <test-suite type="Namespace" name="Tests" executed="True" result="Success" success="True" time="0.092" asserts="0">
+                    <results>
+                      <test-suite type="TestFixture" name="CommandLineTests" executed="True" result="Success" success="True" time="0.038" asserts="0">
+                        <results>
+                          <test-case name="NUnit.Gui.Tests.CommandLineTests.AssemblyName" executed="True" result="Success" success="True" time="0.019" asserts="1" />
+                          <test-case name="NUnit.Gui.Tests.CommandLineTests.Help" executed="True" result="Success" success="True" time="0.001" asserts="1" />
+                          <test-case name="NUnit.Gui.Tests.CommandLineTests.HelpTextUsesCorrectDelimiterForPlatform" executed="True" result="Success" success="True" time="0.001" asserts="1" />
+                          <test-case name="NUnit.Gui.Tests.CommandLineTests.InvalidArgs" executed="True" result="Success" success="True" time="0.001" asserts="1" />
+                          <test-case name="NUnit.Gui.Tests.CommandLineTests.InvalidCommandLineParms" executed="True" result="Success" success="True" time="0.001" asserts="1" />
+                          <test-case name="NUnit.Gui.Tests.CommandLineTests.NoNameValuePairs" executed="True" result="Success" success="True" time="0.001" asserts="1" />
+                          <test-case name="NUnit.Gui.Tests.CommandLineTests.NoParametersCount" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Gui.Tests.CommandLineTests.ShortHelp" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Gui.Tests.CommandLineTests.ValidateSuccessful" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                        </results>
+                      </test-suite>
+                      <test-suite type="TestFixture" name="ExceptionDetailsFormTests" executed="True" result="Success" success="True" time="0.041" asserts="0">
+                        <results>
+                          <test-case name="NUnit.Gui.Tests.ExceptionDetailsFormTests.ControlsArePositionedCorrectly" executed="True" result="Success" success="True" time="0.001" asserts="0" />
+                          <test-case name="NUnit.Gui.Tests.ExceptionDetailsFormTests.ControlsExist" executed="True" result="Success" success="True" time="0.000" asserts="0" />
+                          <test-case name="NUnit.Gui.Tests.ExceptionDetailsFormTests.MessageDisplaysCorrectly" executed="True" result="Success" success="True" time="0.021" asserts="1" />
+                        </results>
+                      </test-suite>
+                      <test-suite type="TestFixture" name="RecentFileMenuHandlerTests" executed="True" result="Success" success="True" time="0.009" asserts="0">
+                        <results>
+                          <test-case name="NUnit.Gui.Tests.RecentFileMenuHandlerTests.DisableOnLoadWhenEmpty" executed="True" result="Success" success="True" time="0.003" asserts="1" />
+                          <test-case name="NUnit.Gui.Tests.RecentFileMenuHandlerTests.EnableOnLoadWhenNotEmpty" executed="True" result="Success" success="True" time="0.001" asserts="1" />
+                          <test-case name="NUnit.Gui.Tests.RecentFileMenuHandlerTests.LoadMenuItems" executed="True" result="Success" success="True" time="0.001" asserts="2" />
+                        </results>
+                      </test-suite>
+                    </results>
+                  </test-suite>
+                </results>
+              </test-suite>
+            </results>
+          </test-suite>
+        </results>
+      </test-suite>
+      <test-suite type="Assembly" name="C:\Program Files\NUnit 2.6\bin\tests/nunit-editor.tests.dll" executed="True" result="Success" success="True" time="1.224" asserts="0">
+        <results>
+          <test-suite type="Namespace" name="NUnit" executed="True" result="Success" success="True" time="1.224" asserts="0">
+            <results>
+              <test-suite type="Namespace" name="ProjectEditor" executed="True" result="Success" success="True" time="1.224" asserts="0">
+                <results>
+                  <test-suite type="Namespace" name="Tests" executed="True" result="Success" success="True" time="1.224" asserts="0">
+                    <results>
+                      <test-suite type="Namespace" name="Model" executed="True" result="Success" success="True" time="0.196" asserts="0">
+                        <results>
+                          <test-suite type="TestFixture" name="AssemblyListTests" executed="True" result="Success" success="True" time="0.021" asserts="0">
+                            <results>
+                              <test-case name="NUnit.ProjectEditor.Tests.Model.AssemblyListTests.CanAddAssemblies" executed="True" result="Success" success="True" time="0.006" asserts="3" />
+                              <test-case name="NUnit.ProjectEditor.Tests.Model.AssemblyListTests.CanInsertAssemblies" executed="True" result="Success" success="True" time="0.002" asserts="4" />
+                              <test-case name="NUnit.ProjectEditor.Tests.Model.AssemblyListTests.CanInsertAssemblyAtEnd" executed="True" result="Success" success="True" time="0.001" asserts="4" />
+                              <test-case name="NUnit.ProjectEditor.Tests.Model.AssemblyListTests.CanInsertAssemblyAtStart" executed="True" result="Success" success="True" time="0.001" asserts="4" />
+                              <test-case name="NUnit.ProjectEditor.Tests.Model.AssemblyListTests.CanRemoveAssemblies" executed="True" result="Success" success="True" time="0.001" asserts="3" />
+                              <test-case name="NUnit.ProjectEditor.Tests.Model.AssemblyListTests.EmptyList" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                            </results>
+                          </test-suite>
+                          <test-suite type="TestFixture" name="NUnitProjectSave" executed="True" result="Success" success="True" time="0.042" asserts="0">
+                            <results>
+                              <test-case name="NUnit.ProjectEditor.Tests.Model.NUnitProjectSave.EmptyConfigs" executed="True" result="Success" success="True" time="0.010" asserts="1" />
+                              <test-case name="NUnit.ProjectEditor.Tests.Model.NUnitProjectSave.EmptyProject" executed="True" result="Success" success="True" time="0.002" asserts="1" />
+                              <test-case name="NUnit.ProjectEditor.Tests.Model.NUnitProjectSave.NormalProject" executed="True" result="Success" success="True" time="0.003" asserts="1" />
+                              <test-case name="NUnit.ProjectEditor.Tests.Model.NUnitProjectSave.NormalProject_RoundTrip" executed="True" result="Success" success="True" time="0.003" asserts="1" />
+                              <test-case name="NUnit.ProjectEditor.Tests.Model.NUnitProjectSave.ProjectWithComplexSettings" executed="True" result="Success" success="True" time="0.004" asserts="1" />
+                              <test-case name="NUnit.ProjectEditor.Tests.Model.NUnitProjectSave.ProjectWithComplexSettings_RoundTrip" executed="True" result="Success" success="True" time="0.002" asserts="1" />
+                              <test-case name="NUnit.ProjectEditor.Tests.Model.NUnitProjectSave.ProjectWithComplexSettings_RoundTripWithChanges" executed="True" result="Success" success="True" time="0.003" asserts="1" />
+                            </results>
+                          </test-suite>
+                          <test-suite type="TestFixture" name="ProjectCreationTests" executed="True" result="Success" success="True" time="0.050" asserts="0">
+                            <results>
+                              <test-case name="NUnit.ProjectEditor.Tests.Model.ProjectCreationTests.AddConfigFiresChangedEvent" executed="True" result="Success" success="True" time="0.002" asserts="1" />
+                              <test-case name="NUnit.ProjectEditor.Tests.Model.ProjectCreationTests.AddConfigMakesProjectDirty" executed="True" result="Success" success="True" time="0.002" asserts="1" />
+                              <test-case name="NUnit.ProjectEditor.Tests.Model.ProjectCreationTests.CanAddConfigs" executed="True" result="Success" success="True" time="0.002" asserts="1" />
+                              <test-case name="NUnit.ProjectEditor.Tests.Model.ProjectCreationTests.CanSetAppBase" executed="True" result="Success" success="True" time="0.001" asserts="1" />
+                              <test-case name="NUnit.ProjectEditor.Tests.Model.ProjectCreationTests.DefaultProjectName" executed="True" result="Success" success="True" time="0.002" asserts="1" />
+                              <test-case name="NUnit.ProjectEditor.Tests.Model.ProjectCreationTests.IsNotDirty" executed="True" result="Success" success="True" time="0.001" asserts="1" />
+                              <test-case name="NUnit.ProjectEditor.Tests.Model.ProjectCreationTests.LoadMakesProjectNotDirty" executed="True" result="Success" success="True" time="0.003" asserts="1" />
+                              <test-case name="NUnit.ProjectEditor.Tests.Model.ProjectCreationTests.NameIsUnique" executed="True" result="Success" success="True" time="0.001" asserts="1" />
+                              <test-case name="NUnit.ProjectEditor.Tests.Model.ProjectCreationTests.NewProjectHasNoConfigs" executed="True" result="Success" success="True" time="0.002" asserts="2" />
+                              <test-case name="NUnit.ProjectEditor.Tests.Model.ProjectCreationTests.ProjectNodeHasNoAttributes" executed="True" result="Success" success="True" time="0.001" asserts="1" />
+                              <test-case name="NUnit.ProjectEditor.Tests.Model.ProjectCreationTests.ProjectNodeHasNoChildren" executed="True" result="Success" success="True" time="0.001" asserts="1" />
+                              <test-case name="NUnit.ProjectEditor.Tests.Model.ProjectCreationTests.ProjectPathIsSameAsName" executed="True" result="Success" success="True" time="0.001" asserts="1" />
+                              <test-case name="NUnit.ProjectEditor.Tests.Model.ProjectCreationTests.RootElementIsNUnitProject" executed="True" result="Success" success="True" time="0.001" asserts="1" />
+                              <test-case name="NUnit.ProjectEditor.Tests.Model.ProjectCreationTests.SaveMakesProjectNotDirty" executed="True" result="Success" success="True" time="0.003" asserts="1" />
+                              <test-case name="NUnit.ProjectEditor.Tests.Model.ProjectCreationTests.SaveSetsProjectPathAndName" executed="True" result="Success" success="True" time="0.002" asserts="2" />
+                            </results>
+                          </test-suite>
+                          <test-suite type="TestFixture" name="ProjectDocumentTests" executed="True" result="Success" success="True" time="0.009" asserts="0">
+                            <results>
+                              <test-case name="NUnit.ProjectEditor.Tests.Model.ProjectDocumentTests.AddingAttributeFiresChangedEvent" executed="True" result="Success" success="True" time="0.001" asserts="1" />
+                              <test-case name="NUnit.ProjectEditor.Tests.Model.ProjectDocumentTests.AddingAttributeMakesProjectDirty" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                              <test-case name="NUnit.ProjectEditor.Tests.Model.ProjectDocumentTests.AddingElementFiresChangedEvent" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                              <test-case name="NUnit.ProjectEditor.Tests.Model.ProjectDocumentTests.AddingElementMakesProjectDirty" executed="True" result="Success" success="True" time="0.001" asserts="1" />
+                            </results>
+                          </test-suite>
+                          <test-suite type="TestFixture" name="ProjectModelChangeTests" executed="True" result="Success" success="True" time="0.035" asserts="0">
+                            <results>
+                              <test-case name="NUnit.ProjectEditor.Tests.Model.ProjectModelChangeTests.AddingAssemblyFiresChangedEvent" executed="True" result="Success" success="True" time="0.001" asserts="1" />
+                              <test-case name="NUnit.ProjectEditor.Tests.Model.ProjectModelChangeTests.CanAddAssemblies" executed="True" result="Success" success="True" time="0.001" asserts="3" />
+                              <test-case name="NUnit.ProjectEditor.Tests.Model.ProjectModelChangeTests.CanSetActiveConfig" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                              <test-case name="NUnit.ProjectEditor.Tests.Model.ProjectModelChangeTests.RemoveAssemblyFiresChangedEvent" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                              <test-case name="NUnit.ProjectEditor.Tests.Model.ProjectModelChangeTests.RemoveConfigFiresChangedEvent" executed="True" result="Success" success="True" time="0.003" asserts="1" />
+                              <test-case name="NUnit.ProjectEditor.Tests.Model.ProjectModelChangeTests.RemoveConfigMakesProjectDirty" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                              <test-case name="NUnit.ProjectEditor.Tests.Model.ProjectModelChangeTests.RemovingActiveConfigRemovesActiveConfigNameAttribute" executed="True" result="Success" success="True" time="0.001" asserts="1" />
+                              <test-case name="NUnit.ProjectEditor.Tests.Model.ProjectModelChangeTests.RenameConfigFiresChangedEvent" executed="True" result="Success" success="True" time="0.001" asserts="1" />
+                              <test-case name="NUnit.ProjectEditor.Tests.Model.ProjectModelChangeTests.RenameConfigMakesProjectDirty" executed="True" result="Success" success="True" time="0.001" asserts="1" />
+                              <test-case name="NUnit.ProjectEditor.Tests.Model.ProjectModelChangeTests.RenamingActiveConfigChangesActiveConfigName" executed="True" result="Success" success="True" time="0.001" asserts="1" />
+                              <test-case name="NUnit.ProjectEditor.Tests.Model.ProjectModelChangeTests.SettingActiveConfigFiresChangedEvent" executed="True" result="Success" success="True" time="0.001" asserts="1" />
+                              <test-case name="NUnit.ProjectEditor.Tests.Model.ProjectModelChangeTests.SettingActiveConfigMakesProjectDirty" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                            </results>
+                          </test-suite>
+                          <test-suite type="TestFixture" name="ProjectModelLoadtests" executed="True" result="Success" success="True" time="0.025" asserts="0">
+                            <results>
+                              <test-case name="NUnit.ProjectEditor.Tests.Model.ProjectModelLoadtests.CanSaveAndReloadProject" executed="True" result="Success" success="True" time="0.004" asserts="8" />
+                              <test-case name="NUnit.ProjectEditor.Tests.Model.ProjectModelLoadtests.LoadEmptyConfigs" executed="True" result="Success" success="True" time="0.002" asserts="10" />
+                              <test-case name="NUnit.ProjectEditor.Tests.Model.ProjectModelLoadtests.LoadEmptyProject" executed="True" result="Success" success="True" time="0.002" asserts="8" />
+                              <test-case name="NUnit.ProjectEditor.Tests.Model.ProjectModelLoadtests.LoadNormalProject" executed="True" result="Success" success="True" time="0.002" asserts="14" />
+                              <test-case name="NUnit.ProjectEditor.Tests.Model.ProjectModelLoadtests.LoadProjectWithComplexSettings" executed="True" result="Success" success="True" time="0.003" asserts="16" />
+                              <test-case name="NUnit.ProjectEditor.Tests.Model.ProjectModelLoadtests.LoadProjectWithManualBinPath" executed="True" result="Success" success="True" time="0.001" asserts="8" />
+                            </results>
+                          </test-suite>
+                        </results>
+                      </test-suite>
+                      <test-suite type="Namespace" name="Presenters" executed="True" result="Success" success="True" time="0.874" asserts="0">
+                        <results>
+                          <test-suite type="TestFixture" name="AddConfigurationPresenterTests" executed="True" result="Success" success="True" time="0.050" asserts="0">
+                            <results>
+                              <test-case name="NUnit.ProjectEditor.Tests.Presenters.AddConfigurationPresenterTests.AddButton_AddExistingConfig_FailsWithErrorMessage" executed="True" result="Success" success="True" time="0.030" asserts="1" />
+                              <test-case name="NUnit.ProjectEditor.Tests.Presenters.AddConfigurationPresenterTests.AddButton_AddNewConfig_IsAddedToList" executed="True" result="Success" success="True" time="0.003" asserts="1" />
+                              <test-case name="NUnit.ProjectEditor.Tests.Presenters.AddConfigurationPresenterTests.ConfigList_LoadFromModel_SetsViewCorrectly" executed="True" result="Success" success="True" time="0.001" asserts="1" />
+                              <test-case name="NUnit.ProjectEditor.Tests.Presenters.AddConfigurationPresenterTests.ConfigToCopy_WhenNotSpecified_ConfigIsEmpty" executed="True" result="Success" success="True" time="0.002" asserts="3" />
+                              <test-case name="NUnit.ProjectEditor.Tests.Presenters.AddConfigurationPresenterTests.ConfigToCopy_WhenSpecified_ConfigIsCopied" executed="True" result="Success" success="True" time="0.005" asserts="3" />
+                            </results>
+                          </test-suite>
+                          <test-suite type="TestFixture" name="ConfigurationEditorTests" executed="True" result="Success" success="True" time="0.126" asserts="0">
+                            <results>
+                              <test-case name="NUnit.ProjectEditor.Tests.Presenters.ConfigurationEditorTests.ActiveButton_OnLoad_IsDisabled" executed="True" result="Success" success="True" time="0.025" asserts="1" />
+                              <test-case name="NUnit.ProjectEditor.Tests.Presenters.ConfigurationEditorTests.ActiveButton_OnLoad_IsSubscribed" executed="True" result="Success" success="True" time="0.004" asserts="0" />
+                              <test-case name="NUnit.ProjectEditor.Tests.Presenters.ConfigurationEditorTests.ActiveButton_WhenClicked_MakesConfigActive" executed="True" result="Success" success="True" time="0.005" asserts="1" />
+                              <test-case name="NUnit.ProjectEditor.Tests.Presenters.ConfigurationEditorTests.AddButton_OnLoad_IsEnabled" executed="True" result="Success" success="True" time="0.003" asserts="1" />
+                              <test-case name="NUnit.ProjectEditor.Tests.Presenters.ConfigurationEditorTests.AddButton_OnLoad_IsSubscribed" executed="True" result="Success" success="True" time="0.003" asserts="0" />
+                              <test-case name="NUnit.ProjectEditor.Tests.Presenters.ConfigurationEditorTests.AddButton_WhenClicked_AddsNewConfig" executed="True" result="Success" success="True" time="0.009" asserts="2" />
+                              <test-case name="NUnit.ProjectEditor.Tests.Presenters.ConfigurationEditorTests.ConfigList_OnLoad_IsCorrectlyInitialized" executed="True" result="Success" success="True" time="0.003" asserts="1" />
+                              <test-case name="NUnit.ProjectEditor.Tests.Presenters.ConfigurationEditorTests.ConfigList_OnLoad_SelectionChangedIsSubscribed" executed="True" result="Success" success="True" time="0.003" asserts="0" />
+                              <test-case name="NUnit.ProjectEditor.Tests.Presenters.ConfigurationEditorTests.RemoveButton_OnLoad_IsEnabled" executed="True" result="Success" success="True" time="0.003" asserts="1" />
+                              <test-case name="NUnit.ProjectEditor.Tests.Presenters.ConfigurationEditorTests.RemoveButton_OnLoad_IsSubscribed" executed="True" result="Success" success="True" time="0.003" asserts="0" />
+                              <test-case name="NUnit.ProjectEditor.Tests.Presenters.ConfigurationEditorTests.RemoveButton_WhenClicked_RemovesConfig" executed="True" result="Success" success="True" time="0.009" asserts="2" />
+                              <test-case name="NUnit.ProjectEditor.Tests.Presenters.ConfigurationEditorTests.RenameButton_OnLoad_IsEnabled" executed="True" result="Success" success="True" time="0.003" asserts="1" />
+                              <test-case name="NUnit.ProjectEditor.Tests.Presenters.ConfigurationEditorTests.RenameButton_OnLoad_IsSubscribed" executed="True" result="Success" success="True" time="0.002" asserts="0" />
+                              <test-case name="NUnit.ProjectEditor.Tests.Presenters.ConfigurationEditorTests.RenameButton_WhenClicked_PerformsRename" executed="True" result="Success" success="True" time="0.021" asserts="1" />
+                            </results>
+                          </test-suite>
+                          <test-suite type="TestFixture" name="MainPresenterTests" executed="True" result="Success" success="True" time="0.317" asserts="0">
+                            <results>
+                              <test-case name="NUnit.ProjectEditor.Tests.Presenters.MainPresenterTests.ActiveViewChanged_WhenNoProjectIsOpen_TabViewsRemainHidden" executed="True" result="Success" success="True" time="0.070" asserts="4" />
+                              <test-case name="NUnit.ProjectEditor.Tests.Presenters.MainPresenterTests.ActiveViewChanged_WhenProjectIsOpen_TabViewsAreVisible" executed="True" result="Success" success="True" time="0.013" asserts="2" />
+                              <test-case name="NUnit.ProjectEditor.Tests.Presenters.MainPresenterTests.CloseProject_AfterCreatingNewProject_IsEnabled" executed="True" result="Success" success="True" time="0.010" asserts="1" />
+                              <test-case name="NUnit.ProjectEditor.Tests.Presenters.MainPresenterTests.CloseProject_AfterOpeningGoodProject_IsEnabled" executed="True" result="Success" success="True" time="0.023" asserts="1" />
+                              <test-case name="NUnit.ProjectEditor.Tests.Presenters.MainPresenterTests.CloseProject_OnLoad_IsDisabled" executed="True" result="Success" success="True" time="0.007" asserts="1" />
+                              <test-case name="NUnit.ProjectEditor.Tests.Presenters.MainPresenterTests.NewProject_OnLoad_IsEnabled" executed="True" result="Success" success="True" time="0.007" asserts="1" />
+                              <test-case name="NUnit.ProjectEditor.Tests.Presenters.MainPresenterTests.NewProject_WhenClicked_CreatesNewProject" executed="True" result="Success" success="True" time="0.009" asserts="2" />
+                              <test-case name="NUnit.ProjectEditor.Tests.Presenters.MainPresenterTests.OpenProject_OnLoad_IsEnabled" executed="True" result="Success" success="True" time="0.007" asserts="1" />
+                              <test-case name="NUnit.ProjectEditor.Tests.Presenters.MainPresenterTests.OpenProject_WhenClickedAndProjectDoesNotExist_DisplaysError" executed="True" result="Success" success="True" time="0.013" asserts="2" />
+                              <test-case name="NUnit.ProjectEditor.Tests.Presenters.MainPresenterTests.OpenProject_WhenClickedAndProjectIsValid_OpensProject" executed="True" result="Success" success="True" time="0.023" asserts="3" />
+                              <test-case name="NUnit.ProjectEditor.Tests.Presenters.MainPresenterTests.OpenProject_WhenClickedAndProjectXmlIsNotValid_OpensProject" executed="True" result="Success" success="True" time="0.017" asserts="4" />
+                              <test-case name="NUnit.ProjectEditor.Tests.Presenters.MainPresenterTests.SaveProject_AfterCreatingNewProject_IsEnabled" executed="True" result="Success" success="True" time="0.012" asserts="1" />
+                              <test-case name="NUnit.ProjectEditor.Tests.Presenters.MainPresenterTests.SaveProject_AfterOpeningGoodProject_IsEnabled" executed="True" result="Success" success="True" time="0.019" asserts="1" />
+                              <test-case name="NUnit.ProjectEditor.Tests.Presenters.MainPresenterTests.SaveProject_OnLoad_IsDisabled" executed="True" result="Success" success="True" time="0.007" asserts="1" />
+                              <test-case name="NUnit.ProjectEditor.Tests.Presenters.MainPresenterTests.SaveProjectAs_AfterCreatingNewProject_IsEnabled" executed="True" result="Success" success="True" time="0.010" asserts="1" />
+                              <test-case name="NUnit.ProjectEditor.Tests.Presenters.MainPresenterTests.SaveProjectAs_AfterOpeningGoodProject_IsEnabled" executed="True" result="Success" success="True" time="0.016" asserts="1" />
+                              <test-case name="NUnit.ProjectEditor.Tests.Presenters.MainPresenterTests.SaveProjectAs_OnLoad_IsDisabled" executed="True" result="Success" success="True" time="0.007" asserts="1" />
+                            </results>
+                          </test-suite>
+                          <test-suite type="TestFixture" name="PropertyPresenterTests" executed="True" result="Success" success="True" time="0.323" asserts="0">
+                            <results>
+                              <test-case name="NUnit.ProjectEditor.Tests.Presenters.PropertyPresenterTests.ActiveConfigName_LoadFromModel_SetsViewCorrectly" executed="True" result="Success" success="True" time="0.016" asserts="1" />
+                              <test-case name="NUnit.ProjectEditor.Tests.Presenters.PropertyPresenterTests.ApplicationBase_LoadFromModel_SetsViewCorrectly" executed="True" result="Success" success="True" time="0.011" asserts="1" />
+                              <test-case name="NUnit.ProjectEditor.Tests.Presenters.PropertyPresenterTests.AssemblyList_LoadFromModel_SetsListCorrectly" executed="True" result="Success" success="True" time="0.009" asserts="1" />
+                              <test-case name="NUnit.ProjectEditor.Tests.Presenters.PropertyPresenterTests.AssemblyList_WhenEmpty_AddIsEnabled" executed="True" result="Success" success="True" time="0.012" asserts="1" />
+                              <test-case name="NUnit.ProjectEditor.Tests.Presenters.PropertyPresenterTests.AssemblyList_WhenEmpty_AssemblyPathBrowseIsDisabled" executed="True" result="Success" success="True" time="0.010" asserts="1" />
+                              <test-case name="NUnit.ProjectEditor.Tests.Presenters.PropertyPresenterTests.AssemblyList_WhenEmpty_RemoveIsDisabled" executed="True" result="Success" success="True" time="0.012" asserts="1" />
+                              <test-case name="NUnit.ProjectEditor.Tests.Presenters.PropertyPresenterTests.AssemblyPath_LoadFromModel_SetsViewCorrectly" executed="True" result="Success" success="True" time="0.009" asserts="1" />
+                              <test-case name="NUnit.ProjectEditor.Tests.Presenters.PropertyPresenterTests.BinPathType_LoadFromModel_SetsViewCorrectly" executed="True" result="Success" success="True" time="0.008" asserts="1" />
+                              <test-case name="NUnit.ProjectEditor.Tests.Presenters.PropertyPresenterTests.ConfigList_LoadFromModel_SelectsFirstConfig" executed="True" result="Success" success="True" time="0.010" asserts="2" />
+                              <test-case name="NUnit.ProjectEditor.Tests.Presenters.PropertyPresenterTests.ConfigList_LoadFromModel_SetsListCorrectly" executed="True" result="Success" success="True" time="0.009" asserts="1" />
+                              <test-case name="NUnit.ProjectEditor.Tests.Presenters.PropertyPresenterTests.ConfigurationFile_LoadFromModel_SetsViewCorrectly" executed="True" result="Success" success="True" time="0.010" asserts="1" />
+                              <test-case name="NUnit.ProjectEditor.Tests.Presenters.PropertyPresenterTests.DomainUsage_LoadFromModel_SelectsDefaultEntry" executed="True" result="Success" success="True" time="0.009" asserts="1" />
+                              <test-case name="NUnit.ProjectEditor.Tests.Presenters.PropertyPresenterTests.DomainUsage_LoadFromModel_SetsOptionsCorrectly" executed="True" result="Success" success="True" time="0.009" asserts="1" />
+                              <test-case name="NUnit.ProjectEditor.Tests.Presenters.PropertyPresenterTests.DomainUsage_WhenChanged_UpdatesProject" executed="True" result="Success" success="True" time="0.009" asserts="1" />
+                              <test-case name="NUnit.ProjectEditor.Tests.Presenters.PropertyPresenterTests.PrivateBinPath_LoadFromModel_SetsViewCorrectly" executed="True" result="Success" success="True" time="0.009" asserts="1" />
+                              <test-case name="NUnit.ProjectEditor.Tests.Presenters.PropertyPresenterTests.ProcessModel_LoadFromModel_SelectsDefaultEntry" executed="True" result="Success" success="True" time="0.010" asserts="1" />
+                              <test-case name="NUnit.ProjectEditor.Tests.Presenters.PropertyPresenterTests.ProcessModel_LoadFromModel_SetsOptionsCorrectly" executed="True" result="Success" success="True" time="0.008" asserts="1" />
+                              <test-case name="NUnit.ProjectEditor.Tests.Presenters.PropertyPresenterTests.ProcessModel_WhenChanged_UpdatesDomainUsageOptions" executed="True" result="Success" success="True" time="0.009" asserts="2" />
+                              <test-case name="NUnit.ProjectEditor.Tests.Presenters.PropertyPresenterTests.ProcessModel_WhenChanged_UpdatesProject" executed="True" result="Success" success="True" time="0.010" asserts="1" />
+                              <test-case name="NUnit.ProjectEditor.Tests.Presenters.PropertyPresenterTests.ProjectBase_LoadFromModel_SetsViewCorrectly" executed="True" result="Success" success="True" time="0.008" asserts="1" />
+                              <test-case name="NUnit.ProjectEditor.Tests.Presenters.PropertyPresenterTests.ProjectBase_WhenChanged_UpdatesProject" executed="True" result="Success" success="True" time="0.011" asserts="1" />
+                              <test-case name="NUnit.ProjectEditor.Tests.Presenters.PropertyPresenterTests.ProjectPath_LoadFromModel_SetsViewCorrectly" executed="True" result="Success" success="True" time="0.009" asserts="1" />
+                              <test-case name="NUnit.ProjectEditor.Tests.Presenters.PropertyPresenterTests.Runtime_LoadFromModel_SelectsAnyRuntime" executed="True" result="Success" success="True" time="0.010" asserts="1" />
+                              <test-case name="NUnit.ProjectEditor.Tests.Presenters.PropertyPresenterTests.Runtime_LoadFromModel_SetsOptionsCorrectly" executed="True" result="Success" success="True" time="0.008" asserts="1" />
+                              <test-case name="NUnit.ProjectEditor.Tests.Presenters.PropertyPresenterTests.Runtime_WhenChanged_UpdatesProject" executed="True" result="Success" success="True" time="0.013" asserts="2" />
+                              <test-case name="NUnit.ProjectEditor.Tests.Presenters.PropertyPresenterTests.RuntimeVersion_LoadFromModel_SetsOptionsCorretly" executed="True" result="Success" success="True" time="0.009" asserts="1" />
+                              <test-case name="NUnit.ProjectEditor.Tests.Presenters.PropertyPresenterTests.RuntimeVersion_WhenSelectionChanged_UpdatesProject" executed="True" result="Success" success="True" time="0.009" asserts="2" />
+                            </results>
+                          </test-suite>
+                          <test-suite type="TestFixture" name="RenameConfigurationPresenterTests" executed="True" result="Success" success="True" time="0.028" asserts="0">
+                            <results>
+                              <test-case name="NUnit.ProjectEditor.Tests.Presenters.RenameConfigurationPresenterTests.ConfigurationName_OnLoad_IsSetToOriginalName" executed="True" result="Success" success="True" time="0.002" asserts="1" />
+                              <test-case name="NUnit.ProjectEditor.Tests.Presenters.RenameConfigurationPresenterTests.ConfigurationName_OnLoad_OriginalNameIsSelected" executed="True" result="Success" success="True" time="0.002" asserts="0" />
+                              <test-case name="NUnit.ProjectEditor.Tests.Presenters.RenameConfigurationPresenterTests.ConfigurationName_WhenCleared_OkButtonIsDisabled" executed="True" result="Success" success="True" time="0.002" asserts="1" />
+                              <test-case name="NUnit.ProjectEditor.Tests.Presenters.RenameConfigurationPresenterTests.ConfigurationName_WhenSetToNewName_OkButtonIsEnabled" executed="True" result="Success" success="True" time="0.002" asserts="1" />
+                              <test-case name="NUnit.ProjectEditor.Tests.Presenters.RenameConfigurationPresenterTests.ConfigurationName_WhenSetToOriginalName_OkButtonIsDisabled" executed="True" result="Success" success="True" time="0.002" asserts="1" />
+                              <test-case name="NUnit.ProjectEditor.Tests.Presenters.RenameConfigurationPresenterTests.Dialog_WhenClosedWithoutClickingOK_LeavesConfigsUnchanged" executed="True" result="Success" success="True" time="0.002" asserts="1" />
+                              <test-case name="NUnit.ProjectEditor.Tests.Presenters.RenameConfigurationPresenterTests.OkButton_OnLoad_IsDisabled" executed="True" result="Success" success="True" time="0.001" asserts="1" />
+                              <test-case name="NUnit.ProjectEditor.Tests.Presenters.RenameConfigurationPresenterTests.OkButton_WhenClicked_PerformsRename" executed="True" result="Success" success="True" time="0.002" asserts="1" />
+                            </results>
+                          </test-suite>
+                          <test-suite type="TestFixture" name="XmlPresenterTests" executed="True" result="Success" success="True" time="0.013" asserts="0">
+                            <results>
+                              <test-case name="NUnit.ProjectEditor.Tests.Presenters.XmlPresenterTests.BadXmlSetsException" executed="True" result="Success" success="True" time="0.004" asserts="3" />
+                              <test-case name="NUnit.ProjectEditor.Tests.Presenters.XmlPresenterTests.XmlText_OnLoad_IsInitializedCorrectly" executed="True" result="Success" success="True" time="0.003" asserts="1" />
+                              <test-case name="NUnit.ProjectEditor.Tests.Presenters.XmlPresenterTests.XmlText_WhenChanged_ModelIsUpdated" executed="True" result="Success" success="True" time="0.001" asserts="1" />
+                            </results>
+                          </test-suite>
+                        </results>
+                      </test-suite>
+                      <test-suite type="Namespace" name="Views" executed="True" result="Success" success="True" time="0.136" asserts="0">
+                        <results>
+                          <test-suite type="TestFixture" name="AddConfigurationDialogTests" executed="True" result="Success" success="True" time="0.049" asserts="0">
+                            <results>
+                              <test-case name="NUnit.ProjectEditor.Tests.Views.AddConfigurationDialogTests.CheckForControls" executed="True" result="Success" success="True" time="0.006" asserts="0" />
+                              <test-case name="NUnit.ProjectEditor.Tests.Views.AddConfigurationDialogTests.ComboBox_OnLoad_IsInitializedCorrectly" executed="True" result="Success" success="True" time="0.010" asserts="5" />
+                              <test-case name="NUnit.ProjectEditor.Tests.Views.AddConfigurationDialogTests.TestComplexEntry" executed="True" result="Success" success="True" time="0.012" asserts="2" />
+                              <test-case name="NUnit.ProjectEditor.Tests.Views.AddConfigurationDialogTests.TestSimpleEntry" executed="True" result="Success" success="True" time="0.011" asserts="2" />
+                              <test-case name="NUnit.ProjectEditor.Tests.Views.AddConfigurationDialogTests.TextBox_OnLoad_IsEmpty" executed="True" result="Success" success="True" time="0.001" asserts="1" />
+                            </results>
+                          </test-suite>
+                          <test-suite type="TestFixture" name="ConfigurationEditorViewTests" executed="True" result="Success" success="True" time="0.020" asserts="0">
+                            <results>
+                              <test-case name="NUnit.ProjectEditor.Tests.Views.ConfigurationEditorViewTests.AllViewElementsAreWrapped" executed="True" result="Success" success="True" time="0.018" asserts="5" />
+                            </results>
+                          </test-suite>
+                          <test-suite type="TestFixture" name="PropertyViewTests" executed="True" result="Success" success="True" time="0.062" asserts="0">
+                            <results>
+                              <test-case name="NUnit.ProjectEditor.Tests.Views.PropertyViewTests.AllViewElementsAreInitialized" executed="True" result="Success" success="True" time="0.062" asserts="0" />
+                            </results>
+                          </test-suite>
+                        </results>
+                      </test-suite>
+                    </results>
+                  </test-suite>
+                </results>
+              </test-suite>
+            </results>
+          </test-suite>
+        </results>
+      </test-suite>
+    </results>
+  </test-suite>
+</test-results>

--- a/src/test-nunit-summary.exe/TestInput/TestResult-2.6.2.xml
+++ b/src/test-nunit-summary.exe/TestInput/TestResult-2.6.2.xml
@@ -1,0 +1,6761 @@
+﻿<?xml version="1.0" encoding="utf-8" standalone="no"?>
+<!--This file represents the results of running a test suite-->
+<test-results name="C:\Program Files\NUnit 2.6.2\bin\NUnitTests.nunit" total="3480" errors="0" failures="0" not-run="8" inconclusive="19" ignored="0" skipped="8" invalid="0" date="2013-09-29" time="14:33:09">
+  <environment nunit-version="2.6.2.12296" clr-version="2.0.50727.5472" os-version="Microsoft Windows NT 6.1.7601 Service Pack 1" platform="Win32NT" cwd="C:\Program Files\NUnit 2.6.2\bin" machine-name="CHARLIE-LAPTOP" user="charlie" user-domain="charlie-laptop" />
+  <culture-info current-culture="en-US" current-uiculture="en-US" />
+  <test-suite type="Project" name="C:\Program Files\NUnit 2.6.2\bin\NUnitTests.nunit" executed="True" result="Success" success="True" time="78.534" asserts="0">
+    <results>
+      <test-suite type="Assembly" name="C:\Program Files\NUnit 2.6.2\bin\tests/nunit.framework.tests.dll" executed="True" result="Success" success="True" time="19.003" asserts="0">
+        <results>
+          <test-suite type="Namespace" name="NUnit" executed="True" result="Success" success="True" time="19.002" asserts="0">
+            <results>
+              <test-suite type="Namespace" name="Framework" executed="True" result="Success" success="True" time="19.002" asserts="0">
+                <results>
+                  <test-suite type="Namespace" name="Constraints" executed="True" result="Success" success="True" time="12.607" asserts="0">
+                    <results>
+                      <test-suite type="TestFixture" name="AfterConstraintTest" executed="True" result="Success" success="True" time="9.016" asserts="0">
+                        <results>
+                          <test-case name="NUnit.Framework.Constraints.AfterConstraintTest.CanTestContentsOfDelegateReturningList" executed="True" result="Success" success="True" time="0.164" asserts="1" />
+                          <test-case name="NUnit.Framework.Constraints.AfterConstraintTest.CanTestContentsOfList" executed="True" result="Success" success="True" time="0.103" asserts="1" />
+                          <test-case name="NUnit.Framework.Constraints.AfterConstraintTest.CanTestContentsOfRefList" executed="True" result="Success" success="True" time="0.104" asserts="1" />
+                          <test-case name="NUnit.Framework.Constraints.AfterConstraintTest.CanTestInitiallyNullDelegate" executed="True" result="Success" success="True" time="1.105" asserts="1" />
+                          <test-case name="NUnit.Framework.Constraints.AfterConstraintTest.CanTestInitiallyNullReference" executed="True" result="Success" success="True" time="1.102" asserts="1" />
+                          <test-case name="NUnit.Framework.Constraints.AfterConstraintTest.ConstraintTestBaseNoData.ProvidesProperDescription" executed="True" result="Success" success="True" time="0.005" asserts="1" />
+                          <test-case name="NUnit.Framework.Constraints.AfterConstraintTest.ConstraintTestBaseNoData.ProvidesProperStringRepresentation" executed="True" result="Success" success="True" time="0.001" asserts="1" />
+                          <test-suite type="ParameterizedTest" name="FailsWithBadDelegates" executed="True" result="Success" success="True" time="1.083" asserts="0">
+                            <results>
+                              <test-case name="NUnit.Framework.Constraints.AfterConstraintTest.FailsWithBadDelegates(NUnit.Framework.Constraints.ActualValueDelegate)" executed="True" result="Success" success="True" time="0.574" asserts="1" />
+                              <test-case name="NUnit.Framework.Constraints.AfterConstraintTest.FailsWithBadDelegates(NUnit.Framework.Constraints.ActualValueDelegate)" executed="True" result="Success" success="True" time="0.501" asserts="1" />
+                            </results>
+                          </test-suite>
+                          <test-suite type="ParameterizedTest" name="FailsWithBadValues" executed="True" result="Success" success="True" time="1.540" asserts="0">
+                            <results>
+                              <test-case name="NUnit.Framework.Constraints.AfterConstraintTest.FailsWithBadValues(False)" executed="True" result="Success" success="True" time="0.501" asserts="1" />
+                              <test-case name="NUnit.Framework.Constraints.AfterConstraintTest.FailsWithBadValues(0)" executed="True" result="Success" success="True" time="0.500" asserts="1" />
+                              <test-case name="NUnit.Framework.Constraints.AfterConstraintTest.FailsWithBadValues(null)" executed="True" result="Success" success="True" time="0.500" asserts="1" />
+                            </results>
+                          </test-suite>
+                          <test-suite type="ParameterizedTest" name="ProvidesProperFailureMessage" executed="True" result="Success" success="True" time="1.512" asserts="0">
+                            <results>
+                              <test-case name="NUnit.Framework.Constraints.AfterConstraintTest.ProvidesProperFailureMessage(False,&quot;False&quot;)" executed="True" result="Success" success="True" time="0.502" asserts="1" />
+                              <test-case name="NUnit.Framework.Constraints.AfterConstraintTest.ProvidesProperFailureMessage(0,&quot;0&quot;)" executed="True" result="Success" success="True" time="0.500" asserts="1" />
+                              <test-case name="NUnit.Framework.Constraints.AfterConstraintTest.ProvidesProperFailureMessage(null,&quot;null&quot;)" executed="True" result="Success" success="True" time="0.500" asserts="1" />
+                            </results>
+                          </test-suite>
+                          <test-case name="NUnit.Framework.Constraints.AfterConstraintTest.SimpleTest" executed="True" result="Success" success="True" time="0.601" asserts="1" />
+                          <test-case name="NUnit.Framework.Constraints.AfterConstraintTest.SimpleTestUsingReference" executed="True" result="Success" success="True" time="0.603" asserts="1" />
+                          <test-suite type="ParameterizedTest" name="SucceedsWithGoodDelegates" executed="True" result="Success" success="True" time="0.503" asserts="0">
+                            <results>
+                              <test-case name="NUnit.Framework.Constraints.AfterConstraintTest.SucceedsWithGoodDelegates(NUnit.Framework.Constraints.ActualValueDelegate)" executed="True" result="Success" success="True" time="0.501" asserts="1" />
+                            </results>
+                          </test-suite>
+                          <test-suite type="ParameterizedTest" name="SucceedsWithGoodValues" executed="True" result="Success" success="True" time="0.501" asserts="0">
+                            <results>
+                              <test-case name="NUnit.Framework.Constraints.AfterConstraintTest.SucceedsWithGoodValues(True)" executed="True" result="Success" success="True" time="0.500" asserts="1" />
+                            </results>
+                          </test-suite>
+                          <test-case name="NUnit.Framework.Constraints.AfterConstraintTest.ThatOverload_DoesNotAcceptNegativeDelayValues" executed="True" result="Success" success="True" time="0.004" asserts="0" />
+                          <test-case name="NUnit.Framework.Constraints.AfterConstraintTest.ThatOverload_ZeroDelayIsAllowed" executed="True" result="Success" success="True" time="0.001" asserts="1" />
+                        </results>
+                      </test-suite>
+                      <test-suite type="TestFixture" name="AllItemsTests" executed="True" result="Success" success="True" time="0.043" asserts="0">
+                        <results>
+                          <test-case name="NUnit.Framework.Constraints.AllItemsTests.AllItemsAreInRange" executed="True" result="Success" success="True" time="0.008" asserts="1" />
+                          <test-case name="NUnit.Framework.Constraints.AllItemsTests.AllItemsAreInRange_UsingComparisonOfT" executed="True" result="Success" success="True" time="0.001" asserts="1" />
+                          <test-case name="NUnit.Framework.Constraints.AllItemsTests.AllItemsAreInRange_UsingIComparer" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Framework.Constraints.AllItemsTests.AllItemsAreInRange_UsingIComparerOfT" executed="True" result="Success" success="True" time="0.001" asserts="1" />
+                          <test-case name="NUnit.Framework.Constraints.AllItemsTests.AllItemsAreInRangeFailureMessage" executed="True" result="Success" success="True" time="0.003" asserts="2" />
+                          <test-case name="NUnit.Framework.Constraints.AllItemsTests.AllItemsAreInstancesOfType" executed="True" result="Success" success="True" time="0.001" asserts="1" />
+                          <test-case name="NUnit.Framework.Constraints.AllItemsTests.AllItemsAreInstancesOfTypeFailureMessage" executed="True" result="Success" success="True" time="0.001" asserts="2" />
+                          <test-case name="NUnit.Framework.Constraints.AllItemsTests.AllItemsAreNotNull" executed="True" result="Success" success="True" time="0.001" asserts="1" />
+                          <test-case name="NUnit.Framework.Constraints.AllItemsTests.AllItemsAreNotNullFails" executed="True" result="Success" success="True" time="0.001" asserts="2" />
+                        </results>
+                      </test-suite>
+                      <test-suite type="TestFixture" name="AndTest" executed="True" result="Success" success="True" time="0.017" asserts="0">
+                        <results>
+                          <test-case name="NUnit.Framework.Constraints.AndTest.CanCombineTestsWithAndOperator" executed="True" result="Success" success="True" time="0.001" asserts="1" />
+                          <test-case name="NUnit.Framework.Constraints.AndTest.ConstraintTestBaseNoData.ProvidesProperDescription" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Framework.Constraints.AndTest.ConstraintTestBaseNoData.ProvidesProperStringRepresentation" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                          <test-suite type="ParameterizedTest" name="FailsWithBadValues" executed="True" result="Success" success="True" time="0.002" asserts="0">
+                            <results>
+                              <test-case name="NUnit.Framework.Constraints.AndTest.FailsWithBadValues(37)" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                              <test-case name="NUnit.Framework.Constraints.AndTest.FailsWithBadValues(53)" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                            </results>
+                          </test-suite>
+                          <test-suite type="ParameterizedTest" name="ProvidesProperFailureMessage" executed="True" result="Success" success="True" time="0.003" asserts="0">
+                            <results>
+                              <test-case name="NUnit.Framework.Constraints.AndTest.ProvidesProperFailureMessage(37,&quot;37&quot;)" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                              <test-case name="NUnit.Framework.Constraints.AndTest.ProvidesProperFailureMessage(53,&quot;53&quot;)" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                            </results>
+                          </test-suite>
+                          <test-suite type="ParameterizedTest" name="SucceedsWithGoodValues" executed="True" result="Success" success="True" time="0.001" asserts="0">
+                            <results>
+                              <test-case name="NUnit.Framework.Constraints.AndTest.SucceedsWithGoodValues(42)" executed="True" result="Success" success="True" time="0.001" asserts="1" />
+                            </results>
+                          </test-suite>
+                        </results>
+                      </test-suite>
+                      <test-suite type="TestFixture" name="AssignableFromTest" executed="True" result="Success" success="True" time="0.011" asserts="0">
+                        <results>
+                          <test-case name="NUnit.Framework.Constraints.AssignableFromTest.ConstraintTestBaseNoData.ProvidesProperDescription" executed="True" result="Success" success="True" time="0.001" asserts="1" />
+                          <test-case name="NUnit.Framework.Constraints.AssignableFromTest.ConstraintTestBaseNoData.ProvidesProperStringRepresentation" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                          <test-suite type="ParameterizedTest" name="FailsWithBadValues" executed="True" result="Success" success="True" time="0.001" asserts="0">
+                            <results>
+                              <test-case name="NUnit.Framework.Constraints.AssignableFromTest.FailsWithBadValues(NUnit.Framework.Constraints.D2)" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                            </results>
+                          </test-suite>
+                          <test-suite type="ParameterizedTest" name="ProvidesProperFailureMessage" executed="True" result="Success" success="True" time="0.001" asserts="0">
+                            <results>
+                              <test-case name="NUnit.Framework.Constraints.AssignableFromTest.ProvidesProperFailureMessage(NUnit.Framework.Constraints.D2,&quot;&lt;NUnit.Framework.Constraints.D2&gt;&quot;)" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                            </results>
+                          </test-suite>
+                          <test-suite type="ParameterizedTest" name="SucceedsWithGoodValues" executed="True" result="Success" success="True" time="0.003" asserts="0">
+                            <results>
+                              <test-case name="NUnit.Framework.Constraints.AssignableFromTest.SucceedsWithGoodValues(NUnit.Framework.Constraints.D1)" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                              <test-case name="NUnit.Framework.Constraints.AssignableFromTest.SucceedsWithGoodValues(NUnit.Framework.Constraints.B)" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                            </results>
+                          </test-suite>
+                        </results>
+                      </test-suite>
+                      <test-suite type="TestFixture" name="AssignableToTest" executed="True" result="Success" success="True" time="0.017" asserts="0">
+                        <results>
+                          <test-case name="NUnit.Framework.Constraints.AssignableToTest.ConstraintTestBaseNoData.ProvidesProperDescription" executed="True" result="Success" success="True" time="0.001" asserts="1" />
+                          <test-case name="NUnit.Framework.Constraints.AssignableToTest.ConstraintTestBaseNoData.ProvidesProperStringRepresentation" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                          <test-suite type="ParameterizedTest" name="FailsWithBadValues" executed="True" result="Success" success="True" time="0.001" asserts="0">
+                            <results>
+                              <test-case name="NUnit.Framework.Constraints.AssignableToTest.FailsWithBadValues(NUnit.Framework.Constraints.B)" executed="True" result="Success" success="True" time="0.001" asserts="1" />
+                            </results>
+                          </test-suite>
+                          <test-suite type="ParameterizedTest" name="ProvidesProperFailureMessage" executed="True" result="Success" success="True" time="0.001" asserts="0">
+                            <results>
+                              <test-case name="NUnit.Framework.Constraints.AssignableToTest.ProvidesProperFailureMessage(NUnit.Framework.Constraints.B,&quot;&lt;NUnit.Framework.Constraints.B&gt;&quot;)" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                            </results>
+                          </test-suite>
+                          <test-suite type="ParameterizedTest" name="SucceedsWithGoodValues" executed="True" result="Success" success="True" time="0.009" asserts="0">
+                            <results>
+                              <test-case name="NUnit.Framework.Constraints.AssignableToTest.SucceedsWithGoodValues(NUnit.Framework.Constraints.D1)" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                              <test-case name="NUnit.Framework.Constraints.AssignableToTest.SucceedsWithGoodValues(NUnit.Framework.Constraints.D2)" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                            </results>
+                          </test-suite>
+                        </results>
+                      </test-suite>
+                      <test-suite type="TestFixture" name="AttributeExistsConstraintTest" executed="True" result="Success" success="True" time="0.019" asserts="0">
+                        <results>
+                          <test-case name="NUnit.Framework.Constraints.AttributeExistsConstraintTest.AttributeExistsOnMethodInfo" executed="True" result="Success" success="True" time="0.001" asserts="1" />
+                          <test-case name="NUnit.Framework.Constraints.AttributeExistsConstraintTest.AttributeTestPropertyValueOnMethodInfo" description="my description" executed="True" result="Success" success="True" time="0.001" asserts="1" />
+                          <test-case name="NUnit.Framework.Constraints.AttributeExistsConstraintTest.CanCombineAttributeConstraints" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Framework.Constraints.AttributeExistsConstraintTest.ConstraintTestBaseNoData.ProvidesProperDescription" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Framework.Constraints.AttributeExistsConstraintTest.ConstraintTestBaseNoData.ProvidesProperStringRepresentation" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                          <test-suite type="ParameterizedTest" name="FailsWithBadValues" executed="True" result="Success" success="True" time="0.000" asserts="0">
+                            <results>
+                              <test-case name="NUnit.Framework.Constraints.AttributeExistsConstraintTest.FailsWithBadValues(NUnit.Framework.Constraints.D2)" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                            </results>
+                          </test-suite>
+                          <test-case name="NUnit.Framework.Constraints.AttributeExistsConstraintTest.NonAttributeThrowsException" executed="True" result="Success" success="True" time="0.001" asserts="0" />
+                          <test-suite type="ParameterizedTest" name="ProvidesProperFailureMessage" executed="True" result="Success" success="True" time="0.001" asserts="0">
+                            <results>
+                              <test-case name="NUnit.Framework.Constraints.AttributeExistsConstraintTest.ProvidesProperFailureMessage(NUnit.Framework.Constraints.D2,&quot;&lt;NUnit.Framework.Constraints.D2&gt;&quot;)" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                            </results>
+                          </test-suite>
+                          <test-suite type="ParameterizedTest" name="SucceedsWithGoodValues" executed="True" result="Success" success="True" time="0.001" asserts="0">
+                            <results>
+                              <test-case name="NUnit.Framework.Constraints.AttributeExistsConstraintTest.SucceedsWithGoodValues(NUnit.Framework.Constraints.AttributeExistsConstraintTest)" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                            </results>
+                          </test-suite>
+                        </results>
+                      </test-suite>
+                      <test-suite type="TestFixture" name="BinarySerializableTest" executed="True" result="Success" success="True" time="0.050" asserts="0">
+                        <results>
+                          <test-case name="NUnit.Framework.Constraints.BinarySerializableTest.ConstraintTestBaseNoData.ProvidesProperDescription" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Framework.Constraints.BinarySerializableTest.ConstraintTestBaseNoData.ProvidesProperStringRepresentation" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                          <test-suite type="ParameterizedTest" name="FailsWithBadValues" executed="True" result="Success" success="True" time="0.030" asserts="0">
+                            <results>
+                              <test-case name="NUnit.Framework.Constraints.BinarySerializableTest.FailsWithBadValues(NUnit.Framework.Constraints.InternalClass)" executed="True" result="Success" success="True" time="0.029" asserts="1" />
+                            </results>
+                          </test-suite>
+                          <test-suite type="ParameterizedTest" name="InvalidDataThrowsArgumentException" executed="True" result="Success" success="True" time="0.002" asserts="0">
+                            <results>
+                              <test-case name="NUnit.Framework.Constraints.BinarySerializableTest.InvalidDataThrowsArgumentException(null)" executed="True" result="Success" success="True" time="0.001" asserts="0" />
+                            </results>
+                          </test-suite>
+                          <test-suite type="ParameterizedTest" name="ProvidesProperFailureMessage" executed="True" result="Success" success="True" time="0.001" asserts="0">
+                            <results>
+                              <test-case name="NUnit.Framework.Constraints.BinarySerializableTest.ProvidesProperFailureMessage(NUnit.Framework.Constraints.InternalClass,&quot;&lt;InternalClass&gt;&quot;)" executed="True" result="Success" success="True" time="0.001" asserts="1" />
+                            </results>
+                          </test-suite>
+                          <test-suite type="ParameterizedTest" name="SucceedsWithGoodValues" executed="True" result="Success" success="True" time="0.007" asserts="0">
+                            <results>
+                              <test-case name="NUnit.Framework.Constraints.BinarySerializableTest.SucceedsWithGoodValues(1)" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                              <test-case name="NUnit.Framework.Constraints.BinarySerializableTest.SucceedsWithGoodValues(&quot;a&quot;)" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                              <test-case name="NUnit.Framework.Constraints.BinarySerializableTest.SucceedsWithGoodValues(System.Collections.ArrayList)" executed="True" result="Success" success="True" time="0.001" asserts="1" />
+                              <test-case name="NUnit.Framework.Constraints.BinarySerializableTest.SucceedsWithGoodValues(NUnit.Framework.Constraints.InternalWithSerializableAttributeClass)" executed="True" result="Success" success="True" time="0.001" asserts="1" />
+                            </results>
+                          </test-suite>
+                        </results>
+                      </test-suite>
+                      <test-suite type="TestFixture" name="CollectionContainsTests" executed="True" result="Success" success="True" time="0.040" asserts="0">
+                        <results>
+                          <test-case name="NUnit.Framework.Constraints.CollectionContainsTests.CanTestContentsOfArray" executed="True" result="Success" success="True" time="0.001" asserts="1" />
+                          <test-case name="NUnit.Framework.Constraints.CollectionContainsTests.CanTestContentsOfArrayList" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Framework.Constraints.CollectionContainsTests.CanTestContentsOfCollectionNotImplementingIList" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Framework.Constraints.CollectionContainsTests.CanTestContentsOfSortedList" executed="True" result="Success" success="True" time="0.000" asserts="2" />
+                          <test-case name="NUnit.Framework.Constraints.CollectionContainsTests.ContainsWithRecursiveStructure" executed="True" result="Success" success="True" time="0.003" asserts="1" />
+                          <test-case name="NUnit.Framework.Constraints.CollectionContainsTests.IgnoreCaseIsHonored" executed="True" result="Success" success="True" time="0.001" asserts="1" />
+                          <test-case name="NUnit.Framework.Constraints.CollectionContainsTests.UsesProvidedComparerOfT" executed="True" result="Success" success="True" time="0.004" asserts="2" />
+                          <test-case name="NUnit.Framework.Constraints.CollectionContainsTests.UsesProvidedComparisonOfT" executed="True" result="Success" success="True" time="0.003" asserts="2" />
+                          <test-case name="NUnit.Framework.Constraints.CollectionContainsTests.UsesProvidedEqualityComparer" executed="True" result="Success" success="True" time="0.001" asserts="2" />
+                          <test-case name="NUnit.Framework.Constraints.CollectionContainsTests.UsesProvidedEqualityComparerOfT" executed="True" result="Success" success="True" time="0.003" asserts="2" />
+                          <test-case name="NUnit.Framework.Constraints.CollectionContainsTests.UsesProvidedIComparer" executed="True" result="Success" success="True" time="0.001" asserts="2" />
+                          <test-case name="NUnit.Framework.Constraints.CollectionContainsTests.UsesProvidedLambdaExpression" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                        </results>
+                      </test-suite>
+                      <test-suite type="TestFixture" name="CollectionEquivalentTests" executed="True" result="Success" success="True" time="0.177" asserts="0">
+                        <results>
+                          <test-case name="NUnit.Framework.Constraints.CollectionEquivalentTests.EqualCollectionsAreEquivalent" executed="True" result="Success" success="True" time="0.002" asserts="1" />
+                          <test-case name="NUnit.Framework.Constraints.CollectionEquivalentTests.EquivalentFailsWithDuplicateElementInActual" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Framework.Constraints.CollectionEquivalentTests.EquivalentFailsWithDuplicateElementInExpected" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Framework.Constraints.CollectionEquivalentTests.EquivalentHandlesNull" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Framework.Constraints.CollectionEquivalentTests.EquivalentHonorsIgnoreCase" executed="True" result="Success" success="True" time="0.001" asserts="1" />
+                          <test-case name="NUnit.Framework.Constraints.CollectionEquivalentTests.EquivalentHonorsUsing" executed="True" result="Success" success="True" time="0.001" asserts="1" />
+                          <test-case name="NUnit.Framework.Constraints.CollectionEquivalentTests.EquivalentIgnoresOrder" executed="True" result="Success" success="True" time="0.001" asserts="1" />
+                          <test-case name="NUnit.Framework.Constraints.CollectionEquivalentTests.FailureMessageWithHashSetAndArray" executed="True" result="Success" success="True" time="0.110" asserts="2" />
+                          <test-case name="NUnit.Framework.Constraints.CollectionEquivalentTests.WorksWithArrayAndHashSet" executed="True" result="Success" success="True" time="0.001" asserts="1" />
+                          <test-case name="NUnit.Framework.Constraints.CollectionEquivalentTests.WorksWithCollectionsOfArrays" executed="True" result="Success" success="True" time="0.001" asserts="2" />
+                          <test-case name="NUnit.Framework.Constraints.CollectionEquivalentTests.WorksWithHashSetAndArray" executed="True" result="Success" success="True" time="0.001" asserts="1" />
+                          <test-case name="NUnit.Framework.Constraints.CollectionEquivalentTests.WorksWithHashSets" executed="True" result="Success" success="True" time="0.001" asserts="1" />
+                        </results>
+                      </test-suite>
+                      <test-suite type="TestFixture" name="CollectionOrderedTests" executed="True" result="Success" success="True" time="0.066" asserts="0">
+                        <results>
+                          <test-case name="NUnit.Framework.Constraints.CollectionOrderedTests.IsOrdered" executed="True" result="Success" success="True" time="0.002" asserts="1" />
+                          <test-case name="NUnit.Framework.Constraints.CollectionOrderedTests.IsOrdered_2" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Framework.Constraints.CollectionOrderedTests.IsOrdered_Allows_adjacent_equal_values" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Framework.Constraints.CollectionOrderedTests.IsOrdered_AtLeastOneArgMustImplementIComparable" executed="True" result="Success" success="True" time="0.002" asserts="1" />
+                          <test-case name="NUnit.Framework.Constraints.CollectionOrderedTests.IsOrdered_Fails" executed="True" result="Success" success="True" time="0.001" asserts="2" />
+                          <test-case name="NUnit.Framework.Constraints.CollectionOrderedTests.IsOrdered_Handles_custom_comparison" executed="True" result="Success" success="True" time="0.008" asserts="2" />
+                          <test-case name="NUnit.Framework.Constraints.CollectionOrderedTests.IsOrdered_Handles_custom_comparison2" executed="True" result="Success" success="True" time="0.001" asserts="2" />
+                          <test-case name="NUnit.Framework.Constraints.CollectionOrderedTests.IsOrdered_Handles_null" executed="True" result="Success" success="True" time="0.001" asserts="1" />
+                          <test-case name="NUnit.Framework.Constraints.CollectionOrderedTests.IsOrdered_TypesMustBeComparable" executed="True" result="Success" success="True" time="0.001" asserts="1" />
+                          <test-case name="NUnit.Framework.Constraints.CollectionOrderedTests.IsOrderedBy" executed="True" result="Success" success="True" time="0.001" asserts="1" />
+                          <test-case name="NUnit.Framework.Constraints.CollectionOrderedTests.IsOrderedBy_Comparer" executed="True" result="Success" success="True" time="0.001" asserts="1" />
+                          <test-case name="NUnit.Framework.Constraints.CollectionOrderedTests.IsOrderedBy_Handles_heterogeneous_classes_as_long_as_the_property_is_of_same_type" executed="True" result="Success" success="True" time="0.001" asserts="1" />
+                          <test-case name="NUnit.Framework.Constraints.CollectionOrderedTests.IsOrderedDescending" executed="True" result="Success" success="True" time="0.001" asserts="1" />
+                          <test-case name="NUnit.Framework.Constraints.CollectionOrderedTests.IsOrderedDescending_2" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Framework.Constraints.CollectionOrderedTests.UsesProvidedComparerOfT" executed="True" result="Success" success="True" time="0.002" asserts="2" />
+                          <test-case name="NUnit.Framework.Constraints.CollectionOrderedTests.UsesProvidedComparisonOfT" executed="True" result="Success" success="True" time="0.003" asserts="2" />
+                          <test-case name="NUnit.Framework.Constraints.CollectionOrderedTests.UsesProvidedLambda" executed="True" result="Success" success="True" time="0.001" asserts="1" />
+                        </results>
+                      </test-suite>
+                      <test-suite type="TestFixture" name="ComparerTests" executed="True" result="Success" success="True" time="0.061" asserts="0">
+                        <results>
+                          <test-suite type="ParameterizedTest" name="EqualItems" executed="True" result="Success" success="True" time="0.021" asserts="0">
+                            <results>
+                              <test-case name="NUnit.Framework.Constraints.ComparerTests.EqualItems(4,4)" executed="True" result="Success" success="True" time="0.001" asserts="2" />
+                              <test-case name="NUnit.Framework.Constraints.ComparerTests.EqualItems(null,null)" executed="True" result="Success" success="True" time="0.001" asserts="2" />
+                              <test-case name="NUnit.Framework.Constraints.ComparerTests.EqualItems(4.0d,4.0d)" executed="True" result="Success" success="True" time="0.002" asserts="2" />
+                              <test-case name="NUnit.Framework.Constraints.ComparerTests.EqualItems(4.0f,4.0f)" executed="True" result="Success" success="True" time="0.002" asserts="2" />
+                              <test-case name="NUnit.Framework.Constraints.ComparerTests.EqualItems(4,4.0d)" executed="True" result="Success" success="True" time="0.001" asserts="2" />
+                              <test-case name="NUnit.Framework.Constraints.ComparerTests.EqualItems(4,4.0f)" executed="True" result="Success" success="True" time="0.000" asserts="2" />
+                              <test-case name="NUnit.Framework.Constraints.ComparerTests.EqualItems(null,null)" executed="True" result="Success" success="True" time="0.000" asserts="2" />
+                              <test-case name="NUnit.Framework.Constraints.ComparerTests.EqualItems(4.0d,4)" executed="True" result="Success" success="True" time="0.000" asserts="2" />
+                              <test-case name="NUnit.Framework.Constraints.ComparerTests.EqualItems(4.0d,4.0f)" executed="True" result="Success" success="True" time="0.001" asserts="2" />
+                              <test-case name="NUnit.Framework.Constraints.ComparerTests.EqualItems(4.0f,4)" executed="True" result="Success" success="True" time="0.000" asserts="2" />
+                              <test-case name="NUnit.Framework.Constraints.ComparerTests.EqualItems(4.0f,4.0d)" executed="True" result="Success" success="True" time="0.000" asserts="2" />
+                            </results>
+                          </test-suite>
+                          <test-suite type="ParameterizedTest" name="SpecialFloatingPointValues" executed="True" result="Success" success="True" time="0.008" asserts="0">
+                            <results>
+                              <test-case name="NUnit.Framework.Constraints.ComparerTests.SpecialFloatingPointValues(double.PositiveInfinity)" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                              <test-case name="NUnit.Framework.Constraints.ComparerTests.SpecialFloatingPointValues(double.NaN)" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                              <test-case name="NUnit.Framework.Constraints.ComparerTests.SpecialFloatingPointValues(float.PositiveInfinity)" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                              <test-case name="NUnit.Framework.Constraints.ComparerTests.SpecialFloatingPointValues(float.NegativeInfinity)" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                              <test-case name="NUnit.Framework.Constraints.ComparerTests.SpecialFloatingPointValues(float.NaN)" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                              <test-case name="NUnit.Framework.Constraints.ComparerTests.SpecialFloatingPointValues(double.NegativeInfinity)" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                            </results>
+                          </test-suite>
+                          <test-suite type="ParameterizedTest" name="UnequalItems" executed="True" result="Success" success="True" time="0.025" asserts="0">
+                            <results>
+                              <test-case name="NUnit.Framework.Constraints.ComparerTests.UnequalItems(4,2)" executed="True" result="Success" success="True" time="0.000" asserts="4" />
+                              <test-case name="NUnit.Framework.Constraints.ComparerTests.UnequalItems(4.0d,2.0d)" executed="True" result="Success" success="True" time="0.000" asserts="4" />
+                              <test-case name="NUnit.Framework.Constraints.ComparerTests.UnequalItems(4,null)" executed="True" result="Success" success="True" time="0.001" asserts="4" />
+                              <test-case name="NUnit.Framework.Constraints.ComparerTests.UnequalItems(4.0f,2.0f)" executed="True" result="Success" success="True" time="0.000" asserts="4" />
+                              <test-case name="NUnit.Framework.Constraints.ComparerTests.UnequalItems(4,2.0f)" executed="True" result="Success" success="True" time="0.000" asserts="4" />
+                              <test-case name="NUnit.Framework.Constraints.ComparerTests.UnequalItems(4.0d,2)" executed="True" result="Success" success="True" time="0.000" asserts="4" />
+                              <test-case name="NUnit.Framework.Constraints.ComparerTests.UnequalItems(4.0d,2.0f)" executed="True" result="Success" success="True" time="0.000" asserts="4" />
+                              <test-case name="NUnit.Framework.Constraints.ComparerTests.UnequalItems(4.0f,2)" executed="True" result="Success" success="True" time="0.000" asserts="4" />
+                              <test-case name="NUnit.Framework.Constraints.ComparerTests.UnequalItems(4.0f,2.0d)" executed="True" result="Success" success="True" time="0.001" asserts="4" />
+                              <test-case name="NUnit.Framework.Constraints.ComparerTests.UnequalItems(4,null)" executed="True" result="Success" success="True" time="0.000" asserts="4" />
+                              <test-case name="NUnit.Framework.Constraints.ComparerTests.UnequalItems(4,2.0d)" executed="True" result="Success" success="True" time="0.000" asserts="4" />
+                            </results>
+                          </test-suite>
+                        </results>
+                      </test-suite>
+                      <test-suite type="TestFixture" name="EmptyConstraintTest" executed="True" result="Success" success="True" time="0.029" asserts="0">
+                        <results>
+                          <test-case name="NUnit.Framework.Constraints.EmptyConstraintTest.ConstraintTestBaseNoData.ProvidesProperDescription" executed="True" result="Success" success="True" time="0.001" asserts="1" />
+                          <test-case name="NUnit.Framework.Constraints.EmptyConstraintTest.ConstraintTestBaseNoData.ProvidesProperStringRepresentation" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                          <test-suite type="ParameterizedTest" name="FailsWithBadValues" executed="True" result="Success" success="True" time="0.003" asserts="0">
+                            <results>
+                              <test-case name="NUnit.Framework.Constraints.EmptyConstraintTest.FailsWithBadValues(&quot;Hello&quot;)" executed="True" result="Success" success="True" time="0.001" asserts="1" />
+                              <test-case name="NUnit.Framework.Constraints.EmptyConstraintTest.FailsWithBadValues(System.Object[])" executed="True" result="Success" success="True" time="0.001" asserts="1" />
+                            </results>
+                          </test-suite>
+                          <test-suite type="ParameterizedTest" name="InvalidDataThrowsArgumentException" executed="True" result="Success" success="True" time="0.003" asserts="0">
+                            <results>
+                              <test-case name="NUnit.Framework.Constraints.EmptyConstraintTest.InvalidDataThrowsArgumentException(null)" executed="True" result="Success" success="True" time="0.000" asserts="0" />
+                              <test-case name="NUnit.Framework.Constraints.EmptyConstraintTest.InvalidDataThrowsArgumentException(5)" executed="True" result="Success" success="True" time="0.000" asserts="0" />
+                            </results>
+                          </test-suite>
+                          <test-suite type="ParameterizedTest" name="ProvidesProperFailureMessage" executed="True" result="Success" success="True" time="0.008" asserts="0">
+                            <results>
+                              <test-case name="NUnit.Framework.Constraints.EmptyConstraintTest.ProvidesProperFailureMessage(&quot;Hello&quot;,&quot;\&quot;Hello\&quot;&quot;)" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                              <test-case name="NUnit.Framework.Constraints.EmptyConstraintTest.ProvidesProperFailureMessage(System.Object[],&quot;&lt; 1, 2, 3 &gt;&quot;)" executed="True" result="Success" success="True" time="0.001" asserts="1" />
+                            </results>
+                          </test-suite>
+                          <test-suite type="ParameterizedTest" name="SucceedsWithGoodValues" executed="True" result="Success" success="True" time="0.005" asserts="0">
+                            <results>
+                              <test-case name="NUnit.Framework.Constraints.EmptyConstraintTest.SucceedsWithGoodValues(&quot;&quot;)" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                              <test-case name="NUnit.Framework.Constraints.EmptyConstraintTest.SucceedsWithGoodValues(System.Object[])" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                              <test-case name="NUnit.Framework.Constraints.EmptyConstraintTest.SucceedsWithGoodValues(System.Collections.ArrayList)" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                              <test-case name="NUnit.Framework.Constraints.EmptyConstraintTest.SucceedsWithGoodValues(System.Collections.Generic.List`1[System.Int32])" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                            </results>
+                          </test-suite>
+                        </results>
+                      </test-suite>
+                      <test-suite type="TestFixture" name="EndsWithTest" executed="True" result="Success" success="True" time="0.036" asserts="0">
+                        <results>
+                          <test-case name="NUnit.Framework.Constraints.EndsWithTest.ConstraintTestBaseNoData.ProvidesProperDescription" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Framework.Constraints.EndsWithTest.ConstraintTestBaseNoData.ProvidesProperStringRepresentation" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                          <test-suite type="ParameterizedTest" name="FailsWithBadValues" executed="True" result="Success" success="True" time="0.009" asserts="0">
+                            <results>
+                              <test-case name="NUnit.Framework.Constraints.EndsWithTest.FailsWithBadValues(&quot;goodbye&quot;)" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                              <test-case name="NUnit.Framework.Constraints.EndsWithTest.FailsWithBadValues(&quot;What the hell?&quot;)" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                              <test-case name="NUnit.Framework.Constraints.EndsWithTest.FailsWithBadValues(&quot;hello there&quot;)" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                              <test-case name="NUnit.Framework.Constraints.EndsWithTest.FailsWithBadValues(&quot;say hello to fred&quot;)" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                              <test-case name="NUnit.Framework.Constraints.EndsWithTest.FailsWithBadValues(&quot;&quot;)" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                              <test-case name="NUnit.Framework.Constraints.EndsWithTest.FailsWithBadValues(null)" executed="True" result="Success" success="True" time="0.001" asserts="1" />
+                            </results>
+                          </test-suite>
+                          <test-suite type="ParameterizedTest" name="ProvidesProperFailureMessage" executed="True" result="Success" success="True" time="0.009" asserts="0">
+                            <results>
+                              <test-case name="NUnit.Framework.Constraints.EndsWithTest.ProvidesProperFailureMessage(&quot;goodbye&quot;,&quot;\&quot;goodbye\&quot;&quot;)" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                              <test-case name="NUnit.Framework.Constraints.EndsWithTest.ProvidesProperFailureMessage(&quot;What the hell?&quot;,&quot;\&quot;What the hell?\&quot;&quot;)" executed="True" result="Success" success="True" time="0.001" asserts="1" />
+                              <test-case name="NUnit.Framework.Constraints.EndsWithTest.ProvidesProperFailureMessage(&quot;hello there&quot;,&quot;\&quot;hello there\&quot;&quot;)" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                              <test-case name="NUnit.Framework.Constraints.EndsWithTest.ProvidesProperFailureMessage(&quot;say hello to fred&quot;,&quot;\&quot;say hello to fred\&quot;&quot;)" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                              <test-case name="NUnit.Framework.Constraints.EndsWithTest.ProvidesProperFailureMessage(&quot;&quot;,&quot;&lt;string.Empty&gt;&quot;)" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                              <test-case name="NUnit.Framework.Constraints.EndsWithTest.ProvidesProperFailureMessage(null,&quot;null&quot;)" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                            </results>
+                          </test-suite>
+                          <test-suite type="ParameterizedTest" name="SucceedsWithGoodValues" executed="True" result="Success" success="True" time="0.010" asserts="0">
+                            <results>
+                              <test-case name="NUnit.Framework.Constraints.EndsWithTest.SucceedsWithGoodValues(&quot;hello&quot;)" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                              <test-case name="NUnit.Framework.Constraints.EndsWithTest.SucceedsWithGoodValues(&quot;I said hello&quot;)" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                            </results>
+                          </test-suite>
+                        </results>
+                      </test-suite>
+                      <test-suite type="TestFixture" name="EndsWithTestIgnoringCase" executed="True" result="Success" success="True" time="0.026" asserts="0">
+                        <results>
+                          <test-case name="NUnit.Framework.Constraints.EndsWithTestIgnoringCase.ConstraintTestBaseNoData.ProvidesProperDescription" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Framework.Constraints.EndsWithTestIgnoringCase.ConstraintTestBaseNoData.ProvidesProperStringRepresentation" executed="True" result="Success" success="True" time="0.001" asserts="1" />
+                          <test-suite type="ParameterizedTest" name="FailsWithBadValues" executed="True" result="Success" success="True" time="0.008" asserts="0">
+                            <results>
+                              <test-case name="NUnit.Framework.Constraints.EndsWithTestIgnoringCase.FailsWithBadValues(&quot;goodbye&quot;)" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                              <test-case name="NUnit.Framework.Constraints.EndsWithTestIgnoringCase.FailsWithBadValues(&quot;What the hell?&quot;)" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                              <test-case name="NUnit.Framework.Constraints.EndsWithTestIgnoringCase.FailsWithBadValues(&quot;hello there&quot;)" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                              <test-case name="NUnit.Framework.Constraints.EndsWithTestIgnoringCase.FailsWithBadValues(&quot;say hello to fred&quot;)" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                              <test-case name="NUnit.Framework.Constraints.EndsWithTestIgnoringCase.FailsWithBadValues(&quot;&quot;)" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                              <test-case name="NUnit.Framework.Constraints.EndsWithTestIgnoringCase.FailsWithBadValues(null)" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                            </results>
+                          </test-suite>
+                          <test-suite type="ParameterizedTest" name="ProvidesProperFailureMessage" executed="True" result="Success" success="True" time="0.008" asserts="0">
+                            <results>
+                              <test-case name="NUnit.Framework.Constraints.EndsWithTestIgnoringCase.ProvidesProperFailureMessage(&quot;goodbye&quot;,&quot;\&quot;goodbye\&quot;&quot;)" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                              <test-case name="NUnit.Framework.Constraints.EndsWithTestIgnoringCase.ProvidesProperFailureMessage(&quot;What the hell?&quot;,&quot;\&quot;What the hell?\&quot;&quot;)" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                              <test-case name="NUnit.Framework.Constraints.EndsWithTestIgnoringCase.ProvidesProperFailureMessage(&quot;hello there&quot;,&quot;\&quot;hello there\&quot;&quot;)" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                              <test-case name="NUnit.Framework.Constraints.EndsWithTestIgnoringCase.ProvidesProperFailureMessage(&quot;say hello to fred&quot;,&quot;\&quot;say hello to fred\&quot;&quot;)" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                              <test-case name="NUnit.Framework.Constraints.EndsWithTestIgnoringCase.ProvidesProperFailureMessage(&quot;&quot;,&quot;&lt;string.Empty&gt;&quot;)" executed="True" result="Success" success="True" time="0.001" asserts="1" />
+                              <test-case name="NUnit.Framework.Constraints.EndsWithTestIgnoringCase.ProvidesProperFailureMessage(null,&quot;null&quot;)" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                            </results>
+                          </test-suite>
+                          <test-suite type="ParameterizedTest" name="SucceedsWithGoodValues" executed="True" result="Success" success="True" time="0.002" asserts="0">
+                            <results>
+                              <test-case name="NUnit.Framework.Constraints.EndsWithTestIgnoringCase.SucceedsWithGoodValues(&quot;HELLO&quot;)" executed="True" result="Success" success="True" time="0.001" asserts="1" />
+                              <test-case name="NUnit.Framework.Constraints.EndsWithTestIgnoringCase.SucceedsWithGoodValues(&quot;I said Hello&quot;)" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                            </results>
+                          </test-suite>
+                        </results>
+                      </test-suite>
+                      <test-suite type="TestFixture" name="EqualConstraintTests" executed="True" result="Success" success="True" time="0.196" asserts="0">
+                        <results>
+                          <test-case name="NUnit.Framework.Constraints.EqualConstraintTests.CanMatchDates" executed="True" result="Success" success="True" time="0.001" asserts="1" />
+                          <test-case name="NUnit.Framework.Constraints.EqualConstraintTests.CanMatchDatesWithinDays" executed="True" result="Success" success="True" time="0.001" asserts="1" />
+                          <test-case name="NUnit.Framework.Constraints.EqualConstraintTests.CanMatchDatesWithinHours" executed="True" result="Success" success="True" time="0.001" asserts="1" />
+                          <test-case name="NUnit.Framework.Constraints.EqualConstraintTests.CanMatchDatesWithinMilliseconds" executed="True" result="Success" success="True" time="0.001" asserts="1" />
+                          <test-case name="NUnit.Framework.Constraints.EqualConstraintTests.CanMatchDatesWithinMinutes" executed="True" result="Success" success="True" time="0.001" asserts="1" />
+                          <test-case name="NUnit.Framework.Constraints.EqualConstraintTests.CanMatchDatesWithinSeconds" executed="True" result="Success" success="True" time="0.001" asserts="1" />
+                          <test-case name="NUnit.Framework.Constraints.EqualConstraintTests.CanMatchDatesWithinTicks" executed="True" result="Success" success="True" time="0.001" asserts="1" />
+                          <test-case name="NUnit.Framework.Constraints.EqualConstraintTests.CanMatchDatesWithinTimeSpan" executed="True" result="Success" success="True" time="0.001" asserts="1" />
+                          <test-case name="NUnit.Framework.Constraints.EqualConstraintTests.CanMatchDictionaries_DifferentOrder" executed="True" result="Success" success="True" time="0.002" asserts="1" />
+                          <test-case name="NUnit.Framework.Constraints.EqualConstraintTests.CanMatchDictionaries_Failure" executed="True" result="Success" success="True" time="0.004" asserts="1" />
+                          <test-case name="NUnit.Framework.Constraints.EqualConstraintTests.CanMatchDictionaries_SameOrder" executed="True" result="Success" success="True" time="0.001" asserts="1" />
+                          <test-suite type="ParameterizedTest" name="CanMatchDoublesWithRelativeTolerance" executed="True" result="Success" success="True" time="0.004" asserts="0">
+                            <results>
+                              <test-case name="NUnit.Framework.Constraints.EqualConstraintTests.CanMatchDoublesWithRelativeTolerance(10000.0d)" executed="True" result="Success" success="True" time="0.001" asserts="1" />
+                              <test-case name="NUnit.Framework.Constraints.EqualConstraintTests.CanMatchDoublesWithRelativeTolerance(9500.0d)" executed="True" result="Success" success="True" time="0.001" asserts="1" />
+                              <test-case name="NUnit.Framework.Constraints.EqualConstraintTests.CanMatchDoublesWithRelativeTolerance(10500.0d)" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                            </results>
+                          </test-suite>
+                          <test-suite type="ParameterizedTest" name="CanMatchDoublesWithUlpTolerance" executed="True" result="Success" success="True" time="0.003" asserts="0">
+                            <results>
+                              <test-case name="NUnit.Framework.Constraints.EqualConstraintTests.CanMatchDoublesWithUlpTolerance(2E+16.0d)" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                              <test-case name="NUnit.Framework.Constraints.EqualConstraintTests.CanMatchDoublesWithUlpTolerance(2E+16.0d)" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                            </results>
+                          </test-suite>
+                          <test-case name="NUnit.Framework.Constraints.EqualConstraintTests.CanMatchHashtables_DifferentOrder" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Framework.Constraints.EqualConstraintTests.CanMatchHashtables_Failure" executed="True" result="Success" success="True" time="0.001" asserts="1" />
+                          <test-case name="NUnit.Framework.Constraints.EqualConstraintTests.CanMatchHashtables_SameOrder" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Framework.Constraints.EqualConstraintTests.CanMatchHashtableWithDictionary" executed="True" result="Success" success="True" time="0.001" asserts="1" />
+                          <test-suite type="ParameterizedTest" name="CanMatchSinglesWithRelativeTolerance" executed="True" result="Success" success="True" time="0.004" asserts="0">
+                            <results>
+                              <test-case name="NUnit.Framework.Constraints.EqualConstraintTests.CanMatchSinglesWithRelativeTolerance(10500.0f)" executed="True" result="Success" success="True" time="0.001" asserts="1" />
+                              <test-case name="NUnit.Framework.Constraints.EqualConstraintTests.CanMatchSinglesWithRelativeTolerance(9500.0f)" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                              <test-case name="NUnit.Framework.Constraints.EqualConstraintTests.CanMatchSinglesWithRelativeTolerance(10000.0f)" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                            </results>
+                          </test-suite>
+                          <test-suite type="ParameterizedTest" name="CanMatchSinglesWithUlpTolerance" executed="True" result="Success" success="True" time="0.003" asserts="0">
+                            <results>
+                              <test-case name="NUnit.Framework.Constraints.EqualConstraintTests.CanMatchSinglesWithUlpTolerance(2E+07.0f)" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                              <test-case name="NUnit.Framework.Constraints.EqualConstraintTests.CanMatchSinglesWithUlpTolerance(2E+07.0f)" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                            </results>
+                          </test-suite>
+                          <test-suite type="ParameterizedTest" name="CanMatchSpecialFloatingPointValues" executed="True" result="Success" success="True" time="0.009" asserts="0">
+                            <results>
+                              <test-case name="NUnit.Framework.Constraints.EqualConstraintTests.CanMatchSpecialFloatingPointValues(float.NaN)" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                              <test-case name="NUnit.Framework.Constraints.EqualConstraintTests.CanMatchSpecialFloatingPointValues(double.NegativeInfinity)" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                              <test-case name="NUnit.Framework.Constraints.EqualConstraintTests.CanMatchSpecialFloatingPointValues(double.NaN)" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                              <test-case name="NUnit.Framework.Constraints.EqualConstraintTests.CanMatchSpecialFloatingPointValues(float.NegativeInfinity)" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                              <test-case name="NUnit.Framework.Constraints.EqualConstraintTests.CanMatchSpecialFloatingPointValues(double.PositiveInfinity)" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                              <test-case name="NUnit.Framework.Constraints.EqualConstraintTests.CanMatchSpecialFloatingPointValues(float.PositiveInfinity)" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                            </results>
+                          </test-suite>
+                          <test-case name="NUnit.Framework.Constraints.EqualConstraintTests.CanMatchTimeSpanWithinMinutes" executed="True" result="Success" success="True" time="0.001" asserts="1" />
+                          <test-case name="NUnit.Framework.Constraints.EqualConstraintTests.ConstraintTestBaseNoData.ProvidesProperDescription" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Framework.Constraints.EqualConstraintTests.ConstraintTestBaseNoData.ProvidesProperStringRepresentation" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Framework.Constraints.EqualConstraintTests.ErrorIfDaysPrecedesWithin" executed="True" result="Success" success="True" time="0.001" asserts="0" />
+                          <test-case name="NUnit.Framework.Constraints.EqualConstraintTests.ErrorIfHoursPrecedesWithin" executed="True" result="Success" success="True" time="0.001" asserts="0" />
+                          <test-case name="NUnit.Framework.Constraints.EqualConstraintTests.ErrorIfMillisecondsPrecedesWithin" executed="True" result="Success" success="True" time="0.001" asserts="0" />
+                          <test-case name="NUnit.Framework.Constraints.EqualConstraintTests.ErrorIfMinutesPrecedesWithin" executed="True" result="Success" success="True" time="0.001" asserts="0" />
+                          <test-case name="NUnit.Framework.Constraints.EqualConstraintTests.ErrorIfPercentPrecedesWithin" executed="True" result="Success" success="True" time="0.001" asserts="0" />
+                          <test-case name="NUnit.Framework.Constraints.EqualConstraintTests.ErrorIfSecondsPrecedesWithin" executed="True" result="Success" success="True" time="0.001" asserts="0" />
+                          <test-case name="NUnit.Framework.Constraints.EqualConstraintTests.ErrorIfTicksPrecedesWithin" executed="True" result="Success" success="True" time="0.001" asserts="0" />
+                          <test-case name="NUnit.Framework.Constraints.EqualConstraintTests.ErrorIfUlpsIsUsedOnDecimal" executed="True" result="Success" success="True" time="0.001" asserts="1" />
+                          <test-suite type="ParameterizedTest" name="ErrorIfUlpsIsUsedOnIntegralType" executed="True" result="Success" success="True" time="0.007" asserts="0">
+                            <results>
+                              <test-case name="NUnit.Framework.Constraints.EqualConstraintTests.ErrorIfUlpsIsUsedOnIntegralType(1000,1010)" executed="True" result="Success" success="True" time="0.001" asserts="1" />
+                              <test-case name="NUnit.Framework.Constraints.EqualConstraintTests.ErrorIfUlpsIsUsedOnIntegralType(1000L,1010L)" executed="True" result="Success" success="True" time="0.001" asserts="1" />
+                              <test-case name="NUnit.Framework.Constraints.EqualConstraintTests.ErrorIfUlpsIsUsedOnIntegralType(1000UL,1010UL)" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                              <test-case name="NUnit.Framework.Constraints.EqualConstraintTests.ErrorIfUlpsIsUsedOnIntegralType(1000,1010)" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                            </results>
+                          </test-suite>
+                          <test-case name="NUnit.Framework.Constraints.EqualConstraintTests.ErrorIfUlpsPrecedesWithin" executed="True" result="Success" success="True" time="0.000" asserts="0" />
+                          <test-case name="NUnit.Framework.Constraints.EqualConstraintTests.ErrorWithPercentAndUlpsToleranceModes" executed="True" result="Success" success="True" time="0.001" asserts="0" />
+                          <test-case name="NUnit.Framework.Constraints.EqualConstraintTests.ErrorWithUlpsAndPercentToleranceModes" executed="True" result="Success" success="True" time="0.001" asserts="0" />
+                          <test-suite type="ParameterizedTest" name="FailsOnDoublesOutsideOfRelativeTolerance" executed="True" result="Success" success="True" time="0.005" asserts="0">
+                            <results>
+                              <test-case name="NUnit.Framework.Constraints.EqualConstraintTests.FailsOnDoublesOutsideOfRelativeTolerance(8500.0d)" executed="True" result="Success" success="True" time="0.002" asserts="1" />
+                              <test-case name="NUnit.Framework.Constraints.EqualConstraintTests.FailsOnDoublesOutsideOfRelativeTolerance(11500.0d)" executed="True" result="Success" success="True" time="0.001" asserts="1" />
+                            </results>
+                          </test-suite>
+                          <test-suite type="ParameterizedTest" name="FailsOnDoublesOutsideOfUlpTolerance" executed="True" result="Success" success="True" time="0.003" asserts="0">
+                            <results>
+                              <test-case name="NUnit.Framework.Constraints.EqualConstraintTests.FailsOnDoublesOutsideOfUlpTolerance(2E+16.0d)" executed="True" result="Success" success="True" time="0.001" asserts="1" />
+                              <test-case name="NUnit.Framework.Constraints.EqualConstraintTests.FailsOnDoublesOutsideOfUlpTolerance(2E+16.0d)" executed="True" result="Success" success="True" time="0.001" asserts="1" />
+                            </results>
+                          </test-suite>
+                          <test-suite type="ParameterizedTest" name="FailsOnSinglesOutsideOfRelativeTolerance" executed="True" result="Success" success="True" time="0.005" asserts="0">
+                            <results>
+                              <test-case name="NUnit.Framework.Constraints.EqualConstraintTests.FailsOnSinglesOutsideOfRelativeTolerance(8500.0f)" executed="True" result="Success" success="True" time="0.001" asserts="1" />
+                              <test-case name="NUnit.Framework.Constraints.EqualConstraintTests.FailsOnSinglesOutsideOfRelativeTolerance(11500.0f)" executed="True" result="Success" success="True" time="0.001" asserts="1" />
+                            </results>
+                          </test-suite>
+                          <test-suite type="ParameterizedTest" name="FailsOnSinglesOutsideOfUlpTolerance" executed="True" result="Success" success="True" time="0.004" asserts="0">
+                            <results>
+                              <test-case name="NUnit.Framework.Constraints.EqualConstraintTests.FailsOnSinglesOutsideOfUlpTolerance(2E+07.0f)" executed="True" result="Success" success="True" time="0.001" asserts="1" />
+                              <test-case name="NUnit.Framework.Constraints.EqualConstraintTests.FailsOnSinglesOutsideOfUlpTolerance(2E+07.0f)" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                            </results>
+                          </test-suite>
+                          <test-suite type="ParameterizedTest" name="FailsWithBadValues" executed="True" result="Success" success="True" time="0.006" asserts="0">
+                            <results>
+                              <test-case name="NUnit.Framework.Constraints.EqualConstraintTests.FailsWithBadValues(5)" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                              <test-case name="NUnit.Framework.Constraints.EqualConstraintTests.FailsWithBadValues(null)" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                              <test-case name="NUnit.Framework.Constraints.EqualConstraintTests.FailsWithBadValues(&quot;Hello&quot;)" executed="True" result="Success" success="True" time="0.001" asserts="1" />
+                              <test-case name="NUnit.Framework.Constraints.EqualConstraintTests.FailsWithBadValues(double.NaN)" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                              <test-case name="NUnit.Framework.Constraints.EqualConstraintTests.FailsWithBadValues(double.PositiveInfinity)" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                            </results>
+                          </test-suite>
+                          <test-suite type="ParameterizedTest" name="ProvidesProperFailureMessage" executed="True" result="Success" success="True" time="0.011" asserts="0">
+                            <results>
+                              <test-case name="NUnit.Framework.Constraints.EqualConstraintTests.ProvidesProperFailureMessage(5,&quot;5&quot;)" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                              <test-case name="NUnit.Framework.Constraints.EqualConstraintTests.ProvidesProperFailureMessage(null,&quot;null&quot;)" executed="True" result="Success" success="True" time="0.004" asserts="1" />
+                              <test-case name="NUnit.Framework.Constraints.EqualConstraintTests.ProvidesProperFailureMessage(&quot;Hello&quot;,&quot;\&quot;Hello\&quot;&quot;)" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                              <test-case name="NUnit.Framework.Constraints.EqualConstraintTests.ProvidesProperFailureMessage(double.NaN,&quot;NaN&quot;)" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                              <test-case name="NUnit.Framework.Constraints.EqualConstraintTests.ProvidesProperFailureMessage(double.PositiveInfinity,&quot;Infinity&quot;)" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                            </results>
+                          </test-suite>
+                          <test-suite type="ParameterizedTest" name="SucceedsWithGoodValues" executed="True" result="Success" success="True" time="0.007" asserts="0">
+                            <results>
+                              <test-case name="NUnit.Framework.Constraints.EqualConstraintTests.SucceedsWithGoodValues(4)" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                              <test-case name="NUnit.Framework.Constraints.EqualConstraintTests.SucceedsWithGoodValues(4.0f)" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                              <test-case name="NUnit.Framework.Constraints.EqualConstraintTests.SucceedsWithGoodValues(4.0d)" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                              <test-case name="NUnit.Framework.Constraints.EqualConstraintTests.SucceedsWithGoodValues(4.0000m)" executed="True" result="Success" success="True" time="0.002" asserts="1" />
+                            </results>
+                          </test-suite>
+                          <test-case name="NUnit.Framework.Constraints.EqualConstraintTests.UsesProvidedArrayComparer" executed="True" result="Success" success="True" time="0.001" asserts="1" />
+                          <test-case name="NUnit.Framework.Constraints.EqualConstraintTests.UsesProvidedComparerOfT" executed="True" result="Success" success="True" time="0.002" asserts="2" />
+                          <test-case name="NUnit.Framework.Constraints.EqualConstraintTests.UsesProvidedComparisonOfT" executed="True" result="Success" success="True" time="0.002" asserts="2" />
+                          <test-case name="NUnit.Framework.Constraints.EqualConstraintTests.UsesProvidedEqualityComparer" executed="True" result="Success" success="True" time="0.001" asserts="2" />
+                          <test-case name="NUnit.Framework.Constraints.EqualConstraintTests.UsesProvidedEqualityComparerOfT" executed="True" result="Success" success="True" time="0.002" asserts="2" />
+                          <test-case name="NUnit.Framework.Constraints.EqualConstraintTests.UsesProvidedIComparer" executed="True" result="Success" success="True" time="0.001" asserts="2" />
+                          <test-case name="NUnit.Framework.Constraints.EqualConstraintTests.UsesProvidedLambda_IntArgs" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Framework.Constraints.EqualConstraintTests.UsesProvidedLambda_StringArgs" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Framework.Constraints.EqualConstraintTests.UsesProvidedListComparer" executed="True" result="Success" success="True" time="0.001" asserts="1" />
+                        </results>
+                      </test-suite>
+                      <test-suite type="TestFixture" name="EqualityComparerTests" executed="True" result="Success" success="True" time="0.020" asserts="0">
+                        <results>
+                          <test-case name="NUnit.Framework.Constraints.EqualityComparerTests.CanCompareArrayContainingSelfToSelf" executed="True" result="Success" success="True" time="0.001" asserts="1" />
+                          <test-case name="NUnit.Framework.Constraints.EqualityComparerTests.IEquatableDifferentTypesSuccess_WhenActualImplementsIEquatable" executed="True" result="Success" success="True" time="0.001" asserts="1" />
+                          <test-case name="NUnit.Framework.Constraints.EqualityComparerTests.IEquatableDifferentTypesSuccess_WhenExpectedImplementsIEquatable" executed="True" result="Success" success="True" time="0.001" asserts="1" />
+                          <test-case name="NUnit.Framework.Constraints.EqualityComparerTests.IEquatableHasPrecedenceOverDefaultEquals" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Framework.Constraints.EqualityComparerTests.IEquatableSuccess" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Framework.Constraints.EqualityComparerTests.RecursiveEnumerablesAreNotEqual" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Framework.Constraints.EqualityComparerTests.RecursiveEnumerablesAreNotEqual2" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Framework.Constraints.EqualityComparerTests.ReferenceEqualityHasPrecedenceOverIEquatable" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                        </results>
+                      </test-suite>
+                      <test-suite type="TestFixture" name="EqualTest" executed="True" result="Success" success="True" time="0.016" asserts="0">
+                        <results>
+                          <test-case name="NUnit.Framework.Constraints.EqualTest.FailedStringMatchShowsFailurePosition" executed="True" result="Success" success="True" time="0.004" asserts="2" />
+                          <test-case name="NUnit.Framework.Constraints.EqualTest.LongStringsAreTruncated" executed="True" result="Success" success="True" time="0.001" asserts="2" />
+                          <test-case name="NUnit.Framework.Constraints.EqualTest.LongStringsAreTruncatedAtBothEndsIfNecessary" executed="True" result="Success" success="True" time="0.000" asserts="2" />
+                          <test-case name="NUnit.Framework.Constraints.EqualTest.LongStringsAreTruncatedAtFrontEndIfNecessary" executed="True" result="Success" success="True" time="0.001" asserts="2" />
+                          <test-case name="NUnit.Framework.Constraints.EqualTest.TestPropertyWithPrivateSetter" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                        </results>
+                      </test-suite>
+                      <test-suite type="TestFixture" name="ExactCountConstraintTests" executed="True" result="Success" success="True" time="0.013" asserts="0">
+                        <results>
+                          <test-case name="NUnit.Framework.Constraints.ExactCountConstraintTests.ExactlyOneItemMatches" executed="True" result="Success" success="True" time="0.002" asserts="2" />
+                          <test-case name="NUnit.Framework.Constraints.ExactCountConstraintTests.ExactlyOneItemMatchFails" executed="True" result="Success" success="True" time="0.002" asserts="2" />
+                          <test-case name="NUnit.Framework.Constraints.ExactCountConstraintTests.ExactlyTwoItemsMatch" executed="True" result="Success" success="True" time="0.001" asserts="2" />
+                          <test-case name="NUnit.Framework.Constraints.ExactCountConstraintTests.ExactlyTwoItemsMatchFails" executed="True" result="Success" success="True" time="0.001" asserts="2" />
+                          <test-case name="NUnit.Framework.Constraints.ExactCountConstraintTests.ZeroItemsMatch" executed="True" result="Success" success="True" time="0.000" asserts="2" />
+                          <test-case name="NUnit.Framework.Constraints.ExactCountConstraintTests.ZeroItemsMatchFails" executed="True" result="Success" success="True" time="0.001" asserts="2" />
+                        </results>
+                      </test-suite>
+                      <test-suite type="TestFixture" name="ExactTypeTest" executed="True" result="Success" success="True" time="0.013" asserts="0">
+                        <results>
+                          <test-case name="NUnit.Framework.Constraints.ExactTypeTest.ConstraintTestBaseNoData.ProvidesProperDescription" executed="True" result="Success" success="True" time="0.001" asserts="1" />
+                          <test-case name="NUnit.Framework.Constraints.ExactTypeTest.ConstraintTestBaseNoData.ProvidesProperStringRepresentation" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                          <test-suite type="ParameterizedTest" name="FailsWithBadValues" executed="True" result="Success" success="True" time="0.003" asserts="0">
+                            <results>
+                              <test-case name="NUnit.Framework.Constraints.ExactTypeTest.FailsWithBadValues(NUnit.Framework.Constraints.B)" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                              <test-case name="NUnit.Framework.Constraints.ExactTypeTest.FailsWithBadValues(NUnit.Framework.Constraints.D2)" executed="True" result="Success" success="True" time="0.001" asserts="1" />
+                            </results>
+                          </test-suite>
+                          <test-suite type="ParameterizedTest" name="ProvidesProperFailureMessage" executed="True" result="Success" success="True" time="0.003" asserts="0">
+                            <results>
+                              <test-case name="NUnit.Framework.Constraints.ExactTypeTest.ProvidesProperFailureMessage(NUnit.Framework.Constraints.B,&quot;&lt;NUnit.Framework.Constraints.B&gt;&quot;)" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                              <test-case name="NUnit.Framework.Constraints.ExactTypeTest.ProvidesProperFailureMessage(NUnit.Framework.Constraints.D2,&quot;&lt;NUnit.Framework.Constraints.D2&gt;&quot;)" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                            </results>
+                          </test-suite>
+                          <test-suite type="ParameterizedTest" name="SucceedsWithGoodValues" executed="True" result="Success" success="True" time="0.001" asserts="0">
+                            <results>
+                              <test-case name="NUnit.Framework.Constraints.ExactTypeTest.SucceedsWithGoodValues(NUnit.Framework.Constraints.D1)" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                            </results>
+                          </test-suite>
+                        </results>
+                      </test-suite>
+                      <test-suite type="TestFixture" name="FalseConstraintTest" executed="True" result="Success" success="True" time="0.053" asserts="0">
+                        <results>
+                          <test-case name="NUnit.Framework.Constraints.FalseConstraintTest.ConstraintTestBaseNoData.ProvidesProperDescription" executed="True" result="Success" success="True" time="0.001" asserts="1" />
+                          <test-case name="NUnit.Framework.Constraints.FalseConstraintTest.ConstraintTestBaseNoData.ProvidesProperStringRepresentation" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                          <test-suite type="ParameterizedTest" name="FailsWithBadValues" executed="True" result="Success" success="True" time="0.005" asserts="0">
+                            <results>
+                              <test-case name="NUnit.Framework.Constraints.FalseConstraintTest.FailsWithBadValues(null)" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                              <test-case name="NUnit.Framework.Constraints.FalseConstraintTest.FailsWithBadValues(&quot;hello&quot;)" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                              <test-case name="NUnit.Framework.Constraints.FalseConstraintTest.FailsWithBadValues(True)" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                              <test-case name="NUnit.Framework.Constraints.FalseConstraintTest.FailsWithBadValues(True)" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                            </results>
+                          </test-suite>
+                          <test-suite type="ParameterizedTest" name="ProvidesProperFailureMessage" executed="True" result="Success" success="True" time="0.005" asserts="0">
+                            <results>
+                              <test-case name="NUnit.Framework.Constraints.FalseConstraintTest.ProvidesProperFailureMessage(null,&quot;null&quot;)" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                              <test-case name="NUnit.Framework.Constraints.FalseConstraintTest.ProvidesProperFailureMessage(&quot;hello&quot;,&quot;\&quot;hello\&quot;&quot;)" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                              <test-case name="NUnit.Framework.Constraints.FalseConstraintTest.ProvidesProperFailureMessage(True,&quot;True&quot;)" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                              <test-case name="NUnit.Framework.Constraints.FalseConstraintTest.ProvidesProperFailureMessage(True,&quot;True&quot;)" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                            </results>
+                          </test-suite>
+                          <test-suite type="ParameterizedTest" name="SucceedsWithGoodValues" executed="True" result="Success" success="True" time="0.002" asserts="0">
+                            <results>
+                              <test-case name="NUnit.Framework.Constraints.FalseConstraintTest.SucceedsWithGoodValues(False)" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                              <test-case name="NUnit.Framework.Constraints.FalseConstraintTest.SucceedsWithGoodValues(False)" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                            </results>
+                          </test-suite>
+                        </results>
+                      </test-suite>
+                      <test-suite type="TestFixture" name="FloatingPointNumericsTest" executed="True" result="Success" success="True" time="0.012" asserts="0">
+                        <results>
+                          <test-case name="NUnit.Framework.Constraints.FloatingPointNumericsTest.DoubleEqualityWithUlps" executed="True" result="Success" success="True" time="0.000" asserts="4" />
+                          <test-case name="NUnit.Framework.Constraints.FloatingPointNumericsTest.FloatEqualityWithUlps" executed="True" result="Success" success="True" time="0.000" asserts="4" />
+                          <test-case name="NUnit.Framework.Constraints.FloatingPointNumericsTest.MirroredDoubleReinterpretation" executed="True" result="Success" success="True" time="0.001" asserts="1" />
+                          <test-case name="NUnit.Framework.Constraints.FloatingPointNumericsTest.MirroredFloatReinterpretation" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Framework.Constraints.FloatingPointNumericsTest.MirroredIntegerReinterpretation" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Framework.Constraints.FloatingPointNumericsTest.MirroredLongReinterpretation" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                        </results>
+                      </test-suite>
+                      <test-suite type="TestFixture" name="GreaterThanOrEqualTest" executed="True" result="Success" success="True" time="0.038" asserts="0">
+                        <results>
+                          <test-case name="NUnit.Framework.Constraints.GreaterThanOrEqualTest.CanCompareIComparables" executed="True" result="Success" success="True" time="0.001" asserts="1" />
+                          <test-case name="NUnit.Framework.Constraints.GreaterThanOrEqualTest.CanCompareIComparablesOfT" executed="True" result="Success" success="True" time="0.001" asserts="1" />
+                          <test-case name="NUnit.Framework.Constraints.GreaterThanOrEqualTest.ComparisonConstraintTest.UsesProvidedComparerOfT" executed="True" result="Success" success="True" time="0.001" asserts="1" />
+                          <test-case name="NUnit.Framework.Constraints.GreaterThanOrEqualTest.ComparisonConstraintTest.UsesProvidedComparisonOfT" executed="True" result="Success" success="True" time="0.001" asserts="1" />
+                          <test-case name="NUnit.Framework.Constraints.GreaterThanOrEqualTest.ComparisonConstraintTest.UsesProvidedIComparer" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Framework.Constraints.GreaterThanOrEqualTest.ComparisonConstraintTest.UsesProvidedLambda" executed="True" result="Success" success="True" time="0.000" asserts="0" />
+                          <test-case name="NUnit.Framework.Constraints.GreaterThanOrEqualTest.ConstraintTestBaseNoData.ProvidesProperDescription" executed="True" result="Success" success="True" time="0.001" asserts="1" />
+                          <test-case name="NUnit.Framework.Constraints.GreaterThanOrEqualTest.ConstraintTestBaseNoData.ProvidesProperStringRepresentation" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                          <test-suite type="ParameterizedTest" name="FailsWithBadValues" executed="True" result="Success" success="True" time="0.002" asserts="0">
+                            <results>
+                              <test-case name="NUnit.Framework.Constraints.GreaterThanOrEqualTest.FailsWithBadValues(4)" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                            </results>
+                          </test-suite>
+                          <test-suite type="ParameterizedTest" name="InvalidDataThrowsArgumentException" executed="True" result="Success" success="True" time="0.004" asserts="0">
+                            <results>
+                              <test-case name="NUnit.Framework.Constraints.GreaterThanOrEqualTest.InvalidDataThrowsArgumentException(null)" executed="True" result="Success" success="True" time="0.001" asserts="0" />
+                              <test-case name="NUnit.Framework.Constraints.GreaterThanOrEqualTest.InvalidDataThrowsArgumentException(&quot;xxx&quot;)" executed="True" result="Success" success="True" time="0.001" asserts="0" />
+                            </results>
+                          </test-suite>
+                          <test-suite type="ParameterizedTest" name="ProvidesProperFailureMessage" executed="True" result="Success" success="True" time="0.000" asserts="0">
+                            <results>
+                              <test-case name="NUnit.Framework.Constraints.GreaterThanOrEqualTest.ProvidesProperFailureMessage(4,&quot;4&quot;)" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                            </results>
+                          </test-suite>
+                          <test-suite type="ParameterizedTest" name="SucceedsWithGoodValues" executed="True" result="Success" success="True" time="0.003" asserts="0">
+                            <results>
+                              <test-case name="NUnit.Framework.Constraints.GreaterThanOrEqualTest.SucceedsWithGoodValues(6)" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                              <test-case name="NUnit.Framework.Constraints.GreaterThanOrEqualTest.SucceedsWithGoodValues(5)" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                            </results>
+                          </test-suite>
+                        </results>
+                      </test-suite>
+                      <test-suite type="TestFixture" name="GreaterThanTest" executed="True" result="Success" success="True" time="0.039" asserts="0">
+                        <results>
+                          <test-case name="NUnit.Framework.Constraints.GreaterThanTest.CanCompareIComparables" executed="True" result="Success" success="True" time="0.001" asserts="1" />
+                          <test-case name="NUnit.Framework.Constraints.GreaterThanTest.CanCompareIComparablesOfT" executed="True" result="Success" success="True" time="0.001" asserts="1" />
+                          <test-case name="NUnit.Framework.Constraints.GreaterThanTest.ComparisonConstraintTest.UsesProvidedComparerOfT" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Framework.Constraints.GreaterThanTest.ComparisonConstraintTest.UsesProvidedComparisonOfT" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Framework.Constraints.GreaterThanTest.ComparisonConstraintTest.UsesProvidedIComparer" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Framework.Constraints.GreaterThanTest.ComparisonConstraintTest.UsesProvidedLambda" executed="True" result="Success" success="True" time="0.000" asserts="0" />
+                          <test-case name="NUnit.Framework.Constraints.GreaterThanTest.ConstraintTestBaseNoData.ProvidesProperDescription" executed="True" result="Success" success="True" time="0.001" asserts="1" />
+                          <test-case name="NUnit.Framework.Constraints.GreaterThanTest.ConstraintTestBaseNoData.ProvidesProperStringRepresentation" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                          <test-suite type="ParameterizedTest" name="FailsWithBadValues" executed="True" result="Success" success="True" time="0.008" asserts="0">
+                            <results>
+                              <test-case name="NUnit.Framework.Constraints.GreaterThanTest.FailsWithBadValues(4)" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                              <test-case name="NUnit.Framework.Constraints.GreaterThanTest.FailsWithBadValues(5)" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                            </results>
+                          </test-suite>
+                          <test-suite type="ParameterizedTest" name="InvalidDataThrowsArgumentException" executed="True" result="Success" success="True" time="0.004" asserts="0">
+                            <results>
+                              <test-case name="NUnit.Framework.Constraints.GreaterThanTest.InvalidDataThrowsArgumentException(null)" executed="True" result="Success" success="True" time="0.000" asserts="0" />
+                              <test-case name="NUnit.Framework.Constraints.GreaterThanTest.InvalidDataThrowsArgumentException(&quot;xxx&quot;)" executed="True" result="Success" success="True" time="0.001" asserts="0" />
+                            </results>
+                          </test-suite>
+                          <test-suite type="ParameterizedTest" name="ProvidesProperFailureMessage" executed="True" result="Success" success="True" time="0.002" asserts="0">
+                            <results>
+                              <test-case name="NUnit.Framework.Constraints.GreaterThanTest.ProvidesProperFailureMessage(4,&quot;4&quot;)" executed="True" result="Success" success="True" time="0.001" asserts="1" />
+                              <test-case name="NUnit.Framework.Constraints.GreaterThanTest.ProvidesProperFailureMessage(5,&quot;5&quot;)" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                            </results>
+                          </test-suite>
+                          <test-suite type="ParameterizedTest" name="SucceedsWithGoodValues" executed="True" result="Success" success="True" time="0.003" asserts="0">
+                            <results>
+                              <test-case name="NUnit.Framework.Constraints.GreaterThanTest.SucceedsWithGoodValues(6)" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                              <test-case name="NUnit.Framework.Constraints.GreaterThanTest.SucceedsWithGoodValues(5.001d)" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                            </results>
+                          </test-suite>
+                        </results>
+                      </test-suite>
+                      <test-suite type="TestFixture" name="InstanceOfTypeTest" executed="True" result="Success" success="True" time="0.012" asserts="0">
+                        <results>
+                          <test-case name="NUnit.Framework.Constraints.InstanceOfTypeTest.ConstraintTestBaseNoData.ProvidesProperDescription" executed="True" result="Success" success="True" time="0.001" asserts="1" />
+                          <test-case name="NUnit.Framework.Constraints.InstanceOfTypeTest.ConstraintTestBaseNoData.ProvidesProperStringRepresentation" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                          <test-suite type="ParameterizedTest" name="FailsWithBadValues" executed="True" result="Success" success="True" time="0.001" asserts="0">
+                            <results>
+                              <test-case name="NUnit.Framework.Constraints.InstanceOfTypeTest.FailsWithBadValues(NUnit.Framework.Constraints.B)" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                            </results>
+                          </test-suite>
+                          <test-suite type="ParameterizedTest" name="ProvidesProperFailureMessage" executed="True" result="Success" success="True" time="0.000" asserts="0">
+                            <results>
+                              <test-case name="NUnit.Framework.Constraints.InstanceOfTypeTest.ProvidesProperFailureMessage(NUnit.Framework.Constraints.B,&quot;&lt;NUnit.Framework.Constraints.B&gt;&quot;)" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                            </results>
+                          </test-suite>
+                          <test-suite type="ParameterizedTest" name="SucceedsWithGoodValues" executed="True" result="Success" success="True" time="0.003" asserts="0">
+                            <results>
+                              <test-case name="NUnit.Framework.Constraints.InstanceOfTypeTest.SucceedsWithGoodValues(NUnit.Framework.Constraints.D1)" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                              <test-case name="NUnit.Framework.Constraints.InstanceOfTypeTest.SucceedsWithGoodValues(NUnit.Framework.Constraints.D2)" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                            </results>
+                          </test-suite>
+                        </results>
+                      </test-suite>
+                      <test-suite type="TestFixture" name="LessThanOrEqualTest" executed="True" result="Success" success="True" time="0.035" asserts="0">
+                        <results>
+                          <test-case name="NUnit.Framework.Constraints.LessThanOrEqualTest.CanCompareIComparables" executed="True" result="Success" success="True" time="0.001" asserts="1" />
+                          <test-case name="NUnit.Framework.Constraints.LessThanOrEqualTest.CanCompareIComparablesOfT" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Framework.Constraints.LessThanOrEqualTest.ComparisonConstraintTest.UsesProvidedComparerOfT" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Framework.Constraints.LessThanOrEqualTest.ComparisonConstraintTest.UsesProvidedComparisonOfT" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Framework.Constraints.LessThanOrEqualTest.ComparisonConstraintTest.UsesProvidedIComparer" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Framework.Constraints.LessThanOrEqualTest.ComparisonConstraintTest.UsesProvidedLambda" executed="True" result="Success" success="True" time="0.000" asserts="0" />
+                          <test-case name="NUnit.Framework.Constraints.LessThanOrEqualTest.ConstraintTestBaseNoData.ProvidesProperDescription" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Framework.Constraints.LessThanOrEqualTest.ConstraintTestBaseNoData.ProvidesProperStringRepresentation" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                          <test-suite type="ParameterizedTest" name="FailsWithBadValues" executed="True" result="Success" success="True" time="0.001" asserts="0">
+                            <results>
+                              <test-case name="NUnit.Framework.Constraints.LessThanOrEqualTest.FailsWithBadValues(6)" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                            </results>
+                          </test-suite>
+                          <test-suite type="ParameterizedTest" name="InvalidDataThrowsArgumentException" executed="True" result="Success" success="True" time="0.003" asserts="0">
+                            <results>
+                              <test-case name="NUnit.Framework.Constraints.LessThanOrEqualTest.InvalidDataThrowsArgumentException(null)" executed="True" result="Success" success="True" time="0.001" asserts="0" />
+                              <test-case name="NUnit.Framework.Constraints.LessThanOrEqualTest.InvalidDataThrowsArgumentException(&quot;xxx&quot;)" executed="True" result="Success" success="True" time="0.000" asserts="0" />
+                            </results>
+                          </test-suite>
+                          <test-suite type="ParameterizedTest" name="ProvidesProperFailureMessage" executed="True" result="Success" success="True" time="0.001" asserts="0">
+                            <results>
+                              <test-case name="NUnit.Framework.Constraints.LessThanOrEqualTest.ProvidesProperFailureMessage(6,&quot;6&quot;)" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                            </results>
+                          </test-suite>
+                          <test-suite type="ParameterizedTest" name="SucceedsWithGoodValues" executed="True" result="Success" success="True" time="0.002" asserts="0">
+                            <results>
+                              <test-case name="NUnit.Framework.Constraints.LessThanOrEqualTest.SucceedsWithGoodValues(4)" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                              <test-case name="NUnit.Framework.Constraints.LessThanOrEqualTest.SucceedsWithGoodValues(5)" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                            </results>
+                          </test-suite>
+                        </results>
+                      </test-suite>
+                      <test-suite type="TestFixture" name="LessThanTest" executed="True" result="Success" success="True" time="0.027" asserts="0">
+                        <results>
+                          <test-case name="NUnit.Framework.Constraints.LessThanTest.CanCompareIComparables" executed="True" result="Success" success="True" time="0.001" asserts="1" />
+                          <test-case name="NUnit.Framework.Constraints.LessThanTest.CanCompareIComparablesOfT" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Framework.Constraints.LessThanTest.ComparisonConstraintTest.UsesProvidedComparerOfT" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Framework.Constraints.LessThanTest.ComparisonConstraintTest.UsesProvidedComparisonOfT" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Framework.Constraints.LessThanTest.ComparisonConstraintTest.UsesProvidedIComparer" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Framework.Constraints.LessThanTest.ComparisonConstraintTest.UsesProvidedLambda" executed="True" result="Success" success="True" time="0.000" asserts="0" />
+                          <test-case name="NUnit.Framework.Constraints.LessThanTest.ConstraintTestBaseNoData.ProvidesProperDescription" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Framework.Constraints.LessThanTest.ConstraintTestBaseNoData.ProvidesProperStringRepresentation" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                          <test-suite type="ParameterizedTest" name="FailsWithBadValues" executed="True" result="Success" success="True" time="0.002" asserts="0">
+                            <results>
+                              <test-case name="NUnit.Framework.Constraints.LessThanTest.FailsWithBadValues(6)" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                              <test-case name="NUnit.Framework.Constraints.LessThanTest.FailsWithBadValues(5)" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                            </results>
+                          </test-suite>
+                          <test-suite type="ParameterizedTest" name="InvalidDataThrowsArgumentException" executed="True" result="Success" success="True" time="0.004" asserts="0">
+                            <results>
+                              <test-case name="NUnit.Framework.Constraints.LessThanTest.InvalidDataThrowsArgumentException(null)" executed="True" result="Success" success="True" time="0.001" asserts="0" />
+                              <test-case name="NUnit.Framework.Constraints.LessThanTest.InvalidDataThrowsArgumentException(&quot;xxx&quot;)" executed="True" result="Success" success="True" time="0.001" asserts="0" />
+                            </results>
+                          </test-suite>
+                          <test-suite type="ParameterizedTest" name="ProvidesProperFailureMessage" executed="True" result="Success" success="True" time="0.003" asserts="0">
+                            <results>
+                              <test-case name="NUnit.Framework.Constraints.LessThanTest.ProvidesProperFailureMessage(6,&quot;6&quot;)" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                              <test-case name="NUnit.Framework.Constraints.LessThanTest.ProvidesProperFailureMessage(5,&quot;5&quot;)" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                            </results>
+                          </test-suite>
+                          <test-suite type="ParameterizedTest" name="SucceedsWithGoodValues" executed="True" result="Success" success="True" time="0.002" asserts="0">
+                            <results>
+                              <test-case name="NUnit.Framework.Constraints.LessThanTest.SucceedsWithGoodValues(4)" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                              <test-case name="NUnit.Framework.Constraints.LessThanTest.SucceedsWithGoodValues(4.999d)" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                            </results>
+                          </test-suite>
+                        </results>
+                      </test-suite>
+                      <test-suite type="TestFixture" name="MsgUtilTests" executed="True" result="Success" success="True" time="0.045" asserts="0">
+                        <results>
+                          <test-case name="NUnit.Framework.Constraints.MsgUtilTests.ClipExpectedAndActual_StringsDoNotFitInLine" executed="True" result="Success" success="True" time="0.000" asserts="4" />
+                          <test-case name="NUnit.Framework.Constraints.MsgUtilTests.ClipExpectedAndActual_StringsFitInLine" executed="True" result="Success" success="True" time="0.001" asserts="4" />
+                          <test-case name="NUnit.Framework.Constraints.MsgUtilTests.ClipExpectedAndActual_StringTailsFitInLine" executed="True" result="Success" success="True" time="0.001" asserts="1" />
+                          <test-suite type="ParameterizedTest" name="EscapeControlCharsTest" executed="True" result="Success" success="True" time="0.030" asserts="0">
+                            <results>
+                              <test-case name="NUnit.Framework.Constraints.MsgUtilTests.EscapeControlCharsTest(&quot;\x2028&quot;,&quot;\\x2028&quot;)" description="Line separator character" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                              <test-case name="NUnit.Framework.Constraints.MsgUtilTests.EscapeControlCharsTest(null,null)" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                              <test-case name="NUnit.Framework.Constraints.MsgUtilTests.EscapeControlCharsTest(&quot;\r\n&quot;,&quot;\\r\\n&quot;)" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                              <test-case name="NUnit.Framework.Constraints.MsgUtilTests.EscapeControlCharsTest(&quot;\\r\\n&quot;,&quot;\\\\r\\\\n&quot;)" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                              <test-case name="NUnit.Framework.Constraints.MsgUtilTests.EscapeControlCharsTest(&quot;\a&quot;,&quot;\\a&quot;)" executed="True" result="Success" success="True" time="0.001" asserts="1" />
+                              <test-case name="NUnit.Framework.Constraints.MsgUtilTests.EscapeControlCharsTest(&quot;\b&quot;,&quot;\\b&quot;)" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                              <test-case name="NUnit.Framework.Constraints.MsgUtilTests.EscapeControlCharsTest(&quot;\f&quot;,&quot;\\f&quot;)" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                              <test-case name="NUnit.Framework.Constraints.MsgUtilTests.EscapeControlCharsTest(&quot;\v&quot;,&quot;\\v&quot;)" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                              <test-case name="NUnit.Framework.Constraints.MsgUtilTests.EscapeControlCharsTest(&quot;\x0085&quot;,&quot;\\x0085&quot;)" description="Next line character" executed="True" result="Success" success="True" time="0.001" asserts="1" />
+                              <test-case name="NUnit.Framework.Constraints.MsgUtilTests.EscapeControlCharsTest(&quot;\n&quot;,&quot;\\n&quot;)" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                              <test-case name="NUnit.Framework.Constraints.MsgUtilTests.EscapeControlCharsTest(&quot;\x2029&quot;,&quot;\\x2029&quot;)" description="Paragraph separator character" executed="True" result="Success" success="True" time="0.001" asserts="1" />
+                              <test-case name="NUnit.Framework.Constraints.MsgUtilTests.EscapeControlCharsTest(&quot;\n\r&quot;,&quot;\\n\\r&quot;)" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                              <test-case name="NUnit.Framework.Constraints.MsgUtilTests.EscapeControlCharsTest(&quot;This is a\rtest message&quot;,&quot;This is a\\rtest message&quot;)" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                              <test-case name="NUnit.Framework.Constraints.MsgUtilTests.EscapeControlCharsTest(&quot;\n\n&quot;,&quot;\\n\\n&quot;)" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                              <test-case name="NUnit.Framework.Constraints.MsgUtilTests.EscapeControlCharsTest(&quot;&quot;,&quot;&quot;)" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                              <test-case name="NUnit.Framework.Constraints.MsgUtilTests.EscapeControlCharsTest(&quot;\t\n&quot;,&quot;\\t\\n&quot;)" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                              <test-case name="NUnit.Framework.Constraints.MsgUtilTests.EscapeControlCharsTest(&quot;\t&quot;,&quot;\\t&quot;)" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                              <test-case name="NUnit.Framework.Constraints.MsgUtilTests.EscapeControlCharsTest(&quot;\n\n\n&quot;,&quot;\\n\\n\\n&quot;)" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                              <test-case name="NUnit.Framework.Constraints.MsgUtilTests.EscapeControlCharsTest(&quot;\r&quot;,&quot;\\r&quot;)" executed="True" result="Success" success="True" time="0.001" asserts="1" />
+                              <test-case name="NUnit.Framework.Constraints.MsgUtilTests.EscapeControlCharsTest(&quot;\r\r&quot;,&quot;\\r\\r&quot;)" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                              <test-case name="NUnit.Framework.Constraints.MsgUtilTests.EscapeControlCharsTest(&quot;\r\r\r&quot;,&quot;\\r\\r\\r&quot;)" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                            </results>
+                          </test-suite>
+                          <test-suite type="ParameterizedTest" name="TestClipString" executed="True" result="Success" success="True" time="0.005" asserts="0">
+                            <results>
+                              <test-case name="NUnit.Framework.Constraints.MsgUtilTests.ClipAtStart" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                              <test-case name="NUnit.Framework.Constraints.MsgUtilTests.NoClippingNeeded" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                              <test-case name="NUnit.Framework.Constraints.MsgUtilTests.ClipAtStartAndEnd" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                              <test-case name="NUnit.Framework.Constraints.MsgUtilTests.ClipAtEnd" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                            </results>
+                          </test-suite>
+                        </results>
+                      </test-suite>
+                      <test-suite type="TestFixture" name="NaNConstraintTest" executed="True" result="Success" success="True" time="0.031" asserts="0">
+                        <results>
+                          <test-case name="NUnit.Framework.Constraints.NaNConstraintTest.ConstraintTestBaseNoData.ProvidesProperDescription" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Framework.Constraints.NaNConstraintTest.ConstraintTestBaseNoData.ProvidesProperStringRepresentation" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                          <test-suite type="ParameterizedTest" name="FailsWithBadValues" executed="True" result="Success" success="True" time="0.010" asserts="0">
+                            <results>
+                              <test-case name="NUnit.Framework.Constraints.NaNConstraintTest.FailsWithBadValues(null)" executed="True" result="Success" success="True" time="0.001" asserts="1" />
+                              <test-case name="NUnit.Framework.Constraints.NaNConstraintTest.FailsWithBadValues(&quot;hello&quot;)" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                              <test-case name="NUnit.Framework.Constraints.NaNConstraintTest.FailsWithBadValues(42)" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                              <test-case name="NUnit.Framework.Constraints.NaNConstraintTest.FailsWithBadValues(double.PositiveInfinity)" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                              <test-case name="NUnit.Framework.Constraints.NaNConstraintTest.FailsWithBadValues(double.NegativeInfinity)" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                              <test-case name="NUnit.Framework.Constraints.NaNConstraintTest.FailsWithBadValues(float.PositiveInfinity)" executed="True" result="Success" success="True" time="0.001" asserts="1" />
+                              <test-case name="NUnit.Framework.Constraints.NaNConstraintTest.FailsWithBadValues(float.NegativeInfinity)" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                            </results>
+                          </test-suite>
+                          <test-suite type="ParameterizedTest" name="ProvidesProperFailureMessage" executed="True" result="Success" success="True" time="0.010" asserts="0">
+                            <results>
+                              <test-case name="NUnit.Framework.Constraints.NaNConstraintTest.ProvidesProperFailureMessage(null,&quot;null&quot;)" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                              <test-case name="NUnit.Framework.Constraints.NaNConstraintTest.ProvidesProperFailureMessage(&quot;hello&quot;,&quot;\&quot;hello\&quot;&quot;)" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                              <test-case name="NUnit.Framework.Constraints.NaNConstraintTest.ProvidesProperFailureMessage(42,&quot;42&quot;)" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                              <test-case name="NUnit.Framework.Constraints.NaNConstraintTest.ProvidesProperFailureMessage(double.PositiveInfinity,&quot;Infinity&quot;)" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                              <test-case name="NUnit.Framework.Constraints.NaNConstraintTest.ProvidesProperFailureMessage(double.NegativeInfinity,&quot;-Infinity&quot;)" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                              <test-case name="NUnit.Framework.Constraints.NaNConstraintTest.ProvidesProperFailureMessage(float.PositiveInfinity,&quot;Infinity&quot;)" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                              <test-case name="NUnit.Framework.Constraints.NaNConstraintTest.ProvidesProperFailureMessage(float.NegativeInfinity,&quot;-Infinity&quot;)" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                            </results>
+                          </test-suite>
+                          <test-suite type="ParameterizedTest" name="SucceedsWithGoodValues" executed="True" result="Success" success="True" time="0.002" asserts="0">
+                            <results>
+                              <test-case name="NUnit.Framework.Constraints.NaNConstraintTest.SucceedsWithGoodValues(double.NaN)" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                              <test-case name="NUnit.Framework.Constraints.NaNConstraintTest.SucceedsWithGoodValues(float.NaN)" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                            </results>
+                          </test-suite>
+                        </results>
+                      </test-suite>
+                      <test-suite type="TestFixture" name="NotTest" executed="True" result="Success" success="True" time="0.025" asserts="0">
+                        <results>
+                          <test-case name="NUnit.Framework.Constraints.NotTest.CanUseNotOperator" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Framework.Constraints.NotTest.ConstraintTestBaseNoData.ProvidesProperDescription" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Framework.Constraints.NotTest.ConstraintTestBaseNoData.ProvidesProperStringRepresentation" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                          <test-suite type="ParameterizedTest" name="FailsWithBadValues" executed="True" result="Success" success="True" time="0.001" asserts="0">
+                            <results>
+                              <test-case name="NUnit.Framework.Constraints.NotTest.FailsWithBadValues(null)" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                            </results>
+                          </test-suite>
+                          <test-case name="NUnit.Framework.Constraints.NotTest.NotHonorsIgnoreCaseUsingConstructors" executed="True" result="Success" success="True" time="0.001" asserts="1" />
+                          <test-case name="NUnit.Framework.Constraints.NotTest.NotHonorsIgnoreCaseUsingPrefixNotation" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Framework.Constraints.NotTest.NotHonorsTolerance" executed="True" result="Success" success="True" time="0.001" asserts="1" />
+                          <test-suite type="ParameterizedTest" name="ProvidesProperFailureMessage" executed="True" result="Success" success="True" time="0.001" asserts="0">
+                            <results>
+                              <test-case name="NUnit.Framework.Constraints.NotTest.ProvidesProperFailureMessage(null,&quot;null&quot;)" executed="True" result="Success" success="True" time="0.001" asserts="1" />
+                            </results>
+                          </test-suite>
+                          <test-suite type="ParameterizedTest" name="SucceedsWithGoodValues" executed="True" result="Success" success="True" time="0.003" asserts="0">
+                            <results>
+                              <test-case name="NUnit.Framework.Constraints.NotTest.SucceedsWithGoodValues(42)" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                              <test-case name="NUnit.Framework.Constraints.NotTest.SucceedsWithGoodValues(&quot;Hello&quot;)" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                            </results>
+                          </test-suite>
+                        </results>
+                      </test-suite>
+                      <test-suite type="TestFixture" name="NullConstraintTest" executed="True" result="Success" success="True" time="0.009" asserts="0">
+                        <results>
+                          <test-case name="NUnit.Framework.Constraints.NullConstraintTest.ConstraintTestBaseNoData.ProvidesProperDescription" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Framework.Constraints.NullConstraintTest.ConstraintTestBaseNoData.ProvidesProperStringRepresentation" executed="True" result="Success" success="True" time="0.001" asserts="1" />
+                          <test-suite type="ParameterizedTest" name="FailsWithBadValues" executed="True" result="Success" success="True" time="0.000" asserts="0">
+                            <results>
+                              <test-case name="NUnit.Framework.Constraints.NullConstraintTest.FailsWithBadValues(&quot;hello&quot;)" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                            </results>
+                          </test-suite>
+                          <test-suite type="ParameterizedTest" name="ProvidesProperFailureMessage" executed="True" result="Success" success="True" time="0.000" asserts="0">
+                            <results>
+                              <test-case name="NUnit.Framework.Constraints.NullConstraintTest.ProvidesProperFailureMessage(&quot;hello&quot;,&quot;\&quot;hello\&quot;&quot;)" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                            </results>
+                          </test-suite>
+                          <test-suite type="ParameterizedTest" name="SucceedsWithGoodValues" executed="True" result="Success" success="True" time="0.001" asserts="0">
+                            <results>
+                              <test-case name="NUnit.Framework.Constraints.NullConstraintTest.SucceedsWithGoodValues(null)" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                            </results>
+                          </test-suite>
+                        </results>
+                      </test-suite>
+                      <test-suite type="TestFixture" name="NullOrEmptyStringConstraintTest" executed="True" result="Success" success="True" time="0.018" asserts="0">
+                        <results>
+                          <test-case name="NUnit.Framework.Constraints.NullOrEmptyStringConstraintTest.ConstraintTestBaseNoData.ProvidesProperDescription" executed="True" result="Success" success="True" time="0.001" asserts="1" />
+                          <test-case name="NUnit.Framework.Constraints.NullOrEmptyStringConstraintTest.ConstraintTestBaseNoData.ProvidesProperStringRepresentation" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                          <test-suite type="ParameterizedTest" name="FailsWithBadValues" executed="True" result="Success" success="True" time="0.001" asserts="0">
+                            <results>
+                              <test-case name="NUnit.Framework.Constraints.NullOrEmptyStringConstraintTest.FailsWithBadValues(&quot;Hello&quot;)" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                            </results>
+                          </test-suite>
+                          <test-suite type="ParameterizedTest" name="InvalidDataThrowsArgumentException" executed="True" result="Success" success="True" time="0.001" asserts="0">
+                            <results>
+                              <test-case name="NUnit.Framework.Constraints.NullOrEmptyStringConstraintTest.InvalidDataThrowsArgumentException(5)" executed="True" result="Success" success="True" time="0.001" asserts="0" />
+                            </results>
+                          </test-suite>
+                          <test-suite type="ParameterizedTest" name="ProvidesProperFailureMessage" executed="True" result="Success" success="True" time="0.000" asserts="0">
+                            <results>
+                              <test-case name="NUnit.Framework.Constraints.NullOrEmptyStringConstraintTest.ProvidesProperFailureMessage(&quot;Hello&quot;,&quot;\&quot;Hello\&quot;&quot;)" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                            </results>
+                          </test-suite>
+                          <test-suite type="ParameterizedTest" name="SucceedsWithGoodValues" executed="True" result="Success" success="True" time="0.003" asserts="0">
+                            <results>
+                              <test-case name="NUnit.Framework.Constraints.NullOrEmptyStringConstraintTest.SucceedsWithGoodValues(&quot;&quot;)" executed="True" result="Success" success="True" time="0.001" asserts="1" />
+                              <test-case name="NUnit.Framework.Constraints.NullOrEmptyStringConstraintTest.SucceedsWithGoodValues(null)" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                            </results>
+                          </test-suite>
+                        </results>
+                      </test-suite>
+                      <test-suite type="TestFixture" name="NumericsTest" executed="True" result="Success" success="True" time="0.070" asserts="0">
+                        <results>
+                          <test-case name="NUnit.Framework.Constraints.NumericsTest.CanMatchDecimalWithoutToleranceMode" executed="True" result="Success" success="True" time="0.001" asserts="1" />
+                          <test-case name="NUnit.Framework.Constraints.NumericsTest.CanMatchDecimalWithPercentage" executed="True" result="Success" success="True" time="0.001" asserts="3" />
+                          <test-suite type="ParameterizedTest" name="CanMatchIntegralsWithPercentage" executed="True" result="Success" success="True" time="0.018" asserts="0">
+                            <results>
+                              <test-case name="NUnit.Framework.Constraints.NumericsTest.CanMatchIntegralsWithPercentage(10500)" executed="True" result="Success" success="True" time="0.001" asserts="1" />
+                              <test-case name="NUnit.Framework.Constraints.NumericsTest.CanMatchIntegralsWithPercentage(9500)" executed="True" result="Success" success="True" time="0.001" asserts="1" />
+                              <test-case name="NUnit.Framework.Constraints.NumericsTest.CanMatchIntegralsWithPercentage(9500L)" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                              <test-case name="NUnit.Framework.Constraints.NumericsTest.CanMatchIntegralsWithPercentage(9500)" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                              <test-case name="NUnit.Framework.Constraints.NumericsTest.CanMatchIntegralsWithPercentage(10000)" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                              <test-case name="NUnit.Framework.Constraints.NumericsTest.CanMatchIntegralsWithPercentage(10000)" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                              <test-case name="NUnit.Framework.Constraints.NumericsTest.CanMatchIntegralsWithPercentage(10500)" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                              <test-case name="NUnit.Framework.Constraints.NumericsTest.CanMatchIntegralsWithPercentage(9500UL)" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                              <test-case name="NUnit.Framework.Constraints.NumericsTest.CanMatchIntegralsWithPercentage(10500L)" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                              <test-case name="NUnit.Framework.Constraints.NumericsTest.CanMatchIntegralsWithPercentage(10000L)" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                              <test-case name="NUnit.Framework.Constraints.NumericsTest.CanMatchIntegralsWithPercentage(10000UL)" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                              <test-case name="NUnit.Framework.Constraints.NumericsTest.CanMatchIntegralsWithPercentage(10500UL)" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                            </results>
+                          </test-suite>
+                          <test-suite type="ParameterizedTest" name="CanMatchWithoutToleranceMode" executed="True" result="Success" success="True" time="0.012" asserts="0">
+                            <results>
+                              <test-case name="NUnit.Framework.Constraints.NumericsTest.CanMatchWithoutToleranceMode(123456789UL)" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                              <test-case name="NUnit.Framework.Constraints.NumericsTest.CanMatchWithoutToleranceMode(123456789)" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                              <test-case name="NUnit.Framework.Constraints.NumericsTest.CanMatchWithoutToleranceMode(123456789)" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                              <test-case name="NUnit.Framework.Constraints.NumericsTest.CanMatchWithoutToleranceMode(123456789L)" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                              <test-case name="NUnit.Framework.Constraints.NumericsTest.CanMatchWithoutToleranceMode(1234.568f)" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                              <test-case name="NUnit.Framework.Constraints.NumericsTest.CanMatchWithoutToleranceMode(1234.5678d)" executed="True" result="Success" success="True" time="0.001" asserts="1" />
+                            </results>
+                          </test-suite>
+                          <test-case name="NUnit.Framework.Constraints.NumericsTest.FailsOnDecimalAbovePercentage" executed="True" result="Success" success="True" time="0.001" asserts="1" />
+                          <test-case name="NUnit.Framework.Constraints.NumericsTest.FailsOnDecimalBelowPercentage" executed="True" result="Success" success="True" time="0.002" asserts="1" />
+                          <test-suite type="ParameterizedTest" name="FailsOnIntegralsOutsideOfPercentage" executed="True" result="Success" success="True" time="0.017" asserts="0">
+                            <results>
+                              <test-case name="NUnit.Framework.Constraints.NumericsTest.FailsOnIntegralsOutsideOfPercentage(11500L)" executed="True" result="Success" success="True" time="0.001" asserts="1" />
+                              <test-case name="NUnit.Framework.Constraints.NumericsTest.FailsOnIntegralsOutsideOfPercentage(8500L)" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                              <test-case name="NUnit.Framework.Constraints.NumericsTest.FailsOnIntegralsOutsideOfPercentage(11500)" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                              <test-case name="NUnit.Framework.Constraints.NumericsTest.FailsOnIntegralsOutsideOfPercentage(8500)" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                              <test-case name="NUnit.Framework.Constraints.NumericsTest.FailsOnIntegralsOutsideOfPercentage(11500)" executed="True" result="Success" success="True" time="0.001" asserts="1" />
+                              <test-case name="NUnit.Framework.Constraints.NumericsTest.FailsOnIntegralsOutsideOfPercentage(8500)" executed="True" result="Success" success="True" time="0.001" asserts="1" />
+                              <test-case name="NUnit.Framework.Constraints.NumericsTest.FailsOnIntegralsOutsideOfPercentage(8500UL)" executed="True" result="Success" success="True" time="0.001" asserts="1" />
+                              <test-case name="NUnit.Framework.Constraints.NumericsTest.FailsOnIntegralsOutsideOfPercentage(11500UL)" executed="True" result="Success" success="True" time="0.001" asserts="1" />
+                            </results>
+                          </test-suite>
+                        </results>
+                      </test-suite>
+                      <test-suite type="TestFixture" name="OrTest" executed="True" result="Success" success="True" time="0.013" asserts="0">
+                        <results>
+                          <test-case name="NUnit.Framework.Constraints.OrTest.CanCombineTestsWithOrOperator" executed="True" result="Success" success="True" time="0.001" asserts="1" />
+                          <test-case name="NUnit.Framework.Constraints.OrTest.ConstraintTestBaseNoData.ProvidesProperDescription" executed="True" result="Success" success="True" time="0.001" asserts="1" />
+                          <test-case name="NUnit.Framework.Constraints.OrTest.ConstraintTestBaseNoData.ProvidesProperStringRepresentation" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                          <test-suite type="ParameterizedTest" name="FailsWithBadValues" executed="True" result="Success" success="True" time="0.001" asserts="0">
+                            <results>
+                              <test-case name="NUnit.Framework.Constraints.OrTest.FailsWithBadValues(37)" executed="True" result="Success" success="True" time="0.001" asserts="1" />
+                            </results>
+                          </test-suite>
+                          <test-suite type="ParameterizedTest" name="ProvidesProperFailureMessage" executed="True" result="Success" success="True" time="0.001" asserts="0">
+                            <results>
+                              <test-case name="NUnit.Framework.Constraints.OrTest.ProvidesProperFailureMessage(37,&quot;37&quot;)" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                            </results>
+                          </test-suite>
+                          <test-suite type="ParameterizedTest" name="SucceedsWithGoodValues" executed="True" result="Success" success="True" time="0.003" asserts="0">
+                            <results>
+                              <test-case name="NUnit.Framework.Constraints.OrTest.SucceedsWithGoodValues(99)" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                              <test-case name="NUnit.Framework.Constraints.OrTest.SucceedsWithGoodValues(42)" executed="True" result="Success" success="True" time="0.001" asserts="1" />
+                            </results>
+                          </test-suite>
+                        </results>
+                      </test-suite>
+                      <test-suite type="TestFixture" name="PredicateConstraintTests" executed="True" result="Success" success="True" time="0.014" asserts="0">
+                        <results>
+                          <test-case name="NUnit.Framework.Constraints.PredicateConstraintTests.ConstraintTestBaseNoData.ProvidesProperDescription" executed="True" result="Success" success="True" time="0.001" asserts="1" />
+                          <test-case name="NUnit.Framework.Constraints.PredicateConstraintTests.ConstraintTestBaseNoData.ProvidesProperStringRepresentation" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                          <test-suite type="ParameterizedTest" name="FailsWithBadValues" executed="True" result="Success" success="True" time="0.002" asserts="0">
+                            <results>
+                              <test-case name="NUnit.Framework.Constraints.PredicateConstraintTests.FailsWithBadValues(123)" executed="True" result="Success" success="True" time="0.001" asserts="1" />
+                            </results>
+                          </test-suite>
+                          <test-suite type="ParameterizedTest" name="ProvidesProperFailureMessage" executed="True" result="Success" success="True" time="0.001" asserts="0">
+                            <results>
+                              <test-case name="NUnit.Framework.Constraints.PredicateConstraintTests.ProvidesProperFailureMessage(123,&quot;123&quot;)" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                            </results>
+                          </test-suite>
+                          <test-suite type="ParameterizedTest" name="SucceedsWithGoodValues" executed="True" result="Success" success="True" time="0.002" asserts="0">
+                            <results>
+                              <test-case name="NUnit.Framework.Constraints.PredicateConstraintTests.SucceedsWithGoodValues(0)" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                              <test-case name="NUnit.Framework.Constraints.PredicateConstraintTests.SucceedsWithGoodValues(-5)" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                            </results>
+                          </test-suite>
+                        </results>
+                      </test-suite>
+                      <test-suite type="TestFixture" name="PropertyExistsTest" executed="True" result="Success" success="True" time="0.028" asserts="0">
+                        <results>
+                          <test-case name="NUnit.Framework.Constraints.PropertyExistsTest.ConstraintTestBaseNoData.ProvidesProperDescription" executed="True" result="Success" success="True" time="0.001" asserts="1" />
+                          <test-case name="NUnit.Framework.Constraints.PropertyExistsTest.ConstraintTestBaseNoData.ProvidesProperStringRepresentation" executed="True" result="Success" success="True" time="0.001" asserts="1" />
+                          <test-suite type="ParameterizedTest" name="FailsWithBadValues" executed="True" result="Success" success="True" time="0.005" asserts="0">
+                            <results>
+                              <test-case name="NUnit.Framework.Constraints.PropertyExistsTest.FailsWithBadValues(42)" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                              <test-case name="NUnit.Framework.Constraints.PropertyExistsTest.FailsWithBadValues(System.Collections.ArrayList)" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                              <test-case name="NUnit.Framework.Constraints.PropertyExistsTest.FailsWithBadValues(System.Int32)" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                            </results>
+                          </test-suite>
+                          <test-suite type="ParameterizedTest" name="InvalidDataThrowsException" executed="True" result="Success" success="True" time="0.002" asserts="0">
+                            <results>
+                              <test-case name="NUnit.Framework.Constraints.PropertyExistsTest.InvalidDataThrowsException(null)" executed="True" result="Success" success="True" time="0.000" asserts="0" />
+                            </results>
+                          </test-suite>
+                          <test-suite type="ParameterizedTest" name="ProvidesProperFailureMessage" executed="True" result="Success" success="True" time="0.005" asserts="0">
+                            <results>
+                              <test-case name="NUnit.Framework.Constraints.PropertyExistsTest.ProvidesProperFailureMessage(42,&quot;&lt;System.Int32&gt;&quot;)" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                              <test-case name="NUnit.Framework.Constraints.PropertyExistsTest.ProvidesProperFailureMessage(System.Collections.ArrayList,&quot;&lt;System.Collections.ArrayList&gt;&quot;)" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                              <test-case name="NUnit.Framework.Constraints.PropertyExistsTest.ProvidesProperFailureMessage(System.Int32,&quot;&lt;System.Int32&gt;&quot;)" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                            </results>
+                          </test-suite>
+                          <test-suite type="ParameterizedTest" name="SucceedsWithGoodValues" executed="True" result="Success" success="True" time="0.006" asserts="0">
+                            <results>
+                              <test-case name="NUnit.Framework.Constraints.PropertyExistsTest.SucceedsWithGoodValues(System.Int32[])" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                              <test-case name="NUnit.Framework.Constraints.PropertyExistsTest.SucceedsWithGoodValues(&quot;hello&quot;)" executed="True" result="Success" success="True" time="0.001" asserts="1" />
+                              <test-case name="NUnit.Framework.Constraints.PropertyExistsTest.SucceedsWithGoodValues(System.Array)" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                            </results>
+                          </test-suite>
+                        </results>
+                      </test-suite>
+                      <test-suite type="TestFixture" name="PropertyTest" executed="True" result="Success" success="True" time="0.024" asserts="0">
+                        <results>
+                          <test-case name="NUnit.Framework.Constraints.PropertyTest.ConstraintTestBaseNoData.ProvidesProperDescription" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Framework.Constraints.PropertyTest.ConstraintTestBaseNoData.ProvidesProperStringRepresentation" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                          <test-suite type="ParameterizedTest" name="FailsWithBadValues" executed="True" result="Success" success="True" time="0.003" asserts="0">
+                            <results>
+                              <test-case name="NUnit.Framework.Constraints.PropertyTest.FailsWithBadValues(System.Int32[])" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                              <test-case name="NUnit.Framework.Constraints.PropertyTest.FailsWithBadValues(&quot;goodbye&quot;)" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                            </results>
+                          </test-suite>
+                          <test-suite type="ParameterizedTest" name="InvalidDataThrowsException" executed="True" result="Success" success="True" time="0.005" asserts="0">
+                            <results>
+                              <test-case name="NUnit.Framework.Constraints.PropertyTest.InvalidDataThrowsException(null)" executed="True" result="Success" success="True" time="0.001" asserts="0" />
+                              <test-case name="NUnit.Framework.Constraints.PropertyTest.InvalidDataThrowsException(42)" executed="True" result="Success" success="True" time="0.001" asserts="0" />
+                              <test-case name="NUnit.Framework.Constraints.PropertyTest.InvalidDataThrowsException(System.Collections.ArrayList)" executed="True" result="Success" success="True" time="0.000" asserts="0" />
+                            </results>
+                          </test-suite>
+                          <test-case name="NUnit.Framework.Constraints.PropertyTest.PropertyEqualToValueWithTolerance" executed="True" result="Success" success="True" time="0.002" asserts="2" />
+                          <test-suite type="ParameterizedTest" name="ProvidesProperFailureMessage" executed="True" result="Success" success="True" time="0.002" asserts="0">
+                            <results>
+                              <test-case name="NUnit.Framework.Constraints.PropertyTest.ProvidesProperFailureMessage(System.Int32[],&quot;3&quot;)" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                              <test-case name="NUnit.Framework.Constraints.PropertyTest.ProvidesProperFailureMessage(&quot;goodbye&quot;,&quot;7&quot;)" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                            </results>
+                          </test-suite>
+                          <test-suite type="ParameterizedTest" name="SucceedsWithGoodValues" executed="True" result="Success" success="True" time="0.002" asserts="0">
+                            <results>
+                              <test-case name="NUnit.Framework.Constraints.PropertyTest.SucceedsWithGoodValues(System.Int32[])" executed="True" result="Success" success="True" time="0.001" asserts="1" />
+                              <test-case name="NUnit.Framework.Constraints.PropertyTest.SucceedsWithGoodValues(&quot;hello&quot;)" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                            </results>
+                          </test-suite>
+                        </results>
+                      </test-suite>
+                      <test-suite type="TestFixture" name="RangeConstraintTest" executed="True" result="Success" success="True" time="0.033" asserts="0">
+                        <results>
+                          <test-case name="NUnit.Framework.Constraints.RangeConstraintTest.ConstraintTestBaseNoData.ProvidesProperDescription" executed="True" result="Success" success="True" time="0.001" asserts="1" />
+                          <test-case name="NUnit.Framework.Constraints.RangeConstraintTest.ConstraintTestBaseNoData.ProvidesProperStringRepresentation" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                          <test-suite type="ParameterizedTest" name="FailsWithBadValues" executed="True" result="Success" success="True" time="0.002" asserts="0">
+                            <results>
+                              <test-case name="NUnit.Framework.Constraints.RangeConstraintTest.FailsWithBadValues(4)" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                              <test-case name="NUnit.Framework.Constraints.RangeConstraintTest.FailsWithBadValues(43)" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                            </results>
+                          </test-suite>
+                          <test-suite type="ParameterizedTest" name="InvalidDataThrowsArgumentException" executed="True" result="Success" success="True" time="0.004" asserts="0">
+                            <results>
+                              <test-case name="NUnit.Framework.Constraints.RangeConstraintTest.InvalidDataThrowsArgumentException(null)" executed="True" result="Success" success="True" time="0.001" asserts="0" />
+                              <test-case name="NUnit.Framework.Constraints.RangeConstraintTest.InvalidDataThrowsArgumentException(&quot;xxx&quot;)" executed="True" result="Success" success="True" time="0.001" asserts="0" />
+                            </results>
+                          </test-suite>
+                          <test-suite type="ParameterizedTest" name="ProvidesProperFailureMessage" executed="True" result="Success" success="True" time="0.003" asserts="0">
+                            <results>
+                              <test-case name="NUnit.Framework.Constraints.RangeConstraintTest.ProvidesProperFailureMessage(4,&quot;4&quot;)" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                              <test-case name="NUnit.Framework.Constraints.RangeConstraintTest.ProvidesProperFailureMessage(43,&quot;43&quot;)" executed="True" result="Success" success="True" time="0.001" asserts="1" />
+                            </results>
+                          </test-suite>
+                          <test-suite type="ParameterizedTest" name="SucceedsWithGoodValues" executed="True" result="Success" success="True" time="0.004" asserts="0">
+                            <results>
+                              <test-case name="NUnit.Framework.Constraints.RangeConstraintTest.SucceedsWithGoodValues(5)" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                              <test-case name="NUnit.Framework.Constraints.RangeConstraintTest.SucceedsWithGoodValues(23)" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                              <test-case name="NUnit.Framework.Constraints.RangeConstraintTest.SucceedsWithGoodValues(42)" executed="True" result="Success" success="True" time="0.001" asserts="1" />
+                            </results>
+                          </test-suite>
+                          <test-case name="NUnit.Framework.Constraints.RangeConstraintTest.UsesProvidedComparerOfT" executed="True" result="Success" success="True" time="0.001" asserts="2" />
+                          <test-case name="NUnit.Framework.Constraints.RangeConstraintTest.UsesProvidedComparisonOfT" executed="True" result="Success" success="True" time="0.001" asserts="2" />
+                          <test-case name="NUnit.Framework.Constraints.RangeConstraintTest.UsesProvidedIComparer" executed="True" result="Success" success="True" time="0.000" asserts="2" />
+                          <test-case name="NUnit.Framework.Constraints.RangeConstraintTest.UsesProvidedLambda" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                        </results>
+                      </test-suite>
+                      <test-suite type="TestFixture" name="ReusableConstraintTests" executed="True" result="Success" success="True" time="0.010" asserts="0">
+                        <results>
+                          <test-case name="NUnit.Framework.Constraints.ReusableConstraintTests.CanCreateReusableConstraintByImplicitConversion" executed="True" result="Success" success="True" time="0.000" asserts="3" />
+                          <test-suite type="Theory" name="CanReuseReusableConstraintMultipleTimes" executed="True" result="Success" success="True" time="0.008" asserts="0">
+                            <results>
+                              <test-case name="NUnit.Framework.Constraints.ReusableConstraintTests.CanReuseReusableConstraintMultipleTimes(&lt;not &lt;empty&gt;&gt;)" executed="True" result="Success" success="True" time="0.000" asserts="3" />
+                              <test-case name="NUnit.Framework.Constraints.ReusableConstraintTests.CanReuseReusableConstraintMultipleTimes(&lt;not &lt;null&gt;&gt;)" executed="True" result="Success" success="True" time="0.000" asserts="3" />
+                              <test-case name="NUnit.Framework.Constraints.ReusableConstraintTests.CanReuseReusableConstraintMultipleTimes(&lt;property Length &lt;greaterthan 3&gt;&gt;)" executed="True" result="Success" success="True" time="0.000" asserts="3" />
+                              <test-case name="NUnit.Framework.Constraints.ReusableConstraintTests.CanReuseReusableConstraintMultipleTimes(&lt;and &lt;property Length &lt;equal 4&gt;&gt; &lt;startswith &quot;te&quot;&gt;&gt;)" executed="True" result="Success" success="True" time="0.001" asserts="3" />
+                            </results>
+                          </test-suite>
+                        </results>
+                      </test-suite>
+                      <test-suite type="TestFixture" name="SameAsTest" executed="True" result="Success" success="True" time="0.018" asserts="0">
+                        <results>
+                          <test-case name="NUnit.Framework.Constraints.SameAsTest.ConstraintTestBaseNoData.ProvidesProperDescription" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Framework.Constraints.SameAsTest.ConstraintTestBaseNoData.ProvidesProperStringRepresentation" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                          <test-suite type="ParameterizedTest" name="FailsWithBadValues" executed="True" result="Success" success="True" time="0.004" asserts="0">
+                            <results>
+                              <test-case name="NUnit.Framework.Constraints.SameAsTest.FailsWithBadValues(System.Object)" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                              <test-case name="NUnit.Framework.Constraints.SameAsTest.FailsWithBadValues(3)" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                              <test-case name="NUnit.Framework.Constraints.SameAsTest.FailsWithBadValues(&quot;Hello&quot;)" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                            </results>
+                          </test-suite>
+                          <test-suite type="ParameterizedTest" name="ProvidesProperFailureMessage" executed="True" result="Success" success="True" time="0.004" asserts="0">
+                            <results>
+                              <test-case name="NUnit.Framework.Constraints.SameAsTest.ProvidesProperFailureMessage(System.Object,&quot;&lt;System.Object&gt;&quot;)" executed="True" result="Success" success="True" time="0.001" asserts="1" />
+                              <test-case name="NUnit.Framework.Constraints.SameAsTest.ProvidesProperFailureMessage(3,&quot;3&quot;)" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                              <test-case name="NUnit.Framework.Constraints.SameAsTest.ProvidesProperFailureMessage(&quot;Hello&quot;,&quot;\&quot;Hello\&quot;&quot;)" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                            </results>
+                          </test-suite>
+                          <test-suite type="ParameterizedTest" name="SucceedsWithGoodValues" executed="True" result="Success" success="True" time="0.001" asserts="0">
+                            <results>
+                              <test-case name="NUnit.Framework.Constraints.SameAsTest.SucceedsWithGoodValues(System.Object)" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                            </results>
+                          </test-suite>
+                        </results>
+                      </test-suite>
+                      <test-suite type="TestFixture" name="SamePathOrUnderTest_Linux" executed="True" result="Success" success="True" time="0.044" asserts="0">
+                        <results>
+                          <test-case name="NUnit.Framework.Constraints.SamePathOrUnderTest_Linux.ConstraintTestBaseNoData.ProvidesProperDescription" executed="True" result="Success" success="True" time="0.001" asserts="1" />
+                          <test-case name="NUnit.Framework.Constraints.SamePathOrUnderTest_Linux.ConstraintTestBaseNoData.ProvidesProperStringRepresentation" executed="True" result="Success" success="True" time="0.001" asserts="1" />
+                          <test-suite type="ParameterizedTest" name="FailsWithBadValues" executed="True" result="Success" success="True" time="0.011" asserts="0">
+                            <results>
+                              <test-case name="NUnit.Framework.Constraints.SamePathOrUnderTest_Linux.FailsWithBadValues(123)" executed="True" result="Success" success="True" time="0.001" asserts="1" />
+                              <test-case name="NUnit.Framework.Constraints.SamePathOrUnderTest_Linux.FailsWithBadValues(&quot;/Folder1/Folder2&quot;)" executed="True" result="Success" success="True" time="0.002" asserts="1" />
+                              <test-case name="NUnit.Framework.Constraints.SamePathOrUnderTest_Linux.FailsWithBadValues(&quot;/FOLDER1/./junk/../Folder2&quot;)" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                              <test-case name="NUnit.Framework.Constraints.SamePathOrUnderTest_Linux.FailsWithBadValues(&quot;/FOLDER1/./junk/../Folder2/temp/../Folder3&quot;)" executed="True" result="Success" success="True" time="0.001" asserts="1" />
+                              <test-case name="NUnit.Framework.Constraints.SamePathOrUnderTest_Linux.FailsWithBadValues(&quot;/folder1/folder3&quot;)" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                              <test-case name="NUnit.Framework.Constraints.SamePathOrUnderTest_Linux.FailsWithBadValues(&quot;/folder1/./folder2/../folder3&quot;)" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                              <test-case name="NUnit.Framework.Constraints.SamePathOrUnderTest_Linux.FailsWithBadValues(&quot;/folder1&quot;)" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                            </results>
+                          </test-suite>
+                          <test-suite type="ParameterizedTest" name="ProvidesProperFailureMessage" executed="True" result="Success" success="True" time="0.011" asserts="0">
+                            <results>
+                              <test-case name="NUnit.Framework.Constraints.SamePathOrUnderTest_Linux.ProvidesProperFailureMessage(123,&quot;123&quot;)" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                              <test-case name="NUnit.Framework.Constraints.SamePathOrUnderTest_Linux.ProvidesProperFailureMessage(&quot;/Folder1/Folder2&quot;,&quot;\&quot;/Folder1/Folder2\&quot;&quot;)" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                              <test-case name="NUnit.Framework.Constraints.SamePathOrUnderTest_Linux.ProvidesProperFailureMessage(&quot;/FOLDER1/./junk/../Folder2&quot;,&quot;\&quot;/FOLDER1/./junk/../Folder2\&quot;&quot;)" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                              <test-case name="NUnit.Framework.Constraints.SamePathOrUnderTest_Linux.ProvidesProperFailureMessage(&quot;/FOLDER1/./junk/../Folder2/temp/../Folder3&quot;,&quot;\&quot;/FOLDER1/./junk/../Folder2/temp/../Folder3\&quot;&quot;)" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                              <test-case name="NUnit.Framework.Constraints.SamePathOrUnderTest_Linux.ProvidesProperFailureMessage(&quot;/folder1/folder3&quot;,&quot;\&quot;/folder1/folder3\&quot;&quot;)" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                              <test-case name="NUnit.Framework.Constraints.SamePathOrUnderTest_Linux.ProvidesProperFailureMessage(&quot;/folder1/./folder2/../folder3&quot;,&quot;\&quot;/folder1/./folder2/../folder3\&quot;&quot;)" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                              <test-case name="NUnit.Framework.Constraints.SamePathOrUnderTest_Linux.ProvidesProperFailureMessage(&quot;/folder1&quot;,&quot;\&quot;/folder1\&quot;&quot;)" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                            </results>
+                          </test-suite>
+                          <test-suite type="ParameterizedTest" name="SucceedsWithGoodValues" executed="True" result="Success" success="True" time="0.012" asserts="0">
+                            <results>
+                              <test-case name="NUnit.Framework.Constraints.SamePathOrUnderTest_Linux.SucceedsWithGoodValues(&quot;/folder1/folder2&quot;)" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                              <test-case name="NUnit.Framework.Constraints.SamePathOrUnderTest_Linux.SucceedsWithGoodValues(&quot;/folder1/./folder2&quot;)" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                              <test-case name="NUnit.Framework.Constraints.SamePathOrUnderTest_Linux.SucceedsWithGoodValues(&quot;/folder1/junk/../folder2&quot;)" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                              <test-case name="NUnit.Framework.Constraints.SamePathOrUnderTest_Linux.SucceedsWithGoodValues(&quot;\\folder1\\folder2&quot;)" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                              <test-case name="NUnit.Framework.Constraints.SamePathOrUnderTest_Linux.SucceedsWithGoodValues(&quot;/folder1/folder2/folder3&quot;)" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                              <test-case name="NUnit.Framework.Constraints.SamePathOrUnderTest_Linux.SucceedsWithGoodValues(&quot;/folder1/./folder2/folder3&quot;)" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                              <test-case name="NUnit.Framework.Constraints.SamePathOrUnderTest_Linux.SucceedsWithGoodValues(&quot;/folder1/junk/../folder2/folder3&quot;)" executed="True" result="Success" success="True" time="0.001" asserts="1" />
+                              <test-case name="NUnit.Framework.Constraints.SamePathOrUnderTest_Linux.SucceedsWithGoodValues(&quot;\\folder1\\folder2\\folder3&quot;)" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                            </results>
+                          </test-suite>
+                        </results>
+                      </test-suite>
+                      <test-suite type="TestFixture" name="SamePathOrUnderTest_Windows" executed="True" result="Success" success="True" time="0.035" asserts="0">
+                        <results>
+                          <test-case name="NUnit.Framework.Constraints.SamePathOrUnderTest_Windows.ConstraintTestBaseNoData.ProvidesProperDescription" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Framework.Constraints.SamePathOrUnderTest_Windows.ConstraintTestBaseNoData.ProvidesProperStringRepresentation" executed="True" result="Success" success="True" time="0.001" asserts="1" />
+                          <test-suite type="ParameterizedTest" name="FailsWithBadValues" executed="True" result="Success" success="True" time="0.004" asserts="0">
+                            <results>
+                              <test-case name="NUnit.Framework.Constraints.SamePathOrUnderTest_Windows.FailsWithBadValues(123)" executed="True" result="Success" success="True" time="0.001" asserts="1" />
+                              <test-case name="NUnit.Framework.Constraints.SamePathOrUnderTest_Windows.FailsWithBadValues(&quot;C:\\folder1\\folder3&quot;)" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                              <test-case name="NUnit.Framework.Constraints.SamePathOrUnderTest_Windows.FailsWithBadValues(&quot;C:\\folder1\\.\\folder2\\..\\file.temp&quot;)" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                            </results>
+                          </test-suite>
+                          <test-suite type="ParameterizedTest" name="ProvidesProperFailureMessage" executed="True" result="Success" success="True" time="0.003" asserts="0">
+                            <results>
+                              <test-case name="NUnit.Framework.Constraints.SamePathOrUnderTest_Windows.ProvidesProperFailureMessage(123,&quot;123&quot;)" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                              <test-case name="NUnit.Framework.Constraints.SamePathOrUnderTest_Windows.ProvidesProperFailureMessage(&quot;C:\\folder1\\folder3&quot;,&quot;\&quot;C:\\folder1\\folder3\&quot;&quot;)" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                              <test-case name="NUnit.Framework.Constraints.SamePathOrUnderTest_Windows.ProvidesProperFailureMessage(&quot;C:\\folder1\\.\\folder2\\..\\file.temp&quot;,&quot;\&quot;C:\\folder1\\.\\folder2\\..\\file.temp\&quot;&quot;)" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                            </results>
+                          </test-suite>
+                          <test-suite type="ParameterizedTest" name="SucceedsWithGoodValues" executed="True" result="Success" success="True" time="0.016" asserts="0">
+                            <results>
+                              <test-case name="NUnit.Framework.Constraints.SamePathOrUnderTest_Windows.SucceedsWithGoodValues(&quot;C:\\folder1\\folder2&quot;)" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                              <test-case name="NUnit.Framework.Constraints.SamePathOrUnderTest_Windows.SucceedsWithGoodValues(&quot;C:\\Folder1\\Folder2&quot;)" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                              <test-case name="NUnit.Framework.Constraints.SamePathOrUnderTest_Windows.SucceedsWithGoodValues(&quot;C:\\folder1\\.\\folder2&quot;)" executed="True" result="Success" success="True" time="0.001" asserts="1" />
+                              <test-case name="NUnit.Framework.Constraints.SamePathOrUnderTest_Windows.SucceedsWithGoodValues(&quot;C:\\folder1\\junk\\..\\folder2&quot;)" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                              <test-case name="NUnit.Framework.Constraints.SamePathOrUnderTest_Windows.SucceedsWithGoodValues(&quot;C:\\FOLDER1\\.\\junk\\..\\Folder2&quot;)" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                              <test-case name="NUnit.Framework.Constraints.SamePathOrUnderTest_Windows.SucceedsWithGoodValues(&quot;C:/folder1/folder2&quot;)" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                              <test-case name="NUnit.Framework.Constraints.SamePathOrUnderTest_Windows.SucceedsWithGoodValues(&quot;C:\\folder1\\folder2\\folder3&quot;)" executed="True" result="Success" success="True" time="0.001" asserts="1" />
+                              <test-case name="NUnit.Framework.Constraints.SamePathOrUnderTest_Windows.SucceedsWithGoodValues(&quot;C:\\folder1\\.\\folder2\\folder3&quot;)" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                              <test-case name="NUnit.Framework.Constraints.SamePathOrUnderTest_Windows.SucceedsWithGoodValues(&quot;C:\\folder1\\junk\\..\\folder2\\folder3&quot;)" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                              <test-case name="NUnit.Framework.Constraints.SamePathOrUnderTest_Windows.SucceedsWithGoodValues(&quot;C:\\FOLDER1\\.\\junk\\..\\Folder2\\temp\\..\\Folder3&quot;)" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                              <test-case name="NUnit.Framework.Constraints.SamePathOrUnderTest_Windows.SucceedsWithGoodValues(&quot;C:/folder1/folder2/folder3&quot;)" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                            </results>
+                          </test-suite>
+                        </results>
+                      </test-suite>
+                      <test-suite type="TestFixture" name="SamePathTest_Linux" executed="True" result="Success" success="True" time="0.035" asserts="0">
+                        <results>
+                          <test-case name="NUnit.Framework.Constraints.SamePathTest_Linux.ConstraintTestBaseNoData.ProvidesProperDescription" executed="True" result="Success" success="True" time="0.001" asserts="1" />
+                          <test-case name="NUnit.Framework.Constraints.SamePathTest_Linux.ConstraintTestBaseNoData.ProvidesProperStringRepresentation" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                          <test-suite type="ParameterizedTest" name="FailsWithBadValues" executed="True" result="Success" success="True" time="0.006" asserts="0">
+                            <results>
+                              <test-case name="NUnit.Framework.Constraints.SamePathTest_Linux.FailsWithBadValues(123)" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                              <test-case name="NUnit.Framework.Constraints.SamePathTest_Linux.FailsWithBadValues(&quot;/folder2/file.tmp&quot;)" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                              <test-case name="NUnit.Framework.Constraints.SamePathTest_Linux.FailsWithBadValues(&quot;/folder1/./folder2/../file.temp&quot;)" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                              <test-case name="NUnit.Framework.Constraints.SamePathTest_Linux.FailsWithBadValues(&quot;/Folder1/File.TMP&quot;)" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                              <test-case name="NUnit.Framework.Constraints.SamePathTest_Linux.FailsWithBadValues(&quot;/FOLDER1/./folder2/../File.TMP&quot;)" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                            </results>
+                          </test-suite>
+                          <test-suite type="ParameterizedTest" name="ProvidesProperFailureMessage" executed="True" result="Success" success="True" time="0.008" asserts="0">
+                            <results>
+                              <test-case name="NUnit.Framework.Constraints.SamePathTest_Linux.ProvidesProperFailureMessage(123,&quot;123&quot;)" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                              <test-case name="NUnit.Framework.Constraints.SamePathTest_Linux.ProvidesProperFailureMessage(&quot;/folder2/file.tmp&quot;,&quot;\&quot;/folder2/file.tmp\&quot;&quot;)" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                              <test-case name="NUnit.Framework.Constraints.SamePathTest_Linux.ProvidesProperFailureMessage(&quot;/folder1/./folder2/../file.temp&quot;,&quot;\&quot;/folder1/./folder2/../file.temp\&quot;&quot;)" executed="True" result="Success" success="True" time="0.001" asserts="1" />
+                              <test-case name="NUnit.Framework.Constraints.SamePathTest_Linux.ProvidesProperFailureMessage(&quot;/Folder1/File.TMP&quot;,&quot;\&quot;/Folder1/File.TMP\&quot;&quot;)" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                              <test-case name="NUnit.Framework.Constraints.SamePathTest_Linux.ProvidesProperFailureMessage(&quot;/FOLDER1/./folder2/../File.TMP&quot;,&quot;\&quot;/FOLDER1/./folder2/../File.TMP\&quot;&quot;)" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                            </results>
+                          </test-suite>
+                          <test-case name="NUnit.Framework.Constraints.SamePathTest_Linux.RootPathEquality" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                          <test-suite type="ParameterizedTest" name="SucceedsWithGoodValues" executed="True" result="Success" success="True" time="0.008" asserts="0">
+                            <results>
+                              <test-case name="NUnit.Framework.Constraints.SamePathTest_Linux.SucceedsWithGoodValues(&quot;/folder1/file.tmp&quot;)" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                              <test-case name="NUnit.Framework.Constraints.SamePathTest_Linux.SucceedsWithGoodValues(&quot;/folder1/./file.tmp&quot;)" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                              <test-case name="NUnit.Framework.Constraints.SamePathTest_Linux.SucceedsWithGoodValues(&quot;/folder1/folder2/../file.tmp&quot;)" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                              <test-case name="NUnit.Framework.Constraints.SamePathTest_Linux.SucceedsWithGoodValues(&quot;/folder1/./folder2/../file.tmp&quot;)" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                              <test-case name="NUnit.Framework.Constraints.SamePathTest_Linux.SucceedsWithGoodValues(&quot;\\folder1\\file.tmp&quot;)" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                            </results>
+                          </test-suite>
+                        </results>
+                      </test-suite>
+                      <test-suite type="TestFixture" name="SamePathTest_Windows" executed="True" result="Success" success="True" time="0.030" asserts="0">
+                        <results>
+                          <test-case name="NUnit.Framework.Constraints.SamePathTest_Windows.ConstraintTestBaseNoData.ProvidesProperDescription" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Framework.Constraints.SamePathTest_Windows.ConstraintTestBaseNoData.ProvidesProperStringRepresentation" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                          <test-suite type="ParameterizedTest" name="FailsWithBadValues" executed="True" result="Success" success="True" time="0.005" asserts="0">
+                            <results>
+                              <test-case name="NUnit.Framework.Constraints.SamePathTest_Windows.FailsWithBadValues(123)" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                              <test-case name="NUnit.Framework.Constraints.SamePathTest_Windows.FailsWithBadValues(&quot;C:\\folder2\\file.tmp&quot;)" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                              <test-case name="NUnit.Framework.Constraints.SamePathTest_Windows.FailsWithBadValues(&quot;C:\\folder1\\.\\folder2\\..\\file.temp&quot;)" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                            </results>
+                          </test-suite>
+                          <test-suite type="ParameterizedTest" name="ProvidesProperFailureMessage" executed="True" result="Success" success="True" time="0.006" asserts="0">
+                            <results>
+                              <test-case name="NUnit.Framework.Constraints.SamePathTest_Windows.ProvidesProperFailureMessage(123,&quot;123&quot;)" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                              <test-case name="NUnit.Framework.Constraints.SamePathTest_Windows.ProvidesProperFailureMessage(&quot;C:\\folder2\\file.tmp&quot;,&quot;\&quot;C:\\folder2\\file.tmp\&quot;&quot;)" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                              <test-case name="NUnit.Framework.Constraints.SamePathTest_Windows.ProvidesProperFailureMessage(&quot;C:\\folder1\\.\\folder2\\..\\file.temp&quot;,&quot;\&quot;C:\\folder1\\.\\folder2\\..\\file.temp\&quot;&quot;)" executed="True" result="Success" success="True" time="0.001" asserts="1" />
+                            </results>
+                          </test-suite>
+                          <test-case name="NUnit.Framework.Constraints.SamePathTest_Windows.RootPathEquality" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                          <test-suite type="ParameterizedTest" name="SucceedsWithGoodValues" executed="True" result="Success" success="True" time="0.010" asserts="0">
+                            <results>
+                              <test-case name="NUnit.Framework.Constraints.SamePathTest_Windows.SucceedsWithGoodValues(&quot;C:\\folder1\\file.tmp&quot;)" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                              <test-case name="NUnit.Framework.Constraints.SamePathTest_Windows.SucceedsWithGoodValues(&quot;C:\\Folder1\\File.TMP&quot;)" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                              <test-case name="NUnit.Framework.Constraints.SamePathTest_Windows.SucceedsWithGoodValues(&quot;C:\\folder1\\.\\file.tmp&quot;)" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                              <test-case name="NUnit.Framework.Constraints.SamePathTest_Windows.SucceedsWithGoodValues(&quot;C:\\folder1\\folder2\\..\\file.tmp&quot;)" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                              <test-case name="NUnit.Framework.Constraints.SamePathTest_Windows.SucceedsWithGoodValues(&quot;C:\\FOLDER1\\.\\folder2\\..\\File.TMP&quot;)" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                              <test-case name="NUnit.Framework.Constraints.SamePathTest_Windows.SucceedsWithGoodValues(&quot;C:/folder1/file.tmp&quot;)" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                            </results>
+                          </test-suite>
+                        </results>
+                      </test-suite>
+                      <test-suite type="TestFixture" name="StartsWithTest" executed="True" result="Success" success="True" time="0.033" asserts="0">
+                        <results>
+                          <test-case name="NUnit.Framework.Constraints.StartsWithTest.ConstraintTestBaseNoData.ProvidesProperDescription" executed="True" result="Success" success="True" time="0.001" asserts="1" />
+                          <test-case name="NUnit.Framework.Constraints.StartsWithTest.ConstraintTestBaseNoData.ProvidesProperStringRepresentation" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                          <test-suite type="ParameterizedTest" name="FailsWithBadValues" executed="True" result="Success" success="True" time="0.009" asserts="0">
+                            <results>
+                              <test-case name="NUnit.Framework.Constraints.StartsWithTest.FailsWithBadValues(&quot;goodbye&quot;)" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                              <test-case name="NUnit.Framework.Constraints.StartsWithTest.FailsWithBadValues(&quot;HELLO THERE&quot;)" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                              <test-case name="NUnit.Framework.Constraints.StartsWithTest.FailsWithBadValues(&quot;I said hello&quot;)" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                              <test-case name="NUnit.Framework.Constraints.StartsWithTest.FailsWithBadValues(&quot;say hello to fred&quot;)" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                              <test-case name="NUnit.Framework.Constraints.StartsWithTest.FailsWithBadValues(&quot;&quot;)" executed="True" result="Success" success="True" time="0.001" asserts="1" />
+                              <test-case name="NUnit.Framework.Constraints.StartsWithTest.FailsWithBadValues(null)" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                            </results>
+                          </test-suite>
+                          <test-suite type="ParameterizedTest" name="ProvidesProperFailureMessage" executed="True" result="Success" success="True" time="0.013" asserts="0">
+                            <results>
+                              <test-case name="NUnit.Framework.Constraints.StartsWithTest.ProvidesProperFailureMessage(&quot;goodbye&quot;,&quot;\&quot;goodbye\&quot;&quot;)" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                              <test-case name="NUnit.Framework.Constraints.StartsWithTest.ProvidesProperFailureMessage(&quot;HELLO THERE&quot;,&quot;\&quot;HELLO THERE\&quot;&quot;)" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                              <test-case name="NUnit.Framework.Constraints.StartsWithTest.ProvidesProperFailureMessage(&quot;I said hello&quot;,&quot;\&quot;I said hello\&quot;&quot;)" executed="True" result="Success" success="True" time="0.001" asserts="1" />
+                              <test-case name="NUnit.Framework.Constraints.StartsWithTest.ProvidesProperFailureMessage(&quot;say hello to fred&quot;,&quot;\&quot;say hello to fred\&quot;&quot;)" executed="True" result="Success" success="True" time="0.001" asserts="1" />
+                              <test-case name="NUnit.Framework.Constraints.StartsWithTest.ProvidesProperFailureMessage(&quot;&quot;,&quot;&lt;string.Empty&gt;&quot;)" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                              <test-case name="NUnit.Framework.Constraints.StartsWithTest.ProvidesProperFailureMessage(null,&quot;null&quot;)" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                            </results>
+                          </test-suite>
+                          <test-suite type="ParameterizedTest" name="SucceedsWithGoodValues" executed="True" result="Success" success="True" time="0.003" asserts="0">
+                            <results>
+                              <test-case name="NUnit.Framework.Constraints.StartsWithTest.SucceedsWithGoodValues(&quot;hello&quot;)" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                              <test-case name="NUnit.Framework.Constraints.StartsWithTest.SucceedsWithGoodValues(&quot;hello there&quot;)" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                            </results>
+                          </test-suite>
+                        </results>
+                      </test-suite>
+                      <test-suite type="TestFixture" name="StartsWithTestIgnoringCase" executed="True" result="Success" success="True" time="0.030" asserts="0">
+                        <results>
+                          <test-case name="NUnit.Framework.Constraints.StartsWithTestIgnoringCase.ConstraintTestBaseNoData.ProvidesProperDescription" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Framework.Constraints.StartsWithTestIgnoringCase.ConstraintTestBaseNoData.ProvidesProperStringRepresentation" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                          <test-suite type="ParameterizedTest" name="FailsWithBadValues" executed="True" result="Success" success="True" time="0.008" asserts="0">
+                            <results>
+                              <test-case name="NUnit.Framework.Constraints.StartsWithTestIgnoringCase.FailsWithBadValues(&quot;goodbye&quot;)" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                              <test-case name="NUnit.Framework.Constraints.StartsWithTestIgnoringCase.FailsWithBadValues(&quot;What the hell?&quot;)" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                              <test-case name="NUnit.Framework.Constraints.StartsWithTestIgnoringCase.FailsWithBadValues(&quot;I said hello&quot;)" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                              <test-case name="NUnit.Framework.Constraints.StartsWithTestIgnoringCase.FailsWithBadValues(&quot;say Hello to fred&quot;)" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                              <test-case name="NUnit.Framework.Constraints.StartsWithTestIgnoringCase.FailsWithBadValues(&quot;&quot;)" executed="True" result="Success" success="True" time="0.001" asserts="1" />
+                              <test-case name="NUnit.Framework.Constraints.StartsWithTestIgnoringCase.FailsWithBadValues(null)" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                            </results>
+                          </test-suite>
+                          <test-suite type="ParameterizedTest" name="ProvidesProperFailureMessage" executed="True" result="Success" success="True" time="0.011" asserts="0">
+                            <results>
+                              <test-case name="NUnit.Framework.Constraints.StartsWithTestIgnoringCase.ProvidesProperFailureMessage(&quot;goodbye&quot;,&quot;\&quot;goodbye\&quot;&quot;)" executed="True" result="Success" success="True" time="0.001" asserts="1" />
+                              <test-case name="NUnit.Framework.Constraints.StartsWithTestIgnoringCase.ProvidesProperFailureMessage(&quot;What the hell?&quot;,&quot;\&quot;What the hell?\&quot;&quot;)" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                              <test-case name="NUnit.Framework.Constraints.StartsWithTestIgnoringCase.ProvidesProperFailureMessage(&quot;I said hello&quot;,&quot;\&quot;I said hello\&quot;&quot;)" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                              <test-case name="NUnit.Framework.Constraints.StartsWithTestIgnoringCase.ProvidesProperFailureMessage(&quot;say Hello to fred&quot;,&quot;\&quot;say Hello to fred\&quot;&quot;)" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                              <test-case name="NUnit.Framework.Constraints.StartsWithTestIgnoringCase.ProvidesProperFailureMessage(&quot;&quot;,&quot;&lt;string.Empty&gt;&quot;)" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                              <test-case name="NUnit.Framework.Constraints.StartsWithTestIgnoringCase.ProvidesProperFailureMessage(null,&quot;null&quot;)" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                            </results>
+                          </test-suite>
+                          <test-suite type="ParameterizedTest" name="SucceedsWithGoodValues" executed="True" result="Success" success="True" time="0.002" asserts="0">
+                            <results>
+                              <test-case name="NUnit.Framework.Constraints.StartsWithTestIgnoringCase.SucceedsWithGoodValues(&quot;Hello&quot;)" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                              <test-case name="NUnit.Framework.Constraints.StartsWithTestIgnoringCase.SucceedsWithGoodValues(&quot;HELLO there&quot;)" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                            </results>
+                          </test-suite>
+                        </results>
+                      </test-suite>
+                      <test-suite type="TestFixture" name="SubPathTest_Linux" executed="True" result="Success" success="True" time="0.051" asserts="0">
+                        <results>
+                          <test-case name="NUnit.Framework.Constraints.SubPathTest_Linux.ConstraintTestBaseNoData.ProvidesProperDescription" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Framework.Constraints.SubPathTest_Linux.ConstraintTestBaseNoData.ProvidesProperStringRepresentation" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                          <test-suite type="ParameterizedTest" name="FailsWithBadValues" executed="True" result="Success" success="True" time="0.017" asserts="0">
+                            <results>
+                              <test-case name="NUnit.Framework.Constraints.SubPathTest_Linux.FailsWithBadValues(123)" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                              <test-case name="NUnit.Framework.Constraints.SubPathTest_Linux.FailsWithBadValues(&quot;/Folder1/Folder2&quot;)" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                              <test-case name="NUnit.Framework.Constraints.SubPathTest_Linux.FailsWithBadValues(&quot;/FOLDER1/./junk/../Folder2&quot;)" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                              <test-case name="NUnit.Framework.Constraints.SubPathTest_Linux.FailsWithBadValues(&quot;/FOLDER1/./junk/../Folder2/temp/../Folder3&quot;)" executed="True" result="Success" success="True" time="0.001" asserts="1" />
+                              <test-case name="NUnit.Framework.Constraints.SubPathTest_Linux.FailsWithBadValues(&quot;/folder1/folder3&quot;)" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                              <test-case name="NUnit.Framework.Constraints.SubPathTest_Linux.FailsWithBadValues(&quot;/folder1/./folder2/../folder3&quot;)" executed="True" result="Success" success="True" time="0.001" asserts="1" />
+                              <test-case name="NUnit.Framework.Constraints.SubPathTest_Linux.FailsWithBadValues(&quot;/folder1&quot;)" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                              <test-case name="NUnit.Framework.Constraints.SubPathTest_Linux.FailsWithBadValues(&quot;/folder1/folder2&quot;)" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                              <test-case name="NUnit.Framework.Constraints.SubPathTest_Linux.FailsWithBadValues(&quot;/folder1/./folder2&quot;)" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                              <test-case name="NUnit.Framework.Constraints.SubPathTest_Linux.FailsWithBadValues(&quot;/folder1/junk/../folder2&quot;)" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                              <test-case name="NUnit.Framework.Constraints.SubPathTest_Linux.FailsWithBadValues(&quot;\\folder1\\folder2&quot;)" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                            </results>
+                          </test-suite>
+                          <test-suite type="ParameterizedTest" name="ProvidesProperFailureMessage" executed="True" result="Success" success="True" time="0.019" asserts="0">
+                            <results>
+                              <test-case name="NUnit.Framework.Constraints.SubPathTest_Linux.ProvidesProperFailureMessage(123,&quot;123&quot;)" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                              <test-case name="NUnit.Framework.Constraints.SubPathTest_Linux.ProvidesProperFailureMessage(&quot;/Folder1/Folder2&quot;,&quot;\&quot;/Folder1/Folder2\&quot;&quot;)" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                              <test-case name="NUnit.Framework.Constraints.SubPathTest_Linux.ProvidesProperFailureMessage(&quot;/FOLDER1/./junk/../Folder2&quot;,&quot;\&quot;/FOLDER1/./junk/../Folder2\&quot;&quot;)" executed="True" result="Success" success="True" time="0.001" asserts="1" />
+                              <test-case name="NUnit.Framework.Constraints.SubPathTest_Linux.ProvidesProperFailureMessage(&quot;/FOLDER1/./junk/../Folder2/temp/../Folder3&quot;,&quot;\&quot;/FOLDER1/./junk/../Folder2/temp/../Folder3\&quot;&quot;)" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                              <test-case name="NUnit.Framework.Constraints.SubPathTest_Linux.ProvidesProperFailureMessage(&quot;/folder1/folder3&quot;,&quot;\&quot;/folder1/folder3\&quot;&quot;)" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                              <test-case name="NUnit.Framework.Constraints.SubPathTest_Linux.ProvidesProperFailureMessage(&quot;/folder1/./folder2/../folder3&quot;,&quot;\&quot;/folder1/./folder2/../folder3\&quot;&quot;)" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                              <test-case name="NUnit.Framework.Constraints.SubPathTest_Linux.ProvidesProperFailureMessage(&quot;/folder1&quot;,&quot;\&quot;/folder1\&quot;&quot;)" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                              <test-case name="NUnit.Framework.Constraints.SubPathTest_Linux.ProvidesProperFailureMessage(&quot;/folder1/folder2&quot;,&quot;\&quot;/folder1/folder2\&quot;&quot;)" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                              <test-case name="NUnit.Framework.Constraints.SubPathTest_Linux.ProvidesProperFailureMessage(&quot;/folder1/./folder2&quot;,&quot;\&quot;/folder1/./folder2\&quot;&quot;)" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                              <test-case name="NUnit.Framework.Constraints.SubPathTest_Linux.ProvidesProperFailureMessage(&quot;/folder1/junk/../folder2&quot;,&quot;\&quot;/folder1/junk/../folder2\&quot;&quot;)" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                              <test-case name="NUnit.Framework.Constraints.SubPathTest_Linux.ProvidesProperFailureMessage(&quot;\\folder1\\folder2&quot;,&quot;\&quot;\\folder1\\folder2\&quot;&quot;)" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                            </results>
+                          </test-suite>
+                          <test-case name="NUnit.Framework.Constraints.SubPathTest_Linux.SubPathOfRoot" executed="True" result="Success" success="True" time="0.001" asserts="1" />
+                          <test-suite type="ParameterizedTest" name="SucceedsWithGoodValues" executed="True" result="Success" success="True" time="0.005" asserts="0">
+                            <results>
+                              <test-case name="NUnit.Framework.Constraints.SubPathTest_Linux.SucceedsWithGoodValues(&quot;/folder1/folder2/folder3&quot;)" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                              <test-case name="NUnit.Framework.Constraints.SubPathTest_Linux.SucceedsWithGoodValues(&quot;/folder1/./folder2/folder3&quot;)" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                              <test-case name="NUnit.Framework.Constraints.SubPathTest_Linux.SucceedsWithGoodValues(&quot;/folder1/junk/../folder2/folder3&quot;)" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                              <test-case name="NUnit.Framework.Constraints.SubPathTest_Linux.SucceedsWithGoodValues(&quot;\\folder1\\folder2\\folder3&quot;)" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                            </results>
+                          </test-suite>
+                        </results>
+                      </test-suite>
+                      <test-suite type="TestFixture" name="SubPathTest_Windows" executed="True" result="Success" success="True" time="0.046" asserts="0">
+                        <results>
+                          <test-case name="NUnit.Framework.Constraints.SubPathTest_Windows.ConstraintTestBaseNoData.ProvidesProperDescription" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Framework.Constraints.SubPathTest_Windows.ConstraintTestBaseNoData.ProvidesProperStringRepresentation" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                          <test-suite type="ParameterizedTest" name="FailsWithBadValues" executed="True" result="Success" success="True" time="0.014" asserts="0">
+                            <results>
+                              <test-case name="NUnit.Framework.Constraints.SubPathTest_Windows.FailsWithBadValues(123)" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                              <test-case name="NUnit.Framework.Constraints.SubPathTest_Windows.FailsWithBadValues(&quot;C:\\folder1\\folder3&quot;)" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                              <test-case name="NUnit.Framework.Constraints.SubPathTest_Windows.FailsWithBadValues(&quot;C:\\folder1\\.\\folder2\\..\\file.temp&quot;)" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                              <test-case name="NUnit.Framework.Constraints.SubPathTest_Windows.FailsWithBadValues(&quot;C:\\folder1\\folder2&quot;)" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                              <test-case name="NUnit.Framework.Constraints.SubPathTest_Windows.FailsWithBadValues(&quot;C:\\Folder1\\Folder2&quot;)" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                              <test-case name="NUnit.Framework.Constraints.SubPathTest_Windows.FailsWithBadValues(&quot;C:\\folder1\\.\\folder2&quot;)" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                              <test-case name="NUnit.Framework.Constraints.SubPathTest_Windows.FailsWithBadValues(&quot;C:\\folder1\\junk\\..\\folder2&quot;)" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                              <test-case name="NUnit.Framework.Constraints.SubPathTest_Windows.FailsWithBadValues(&quot;C:\\FOLDER1\\.\\junk\\..\\Folder2&quot;)" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                              <test-case name="NUnit.Framework.Constraints.SubPathTest_Windows.FailsWithBadValues(&quot;C:/folder1/folder2&quot;)" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                            </results>
+                          </test-suite>
+                          <test-suite type="ParameterizedTest" name="ProvidesProperFailureMessage" executed="True" result="Success" success="True" time="0.013" asserts="0">
+                            <results>
+                              <test-case name="NUnit.Framework.Constraints.SubPathTest_Windows.ProvidesProperFailureMessage(123,&quot;123&quot;)" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                              <test-case name="NUnit.Framework.Constraints.SubPathTest_Windows.ProvidesProperFailureMessage(&quot;C:\\folder1\\folder3&quot;,&quot;\&quot;C:\\folder1\\folder3\&quot;&quot;)" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                              <test-case name="NUnit.Framework.Constraints.SubPathTest_Windows.ProvidesProperFailureMessage(&quot;C:\\folder1\\.\\folder2\\..\\file.temp&quot;,&quot;\&quot;C:\\folder1\\.\\folder2\\..\\file.temp\&quot;&quot;)" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                              <test-case name="NUnit.Framework.Constraints.SubPathTest_Windows.ProvidesProperFailureMessage(&quot;C:\\folder1\\folder2&quot;,&quot;\&quot;C:\\folder1\\folder2\&quot;&quot;)" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                              <test-case name="NUnit.Framework.Constraints.SubPathTest_Windows.ProvidesProperFailureMessage(&quot;C:\\Folder1\\Folder2&quot;,&quot;\&quot;C:\\Folder1\\Folder2\&quot;&quot;)" executed="True" result="Success" success="True" time="0.001" asserts="1" />
+                              <test-case name="NUnit.Framework.Constraints.SubPathTest_Windows.ProvidesProperFailureMessage(&quot;C:\\folder1\\.\\folder2&quot;,&quot;\&quot;C:\\folder1\\.\\folder2\&quot;&quot;)" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                              <test-case name="NUnit.Framework.Constraints.SubPathTest_Windows.ProvidesProperFailureMessage(&quot;C:\\folder1\\junk\\..\\folder2&quot;,&quot;\&quot;C:\\folder1\\junk\\..\\folder2\&quot;&quot;)" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                              <test-case name="NUnit.Framework.Constraints.SubPathTest_Windows.ProvidesProperFailureMessage(&quot;C:\\FOLDER1\\.\\junk\\..\\Folder2&quot;,&quot;\&quot;C:\\FOLDER1\\.\\junk\\..\\Folder2\&quot;&quot;)" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                              <test-case name="NUnit.Framework.Constraints.SubPathTest_Windows.ProvidesProperFailureMessage(&quot;C:/folder1/folder2&quot;,&quot;\&quot;C:/folder1/folder2\&quot;&quot;)" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                            </results>
+                          </test-suite>
+                          <test-case name="NUnit.Framework.Constraints.SubPathTest_Windows.SubPathOfRoot" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                          <test-suite type="ParameterizedTest" name="SucceedsWithGoodValues" executed="True" result="Success" success="True" time="0.007" asserts="0">
+                            <results>
+                              <test-case name="NUnit.Framework.Constraints.SubPathTest_Windows.SucceedsWithGoodValues(&quot;C:\\folder1\\folder2\\folder3&quot;)" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                              <test-case name="NUnit.Framework.Constraints.SubPathTest_Windows.SucceedsWithGoodValues(&quot;C:\\folder1\\.\\folder2\\folder3&quot;)" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                              <test-case name="NUnit.Framework.Constraints.SubPathTest_Windows.SucceedsWithGoodValues(&quot;C:\\folder1\\junk\\..\\folder2\\folder3&quot;)" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                              <test-case name="NUnit.Framework.Constraints.SubPathTest_Windows.SucceedsWithGoodValues(&quot;C:\\FOLDER1\\.\\junk\\..\\Folder2\\temp\\..\\Folder3&quot;)" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                              <test-case name="NUnit.Framework.Constraints.SubPathTest_Windows.SucceedsWithGoodValues(&quot;C:/folder1/folder2/folder3&quot;)" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                            </results>
+                          </test-suite>
+                        </results>
+                      </test-suite>
+                      <test-suite type="TestFixture" name="SubstringTest" executed="True" result="Success" success="True" time="0.027" asserts="0">
+                        <results>
+                          <test-case name="NUnit.Framework.Constraints.SubstringTest.ConstraintTestBaseNoData.ProvidesProperDescription" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Framework.Constraints.SubstringTest.ConstraintTestBaseNoData.ProvidesProperStringRepresentation" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                          <test-suite type="ParameterizedTest" name="FailsWithBadValues" executed="True" result="Success" success="True" time="0.007" asserts="0">
+                            <results>
+                              <test-case name="NUnit.Framework.Constraints.SubstringTest.FailsWithBadValues(&quot;goodbye&quot;)" executed="True" result="Success" success="True" time="0.001" asserts="1" />
+                              <test-case name="NUnit.Framework.Constraints.SubstringTest.FailsWithBadValues(&quot;HELLO&quot;)" executed="True" result="Success" success="True" time="0.001" asserts="1" />
+                              <test-case name="NUnit.Framework.Constraints.SubstringTest.FailsWithBadValues(&quot;What the hell?&quot;)" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                              <test-case name="NUnit.Framework.Constraints.SubstringTest.FailsWithBadValues(&quot;&quot;)" executed="True" result="Success" success="True" time="0.001" asserts="1" />
+                              <test-case name="NUnit.Framework.Constraints.SubstringTest.FailsWithBadValues(null)" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                            </results>
+                          </test-suite>
+                          <test-suite type="ParameterizedTest" name="ProvidesProperFailureMessage" executed="True" result="Success" success="True" time="0.007" asserts="0">
+                            <results>
+                              <test-case name="NUnit.Framework.Constraints.SubstringTest.ProvidesProperFailureMessage(&quot;goodbye&quot;,&quot;\&quot;goodbye\&quot;&quot;)" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                              <test-case name="NUnit.Framework.Constraints.SubstringTest.ProvidesProperFailureMessage(&quot;HELLO&quot;,&quot;\&quot;HELLO\&quot;&quot;)" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                              <test-case name="NUnit.Framework.Constraints.SubstringTest.ProvidesProperFailureMessage(&quot;What the hell?&quot;,&quot;\&quot;What the hell?\&quot;&quot;)" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                              <test-case name="NUnit.Framework.Constraints.SubstringTest.ProvidesProperFailureMessage(&quot;&quot;,&quot;&lt;string.Empty&gt;&quot;)" executed="True" result="Success" success="True" time="0.001" asserts="1" />
+                              <test-case name="NUnit.Framework.Constraints.SubstringTest.ProvidesProperFailureMessage(null,&quot;null&quot;)" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                            </results>
+                          </test-suite>
+                          <test-suite type="ParameterizedTest" name="SucceedsWithGoodValues" executed="True" result="Success" success="True" time="0.005" asserts="0">
+                            <results>
+                              <test-case name="NUnit.Framework.Constraints.SubstringTest.SucceedsWithGoodValues(&quot;hello&quot;)" executed="True" result="Success" success="True" time="0.001" asserts="1" />
+                              <test-case name="NUnit.Framework.Constraints.SubstringTest.SucceedsWithGoodValues(&quot;hello there&quot;)" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                              <test-case name="NUnit.Framework.Constraints.SubstringTest.SucceedsWithGoodValues(&quot;I said hello&quot;)" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                              <test-case name="NUnit.Framework.Constraints.SubstringTest.SucceedsWithGoodValues(&quot;say hello to fred&quot;)" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                            </results>
+                          </test-suite>
+                        </results>
+                      </test-suite>
+                      <test-suite type="TestFixture" name="SubstringTestIgnoringCase" executed="True" result="Success" success="True" time="0.028" asserts="0">
+                        <results>
+                          <test-case name="NUnit.Framework.Constraints.SubstringTestIgnoringCase.ConstraintTestBaseNoData.ProvidesProperDescription" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Framework.Constraints.SubstringTestIgnoringCase.ConstraintTestBaseNoData.ProvidesProperStringRepresentation" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                          <test-suite type="ParameterizedTest" name="FailsWithBadValues" executed="True" result="Success" success="True" time="0.005" asserts="0">
+                            <results>
+                              <test-case name="NUnit.Framework.Constraints.SubstringTestIgnoringCase.FailsWithBadValues(&quot;goodbye&quot;)" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                              <test-case name="NUnit.Framework.Constraints.SubstringTestIgnoringCase.FailsWithBadValues(&quot;What the hell?&quot;)" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                              <test-case name="NUnit.Framework.Constraints.SubstringTestIgnoringCase.FailsWithBadValues(&quot;&quot;)" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                              <test-case name="NUnit.Framework.Constraints.SubstringTestIgnoringCase.FailsWithBadValues(null)" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                            </results>
+                          </test-suite>
+                          <test-suite type="ParameterizedTest" name="ProvidesProperFailureMessage" executed="True" result="Success" success="True" time="0.005" asserts="0">
+                            <results>
+                              <test-case name="NUnit.Framework.Constraints.SubstringTestIgnoringCase.ProvidesProperFailureMessage(&quot;goodbye&quot;,&quot;\&quot;goodbye\&quot;&quot;)" executed="True" result="Success" success="True" time="0.001" asserts="1" />
+                              <test-case name="NUnit.Framework.Constraints.SubstringTestIgnoringCase.ProvidesProperFailureMessage(&quot;What the hell?&quot;,&quot;\&quot;What the hell?\&quot;&quot;)" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                              <test-case name="NUnit.Framework.Constraints.SubstringTestIgnoringCase.ProvidesProperFailureMessage(&quot;&quot;,&quot;&lt;string.Empty&gt;&quot;)" executed="True" result="Success" success="True" time="0.001" asserts="1" />
+                              <test-case name="NUnit.Framework.Constraints.SubstringTestIgnoringCase.ProvidesProperFailureMessage(null,&quot;null&quot;)" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                            </results>
+                          </test-suite>
+                          <test-suite type="ParameterizedTest" name="SucceedsWithGoodValues" executed="True" result="Success" success="True" time="0.005" asserts="0">
+                            <results>
+                              <test-case name="NUnit.Framework.Constraints.SubstringTestIgnoringCase.SucceedsWithGoodValues(&quot;Hello&quot;)" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                              <test-case name="NUnit.Framework.Constraints.SubstringTestIgnoringCase.SucceedsWithGoodValues(&quot;HellO there&quot;)" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                              <test-case name="NUnit.Framework.Constraints.SubstringTestIgnoringCase.SucceedsWithGoodValues(&quot;I said HELLO&quot;)" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                              <test-case name="NUnit.Framework.Constraints.SubstringTestIgnoringCase.SucceedsWithGoodValues(&quot;say hello to fred&quot;)" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                            </results>
+                          </test-suite>
+                        </results>
+                      </test-suite>
+                      <test-suite type="TestFixture" name="ThrowsConstraintTest_ExactType" executed="True" result="Success" success="True" time="0.017" asserts="0">
+                        <results>
+                          <test-case name="NUnit.Framework.Constraints.ThrowsConstraintTest_ExactType.ConstraintTestBaseNoData.ProvidesProperDescription" executed="True" result="Success" success="True" time="0.001" asserts="1" />
+                          <test-case name="NUnit.Framework.Constraints.ThrowsConstraintTest_ExactType.ConstraintTestBaseNoData.ProvidesProperStringRepresentation" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                          <test-suite type="ParameterizedTest" name="FailsWithBadValues" executed="True" result="Success" success="True" time="0.004" asserts="0">
+                            <results>
+                              <test-case name="NUnit.Framework.Constraints.ThrowsConstraintTest_ExactType.FailsWithBadValues(NUnit.Framework.TestDelegate)" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                              <test-case name="NUnit.Framework.Constraints.ThrowsConstraintTest_ExactType.FailsWithBadValues(NUnit.Framework.TestDelegate)" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                              <test-case name="NUnit.Framework.Constraints.ThrowsConstraintTest_ExactType.FailsWithBadValues(NUnit.Framework.TestDelegate)" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                            </results>
+                          </test-suite>
+                          <test-suite type="ParameterizedTest" name="ProvidesProperFailureMessage" executed="True" result="Success" success="True" time="0.004" asserts="0">
+                            <results>
+                              <test-case name="NUnit.Framework.Constraints.ThrowsConstraintTest_ExactType.ProvidesProperFailureMessage(NUnit.Framework.TestDelegate,&quot;&lt;System.ApplicationException&gt;&quot;)" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                              <test-case name="NUnit.Framework.Constraints.ThrowsConstraintTest_ExactType.ProvidesProperFailureMessage(NUnit.Framework.TestDelegate,&quot;no exception thrown&quot;)" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                              <test-case name="NUnit.Framework.Constraints.ThrowsConstraintTest_ExactType.ProvidesProperFailureMessage(NUnit.Framework.TestDelegate,&quot;&lt;System.Exception&gt;&quot;)" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                            </results>
+                          </test-suite>
+                          <test-suite type="ParameterizedTest" name="SucceedsWithGoodValues" executed="True" result="Success" success="True" time="0.001" asserts="0">
+                            <results>
+                              <test-case name="NUnit.Framework.Constraints.ThrowsConstraintTest_ExactType.SucceedsWithGoodValues(NUnit.Framework.TestDelegate)" executed="True" result="Success" success="True" time="0.001" asserts="1" />
+                            </results>
+                          </test-suite>
+                        </results>
+                      </test-suite>
+                      <test-suite type="TestFixture" name="ThrowsConstraintTest_InstanceOfType" executed="True" result="Success" success="True" time="0.020" asserts="0">
+                        <results>
+                          <test-case name="NUnit.Framework.Constraints.ThrowsConstraintTest_InstanceOfType.ConstraintTestBaseNoData.ProvidesProperDescription" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Framework.Constraints.ThrowsConstraintTest_InstanceOfType.ConstraintTestBaseNoData.ProvidesProperStringRepresentation" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                          <test-suite type="ParameterizedTest" name="FailsWithBadValues" executed="True" result="Success" success="True" time="0.003" asserts="0">
+                            <results>
+                              <test-case name="NUnit.Framework.Constraints.ThrowsConstraintTest_InstanceOfType.FailsWithBadValues(NUnit.Framework.TestDelegate)" executed="True" result="Success" success="True" time="0.001" asserts="1" />
+                              <test-case name="NUnit.Framework.Constraints.ThrowsConstraintTest_InstanceOfType.FailsWithBadValues(NUnit.Framework.TestDelegate)" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                              <test-case name="NUnit.Framework.Constraints.ThrowsConstraintTest_InstanceOfType.FailsWithBadValues(NUnit.Framework.TestDelegate)" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                            </results>
+                          </test-suite>
+                          <test-suite type="ParameterizedTest" name="ProvidesProperFailureMessage" executed="True" result="Success" success="True" time="0.004" asserts="0">
+                            <results>
+                              <test-case name="NUnit.Framework.Constraints.ThrowsConstraintTest_InstanceOfType.ProvidesProperFailureMessage(NUnit.Framework.TestDelegate,&quot;&lt;System.ArgumentException&gt;&quot;)" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                              <test-case name="NUnit.Framework.Constraints.ThrowsConstraintTest_InstanceOfType.ProvidesProperFailureMessage(NUnit.Framework.TestDelegate,&quot;no exception thrown&quot;)" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                              <test-case name="NUnit.Framework.Constraints.ThrowsConstraintTest_InstanceOfType.ProvidesProperFailureMessage(NUnit.Framework.TestDelegate,&quot;&lt;System.Exception&gt;&quot;)" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                            </results>
+                          </test-suite>
+                          <test-suite type="ParameterizedTest" name="SucceedsWithGoodValues" executed="True" result="Success" success="True" time="0.002" asserts="0">
+                            <results>
+                              <test-case name="NUnit.Framework.Constraints.ThrowsConstraintTest_InstanceOfType.SucceedsWithGoodValues(NUnit.Framework.TestDelegate)" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                              <test-case name="NUnit.Framework.Constraints.ThrowsConstraintTest_InstanceOfType.SucceedsWithGoodValues(NUnit.Framework.TestDelegate)" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                            </results>
+                          </test-suite>
+                        </results>
+                      </test-suite>
+                      <test-suite type="TestFixture" name="ThrowsConstraintTest_WithConstraint" executed="True" result="Success" success="True" time="0.016" asserts="0">
+                        <results>
+                          <test-case name="NUnit.Framework.Constraints.ThrowsConstraintTest_WithConstraint.ConstraintTestBaseNoData.ProvidesProperDescription" executed="True" result="Success" success="True" time="0.001" asserts="1" />
+                          <test-case name="NUnit.Framework.Constraints.ThrowsConstraintTest_WithConstraint.ConstraintTestBaseNoData.ProvidesProperStringRepresentation" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                          <test-suite type="ParameterizedTest" name="FailsWithBadValues" executed="True" result="Success" success="True" time="0.004" asserts="0">
+                            <results>
+                              <test-case name="NUnit.Framework.Constraints.ThrowsConstraintTest_WithConstraint.FailsWithBadValues(NUnit.Framework.TestDelegate)" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                              <test-case name="NUnit.Framework.Constraints.ThrowsConstraintTest_WithConstraint.FailsWithBadValues(NUnit.Framework.TestDelegate)" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                              <test-case name="NUnit.Framework.Constraints.ThrowsConstraintTest_WithConstraint.FailsWithBadValues(NUnit.Framework.TestDelegate)" executed="True" result="Success" success="True" time="0.001" asserts="1" />
+                            </results>
+                          </test-suite>
+                          <test-suite type="ParameterizedTest" name="ProvidesProperFailureMessage" executed="True" result="Success" success="True" time="0.004" asserts="0">
+                            <results>
+                              <test-case name="NUnit.Framework.Constraints.ThrowsConstraintTest_WithConstraint.ProvidesProperFailureMessage(NUnit.Framework.TestDelegate,&quot;&lt;System.ApplicationException&gt;&quot;)" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                              <test-case name="NUnit.Framework.Constraints.ThrowsConstraintTest_WithConstraint.ProvidesProperFailureMessage(NUnit.Framework.TestDelegate,&quot;no exception thrown&quot;)" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                              <test-case name="NUnit.Framework.Constraints.ThrowsConstraintTest_WithConstraint.ProvidesProperFailureMessage(NUnit.Framework.TestDelegate,&quot;&lt;System.Exception&gt;&quot;)" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                            </results>
+                          </test-suite>
+                          <test-suite type="ParameterizedTest" name="SucceedsWithGoodValues" executed="True" result="Success" success="True" time="0.000" asserts="0">
+                            <results>
+                              <test-case name="NUnit.Framework.Constraints.ThrowsConstraintTest_WithConstraint.SucceedsWithGoodValues(NUnit.Framework.TestDelegate)" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                            </results>
+                          </test-suite>
+                        </results>
+                      </test-suite>
+                      <test-suite type="TestFixture" name="ToStringTests" executed="True" result="Success" success="True" time="0.014" asserts="0">
+                        <results>
+                          <test-case name="NUnit.Framework.Constraints.ToStringTests.CanDisplayPrefixConstraints_Resolved" executed="True" result="Success" success="True" time="0.001" asserts="3" />
+                          <test-case name="NUnit.Framework.Constraints.ToStringTests.CanDisplaySimpleConstraints_Resolved" executed="True" result="Success" success="True" time="0.001" asserts="3" />
+                          <test-case name="NUnit.Framework.Constraints.ToStringTests.CanDisplaySimpleConstraints_Unresolved" executed="True" result="Success" success="True" time="0.000" asserts="3" />
+                          <test-case name="NUnit.Framework.Constraints.ToStringTests.DisplayBinaryConstraints_Resolved" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Framework.Constraints.ToStringTests.DisplayBinaryConstraints_UnResolved" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Framework.Constraints.ToStringTests.DisplayPrefixConstraints_Unresolved" executed="True" result="Success" success="True" time="0.001" asserts="4" />
+                        </results>
+                      </test-suite>
+                      <test-suite type="TestFixture" name="TrueConstraintTest" executed="True" result="Success" success="True" time="0.019" asserts="0">
+                        <results>
+                          <test-case name="NUnit.Framework.Constraints.TrueConstraintTest.ConstraintTestBaseNoData.ProvidesProperDescription" executed="True" result="Success" success="True" time="0.001" asserts="1" />
+                          <test-case name="NUnit.Framework.Constraints.TrueConstraintTest.ConstraintTestBaseNoData.ProvidesProperStringRepresentation" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                          <test-suite type="ParameterizedTest" name="FailsWithBadValues" executed="True" result="Success" success="True" time="0.006" asserts="0">
+                            <results>
+                              <test-case name="NUnit.Framework.Constraints.TrueConstraintTest.FailsWithBadValues(null)" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                              <test-case name="NUnit.Framework.Constraints.TrueConstraintTest.FailsWithBadValues(&quot;hello&quot;)" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                              <test-case name="NUnit.Framework.Constraints.TrueConstraintTest.FailsWithBadValues(False)" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                              <test-case name="NUnit.Framework.Constraints.TrueConstraintTest.FailsWithBadValues(False)" executed="True" result="Success" success="True" time="0.001" asserts="1" />
+                            </results>
+                          </test-suite>
+                          <test-suite type="ParameterizedTest" name="ProvidesProperFailureMessage" executed="True" result="Success" success="True" time="0.004" asserts="0">
+                            <results>
+                              <test-case name="NUnit.Framework.Constraints.TrueConstraintTest.ProvidesProperFailureMessage(null,&quot;null&quot;)" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                              <test-case name="NUnit.Framework.Constraints.TrueConstraintTest.ProvidesProperFailureMessage(&quot;hello&quot;,&quot;\&quot;hello\&quot;&quot;)" executed="True" result="Success" success="True" time="0.001" asserts="1" />
+                              <test-case name="NUnit.Framework.Constraints.TrueConstraintTest.ProvidesProperFailureMessage(False,&quot;False&quot;)" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                              <test-case name="NUnit.Framework.Constraints.TrueConstraintTest.ProvidesProperFailureMessage(False,&quot;False&quot;)" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                            </results>
+                          </test-suite>
+                          <test-suite type="ParameterizedTest" name="SucceedsWithGoodValues" executed="True" result="Success" success="True" time="0.002" asserts="0">
+                            <results>
+                              <test-case name="NUnit.Framework.Constraints.TrueConstraintTest.SucceedsWithGoodValues(True)" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                              <test-case name="NUnit.Framework.Constraints.TrueConstraintTest.SucceedsWithGoodValues(True)" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                            </results>
+                          </test-suite>
+                        </results>
+                      </test-suite>
+                      <test-suite type="TestFixture" name="XmlSerializableTest" executed="True" result="Success" success="True" time="1.523" asserts="0">
+                        <results>
+                          <test-case name="NUnit.Framework.Constraints.XmlSerializableTest.ConstraintTestBaseNoData.ProvidesProperDescription" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Framework.Constraints.XmlSerializableTest.ConstraintTestBaseNoData.ProvidesProperStringRepresentation" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                          <test-suite type="ParameterizedTest" name="FailsWithBadValues" executed="True" result="Success" success="True" time="0.509" asserts="0">
+                            <results>
+                              <test-case name="NUnit.Framework.Constraints.XmlSerializableTest.FailsWithBadValues(System.Collections.Generic.Dictionary`2[System.String,System.String])" executed="True" result="Success" success="True" time="0.188" asserts="1" />
+                              <test-case name="NUnit.Framework.Constraints.XmlSerializableTest.FailsWithBadValues(NUnit.Framework.Constraints.InternalClass)" executed="True" result="Success" success="True" time="0.188" asserts="1" />
+                              <test-case name="NUnit.Framework.Constraints.XmlSerializableTest.FailsWithBadValues(NUnit.Framework.Constraints.InternalWithSerializableAttributeClass)" executed="True" result="Success" success="True" time="0.130" asserts="1" />
+                            </results>
+                          </test-suite>
+                          <test-suite type="ParameterizedTest" name="InvalidDataThrowsArgumentException" executed="True" result="Success" success="True" time="0.002" asserts="0">
+                            <results>
+                              <test-case name="NUnit.Framework.Constraints.XmlSerializableTest.InvalidDataThrowsArgumentException(null)" executed="True" result="Success" success="True" time="0.001" asserts="0" />
+                            </results>
+                          </test-suite>
+                          <test-suite type="ParameterizedTest" name="ProvidesProperFailureMessage" executed="True" result="Success" success="True" time="0.389" asserts="0">
+                            <results>
+                              <test-case name="NUnit.Framework.Constraints.XmlSerializableTest.ProvidesProperFailureMessage(System.Collections.Generic.Dictionary`2[System.String,System.String],&quot;&lt;Dictionary`2&gt;&quot;)" executed="True" result="Success" success="True" time="0.134" asserts="1" />
+                              <test-case name="NUnit.Framework.Constraints.XmlSerializableTest.ProvidesProperFailureMessage(NUnit.Framework.Constraints.InternalClass,&quot;&lt;InternalClass&gt;&quot;)" executed="True" result="Success" success="True" time="0.126" asserts="1" />
+                              <test-case name="NUnit.Framework.Constraints.XmlSerializableTest.ProvidesProperFailureMessage(NUnit.Framework.Constraints.InternalWithSerializableAttributeClass,&quot;&lt;InternalWithSerializableAttributeClass&gt;&quot;)" executed="True" result="Success" success="True" time="0.125" asserts="1" />
+                            </results>
+                          </test-suite>
+                          <test-suite type="ParameterizedTest" name="SucceedsWithGoodValues" executed="True" result="Success" success="True" time="0.611" asserts="0">
+                            <results>
+                              <test-case name="NUnit.Framework.Constraints.XmlSerializableTest.SucceedsWithGoodValues(1)" executed="True" result="Success" success="True" time="0.020" asserts="1" />
+                              <test-case name="NUnit.Framework.Constraints.XmlSerializableTest.SucceedsWithGoodValues(&quot;a&quot;)" executed="True" result="Success" success="True" time="0.003" asserts="1" />
+                              <test-case name="NUnit.Framework.Constraints.XmlSerializableTest.SucceedsWithGoodValues(System.Collections.ArrayList)" executed="True" result="Success" success="True" time="0.582" asserts="1" />
+                            </results>
+                          </test-suite>
+                        </results>
+                      </test-suite>
+                    </results>
+                  </test-suite>
+                  <test-suite type="Namespace" name="Syntax" executed="True" result="Success" success="True" time="4.798" asserts="0">
+                    <results>
+                      <test-suite type="TestFixture" name="AfterSyntaxUsingActualPassedByRef" executed="True" result="Success" success="True" time="1.433" asserts="0">
+                        <results>
+                          <test-case name="NUnit.Framework.Syntax.AfterSyntaxUsingActualPassedByRef.EqualToTest" executed="True" result="Success" success="True" time="0.202" asserts="1" />
+                          <test-case name="NUnit.Framework.Syntax.AfterSyntaxUsingActualPassedByRef.GreaterTest" executed="True" result="Success" success="True" time="0.201" asserts="1" />
+                          <test-case name="NUnit.Framework.Syntax.AfterSyntaxUsingActualPassedByRef.HasMemberTest" executed="True" result="Success" success="True" time="0.201" asserts="1" />
+                          <test-case name="NUnit.Framework.Syntax.AfterSyntaxUsingActualPassedByRef.NullTest" executed="True" result="Success" success="True" time="0.201" asserts="1" />
+                          <test-case name="NUnit.Framework.Syntax.AfterSyntaxUsingActualPassedByRef.SameAsTest" executed="True" result="Success" success="True" time="0.201" asserts="1" />
+                          <test-case name="NUnit.Framework.Syntax.AfterSyntaxUsingActualPassedByRef.TextTest" executed="True" result="Success" success="True" time="0.201" asserts="1" />
+                          <test-case name="NUnit.Framework.Syntax.AfterSyntaxUsingActualPassedByRef.TrueTest" executed="True" result="Success" success="True" time="0.201" asserts="1" />
+                        </results>
+                      </test-suite>
+                      <test-suite type="TestFixture" name="AfterSyntaxUsingAnonymousDelegates" executed="True" result="Success" success="True" time="1.439" asserts="0">
+                        <results>
+                          <test-case name="NUnit.Framework.Syntax.AfterSyntaxUsingAnonymousDelegates.EqualToTest" executed="True" result="Success" success="True" time="0.201" asserts="1" />
+                          <test-case name="NUnit.Framework.Syntax.AfterSyntaxUsingAnonymousDelegates.GreaterTest" executed="True" result="Success" success="True" time="0.201" asserts="1" />
+                          <test-case name="NUnit.Framework.Syntax.AfterSyntaxUsingAnonymousDelegates.HasMemberTest" executed="True" result="Success" success="True" time="0.201" asserts="1" />
+                          <test-case name="NUnit.Framework.Syntax.AfterSyntaxUsingAnonymousDelegates.NullTest" executed="True" result="Success" success="True" time="0.201" asserts="1" />
+                          <test-case name="NUnit.Framework.Syntax.AfterSyntaxUsingAnonymousDelegates.SameAsTest" executed="True" result="Success" success="True" time="0.200" asserts="1" />
+                          <test-case name="NUnit.Framework.Syntax.AfterSyntaxUsingAnonymousDelegates.TextTest" executed="True" result="Success" success="True" time="0.212" asserts="1" />
+                          <test-case name="NUnit.Framework.Syntax.AfterSyntaxUsingAnonymousDelegates.TrueTest" executed="True" result="Success" success="True" time="0.201" asserts="1" />
+                        </results>
+                      </test-suite>
+                      <test-suite type="TestFixture" name="AfterTest_AndOperator" executed="True" result="Success" success="True" time="0.009" asserts="0">
+                        <results>
+                          <test-case name="NUnit.Framework.Syntax.AfterTest_AndOperator.SyntaxTest.SupportedByConstraintBuilder" executed="True" result="Success" success="True" time="0.002" asserts="1" />
+                          <test-case name="NUnit.Framework.Syntax.AfterTest_AndOperator.SyntaxTest.SupportedByInheritedSyntax" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Framework.Syntax.AfterTest_AndOperator.SyntaxTest.SupportedByStaticSyntax" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                        </results>
+                      </test-suite>
+                      <test-suite type="TestFixture" name="AfterTest_ProperyTest" executed="True" result="Success" success="True" time="0.005" asserts="0">
+                        <results>
+                          <test-case name="NUnit.Framework.Syntax.AfterTest_ProperyTest.SyntaxTest.SupportedByConstraintBuilder" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Framework.Syntax.AfterTest_ProperyTest.SyntaxTest.SupportedByInheritedSyntax" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Framework.Syntax.AfterTest_ProperyTest.SyntaxTest.SupportedByStaticSyntax" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                        </results>
+                      </test-suite>
+                      <test-suite type="TestFixture" name="AfterTest_SimpleConstraint" executed="True" result="Success" success="True" time="0.007" asserts="0">
+                        <results>
+                          <test-case name="NUnit.Framework.Syntax.AfterTest_SimpleConstraint.SyntaxTest.SupportedByConstraintBuilder" executed="True" result="Success" success="True" time="0.001" asserts="1" />
+                          <test-case name="NUnit.Framework.Syntax.AfterTest_SimpleConstraint.SyntaxTest.SupportedByInheritedSyntax" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Framework.Syntax.AfterTest_SimpleConstraint.SyntaxTest.SupportedByStaticSyntax" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                        </results>
+                      </test-suite>
+                      <test-suite type="TestFixture" name="AllTest" executed="True" result="Success" success="True" time="0.005" asserts="0">
+                        <results>
+                          <test-case name="NUnit.Framework.Syntax.AllTest.SyntaxTest.SupportedByConstraintBuilder" executed="True" result="Success" success="True" time="0.001" asserts="1" />
+                          <test-case name="NUnit.Framework.Syntax.AllTest.SyntaxTest.SupportedByInheritedSyntax" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Framework.Syntax.AllTest.SyntaxTest.SupportedByStaticSyntax" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                        </results>
+                      </test-suite>
+                      <test-suite type="TestFixture" name="AndIsEvaluatedBeforeFollowingOr" executed="True" result="Success" success="True" time="0.006" asserts="0">
+                        <results>
+                          <test-case name="NUnit.Framework.Syntax.AndIsEvaluatedBeforeFollowingOr.SyntaxTest.SupportedByConstraintBuilder" executed="True" result="Success" success="True" time="0.001" asserts="1" />
+                          <test-case name="NUnit.Framework.Syntax.AndIsEvaluatedBeforeFollowingOr.SyntaxTest.SupportedByInheritedSyntax" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Framework.Syntax.AndIsEvaluatedBeforeFollowingOr.SyntaxTest.SupportedByStaticSyntax" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                        </results>
+                      </test-suite>
+                      <test-suite type="TestFixture" name="AndIsEvaluatedBeforePrecedingOr" executed="True" result="Success" success="True" time="0.005" asserts="0">
+                        <results>
+                          <test-case name="NUnit.Framework.Syntax.AndIsEvaluatedBeforePrecedingOr.SyntaxTest.SupportedByConstraintBuilder" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Framework.Syntax.AndIsEvaluatedBeforePrecedingOr.SyntaxTest.SupportedByInheritedSyntax" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Framework.Syntax.AndIsEvaluatedBeforePrecedingOr.SyntaxTest.SupportedByStaticSyntax" executed="True" result="Success" success="True" time="0.001" asserts="1" />
+                        </results>
+                      </test-suite>
+                      <test-suite type="TestFixture" name="AndOperatorOverride" description="Test" executed="True" result="Success" success="True" time="0.010" asserts="0">
+                        <results>
+                          <test-case name="NUnit.Framework.Syntax.AndOperatorOverride.AndOperatorCanCombineConstraintAndResolvableConstraintExpression" executed="True" result="Success" success="True" time="0.001" asserts="1" />
+                          <test-case name="NUnit.Framework.Syntax.AndOperatorOverride.AndOperatorCanCombineResolvableConstraintExpressionAndConstraint" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Framework.Syntax.AndOperatorOverride.AndOperatorCanCombineTwoResolvableConstraintExpressions" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Framework.Syntax.AndOperatorOverride.SyntaxTest.SupportedByConstraintBuilder" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Framework.Syntax.AndOperatorOverride.SyntaxTest.SupportedByInheritedSyntax" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Framework.Syntax.AndOperatorOverride.SyntaxTest.SupportedByStaticSyntax" executed="True" result="Success" success="True" time="0.001" asserts="1" />
+                        </results>
+                      </test-suite>
+                      <test-suite type="TestFixture" name="AndTest" executed="True" result="Success" success="True" time="0.006" asserts="0">
+                        <results>
+                          <test-case name="NUnit.Framework.Syntax.AndTest.SyntaxTest.SupportedByConstraintBuilder" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Framework.Syntax.AndTest.SyntaxTest.SupportedByInheritedSyntax" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Framework.Syntax.AndTest.SyntaxTest.SupportedByStaticSyntax" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                        </results>
+                      </test-suite>
+                      <test-suite type="TestFixture" name="AndTest_ThreeAndsWithNot" executed="True" result="Success" success="True" time="0.005" asserts="0">
+                        <results>
+                          <test-case name="NUnit.Framework.Syntax.AndTest_ThreeAndsWithNot.SyntaxTest.SupportedByConstraintBuilder" executed="True" result="Success" success="True" time="0.001" asserts="1" />
+                          <test-case name="NUnit.Framework.Syntax.AndTest_ThreeAndsWithNot.SyntaxTest.SupportedByInheritedSyntax" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Framework.Syntax.AndTest_ThreeAndsWithNot.SyntaxTest.SupportedByStaticSyntax" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                        </results>
+                      </test-suite>
+                      <test-suite type="TestFixture" name="ArbitraryConstraintMatching" executed="True" result="Success" success="True" time="0.009" asserts="0">
+                        <results>
+                          <test-case name="NUnit.Framework.Syntax.ArbitraryConstraintMatching.CanMatchCustomConstraint" executed="True" result="Success" success="True" time="0.001" asserts="1" />
+                          <test-case name="NUnit.Framework.Syntax.ArbitraryConstraintMatching.CanMatchCustomConstraintAfterPrefix" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Framework.Syntax.ArbitraryConstraintMatching.CanMatchCustomConstraintsUnderAndOperator" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Framework.Syntax.ArbitraryConstraintMatching.CanMatchLambda" executed="True" result="Success" success="True" time="0.001" asserts="2" />
+                          <test-case name="NUnit.Framework.Syntax.ArbitraryConstraintMatching.CanMatchPredicate" executed="True" result="Success" success="True" time="0.001" asserts="2" />
+                        </results>
+                      </test-suite>
+                      <test-suite type="TestFixture" name="AssignableFromTest" executed="True" result="Success" success="True" time="0.004" asserts="0">
+                        <results>
+                          <test-case name="NUnit.Framework.Syntax.AssignableFromTest.SyntaxTest.SupportedByConstraintBuilder" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Framework.Syntax.AssignableFromTest.SyntaxTest.SupportedByInheritedSyntax" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Framework.Syntax.AssignableFromTest.SyntaxTest.SupportedByStaticSyntax" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                        </results>
+                      </test-suite>
+                      <test-suite type="TestFixture" name="AssignableFromTest_Generic" executed="True" result="Success" success="True" time="0.006" asserts="0">
+                        <results>
+                          <test-case name="NUnit.Framework.Syntax.AssignableFromTest_Generic.SyntaxTest.SupportedByConstraintBuilder" executed="True" result="Success" success="True" time="0.001" asserts="1" />
+                          <test-case name="NUnit.Framework.Syntax.AssignableFromTest_Generic.SyntaxTest.SupportedByInheritedSyntax" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Framework.Syntax.AssignableFromTest_Generic.SyntaxTest.SupportedByStaticSyntax" executed="True" result="Success" success="True" time="0.001" asserts="1" />
+                        </results>
+                      </test-suite>
+                      <test-suite type="TestFixture" name="AssignableToTest" executed="True" result="Success" success="True" time="0.005" asserts="0">
+                        <results>
+                          <test-case name="NUnit.Framework.Syntax.AssignableToTest.SyntaxTest.SupportedByConstraintBuilder" executed="True" result="Success" success="True" time="0.001" asserts="1" />
+                          <test-case name="NUnit.Framework.Syntax.AssignableToTest.SyntaxTest.SupportedByInheritedSyntax" executed="True" result="Success" success="True" time="0.001" asserts="1" />
+                          <test-case name="NUnit.Framework.Syntax.AssignableToTest.SyntaxTest.SupportedByStaticSyntax" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                        </results>
+                      </test-suite>
+                      <test-suite type="TestFixture" name="AssignableToTest_Generic" executed="True" result="Success" success="True" time="0.009" asserts="0">
+                        <results>
+                          <test-case name="NUnit.Framework.Syntax.AssignableToTest_Generic.SyntaxTest.SupportedByConstraintBuilder" executed="True" result="Success" success="True" time="0.002" asserts="1" />
+                          <test-case name="NUnit.Framework.Syntax.AssignableToTest_Generic.SyntaxTest.SupportedByInheritedSyntax" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Framework.Syntax.AssignableToTest_Generic.SyntaxTest.SupportedByStaticSyntax" executed="True" result="Success" success="True" time="0.001" asserts="1" />
+                        </results>
+                      </test-suite>
+                      <test-suite type="TestFixture" name="AtLeastTest" executed="True" result="Success" success="True" time="0.006" asserts="0">
+                        <results>
+                          <test-case name="NUnit.Framework.Syntax.AtLeastTest.SyntaxTest.SupportedByConstraintBuilder" executed="True" result="Success" success="True" time="0.001" asserts="1" />
+                          <test-case name="NUnit.Framework.Syntax.AtLeastTest.SyntaxTest.SupportedByInheritedSyntax" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Framework.Syntax.AtLeastTest.SyntaxTest.SupportedByStaticSyntax" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                        </results>
+                      </test-suite>
+                      <test-suite type="TestFixture" name="AtMostTest" executed="True" result="Success" success="True" time="0.007" asserts="0">
+                        <results>
+                          <test-case name="NUnit.Framework.Syntax.AtMostTest.SyntaxTest.SupportedByConstraintBuilder" executed="True" result="Success" success="True" time="0.001" asserts="1" />
+                          <test-case name="NUnit.Framework.Syntax.AtMostTest.SyntaxTest.SupportedByInheritedSyntax" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Framework.Syntax.AtMostTest.SyntaxTest.SupportedByStaticSyntax" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                        </results>
+                      </test-suite>
+                      <test-suite type="TestFixture" name="AttributeTest" executed="True" result="Success" success="True" time="0.006" asserts="0">
+                        <results>
+                          <test-case name="NUnit.Framework.Syntax.AttributeTest.SyntaxTest.SupportedByConstraintBuilder" executed="True" result="Success" success="True" time="0.001" asserts="1" />
+                          <test-case name="NUnit.Framework.Syntax.AttributeTest.SyntaxTest.SupportedByInheritedSyntax" executed="True" result="Success" success="True" time="0.001" asserts="1" />
+                          <test-case name="NUnit.Framework.Syntax.AttributeTest.SyntaxTest.SupportedByStaticSyntax" executed="True" result="Success" success="True" time="0.001" asserts="1" />
+                        </results>
+                      </test-suite>
+                      <test-suite type="TestFixture" name="AttributeTest_Generic" executed="True" result="Success" success="True" time="0.007" asserts="0">
+                        <results>
+                          <test-case name="NUnit.Framework.Syntax.AttributeTest_Generic.SyntaxTest.SupportedByConstraintBuilder" executed="True" result="Success" success="True" time="0.001" asserts="1" />
+                          <test-case name="NUnit.Framework.Syntax.AttributeTest_Generic.SyntaxTest.SupportedByInheritedSyntax" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Framework.Syntax.AttributeTest_Generic.SyntaxTest.SupportedByStaticSyntax" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                        </results>
+                      </test-suite>
+                      <test-suite type="TestFixture" name="AttributeTestWithFollowingConstraint" executed="True" result="Success" success="True" time="0.006" asserts="0">
+                        <results>
+                          <test-case name="NUnit.Framework.Syntax.AttributeTestWithFollowingConstraint.SyntaxTest.SupportedByConstraintBuilder" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Framework.Syntax.AttributeTestWithFollowingConstraint.SyntaxTest.SupportedByInheritedSyntax" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Framework.Syntax.AttributeTestWithFollowingConstraint.SyntaxTest.SupportedByStaticSyntax" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                        </results>
+                      </test-suite>
+                      <test-suite type="TestFixture" name="BinarySerializableTest" executed="True" result="Success" success="True" time="0.008" asserts="0">
+                        <results>
+                          <test-case name="NUnit.Framework.Syntax.BinarySerializableTest.SyntaxTest.SupportedByConstraintBuilder" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Framework.Syntax.BinarySerializableTest.SyntaxTest.SupportedByInheritedSyntax" executed="True" result="Success" success="True" time="0.001" asserts="1" />
+                          <test-case name="NUnit.Framework.Syntax.BinarySerializableTest.SyntaxTest.SupportedByStaticSyntax" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                        </results>
+                      </test-suite>
+                      <test-suite type="TestFixture" name="CollectionContainsTest" executed="True" result="Success" success="True" time="0.006" asserts="0">
+                        <results>
+                          <test-case name="NUnit.Framework.Syntax.CollectionContainsTest.SyntaxTest.SupportedByConstraintBuilder" executed="True" result="Success" success="True" time="0.001" asserts="1" />
+                          <test-case name="NUnit.Framework.Syntax.CollectionContainsTest.SyntaxTest.SupportedByInheritedSyntax" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Framework.Syntax.CollectionContainsTest.SyntaxTest.SupportedByStaticSyntax" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                        </results>
+                      </test-suite>
+                      <test-suite type="TestFixture" name="CollectionContainsTest_Comparer" executed="True" result="Success" success="True" time="0.011" asserts="0">
+                        <results>
+                          <test-case name="NUnit.Framework.Syntax.CollectionContainsTest_Comparer.ComparerIsCalled" executed="True" result="Success" success="True" time="0.001" asserts="2" />
+                          <test-case name="NUnit.Framework.Syntax.CollectionContainsTest_Comparer.ComparerIsCalledInExpression" executed="True" result="Success" success="True" time="0.001" asserts="2" />
+                          <test-case name="NUnit.Framework.Syntax.CollectionContainsTest_Comparer.SyntaxTest.SupportedByConstraintBuilder" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Framework.Syntax.CollectionContainsTest_Comparer.SyntaxTest.SupportedByInheritedSyntax" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Framework.Syntax.CollectionContainsTest_Comparer.SyntaxTest.SupportedByStaticSyntax" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                        </results>
+                      </test-suite>
+                      <test-suite type="TestFixture" name="CollectionContainsTest_Comparer_String" executed="True" result="Success" success="True" time="0.013" asserts="0">
+                        <results>
+                          <test-case name="NUnit.Framework.Syntax.CollectionContainsTest_Comparer_String.ComparerIsCalled" executed="True" result="Success" success="True" time="0.002" asserts="2" />
+                          <test-case name="NUnit.Framework.Syntax.CollectionContainsTest_Comparer_String.ComparerIsCalledInExpression" executed="True" result="Success" success="True" time="0.001" asserts="2" />
+                          <test-case name="NUnit.Framework.Syntax.CollectionContainsTest_Comparer_String.SyntaxTest.SupportedByConstraintBuilder" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Framework.Syntax.CollectionContainsTest_Comparer_String.SyntaxTest.SupportedByInheritedSyntax" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Framework.Syntax.CollectionContainsTest_Comparer_String.SyntaxTest.SupportedByStaticSyntax" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                        </results>
+                      </test-suite>
+                      <test-suite type="TestFixture" name="CollectionContainsTest_String" executed="True" result="Success" success="True" time="0.006" asserts="0">
+                        <results>
+                          <test-case name="NUnit.Framework.Syntax.CollectionContainsTest_String.SyntaxTest.SupportedByConstraintBuilder" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Framework.Syntax.CollectionContainsTest_String.SyntaxTest.SupportedByInheritedSyntax" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Framework.Syntax.CollectionContainsTest_String.SyntaxTest.SupportedByStaticSyntax" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                        </results>
+                      </test-suite>
+                      <test-suite type="TestFixture" name="CollectionEquivalentTest" executed="True" result="Success" success="True" time="0.008" asserts="0">
+                        <results>
+                          <test-case name="NUnit.Framework.Syntax.CollectionEquivalentTest.SyntaxTest.SupportedByConstraintBuilder" executed="True" result="Success" success="True" time="0.001" asserts="1" />
+                          <test-case name="NUnit.Framework.Syntax.CollectionEquivalentTest.SyntaxTest.SupportedByInheritedSyntax" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Framework.Syntax.CollectionEquivalentTest.SyntaxTest.SupportedByStaticSyntax" executed="True" result="Success" success="True" time="0.001" asserts="1" />
+                        </results>
+                      </test-suite>
+                      <test-suite type="TestFixture" name="CollectionMemberTest" executed="True" result="Success" success="True" time="0.006" asserts="0">
+                        <results>
+                          <test-case name="NUnit.Framework.Syntax.CollectionMemberTest.SyntaxTest.SupportedByConstraintBuilder" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Framework.Syntax.CollectionMemberTest.SyntaxTest.SupportedByInheritedSyntax" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Framework.Syntax.CollectionMemberTest.SyntaxTest.SupportedByStaticSyntax" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                        </results>
+                      </test-suite>
+                      <test-suite type="TestFixture" name="CollectionMemberTest_Comparer" executed="True" result="Success" success="True" time="0.006" asserts="0">
+                        <results>
+                          <test-case name="NUnit.Framework.Syntax.CollectionMemberTest_Comparer.SyntaxTest.SupportedByConstraintBuilder" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Framework.Syntax.CollectionMemberTest_Comparer.SyntaxTest.SupportedByInheritedSyntax" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Framework.Syntax.CollectionMemberTest_Comparer.SyntaxTest.SupportedByStaticSyntax" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                        </results>
+                      </test-suite>
+                      <test-suite type="TestFixture" name="CollectionOrderedByTest" executed="True" result="Success" success="True" time="0.006" asserts="0">
+                        <results>
+                          <test-case name="NUnit.Framework.Syntax.CollectionOrderedByTest.SyntaxTest.SupportedByConstraintBuilder" executed="True" result="Success" success="True" time="0.002" asserts="1" />
+                          <test-case name="NUnit.Framework.Syntax.CollectionOrderedByTest.SyntaxTest.SupportedByInheritedSyntax" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Framework.Syntax.CollectionOrderedByTest.SyntaxTest.SupportedByStaticSyntax" executed="True" result="Success" success="True" time="0.001" asserts="1" />
+                        </results>
+                      </test-suite>
+                      <test-suite type="TestFixture" name="CollectionOrderedByTest_Comparer" executed="True" result="Success" success="True" time="0.006" asserts="0">
+                        <results>
+                          <test-case name="NUnit.Framework.Syntax.CollectionOrderedByTest_Comparer.SyntaxTest.SupportedByConstraintBuilder" executed="True" result="Success" success="True" time="0.001" asserts="1" />
+                          <test-case name="NUnit.Framework.Syntax.CollectionOrderedByTest_Comparer.SyntaxTest.SupportedByInheritedSyntax" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Framework.Syntax.CollectionOrderedByTest_Comparer.SyntaxTest.SupportedByStaticSyntax" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                        </results>
+                      </test-suite>
+                      <test-suite type="TestFixture" name="CollectionOrderedByTest_Comparer_Descending" executed="True" result="Success" success="True" time="0.006" asserts="0">
+                        <results>
+                          <test-case name="NUnit.Framework.Syntax.CollectionOrderedByTest_Comparer_Descending.SyntaxTest.SupportedByConstraintBuilder" executed="True" result="Success" success="True" time="0.001" asserts="1" />
+                          <test-case name="NUnit.Framework.Syntax.CollectionOrderedByTest_Comparer_Descending.SyntaxTest.SupportedByInheritedSyntax" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Framework.Syntax.CollectionOrderedByTest_Comparer_Descending.SyntaxTest.SupportedByStaticSyntax" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                        </results>
+                      </test-suite>
+                      <test-suite type="TestFixture" name="CollectionOrderedByTest_Descending" executed="True" result="Success" success="True" time="0.007" asserts="0">
+                        <results>
+                          <test-case name="NUnit.Framework.Syntax.CollectionOrderedByTest_Descending.SyntaxTest.SupportedByConstraintBuilder" executed="True" result="Success" success="True" time="0.001" asserts="1" />
+                          <test-case name="NUnit.Framework.Syntax.CollectionOrderedByTest_Descending.SyntaxTest.SupportedByInheritedSyntax" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Framework.Syntax.CollectionOrderedByTest_Descending.SyntaxTest.SupportedByStaticSyntax" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                        </results>
+                      </test-suite>
+                      <test-suite type="TestFixture" name="CollectionOrderedTest" executed="True" result="Success" success="True" time="0.005" asserts="0">
+                        <results>
+                          <test-case name="NUnit.Framework.Syntax.CollectionOrderedTest.SyntaxTest.SupportedByConstraintBuilder" executed="True" result="Success" success="True" time="0.001" asserts="1" />
+                          <test-case name="NUnit.Framework.Syntax.CollectionOrderedTest.SyntaxTest.SupportedByInheritedSyntax" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Framework.Syntax.CollectionOrderedTest.SyntaxTest.SupportedByStaticSyntax" executed="True" result="Success" success="True" time="0.001" asserts="1" />
+                        </results>
+                      </test-suite>
+                      <test-suite type="TestFixture" name="CollectionOrderedTest_Comparer" executed="True" result="Success" success="True" time="0.005" asserts="0">
+                        <results>
+                          <test-case name="NUnit.Framework.Syntax.CollectionOrderedTest_Comparer.SyntaxTest.SupportedByConstraintBuilder" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Framework.Syntax.CollectionOrderedTest_Comparer.SyntaxTest.SupportedByInheritedSyntax" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Framework.Syntax.CollectionOrderedTest_Comparer.SyntaxTest.SupportedByStaticSyntax" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                        </results>
+                      </test-suite>
+                      <test-suite type="TestFixture" name="CollectionOrderedTest_Comparer_Descending" executed="True" result="Success" success="True" time="0.005" asserts="0">
+                        <results>
+                          <test-case name="NUnit.Framework.Syntax.CollectionOrderedTest_Comparer_Descending.SyntaxTest.SupportedByConstraintBuilder" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Framework.Syntax.CollectionOrderedTest_Comparer_Descending.SyntaxTest.SupportedByInheritedSyntax" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Framework.Syntax.CollectionOrderedTest_Comparer_Descending.SyntaxTest.SupportedByStaticSyntax" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                        </results>
+                      </test-suite>
+                      <test-suite type="TestFixture" name="CollectionOrderedTest_Descending" executed="True" result="Success" success="True" time="0.005" asserts="0">
+                        <results>
+                          <test-case name="NUnit.Framework.Syntax.CollectionOrderedTest_Descending.SyntaxTest.SupportedByConstraintBuilder" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Framework.Syntax.CollectionOrderedTest_Descending.SyntaxTest.SupportedByInheritedSyntax" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Framework.Syntax.CollectionOrderedTest_Descending.SyntaxTest.SupportedByStaticSyntax" executed="True" result="Success" success="True" time="0.001" asserts="1" />
+                        </results>
+                      </test-suite>
+                      <test-suite type="TestFixture" name="CollectionSubsetTest" executed="True" result="Success" success="True" time="0.004" asserts="0">
+                        <results>
+                          <test-case name="NUnit.Framework.Syntax.CollectionSubsetTest.SyntaxTest.SupportedByConstraintBuilder" executed="True" result="Success" success="True" time="0.001" asserts="1" />
+                          <test-case name="NUnit.Framework.Syntax.CollectionSubsetTest.SyntaxTest.SupportedByInheritedSyntax" executed="True" result="Success" success="True" time="0.001" asserts="1" />
+                          <test-case name="NUnit.Framework.Syntax.CollectionSubsetTest.SyntaxTest.SupportedByStaticSyntax" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                        </results>
+                      </test-suite>
+                      <test-suite type="TestFixture" name="CountTest" executed="True" result="Success" success="True" time="0.004" asserts="0">
+                        <results>
+                          <test-case name="NUnit.Framework.Syntax.CountTest.SyntaxTest.SupportedByConstraintBuilder" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Framework.Syntax.CountTest.SyntaxTest.SupportedByInheritedSyntax" executed="True" result="Success" success="True" time="0.001" asserts="1" />
+                          <test-case name="NUnit.Framework.Syntax.CountTest.SyntaxTest.SupportedByStaticSyntax" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                        </results>
+                      </test-suite>
+                      <test-suite type="TestFixture" name="EmptyTest" executed="True" result="Success" success="True" time="0.004" asserts="0">
+                        <results>
+                          <test-case name="NUnit.Framework.Syntax.EmptyTest.SyntaxTest.SupportedByConstraintBuilder" executed="True" result="Success" success="True" time="0.001" asserts="1" />
+                          <test-case name="NUnit.Framework.Syntax.EmptyTest.SyntaxTest.SupportedByInheritedSyntax" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Framework.Syntax.EmptyTest.SyntaxTest.SupportedByStaticSyntax" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                        </results>
+                      </test-suite>
+                      <test-suite type="TestFixture" name="EndsWithTest" executed="True" result="Success" success="True" time="0.005" asserts="0">
+                        <results>
+                          <test-case name="NUnit.Framework.Syntax.EndsWithTest.SyntaxTest.SupportedByConstraintBuilder" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Framework.Syntax.EndsWithTest.SyntaxTest.SupportedByInheritedSyntax" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Framework.Syntax.EndsWithTest.SyntaxTest.SupportedByStaticSyntax" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                        </results>
+                      </test-suite>
+                      <test-suite type="TestFixture" name="EndsWithTest_IgnoreCase" executed="True" result="Success" success="True" time="0.005" asserts="0">
+                        <results>
+                          <test-case name="NUnit.Framework.Syntax.EndsWithTest_IgnoreCase.SyntaxTest.SupportedByConstraintBuilder" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Framework.Syntax.EndsWithTest_IgnoreCase.SyntaxTest.SupportedByInheritedSyntax" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Framework.Syntax.EndsWithTest_IgnoreCase.SyntaxTest.SupportedByStaticSyntax" executed="True" result="Success" success="True" time="0.001" asserts="1" />
+                        </results>
+                      </test-suite>
+                      <test-suite type="TestFixture" name="EqualityTests" executed="True" result="Success" success="True" time="0.012" asserts="0">
+                        <results>
+                          <test-case name="NUnit.Framework.Syntax.EqualityTests.EqualityTestsUsingDefaultFloatingPointTolerance" executed="True" result="Success" success="True" time="0.001" asserts="3" />
+                          <test-case name="NUnit.Framework.Syntax.EqualityTests.EqualityTestsWithTolerance" executed="True" result="Success" success="True" time="0.002" asserts="8" />
+                          <test-case name="NUnit.Framework.Syntax.EqualityTests.EqualityTestsWithTolerance_MixedFloatAndDouble" executed="True" result="Success" success="True" time="0.001" asserts="6" />
+                          <test-case name="NUnit.Framework.Syntax.EqualityTests.EqualityTestsWithTolerance_MixingTypesGenerally" executed="True" result="Success" success="True" time="0.001" asserts="7" />
+                          <test-case name="NUnit.Framework.Syntax.EqualityTests.SimpleEqualityTests" executed="True" result="Success" success="True" time="0.001" asserts="6" />
+                        </results>
+                      </test-suite>
+                      <test-suite type="TestFixture" name="EqualToTest" executed="True" result="Success" success="True" time="0.004" asserts="0">
+                        <results>
+                          <test-case name="NUnit.Framework.Syntax.EqualToTest.SyntaxTest.SupportedByConstraintBuilder" executed="True" result="Success" success="True" time="0.001" asserts="1" />
+                          <test-case name="NUnit.Framework.Syntax.EqualToTest.SyntaxTest.SupportedByInheritedSyntax" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Framework.Syntax.EqualToTest.SyntaxTest.SupportedByStaticSyntax" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                        </results>
+                      </test-suite>
+                      <test-suite type="TestFixture" name="EqualToTest_IgnoreCase" executed="True" result="Success" success="True" time="0.015" asserts="0">
+                        <results>
+                          <test-case name="NUnit.Framework.Syntax.EqualToTest_IgnoreCase.SyntaxTest.SupportedByConstraintBuilder" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Framework.Syntax.EqualToTest_IgnoreCase.SyntaxTest.SupportedByInheritedSyntax" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Framework.Syntax.EqualToTest_IgnoreCase.SyntaxTest.SupportedByStaticSyntax" executed="True" result="Success" success="True" time="0.001" asserts="1" />
+                        </results>
+                      </test-suite>
+                      <test-suite type="TestFixture" name="EqualToTest_WithinTolerance" executed="True" result="Success" success="True" time="0.005" asserts="0">
+                        <results>
+                          <test-case name="NUnit.Framework.Syntax.EqualToTest_WithinTolerance.SyntaxTest.SupportedByConstraintBuilder" executed="True" result="Success" success="True" time="0.001" asserts="1" />
+                          <test-case name="NUnit.Framework.Syntax.EqualToTest_WithinTolerance.SyntaxTest.SupportedByInheritedSyntax" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Framework.Syntax.EqualToTest_WithinTolerance.SyntaxTest.SupportedByStaticSyntax" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                        </results>
+                      </test-suite>
+                      <test-suite type="TestFixture" name="ExactTypeTest" executed="True" result="Success" success="True" time="0.006" asserts="0">
+                        <results>
+                          <test-case name="NUnit.Framework.Syntax.ExactTypeTest.SyntaxTest.SupportedByConstraintBuilder" executed="True" result="Success" success="True" time="0.001" asserts="1" />
+                          <test-case name="NUnit.Framework.Syntax.ExactTypeTest.SyntaxTest.SupportedByInheritedSyntax" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Framework.Syntax.ExactTypeTest.SyntaxTest.SupportedByStaticSyntax" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                        </results>
+                      </test-suite>
+                      <test-suite type="TestFixture" name="ExactTypeTest_Generic" executed="True" result="Success" success="True" time="0.007" asserts="0">
+                        <results>
+                          <test-case name="NUnit.Framework.Syntax.ExactTypeTest_Generic.SyntaxTest.SupportedByConstraintBuilder" executed="True" result="Success" success="True" time="0.002" asserts="1" />
+                          <test-case name="NUnit.Framework.Syntax.ExactTypeTest_Generic.SyntaxTest.SupportedByInheritedSyntax" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Framework.Syntax.ExactTypeTest_Generic.SyntaxTest.SupportedByStaticSyntax" executed="True" result="Success" success="True" time="0.001" asserts="1" />
+                        </results>
+                      </test-suite>
+                      <test-suite type="TestFixture" name="FalseTest" executed="True" result="Success" success="True" time="0.006" asserts="0">
+                        <results>
+                          <test-case name="NUnit.Framework.Syntax.FalseTest.SyntaxTest.SupportedByConstraintBuilder" executed="True" result="Success" success="True" time="0.001" asserts="1" />
+                          <test-case name="NUnit.Framework.Syntax.FalseTest.SyntaxTest.SupportedByInheritedSyntax" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Framework.Syntax.FalseTest.SyntaxTest.SupportedByStaticSyntax" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                        </results>
+                      </test-suite>
+                      <test-suite type="TestFixture" name="GreaterThanOrEqualTest" executed="True" result="Success" success="True" time="0.006" asserts="0">
+                        <results>
+                          <test-case name="NUnit.Framework.Syntax.GreaterThanOrEqualTest.SyntaxTest.SupportedByConstraintBuilder" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Framework.Syntax.GreaterThanOrEqualTest.SyntaxTest.SupportedByInheritedSyntax" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Framework.Syntax.GreaterThanOrEqualTest.SyntaxTest.SupportedByStaticSyntax" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                        </results>
+                      </test-suite>
+                      <test-suite type="TestFixture" name="GreaterThanTest" executed="True" result="Success" success="True" time="0.007" asserts="0">
+                        <results>
+                          <test-case name="NUnit.Framework.Syntax.GreaterThanTest.SyntaxTest.SupportedByConstraintBuilder" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Framework.Syntax.GreaterThanTest.SyntaxTest.SupportedByInheritedSyntax" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Framework.Syntax.GreaterThanTest.SyntaxTest.SupportedByStaticSyntax" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                        </results>
+                      </test-suite>
+                      <test-suite type="TestFixture" name="InstanceOfTest" executed="True" result="Success" success="True" time="0.005" asserts="0">
+                        <results>
+                          <test-case name="NUnit.Framework.Syntax.InstanceOfTest.SyntaxTest.SupportedByConstraintBuilder" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Framework.Syntax.InstanceOfTest.SyntaxTest.SupportedByInheritedSyntax" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Framework.Syntax.InstanceOfTest.SyntaxTest.SupportedByStaticSyntax" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                        </results>
+                      </test-suite>
+                      <test-suite type="TestFixture" name="InstanceOfTest_Generic" executed="True" result="Success" success="True" time="0.007" asserts="0">
+                        <results>
+                          <test-case name="NUnit.Framework.Syntax.InstanceOfTest_Generic.SyntaxTest.SupportedByConstraintBuilder" executed="True" result="Success" success="True" time="0.002" asserts="1" />
+                          <test-case name="NUnit.Framework.Syntax.InstanceOfTest_Generic.SyntaxTest.SupportedByInheritedSyntax" executed="True" result="Success" success="True" time="0.001" asserts="1" />
+                          <test-case name="NUnit.Framework.Syntax.InstanceOfTest_Generic.SyntaxTest.SupportedByStaticSyntax" executed="True" result="Success" success="True" time="0.001" asserts="1" />
+                        </results>
+                      </test-suite>
+                      <test-suite type="TestFixture" name="InstanceOfTypeTest" executed="True" result="Success" success="True" time="0.006" asserts="0">
+                        <results>
+                          <test-case name="NUnit.Framework.Syntax.InstanceOfTypeTest.SyntaxTest.SupportedByConstraintBuilder" executed="True" result="Success" success="True" time="0.001" asserts="1" />
+                          <test-case name="NUnit.Framework.Syntax.InstanceOfTypeTest.SyntaxTest.SupportedByInheritedSyntax" executed="True" result="Success" success="True" time="0.001" asserts="1" />
+                          <test-case name="NUnit.Framework.Syntax.InstanceOfTypeTest.SyntaxTest.SupportedByStaticSyntax" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                        </results>
+                      </test-suite>
+                      <test-suite type="TestFixture" name="InstanceOfTypeTest_Generic" executed="True" result="Success" success="True" time="0.006" asserts="0">
+                        <results>
+                          <test-case name="NUnit.Framework.Syntax.InstanceOfTypeTest_Generic.SyntaxTest.SupportedByConstraintBuilder" executed="True" result="Success" success="True" time="0.001" asserts="1" />
+                          <test-case name="NUnit.Framework.Syntax.InstanceOfTypeTest_Generic.SyntaxTest.SupportedByInheritedSyntax" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Framework.Syntax.InstanceOfTypeTest_Generic.SyntaxTest.SupportedByStaticSyntax" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                        </results>
+                      </test-suite>
+                      <test-suite type="TestFixture" name="InvalidCodeTests" executed="True" result="Success" success="True" time="1.038" asserts="0">
+                        <results>
+                          <test-suite type="ParameterizedTest" name="CodeShouldNotCompile" executed="True" result="Success" success="True" time="0.676" asserts="0">
+                            <results>
+                              <test-case name="NUnit.Framework.Syntax.InvalidCodeTests.CodeShouldNotCompile(&quot;Is.Not.Null.GreaterThan(10))&quot;)" executed="True" result="Success" success="True" time="0.199" asserts="0" />
+                              <test-case name="NUnit.Framework.Syntax.InvalidCodeTests.CodeShouldNotCompile(&quot;Is.Null.All&quot;)" executed="True" result="Success" success="True" time="0.107" asserts="0" />
+                              <test-case name="NUnit.Framework.Syntax.InvalidCodeTests.CodeShouldNotCompile(&quot;Is.And&quot;)" executed="True" result="Success" success="True" time="0.092" asserts="0" />
+                              <test-case name="NUnit.Framework.Syntax.InvalidCodeTests.CodeShouldNotCompile(&quot;Is.All.And.And&quot;)" executed="True" result="Success" success="True" time="0.085" asserts="0" />
+                              <test-case name="NUnit.Framework.Syntax.InvalidCodeTests.CodeShouldNotCompile(&quot;Is.Null.And.Throws&quot;)" executed="True" result="Success" success="True" time="0.093" asserts="0" />
+                              <test-case name="NUnit.Framework.Syntax.InvalidCodeTests.CodeShouldNotCompile(&quot;Is.Null.Not&quot;)" executed="True" result="Success" success="True" time="0.086" asserts="0" />
+                            </results>
+                          </test-suite>
+                          <test-suite type="ParameterizedTest" name="CodeShouldNotCompileAsFinishedConstraint" executed="True" result="Success" success="True" time="0.358" asserts="0">
+                            <results>
+                              <test-case name="NUnit.Framework.Syntax.InvalidCodeTests.CodeShouldNotCompileAsFinishedConstraint(&quot;Is.Not&quot;)" executed="True" result="Success" success="True" time="0.080" asserts="0" />
+                              <test-case name="NUnit.Framework.Syntax.InvalidCodeTests.CodeShouldNotCompileAsFinishedConstraint(&quot;Is.Not.All&quot;)" executed="True" result="Success" success="True" time="0.082" asserts="0" />
+                              <test-case name="NUnit.Framework.Syntax.InvalidCodeTests.CodeShouldNotCompileAsFinishedConstraint(&quot;Is.All.Not&quot;)" executed="True" result="Success" success="True" time="0.093" asserts="0" />
+                              <test-case name="NUnit.Framework.Syntax.InvalidCodeTests.CodeShouldNotCompileAsFinishedConstraint(&quot;Is.All&quot;)" executed="True" result="Success" success="True" time="0.094" asserts="0" />
+                            </results>
+                          </test-suite>
+                        </results>
+                      </test-suite>
+                      <test-suite type="TestFixture" name="LengthTest" executed="True" result="Success" success="True" time="0.005" asserts="0">
+                        <results>
+                          <test-case name="NUnit.Framework.Syntax.LengthTest.SyntaxTest.SupportedByConstraintBuilder" executed="True" result="Success" success="True" time="0.001" asserts="1" />
+                          <test-case name="NUnit.Framework.Syntax.LengthTest.SyntaxTest.SupportedByInheritedSyntax" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Framework.Syntax.LengthTest.SyntaxTest.SupportedByStaticSyntax" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                        </results>
+                      </test-suite>
+                      <test-suite type="TestFixture" name="LessThanOrEqualTest" executed="True" result="Success" success="True" time="0.004" asserts="0">
+                        <results>
+                          <test-case name="NUnit.Framework.Syntax.LessThanOrEqualTest.SyntaxTest.SupportedByConstraintBuilder" executed="True" result="Success" success="True" time="0.001" asserts="1" />
+                          <test-case name="NUnit.Framework.Syntax.LessThanOrEqualTest.SyntaxTest.SupportedByInheritedSyntax" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Framework.Syntax.LessThanOrEqualTest.SyntaxTest.SupportedByStaticSyntax" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                        </results>
+                      </test-suite>
+                      <test-suite type="TestFixture" name="LessThanTest" executed="True" result="Success" success="True" time="0.005" asserts="0">
+                        <results>
+                          <test-case name="NUnit.Framework.Syntax.LessThanTest.SyntaxTest.SupportedByConstraintBuilder" executed="True" result="Success" success="True" time="0.001" asserts="1" />
+                          <test-case name="NUnit.Framework.Syntax.LessThanTest.SyntaxTest.SupportedByInheritedSyntax" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Framework.Syntax.LessThanTest.SyntaxTest.SupportedByStaticSyntax" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                        </results>
+                      </test-suite>
+                      <test-suite type="TestFixture" name="MessageTest" executed="True" result="Success" success="True" time="0.005" asserts="0">
+                        <results>
+                          <test-case name="NUnit.Framework.Syntax.MessageTest.SyntaxTest.SupportedByConstraintBuilder" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Framework.Syntax.MessageTest.SyntaxTest.SupportedByInheritedSyntax" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Framework.Syntax.MessageTest.SyntaxTest.SupportedByStaticSyntax" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                        </results>
+                      </test-suite>
+                      <test-suite type="TestFixture" name="MixedOperatorOverrides" executed="True" result="Success" success="True" time="0.002" asserts="0">
+                        <results>
+                          <test-case name="NUnit.Framework.Syntax.MixedOperatorOverrides.ComplexTests" executed="True" result="Success" success="True" time="0.001" asserts="3" />
+                        </results>
+                      </test-suite>
+                      <test-suite type="TestFixture" name="NaNTest" executed="True" result="Success" success="True" time="0.005" asserts="0">
+                        <results>
+                          <test-case name="NUnit.Framework.Syntax.NaNTest.SyntaxTest.SupportedByConstraintBuilder" executed="True" result="Success" success="True" time="0.001" asserts="1" />
+                          <test-case name="NUnit.Framework.Syntax.NaNTest.SyntaxTest.SupportedByInheritedSyntax" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Framework.Syntax.NaNTest.SyntaxTest.SupportedByStaticSyntax" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                        </results>
+                      </test-suite>
+                      <test-suite type="TestFixture" name="NegativeTest" executed="True" result="Success" success="True" time="0.006" asserts="0">
+                        <results>
+                          <test-case name="NUnit.Framework.Syntax.NegativeTest.SyntaxTest.SupportedByConstraintBuilder" executed="True" result="Success" success="True" time="0.001" asserts="1" />
+                          <test-case name="NUnit.Framework.Syntax.NegativeTest.SyntaxTest.SupportedByInheritedSyntax" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Framework.Syntax.NegativeTest.SyntaxTest.SupportedByStaticSyntax" executed="True" result="Success" success="True" time="0.001" asserts="1" />
+                        </results>
+                      </test-suite>
+                      <test-suite type="TestFixture" name="NoneTest" executed="True" result="Success" success="True" time="0.006" asserts="0">
+                        <results>
+                          <test-case name="NUnit.Framework.Syntax.NoneTest.SyntaxTest.SupportedByConstraintBuilder" executed="True" result="Success" success="True" time="0.001" asserts="1" />
+                          <test-case name="NUnit.Framework.Syntax.NoneTest.SyntaxTest.SupportedByInheritedSyntax" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Framework.Syntax.NoneTest.SyntaxTest.SupportedByStaticSyntax" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                        </results>
+                      </test-suite>
+                      <test-suite type="TestFixture" name="NotOperatorOverride" executed="True" result="Success" success="True" time="0.008" asserts="0">
+                        <results>
+                          <test-case name="NUnit.Framework.Syntax.NotOperatorOverride.NotOperatorCanApplyToResolvableConstraintExpression" executed="True" result="Success" success="True" time="0.001" asserts="1" />
+                          <test-case name="NUnit.Framework.Syntax.NotOperatorOverride.SyntaxTest.SupportedByConstraintBuilder" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Framework.Syntax.NotOperatorOverride.SyntaxTest.SupportedByInheritedSyntax" executed="True" result="Success" success="True" time="0.001" asserts="1" />
+                          <test-case name="NUnit.Framework.Syntax.NotOperatorOverride.SyntaxTest.SupportedByStaticSyntax" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                        </results>
+                      </test-suite>
+                      <test-suite type="TestFixture" name="NotSamePathOrUnderTest_IgnoreCase" executed="True" result="Success" success="True" time="0.006" asserts="0">
+                        <results>
+                          <test-case name="NUnit.Framework.Syntax.NotSamePathOrUnderTest_IgnoreCase.SyntaxTest.SupportedByConstraintBuilder" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Framework.Syntax.NotSamePathOrUnderTest_IgnoreCase.SyntaxTest.SupportedByInheritedSyntax" executed="True" result="Success" success="True" time="0.001" asserts="1" />
+                          <test-case name="NUnit.Framework.Syntax.NotSamePathOrUnderTest_IgnoreCase.SyntaxTest.SupportedByStaticSyntax" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                        </results>
+                      </test-suite>
+                      <test-suite type="TestFixture" name="NotSamePathOrUnderTest_RespectCase" executed="True" result="Success" success="True" time="0.005" asserts="0">
+                        <results>
+                          <test-case name="NUnit.Framework.Syntax.NotSamePathOrUnderTest_RespectCase.SyntaxTest.SupportedByConstraintBuilder" executed="True" result="Success" success="True" time="0.001" asserts="1" />
+                          <test-case name="NUnit.Framework.Syntax.NotSamePathOrUnderTest_RespectCase.SyntaxTest.SupportedByInheritedSyntax" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Framework.Syntax.NotSamePathOrUnderTest_RespectCase.SyntaxTest.SupportedByStaticSyntax" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                        </results>
+                      </test-suite>
+                      <test-suite type="TestFixture" name="NotSamePathTest_IgnoreCase" executed="True" result="Success" success="True" time="0.006" asserts="0">
+                        <results>
+                          <test-case name="NUnit.Framework.Syntax.NotSamePathTest_IgnoreCase.SyntaxTest.SupportedByConstraintBuilder" executed="True" result="Success" success="True" time="0.001" asserts="1" />
+                          <test-case name="NUnit.Framework.Syntax.NotSamePathTest_IgnoreCase.SyntaxTest.SupportedByInheritedSyntax" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Framework.Syntax.NotSamePathTest_IgnoreCase.SyntaxTest.SupportedByStaticSyntax" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                        </results>
+                      </test-suite>
+                      <test-suite type="TestFixture" name="NotSamePathTest_RespectCase" executed="True" result="Success" success="True" time="0.008" asserts="0">
+                        <results>
+                          <test-case name="NUnit.Framework.Syntax.NotSamePathTest_RespectCase.SyntaxTest.SupportedByConstraintBuilder" executed="True" result="Success" success="True" time="0.001" asserts="1" />
+                          <test-case name="NUnit.Framework.Syntax.NotSamePathTest_RespectCase.SyntaxTest.SupportedByInheritedSyntax" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Framework.Syntax.NotSamePathTest_RespectCase.SyntaxTest.SupportedByStaticSyntax" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                        </results>
+                      </test-suite>
+                      <test-suite type="TestFixture" name="NotTest" executed="True" result="Success" success="True" time="0.008" asserts="0">
+                        <results>
+                          <test-case name="NUnit.Framework.Syntax.NotTest.SyntaxTest.SupportedByConstraintBuilder" executed="True" result="Success" success="True" time="0.001" asserts="1" />
+                          <test-case name="NUnit.Framework.Syntax.NotTest.SyntaxTest.SupportedByInheritedSyntax" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Framework.Syntax.NotTest.SyntaxTest.SupportedByStaticSyntax" executed="True" result="Success" success="True" time="0.001" asserts="1" />
+                        </results>
+                      </test-suite>
+                      <test-suite type="TestFixture" name="NotTest_Cascaded" executed="True" result="Success" success="True" time="0.006" asserts="0">
+                        <results>
+                          <test-case name="NUnit.Framework.Syntax.NotTest_Cascaded.SyntaxTest.SupportedByConstraintBuilder" executed="True" result="Success" success="True" time="0.001" asserts="1" />
+                          <test-case name="NUnit.Framework.Syntax.NotTest_Cascaded.SyntaxTest.SupportedByInheritedSyntax" executed="True" result="Success" success="True" time="0.001" asserts="1" />
+                          <test-case name="NUnit.Framework.Syntax.NotTest_Cascaded.SyntaxTest.SupportedByStaticSyntax" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                        </results>
+                      </test-suite>
+                      <test-suite type="TestFixture" name="NullTest" executed="True" result="Success" success="True" time="0.007" asserts="0">
+                        <results>
+                          <test-case name="NUnit.Framework.Syntax.NullTest.SyntaxTest.SupportedByConstraintBuilder" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Framework.Syntax.NullTest.SyntaxTest.SupportedByInheritedSyntax" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Framework.Syntax.NullTest.SyntaxTest.SupportedByStaticSyntax" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                        </results>
+                      </test-suite>
+                      <test-suite type="TestFixture" name="OperatorPrecedenceTests" executed="True" result="Success" success="True" time="0.006" asserts="0">
+                        <results>
+                          <test-case name="NUnit.Framework.Syntax.OperatorPrecedenceTests.SomeTests" executed="True" result="Success" success="True" time="0.002" asserts="2" />
+                          <test-case name="NUnit.Framework.Syntax.OperatorPrecedenceTests.WithTests" executed="True" result="Success" success="True" time="0.002" asserts="6" />
+                        </results>
+                      </test-suite>
+                      <test-suite type="TestFixture" name="OrOperatorOverride" executed="True" result="Success" success="True" time="0.014" asserts="0">
+                        <results>
+                          <test-case name="NUnit.Framework.Syntax.OrOperatorOverride.OrOperatorCanCombineConstraintAndResolvableConstraintExpression" executed="True" result="Success" success="True" time="0.002" asserts="1" />
+                          <test-case name="NUnit.Framework.Syntax.OrOperatorOverride.OrOperatorCanCombineResolvableConstraintExpressionAndConstraint" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Framework.Syntax.OrOperatorOverride.OrOperatorCanCombineTwoResolvableConstraintExpressions" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Framework.Syntax.OrOperatorOverride.SyntaxTest.SupportedByConstraintBuilder" executed="True" result="Success" success="True" time="0.001" asserts="1" />
+                          <test-case name="NUnit.Framework.Syntax.OrOperatorOverride.SyntaxTest.SupportedByInheritedSyntax" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Framework.Syntax.OrOperatorOverride.SyntaxTest.SupportedByStaticSyntax" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                        </results>
+                      </test-suite>
+                      <test-suite type="TestFixture" name="OrTest" executed="True" result="Success" success="True" time="0.007" asserts="0">
+                        <results>
+                          <test-case name="NUnit.Framework.Syntax.OrTest.SyntaxTest.SupportedByConstraintBuilder" executed="True" result="Success" success="True" time="0.001" asserts="1" />
+                          <test-case name="NUnit.Framework.Syntax.OrTest.SyntaxTest.SupportedByInheritedSyntax" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Framework.Syntax.OrTest.SyntaxTest.SupportedByStaticSyntax" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                        </results>
+                      </test-suite>
+                      <test-suite type="TestFixture" name="OrTest_ThreeOrs" executed="True" result="Success" success="True" time="0.006" asserts="0">
+                        <results>
+                          <test-case name="NUnit.Framework.Syntax.OrTest_ThreeOrs.SyntaxTest.SupportedByConstraintBuilder" executed="True" result="Success" success="True" time="0.001" asserts="1" />
+                          <test-case name="NUnit.Framework.Syntax.OrTest_ThreeOrs.SyntaxTest.SupportedByInheritedSyntax" executed="True" result="Success" success="True" time="0.001" asserts="1" />
+                          <test-case name="NUnit.Framework.Syntax.OrTest_ThreeOrs.SyntaxTest.SupportedByStaticSyntax" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                        </results>
+                      </test-suite>
+                      <test-suite type="TestFixture" name="PositiveTest" executed="True" result="Success" success="True" time="0.006" asserts="0">
+                        <results>
+                          <test-case name="NUnit.Framework.Syntax.PositiveTest.SyntaxTest.SupportedByConstraintBuilder" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Framework.Syntax.PositiveTest.SyntaxTest.SupportedByInheritedSyntax" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Framework.Syntax.PositiveTest.SyntaxTest.SupportedByStaticSyntax" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                        </results>
+                      </test-suite>
+                      <test-suite type="TestFixture" name="PropertyExistsTest" executed="True" result="Success" success="True" time="0.005" asserts="0">
+                        <results>
+                          <test-case name="NUnit.Framework.Syntax.PropertyExistsTest.SyntaxTest.SupportedByConstraintBuilder" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Framework.Syntax.PropertyExistsTest.SyntaxTest.SupportedByInheritedSyntax" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Framework.Syntax.PropertyExistsTest.SyntaxTest.SupportedByStaticSyntax" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                        </results>
+                      </test-suite>
+                      <test-suite type="TestFixture" name="PropertyExistsTest_AndFollows" executed="True" result="Success" success="True" time="0.006" asserts="0">
+                        <results>
+                          <test-case name="NUnit.Framework.Syntax.PropertyExistsTest_AndFollows.SyntaxTest.SupportedByConstraintBuilder" executed="True" result="Success" success="True" time="0.001" asserts="1" />
+                          <test-case name="NUnit.Framework.Syntax.PropertyExistsTest_AndFollows.SyntaxTest.SupportedByInheritedSyntax" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Framework.Syntax.PropertyExistsTest_AndFollows.SyntaxTest.SupportedByStaticSyntax" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                        </results>
+                      </test-suite>
+                      <test-suite type="TestFixture" name="PropertySyntaxVariations" executed="True" result="Success" success="True" time="0.004" asserts="0">
+                        <results>
+                          <test-case name="NUnit.Framework.Syntax.PropertySyntaxVariations.ExistenceTest" executed="True" result="Success" success="True" time="0.001" asserts="2" />
+                          <test-case name="NUnit.Framework.Syntax.PropertySyntaxVariations.SeparateConstraintTest" executed="True" result="Success" success="True" time="0.000" asserts="2" />
+                        </results>
+                      </test-suite>
+                      <test-suite type="TestFixture" name="PropertyTest_ConstraintFollows" executed="True" result="Success" success="True" time="0.008" asserts="0">
+                        <results>
+                          <test-case name="NUnit.Framework.Syntax.PropertyTest_ConstraintFollows.SyntaxTest.SupportedByConstraintBuilder" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Framework.Syntax.PropertyTest_ConstraintFollows.SyntaxTest.SupportedByInheritedSyntax" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Framework.Syntax.PropertyTest_ConstraintFollows.SyntaxTest.SupportedByStaticSyntax" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                        </results>
+                      </test-suite>
+                      <test-suite type="TestFixture" name="PropertyTest_NotFollows" executed="True" result="Success" success="True" time="0.006" asserts="0">
+                        <results>
+                          <test-case name="NUnit.Framework.Syntax.PropertyTest_NotFollows.SyntaxTest.SupportedByConstraintBuilder" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Framework.Syntax.PropertyTest_NotFollows.SyntaxTest.SupportedByInheritedSyntax" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Framework.Syntax.PropertyTest_NotFollows.SyntaxTest.SupportedByStaticSyntax" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                        </results>
+                      </test-suite>
+                      <test-suite type="TestFixture" name="RegexTest" executed="True" result="Success" success="True" time="0.007" asserts="0">
+                        <results>
+                          <test-case name="NUnit.Framework.Syntax.RegexTest.SyntaxTest.SupportedByConstraintBuilder" executed="True" result="Success" success="True" time="0.001" asserts="1" />
+                          <test-case name="NUnit.Framework.Syntax.RegexTest.SyntaxTest.SupportedByInheritedSyntax" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Framework.Syntax.RegexTest.SyntaxTest.SupportedByStaticSyntax" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                        </results>
+                      </test-suite>
+                      <test-suite type="TestFixture" name="RegexTest_IgnoreCase" executed="True" result="Success" success="True" time="0.005" asserts="0">
+                        <results>
+                          <test-case name="NUnit.Framework.Syntax.RegexTest_IgnoreCase.SyntaxTest.SupportedByConstraintBuilder" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Framework.Syntax.RegexTest_IgnoreCase.SyntaxTest.SupportedByInheritedSyntax" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Framework.Syntax.RegexTest_IgnoreCase.SyntaxTest.SupportedByStaticSyntax" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                        </results>
+                      </test-suite>
+                      <test-suite type="TestFixture" name="SamePathOrUnderTest" executed="True" result="Success" success="True" time="0.006" asserts="0">
+                        <results>
+                          <test-case name="NUnit.Framework.Syntax.SamePathOrUnderTest.SyntaxTest.SupportedByConstraintBuilder" executed="True" result="Success" success="True" time="0.001" asserts="1" />
+                          <test-case name="NUnit.Framework.Syntax.SamePathOrUnderTest.SyntaxTest.SupportedByInheritedSyntax" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Framework.Syntax.SamePathOrUnderTest.SyntaxTest.SupportedByStaticSyntax" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                        </results>
+                      </test-suite>
+                      <test-suite type="TestFixture" name="SamePathOrUnderTest_IgnoreCase" executed="True" result="Success" success="True" time="0.006" asserts="0">
+                        <results>
+                          <test-case name="NUnit.Framework.Syntax.SamePathOrUnderTest_IgnoreCase.SyntaxTest.SupportedByConstraintBuilder" executed="True" result="Success" success="True" time="0.001" asserts="1" />
+                          <test-case name="NUnit.Framework.Syntax.SamePathOrUnderTest_IgnoreCase.SyntaxTest.SupportedByInheritedSyntax" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Framework.Syntax.SamePathOrUnderTest_IgnoreCase.SyntaxTest.SupportedByStaticSyntax" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                        </results>
+                      </test-suite>
+                      <test-suite type="TestFixture" name="SamePathOrUnderTest_RespectCase" executed="True" result="Success" success="True" time="0.007" asserts="0">
+                        <results>
+                          <test-case name="NUnit.Framework.Syntax.SamePathOrUnderTest_RespectCase.SyntaxTest.SupportedByConstraintBuilder" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Framework.Syntax.SamePathOrUnderTest_RespectCase.SyntaxTest.SupportedByInheritedSyntax" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Framework.Syntax.SamePathOrUnderTest_RespectCase.SyntaxTest.SupportedByStaticSyntax" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                        </results>
+                      </test-suite>
+                      <test-suite type="TestFixture" name="SamePathTest" executed="True" result="Success" success="True" time="0.005" asserts="0">
+                        <results>
+                          <test-case name="NUnit.Framework.Syntax.SamePathTest.SyntaxTest.SupportedByConstraintBuilder" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Framework.Syntax.SamePathTest.SyntaxTest.SupportedByInheritedSyntax" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Framework.Syntax.SamePathTest.SyntaxTest.SupportedByStaticSyntax" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                        </results>
+                      </test-suite>
+                      <test-suite type="TestFixture" name="SamePathTest_IgnoreCase" executed="True" result="Success" success="True" time="0.005" asserts="0">
+                        <results>
+                          <test-case name="NUnit.Framework.Syntax.SamePathTest_IgnoreCase.SyntaxTest.SupportedByConstraintBuilder" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Framework.Syntax.SamePathTest_IgnoreCase.SyntaxTest.SupportedByInheritedSyntax" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Framework.Syntax.SamePathTest_IgnoreCase.SyntaxTest.SupportedByStaticSyntax" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                        </results>
+                      </test-suite>
+                      <test-suite type="TestFixture" name="SamePathTest_RespectCase" executed="True" result="Success" success="True" time="0.005" asserts="0">
+                        <results>
+                          <test-case name="NUnit.Framework.Syntax.SamePathTest_RespectCase.SyntaxTest.SupportedByConstraintBuilder" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Framework.Syntax.SamePathTest_RespectCase.SyntaxTest.SupportedByInheritedSyntax" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Framework.Syntax.SamePathTest_RespectCase.SyntaxTest.SupportedByStaticSyntax" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                        </results>
+                      </test-suite>
+                      <test-suite type="TestFixture" name="SomeTest" executed="True" result="Success" success="True" time="0.005" asserts="0">
+                        <results>
+                          <test-case name="NUnit.Framework.Syntax.SomeTest.SyntaxTest.SupportedByConstraintBuilder" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Framework.Syntax.SomeTest.SyntaxTest.SupportedByInheritedSyntax" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Framework.Syntax.SomeTest.SyntaxTest.SupportedByStaticSyntax" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                        </results>
+                      </test-suite>
+                      <test-suite type="TestFixture" name="SomeTest_BeforeBinaryOperators" executed="True" result="Success" success="True" time="0.005" asserts="0">
+                        <results>
+                          <test-case name="NUnit.Framework.Syntax.SomeTest_BeforeBinaryOperators.SyntaxTest.SupportedByConstraintBuilder" executed="True" result="Success" success="True" time="0.001" asserts="1" />
+                          <test-case name="NUnit.Framework.Syntax.SomeTest_BeforeBinaryOperators.SyntaxTest.SupportedByInheritedSyntax" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Framework.Syntax.SomeTest_BeforeBinaryOperators.SyntaxTest.SupportedByStaticSyntax" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                        </results>
+                      </test-suite>
+                      <test-suite type="TestFixture" name="SomeTest_NestedSome" executed="True" result="Success" success="True" time="0.006" asserts="0">
+                        <results>
+                          <test-case name="NUnit.Framework.Syntax.SomeTest_NestedSome.SyntaxTest.SupportedByConstraintBuilder" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Framework.Syntax.SomeTest_NestedSome.SyntaxTest.SupportedByInheritedSyntax" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Framework.Syntax.SomeTest_NestedSome.SyntaxTest.SupportedByStaticSyntax" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                        </results>
+                      </test-suite>
+                      <test-suite type="TestFixture" name="SomeTest_UseOfAndSome" executed="True" result="Success" success="True" time="0.006" asserts="0">
+                        <results>
+                          <test-case name="NUnit.Framework.Syntax.SomeTest_UseOfAndSome.SyntaxTest.SupportedByConstraintBuilder" executed="True" result="Success" success="True" time="0.001" asserts="1" />
+                          <test-case name="NUnit.Framework.Syntax.SomeTest_UseOfAndSome.SyntaxTest.SupportedByInheritedSyntax" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Framework.Syntax.SomeTest_UseOfAndSome.SyntaxTest.SupportedByStaticSyntax" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                        </results>
+                      </test-suite>
+                      <test-suite type="TestFixture" name="StartsWithTest" executed="True" result="Success" success="True" time="0.005" asserts="0">
+                        <results>
+                          <test-case name="NUnit.Framework.Syntax.StartsWithTest.SyntaxTest.SupportedByConstraintBuilder" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Framework.Syntax.StartsWithTest.SyntaxTest.SupportedByInheritedSyntax" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Framework.Syntax.StartsWithTest.SyntaxTest.SupportedByStaticSyntax" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                        </results>
+                      </test-suite>
+                      <test-suite type="TestFixture" name="StartsWithTest_IgnoreCase" executed="True" result="Success" success="True" time="0.005" asserts="0">
+                        <results>
+                          <test-case name="NUnit.Framework.Syntax.StartsWithTest_IgnoreCase.SyntaxTest.SupportedByConstraintBuilder" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Framework.Syntax.StartsWithTest_IgnoreCase.SyntaxTest.SupportedByInheritedSyntax" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Framework.Syntax.StartsWithTest_IgnoreCase.SyntaxTest.SupportedByStaticSyntax" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                        </results>
+                      </test-suite>
+                      <test-suite type="TestFixture" name="SubstringTest" executed="True" result="Success" success="True" time="0.005" asserts="0">
+                        <results>
+                          <test-case name="NUnit.Framework.Syntax.SubstringTest.SyntaxTest.SupportedByConstraintBuilder" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Framework.Syntax.SubstringTest.SyntaxTest.SupportedByInheritedSyntax" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Framework.Syntax.SubstringTest.SyntaxTest.SupportedByStaticSyntax" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                        </results>
+                      </test-suite>
+                      <test-suite type="TestFixture" name="SubstringTest_IgnoreCase" executed="True" result="Success" success="True" time="0.005" asserts="0">
+                        <results>
+                          <test-case name="NUnit.Framework.Syntax.SubstringTest_IgnoreCase.SyntaxTest.SupportedByConstraintBuilder" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Framework.Syntax.SubstringTest_IgnoreCase.SyntaxTest.SupportedByInheritedSyntax" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Framework.Syntax.SubstringTest_IgnoreCase.SyntaxTest.SupportedByStaticSyntax" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                        </results>
+                      </test-suite>
+                      <test-suite type="TestFixture" name="TextContains" executed="True" result="Success" success="True" time="0.005" asserts="0">
+                        <results>
+                          <test-case name="NUnit.Framework.Syntax.TextContains.SyntaxTest.SupportedByConstraintBuilder" executed="True" result="Success" success="True" time="0.001" asserts="1" />
+                          <test-case name="NUnit.Framework.Syntax.TextContains.SyntaxTest.SupportedByInheritedSyntax" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Framework.Syntax.TextContains.SyntaxTest.SupportedByStaticSyntax" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                        </results>
+                      </test-suite>
+                      <test-suite type="TestFixture" name="TextEndsWithTest" executed="True" result="Success" success="True" time="0.004" asserts="0">
+                        <results>
+                          <test-case name="NUnit.Framework.Syntax.TextEndsWithTest.SyntaxTest.SupportedByConstraintBuilder" executed="True" result="Success" success="True" time="0.001" asserts="1" />
+                          <test-case name="NUnit.Framework.Syntax.TextEndsWithTest.SyntaxTest.SupportedByInheritedSyntax" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Framework.Syntax.TextEndsWithTest.SyntaxTest.SupportedByStaticSyntax" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                        </results>
+                      </test-suite>
+                      <test-suite type="TestFixture" name="TextMatchesTest" executed="True" result="Success" success="True" time="0.005" asserts="0">
+                        <results>
+                          <test-case name="NUnit.Framework.Syntax.TextMatchesTest.SyntaxTest.SupportedByConstraintBuilder" executed="True" result="Success" success="True" time="0.001" asserts="1" />
+                          <test-case name="NUnit.Framework.Syntax.TextMatchesTest.SyntaxTest.SupportedByInheritedSyntax" executed="True" result="Success" success="True" time="0.001" asserts="1" />
+                          <test-case name="NUnit.Framework.Syntax.TextMatchesTest.SyntaxTest.SupportedByStaticSyntax" executed="True" result="Success" success="True" time="0.001" asserts="1" />
+                        </results>
+                      </test-suite>
+                      <test-suite type="TestFixture" name="TextStartsWithTest" executed="True" result="Success" success="True" time="0.004" asserts="0">
+                        <results>
+                          <test-case name="NUnit.Framework.Syntax.TextStartsWithTest.SyntaxTest.SupportedByConstraintBuilder" executed="True" result="Success" success="True" time="0.001" asserts="1" />
+                          <test-case name="NUnit.Framework.Syntax.TextStartsWithTest.SyntaxTest.SupportedByInheritedSyntax" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Framework.Syntax.TextStartsWithTest.SyntaxTest.SupportedByStaticSyntax" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                        </results>
+                      </test-suite>
+                      <test-suite type="TestFixture" name="ThrowsTests" executed="True" result="Success" success="True" time="0.039" asserts="0">
+                        <results>
+                          <test-case name="NUnit.Framework.Syntax.ThrowsTests.DelegateThrowsException" executed="True" result="Success" success="True" time="0.001" asserts="1" />
+                          <test-case name="NUnit.Framework.Syntax.ThrowsTests.LambdaThrowsException" executed="True" result="Success" success="True" time="0.001" asserts="1" />
+                          <test-case name="NUnit.Framework.Syntax.ThrowsTests.LambdaThrowsExceptionWithMessage" executed="True" result="Success" success="True" time="0.001" asserts="1" />
+                          <test-case name="NUnit.Framework.Syntax.ThrowsTests.LambdaThrowsNothing" executed="True" result="Success" success="True" time="0.001" asserts="1" />
+                          <test-case name="NUnit.Framework.Syntax.ThrowsTests.ThrowsArgumentException" executed="True" result="Success" success="True" time="0.001" asserts="1" />
+                          <test-case name="NUnit.Framework.Syntax.ThrowsTests.ThrowsException" executed="True" result="Success" success="True" time="0.001" asserts="1" />
+                          <test-case name="NUnit.Framework.Syntax.ThrowsTests.ThrowsExceptionInstanceOf" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Framework.Syntax.ThrowsTests.ThrowsExceptionTypeOf" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Framework.Syntax.ThrowsTests.ThrowsExceptionTypeOfAndConstraint" executed="True" result="Success" success="True" time="0.001" asserts="1" />
+                          <test-case name="NUnit.Framework.Syntax.ThrowsTests.ThrowsExceptionWithConstraint" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Framework.Syntax.ThrowsTests.ThrowsExceptionWithInnerException" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Framework.Syntax.ThrowsTests.ThrowsInnerException" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Framework.Syntax.ThrowsTests.ThrowsInstanceOf" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Framework.Syntax.ThrowsTests.ThrowsInvalidOperationException" executed="True" result="Success" success="True" time="0.001" asserts="1" />
+                          <test-case name="NUnit.Framework.Syntax.ThrowsTests.ThrowsTargetInvocationExceptionWithInnerException" executed="True" result="Success" success="True" time="0.001" asserts="1" />
+                          <test-case name="NUnit.Framework.Syntax.ThrowsTests.ThrowsTypeOf" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Framework.Syntax.ThrowsTests.ThrowsTypeOfAndConstraint" executed="True" result="Success" success="True" time="0.001" asserts="1" />
+                          <test-case name="NUnit.Framework.Syntax.ThrowsTests.ThrowsTypeOfWithConstraint" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Framework.Syntax.ThrowsTests.ThrowsTypeOfWithInnerException" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Framework.Syntax.ThrowsTests.ThrowsTypeofWithMessage" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                        </results>
+                      </test-suite>
+                      <test-suite type="TestFixture" name="TrueTest" executed="True" result="Success" success="True" time="0.005" asserts="0">
+                        <results>
+                          <test-case name="NUnit.Framework.Syntax.TrueTest.SyntaxTest.SupportedByConstraintBuilder" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Framework.Syntax.TrueTest.SyntaxTest.SupportedByInheritedSyntax" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Framework.Syntax.TrueTest.SyntaxTest.SupportedByStaticSyntax" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                        </results>
+                      </test-suite>
+                      <test-suite type="TestFixture" name="UniqueTest" executed="True" result="Success" success="True" time="0.005" asserts="0">
+                        <results>
+                          <test-case name="NUnit.Framework.Syntax.UniqueTest.SyntaxTest.SupportedByConstraintBuilder" executed="True" result="Success" success="True" time="0.001" asserts="1" />
+                          <test-case name="NUnit.Framework.Syntax.UniqueTest.SyntaxTest.SupportedByInheritedSyntax" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Framework.Syntax.UniqueTest.SyntaxTest.SupportedByStaticSyntax" executed="True" result="Success" success="True" time="0.001" asserts="1" />
+                        </results>
+                      </test-suite>
+                      <test-suite type="TestFixture" name="XmlSerializableTest" executed="True" result="Success" success="True" time="0.005" asserts="0">
+                        <results>
+                          <test-case name="NUnit.Framework.Syntax.XmlSerializableTest.SyntaxTest.SupportedByConstraintBuilder" executed="True" result="Success" success="True" time="0.001" asserts="1" />
+                          <test-case name="NUnit.Framework.Syntax.XmlSerializableTest.SyntaxTest.SupportedByInheritedSyntax" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Framework.Syntax.XmlSerializableTest.SyntaxTest.SupportedByStaticSyntax" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                        </results>
+                      </test-suite>
+                    </results>
+                  </test-suite>
+                  <test-suite type="Namespace" name="Tests" executed="True" result="Success" success="True" time="1.435" asserts="0">
+                    <results>
+                      <test-suite type="TestFixture" name="ArrayEqualsFailureMessageFixture" executed="True" result="Success" success="True" time="0.051" asserts="0">
+                        <results>
+                          <test-case name="NUnit.Framework.Tests.ArrayEqualsFailureMessageFixture.ActualArrayIsLonger" executed="True" result="Success" success="True" time="0.002" asserts="2" />
+                          <test-case name="NUnit.Framework.Tests.ArrayEqualsFailureMessageFixture.ArrayAndCollection_Failure" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Framework.Tests.ArrayEqualsFailureMessageFixture.ArraysDeclaredAsDifferentTypes" executed="True" result="Success" success="True" time="0.001" asserts="2" />
+                          <test-case name="NUnit.Framework.Tests.ArrayEqualsFailureMessageFixture.ArraysHaveDifferentRanks" executed="True" result="Success" success="True" time="0.001" asserts="2" />
+                          <test-case name="NUnit.Framework.Tests.ArrayEqualsFailureMessageFixture.ArraysWithDifferentDimensionsAsCollection" executed="True" result="Success" success="True" time="0.001" asserts="2" />
+                          <test-case name="NUnit.Framework.Tests.ArrayEqualsFailureMessageFixture.ArraysWithDifferentRanksAsCollection" executed="True" result="Success" success="True" time="0.001" asserts="2" />
+                          <test-case name="NUnit.Framework.Tests.ArrayEqualsFailureMessageFixture.DifferentArrayTypesEqualFails" executed="True" result="Success" success="True" time="0.001" asserts="2" />
+                          <test-case name="NUnit.Framework.Tests.ArrayEqualsFailureMessageFixture.DoubleDimensionedArrays" executed="True" result="Success" success="True" time="0.001" asserts="2" />
+                          <test-case name="NUnit.Framework.Tests.ArrayEqualsFailureMessageFixture.ExpectedArrayIsLonger" executed="True" result="Success" success="True" time="0.001" asserts="2" />
+                          <test-case name="NUnit.Framework.Tests.ArrayEqualsFailureMessageFixture.FailureOnSingleDimensionedArrays" executed="True" result="Success" success="True" time="0.001" asserts="2" />
+                          <test-case name="NUnit.Framework.Tests.ArrayEqualsFailureMessageFixture.FiveDimensionedArrays" executed="True" result="Success" success="True" time="0.001" asserts="2" />
+                          <test-case name="NUnit.Framework.Tests.ArrayEqualsFailureMessageFixture.JaggedArrayComparedToSimpleArray" executed="True" result="Success" success="True" time="0.001" asserts="2" />
+                          <test-case name="NUnit.Framework.Tests.ArrayEqualsFailureMessageFixture.JaggedArrays" executed="True" result="Success" success="True" time="0.001" asserts="2" />
+                          <test-case name="NUnit.Framework.Tests.ArrayEqualsFailureMessageFixture.SameLengthDifferentContent" executed="True" result="Success" success="True" time="0.001" asserts="2" />
+                          <test-case name="NUnit.Framework.Tests.ArrayEqualsFailureMessageFixture.TripleDimensionedArrays" executed="True" result="Success" success="True" time="0.001" asserts="2" />
+                        </results>
+                      </test-suite>
+                      <test-suite type="TestFixture" name="ArrayEqualsFixture" executed="True" result="Success" success="True" time="0.047" asserts="0">
+                        <results>
+                          <test-case name="NUnit.Framework.Tests.ArrayEqualsFixture.ArrayAndCollection" executed="True" result="Success" success="True" time="0.000" asserts="4" />
+                          <test-case name="NUnit.Framework.Tests.ArrayEqualsFixture.ArrayIsEqualToItself" executed="True" result="Success" success="True" time="0.000" asserts="3" />
+                          <test-case name="NUnit.Framework.Tests.ArrayEqualsFixture.ArrayOfIntAndArrayOfDouble" executed="True" result="Success" success="True" time="0.001" asserts="4" />
+                          <test-case name="NUnit.Framework.Tests.ArrayEqualsFixture.ArraysDeclaredAsDifferentTypes" executed="True" result="Success" success="True" time="0.001" asserts="4" />
+                          <test-case name="NUnit.Framework.Tests.ArrayEqualsFixture.ArraysOfArrays" executed="True" result="Success" success="True" time="0.001" asserts="4" />
+                          <test-case name="NUnit.Framework.Tests.ArrayEqualsFixture.ArraysOfDecimal" executed="True" result="Success" success="True" time="0.000" asserts="4" />
+                          <test-case name="NUnit.Framework.Tests.ArrayEqualsFixture.ArraysOfDouble" executed="True" result="Success" success="True" time="0.000" asserts="4" />
+                          <test-case name="NUnit.Framework.Tests.ArrayEqualsFixture.ArraysOfInt" executed="True" result="Success" success="True" time="0.000" asserts="4" />
+                          <test-case name="NUnit.Framework.Tests.ArrayEqualsFixture.ArraysOfMixedTypes" executed="True" result="Success" success="True" time="0.001" asserts="4" />
+                          <test-case name="NUnit.Framework.Tests.ArrayEqualsFixture.ArraysOfString" executed="True" result="Success" success="True" time="0.000" asserts="5" />
+                          <test-case name="NUnit.Framework.Tests.ArrayEqualsFixture.ArraysPassedAsObjects" executed="True" result="Success" success="True" time="0.000" asserts="4" />
+                          <test-case name="NUnit.Framework.Tests.ArrayEqualsFixture.ArraysWithDifferentDimensionsMatchedAsCollection" executed="True" result="Success" success="True" time="0.001" asserts="3" />
+                          <test-case name="NUnit.Framework.Tests.ArrayEqualsFixture.ArraysWithDifferentRanksComparedAsCollection" executed="True" result="Success" success="True" time="0.000" asserts="3" />
+                          <test-case name="NUnit.Framework.Tests.ArrayEqualsFixture.DoubleDimensionedArrays" executed="True" result="Success" success="True" time="0.000" asserts="4" />
+                          <test-case name="NUnit.Framework.Tests.ArrayEqualsFixture.FiveDimensionedArrays" executed="True" result="Success" success="True" time="0.000" asserts="2" />
+                          <test-case name="NUnit.Framework.Tests.ArrayEqualsFixture.JaggedArrays" executed="True" result="Success" success="True" time="0.001" asserts="2" />
+                          <test-case name="NUnit.Framework.Tests.ArrayEqualsFixture.TripleDimensionedArrays" executed="True" result="Success" success="True" time="0.000" asserts="2" />
+                        </results>
+                      </test-suite>
+                      <test-suite type="TestFixture" name="ArrayNotEqualFixture" executed="True" result="Success" success="True" time="0.005" asserts="0">
+                        <results>
+                          <test-case name="NUnit.Framework.Tests.ArrayNotEqualFixture.ArraysDeclaredAsDifferentTypes" executed="True" result="Success" success="True" time="0.000" asserts="3" />
+                          <test-case name="NUnit.Framework.Tests.ArrayNotEqualFixture.DifferentLengthArrays" executed="True" result="Success" success="True" time="0.001" asserts="4" />
+                          <test-case name="NUnit.Framework.Tests.ArrayNotEqualFixture.SameLengthDifferentContent" executed="True" result="Success" success="True" time="0.000" asserts="4" />
+                        </results>
+                      </test-suite>
+                      <test-suite type="TestFixture" name="AssertThrowsTests" executed="True" result="Success" success="True" time="0.033" asserts="0">
+                        <results>
+                          <test-case name="NUnit.Framework.Tests.AssertThrowsTests.BaseExceptionThrown" executed="True" result="Success" success="True" time="0.007" asserts="2" />
+                          <test-case name="NUnit.Framework.Tests.AssertThrowsTests.CanCatchExceptionOfDerivedType" executed="True" result="Success" success="True" time="0.001" asserts="4" />
+                          <test-case name="NUnit.Framework.Tests.AssertThrowsTests.CanCatchExceptionOfExactType" executed="True" result="Success" success="True" time="0.001" asserts="4" />
+                          <test-case name="NUnit.Framework.Tests.AssertThrowsTests.CanCatchUnspecifiedException" executed="True" result="Success" success="True" time="0.001" asserts="4" />
+                          <test-case name="NUnit.Framework.Tests.AssertThrowsTests.CorrectExceptionIsReturnedToMethod" executed="True" result="Success" success="True" time="0.002" asserts="16" />
+                          <test-case name="NUnit.Framework.Tests.AssertThrowsTests.CorrectExceptionThrown" executed="True" result="Success" success="True" time="0.002" asserts="5" />
+                          <test-case name="NUnit.Framework.Tests.AssertThrowsTests.DerivedExceptionThrown" executed="True" result="Success" success="True" time="0.001" asserts="2" />
+                          <test-case name="NUnit.Framework.Tests.AssertThrowsTests.DoesNotThrowFails" executed="True" result="Success" success="True" time="0.001" asserts="1" />
+                          <test-case name="NUnit.Framework.Tests.AssertThrowsTests.DoesNotThrowSuceeds" executed="True" result="Success" success="True" time="0.001" asserts="1" />
+                          <test-case name="NUnit.Framework.Tests.AssertThrowsTests.NoExceptionThrown" executed="True" result="Success" success="True" time="0.001" asserts="2" />
+                          <test-case name="NUnit.Framework.Tests.AssertThrowsTests.UnrelatedExceptionThrown" executed="True" result="Success" success="True" time="0.001" asserts="2" />
+                        </results>
+                      </test-suite>
+                      <test-suite type="TestFixture" name="AssumeThatTests" executed="True" result="Success" success="True" time="0.054" asserts="0">
+                        <results>
+                          <test-case name="NUnit.Framework.Tests.AssumeThatTests.AssumptionPasses_ActualAndConstraint" executed="True" result="Success" success="True" time="0.000" asserts="0" />
+                          <test-case name="NUnit.Framework.Tests.AssumeThatTests.AssumptionPasses_ActualAndConstraintWithMessage" executed="True" result="Success" success="True" time="0.000" asserts="0" />
+                          <test-case name="NUnit.Framework.Tests.AssumeThatTests.AssumptionPasses_ActualAndConstraintWithMessageAndArgs" executed="True" result="Success" success="True" time="0.000" asserts="0" />
+                          <test-case name="NUnit.Framework.Tests.AssumeThatTests.AssumptionPasses_Boolean" executed="True" result="Success" success="True" time="0.000" asserts="0" />
+                          <test-case name="NUnit.Framework.Tests.AssumeThatTests.AssumptionPasses_BooleanWithMessage" executed="True" result="Success" success="True" time="0.000" asserts="0" />
+                          <test-case name="NUnit.Framework.Tests.AssumeThatTests.AssumptionPasses_BooleanWithMessageAndArgs" executed="True" result="Success" success="True" time="0.000" asserts="0" />
+                          <test-case name="NUnit.Framework.Tests.AssumeThatTests.AssumptionPasses_DelegateAndConstraint" executed="True" result="Success" success="True" time="0.001" asserts="0" />
+                          <test-case name="NUnit.Framework.Tests.AssumeThatTests.AssumptionPasses_DelegateAndConstraintWithMessage" executed="True" result="Success" success="True" time="0.000" asserts="0" />
+                          <test-case name="NUnit.Framework.Tests.AssumeThatTests.AssumptionPasses_DelegateAndConstraintWithMessageAndArgs" executed="True" result="Success" success="True" time="0.000" asserts="0" />
+                          <test-case name="NUnit.Framework.Tests.AssumeThatTests.AssumptionPasses_ReferenceAndConstraint" executed="True" result="Success" success="True" time="0.001" asserts="0" />
+                          <test-case name="NUnit.Framework.Tests.AssumeThatTests.AssumptionPasses_ReferenceAndConstraintWithMessage" executed="True" result="Success" success="True" time="0.000" asserts="0" />
+                          <test-case name="NUnit.Framework.Tests.AssumeThatTests.AssumptionPasses_ReferenceAndConstraintWithMessageAndArgs" executed="True" result="Success" success="True" time="0.000" asserts="0" />
+                          <test-case name="NUnit.Framework.Tests.AssumeThatTests.FailureThrowsInconclusiveException_ActualAndConstraint" executed="True" result="Success" success="True" time="0.001" asserts="0" />
+                          <test-case name="NUnit.Framework.Tests.AssumeThatTests.FailureThrowsInconclusiveException_ActualAndConstraintWithMessage" executed="True" result="Success" success="True" time="0.001" asserts="0" />
+                          <test-case name="NUnit.Framework.Tests.AssumeThatTests.FailureThrowsInconclusiveException_ActualAndConstraintWithMessageAndArgs" executed="True" result="Success" success="True" time="0.001" asserts="0" />
+                          <test-case name="NUnit.Framework.Tests.AssumeThatTests.FailureThrowsInconclusiveException_Boolean" executed="True" result="Success" success="True" time="0.001" asserts="0" />
+                          <test-case name="NUnit.Framework.Tests.AssumeThatTests.FailureThrowsInconclusiveException_BooleanWithMessage" executed="True" result="Success" success="True" time="0.001" asserts="0" />
+                          <test-case name="NUnit.Framework.Tests.AssumeThatTests.FailureThrowsInconclusiveException_BooleanWithMessageAndArgs" executed="True" result="Success" success="True" time="0.001" asserts="0" />
+                          <test-case name="NUnit.Framework.Tests.AssumeThatTests.FailureThrowsInconclusiveException_DelegateAndConstraint" executed="True" result="Success" success="True" time="0.000" asserts="0" />
+                          <test-case name="NUnit.Framework.Tests.AssumeThatTests.FailureThrowsInconclusiveException_DelegateAndConstraintWithMessage" executed="True" result="Success" success="True" time="0.001" asserts="0" />
+                          <test-case name="NUnit.Framework.Tests.AssumeThatTests.FailureThrowsInconclusiveException_DelegateAndConstraintWithMessageAndArgs" executed="True" result="Success" success="True" time="0.001" asserts="0" />
+                          <test-case name="NUnit.Framework.Tests.AssumeThatTests.FailureThrowsInconclusiveException_ReferenceAndConstraint" executed="True" result="Success" success="True" time="0.001" asserts="0" />
+                          <test-case name="NUnit.Framework.Tests.AssumeThatTests.FailureThrowsInconclusiveException_ReferenceAndConstraintWithMessage" executed="True" result="Success" success="True" time="0.001" asserts="0" />
+                          <test-case name="NUnit.Framework.Tests.AssumeThatTests.FailureThrowsInconclusiveException_ReferenceAndConstraintWithMessageAndArgs" executed="True" result="Success" success="True" time="0.000" asserts="0" />
+                        </results>
+                      </test-suite>
+                      <test-suite type="TestFixture" name="CollectionAssertTest" executed="True" result="Success" success="True" time="0.162" asserts="0">
+                        <results>
+                          <test-case name="NUnit.Framework.Tests.CollectionAssertTest.AreEqual" executed="True" result="Success" success="True" time="0.001" asserts="3" />
+                          <test-case name="NUnit.Framework.Tests.CollectionAssertTest.AreEqual_HandlesNull" executed="True" result="Success" success="True" time="0.000" asserts="2" />
+                          <test-case name="NUnit.Framework.Tests.CollectionAssertTest.AreEqual_UsingIterator" executed="True" result="Success" success="True" time="0.001" asserts="1" />
+                          <test-case name="NUnit.Framework.Tests.CollectionAssertTest.AreEqual_UsingIterator_Fails" executed="True" result="Success" success="True" time="0.001" asserts="2" />
+                          <test-case name="NUnit.Framework.Tests.CollectionAssertTest.AreEqual_UsingLinqQuery" executed="True" result="Success" success="True" time="0.032" asserts="1" />
+                          <test-case name="NUnit.Framework.Tests.CollectionAssertTest.AreEqual_UsingLinqQuery_Fails" executed="True" result="Success" success="True" time="0.001" asserts="2" />
+                          <test-case name="NUnit.Framework.Tests.CollectionAssertTest.AreEqualFail" executed="True" result="Success" success="True" time="0.001" asserts="2" />
+                          <test-case name="NUnit.Framework.Tests.CollectionAssertTest.AreEqualFailCount" executed="True" result="Success" success="True" time="0.001" asserts="2" />
+                          <test-case name="NUnit.Framework.Tests.CollectionAssertTest.AreEquivalentHandlesNull" executed="True" result="Success" success="True" time="0.001" asserts="1" />
+                          <test-case name="NUnit.Framework.Tests.CollectionAssertTest.AreNotEqual" executed="True" result="Success" success="True" time="0.001" asserts="6" />
+                          <test-case name="NUnit.Framework.Tests.CollectionAssertTest.AreNotEqual_Fails" executed="True" result="Success" success="True" time="0.001" asserts="2" />
+                          <test-case name="NUnit.Framework.Tests.CollectionAssertTest.AreNotEqual_HandlesNull" executed="True" result="Success" success="True" time="0.000" asserts="2" />
+                          <test-case name="NUnit.Framework.Tests.CollectionAssertTest.Contains_ICollection" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Framework.Tests.CollectionAssertTest.Contains_IList" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Framework.Tests.CollectionAssertTest.ContainsFails_EmptyICollection" executed="True" result="Success" success="True" time="0.001" asserts="2" />
+                          <test-case name="NUnit.Framework.Tests.CollectionAssertTest.ContainsFails_EmptyIList" executed="True" result="Success" success="True" time="0.000" asserts="2" />
+                          <test-case name="NUnit.Framework.Tests.CollectionAssertTest.ContainsFails_ICollection" executed="True" result="Success" success="True" time="0.001" asserts="2" />
+                          <test-case name="NUnit.Framework.Tests.CollectionAssertTest.ContainsFails_ILIst" executed="True" result="Success" success="True" time="0.001" asserts="2" />
+                          <test-case name="NUnit.Framework.Tests.CollectionAssertTest.ContainsNull_ICollection" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Framework.Tests.CollectionAssertTest.ContainsNull_IList" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Framework.Tests.CollectionAssertTest.DoesNotContain" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Framework.Tests.CollectionAssertTest.DoesNotContain_Empty" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Framework.Tests.CollectionAssertTest.DoesNotContain_Fails" executed="True" result="Success" success="True" time="0.001" asserts="2" />
+                          <test-case name="NUnit.Framework.Tests.CollectionAssertTest.EnsureComparerIsUsed" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Framework.Tests.CollectionAssertTest.Equivalent" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Framework.Tests.CollectionAssertTest.EquivalentFailOne" executed="True" result="Success" success="True" time="0.001" asserts="2" />
+                          <test-case name="NUnit.Framework.Tests.CollectionAssertTest.EquivalentFailTwo" executed="True" result="Success" success="True" time="0.000" asserts="2" />
+                          <test-case name="NUnit.Framework.Tests.CollectionAssertTest.IsNotSubsetOf" executed="True" result="Success" success="True" time="0.001" asserts="2" />
+                          <test-case name="NUnit.Framework.Tests.CollectionAssertTest.IsNotSubsetOf_Fails" executed="True" result="Success" success="True" time="0.001" asserts="2" />
+                          <test-case name="NUnit.Framework.Tests.CollectionAssertTest.IsNotSubsetOfHandlesNull" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Framework.Tests.CollectionAssertTest.IsOrdered" executed="True" result="Success" success="True" time="0.001" asserts="1" />
+                          <test-case name="NUnit.Framework.Tests.CollectionAssertTest.IsOrdered_Allows_adjacent_equal_values" executed="True" result="Success" success="True" time="0.001" asserts="1" />
+                          <test-case name="NUnit.Framework.Tests.CollectionAssertTest.IsOrdered_ContainedTypesMustBeCompatible" executed="True" result="Success" success="True" time="0.001" asserts="1" />
+                          <test-case name="NUnit.Framework.Tests.CollectionAssertTest.IsOrdered_Fails" executed="True" result="Success" success="True" time="0.001" asserts="2" />
+                          <test-case name="NUnit.Framework.Tests.CollectionAssertTest.IsOrdered_Handles_custom_comparison" executed="True" result="Success" success="True" time="0.001" asserts="1" />
+                          <test-case name="NUnit.Framework.Tests.CollectionAssertTest.IsOrdered_Handles_custom_comparison2" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Framework.Tests.CollectionAssertTest.IsOrdered_Handles_null" executed="True" result="Success" success="True" time="0.001" asserts="1" />
+                          <test-case name="NUnit.Framework.Tests.CollectionAssertTest.IsOrdered_TypesMustImplementIComparable" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Framework.Tests.CollectionAssertTest.IsSubsetOf" executed="True" result="Success" success="True" time="0.001" asserts="2" />
+                          <test-case name="NUnit.Framework.Tests.CollectionAssertTest.IsSubsetOf_Fails" executed="True" result="Success" success="True" time="0.001" asserts="2" />
+                          <test-case name="NUnit.Framework.Tests.CollectionAssertTest.IsSubsetOfHandlesNull" executed="True" result="Success" success="True" time="0.000" asserts="2" />
+                          <test-case name="NUnit.Framework.Tests.CollectionAssertTest.ItemsNotNull" executed="True" result="Success" success="True" time="0.001" asserts="1" />
+                          <test-case name="NUnit.Framework.Tests.CollectionAssertTest.ItemsNotNullFailure" executed="True" result="Success" success="True" time="0.001" asserts="2" />
+                          <test-case name="NUnit.Framework.Tests.CollectionAssertTest.ItemsOfType" executed="True" result="Success" success="True" time="0.001" asserts="1" />
+                          <test-case name="NUnit.Framework.Tests.CollectionAssertTest.ItemsOfTypeFailure" executed="True" result="Success" success="True" time="0.001" asserts="2" />
+                          <test-case name="NUnit.Framework.Tests.CollectionAssertTest.NotEquivalent" executed="True" result="Success" success="True" time="0.001" asserts="1" />
+                          <test-case name="NUnit.Framework.Tests.CollectionAssertTest.NotEquivalent_Fails" executed="True" result="Success" success="True" time="0.001" asserts="2" />
+                          <test-case name="NUnit.Framework.Tests.CollectionAssertTest.NotEquivalentHandlesNull" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Framework.Tests.CollectionAssertTest.Unique_WithNull" executed="True" result="Success" success="True" time="0.001" asserts="1" />
+                          <test-case name="NUnit.Framework.Tests.CollectionAssertTest.Unique_WithObjects" executed="True" result="Success" success="True" time="0.001" asserts="1" />
+                          <test-case name="NUnit.Framework.Tests.CollectionAssertTest.Unique_WithStrings" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Framework.Tests.CollectionAssertTest.UniqueFailure" executed="True" result="Success" success="True" time="0.001" asserts="2" />
+                          <test-case name="NUnit.Framework.Tests.CollectionAssertTest.UniqueFailure_WithTwoNulls" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                        </results>
+                      </test-suite>
+                      <test-suite type="TestFixture" name="ConditionAssertTests" executed="True" result="Success" success="True" time="0.048" asserts="0">
+                        <results>
+                          <test-case name="NUnit.Framework.Tests.ConditionAssertTests.IsEmpty" executed="True" result="Success" success="True" time="0.000" asserts="5" />
+                          <test-case name="NUnit.Framework.Tests.ConditionAssertTests.IsEmptyFailsOnNonEmptyArray" executed="True" result="Success" success="True" time="0.001" asserts="2" />
+                          <test-case name="NUnit.Framework.Tests.ConditionAssertTests.IsEmptyFailsOnNonEmptyIEnumerable" executed="True" result="Success" success="True" time="0.001" asserts="2" />
+                          <test-case name="NUnit.Framework.Tests.ConditionAssertTests.IsEmptyFailsOnNullString" executed="True" result="Success" success="True" time="0.001" asserts="2" />
+                          <test-case name="NUnit.Framework.Tests.ConditionAssertTests.IsEmptyFailsOnString" executed="True" result="Success" success="True" time="0.000" asserts="2" />
+                          <test-case name="NUnit.Framework.Tests.ConditionAssertTests.IsFalse" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Framework.Tests.ConditionAssertTests.IsFalseFails" executed="True" result="Success" success="True" time="0.001" asserts="2" />
+                          <test-case name="NUnit.Framework.Tests.ConditionAssertTests.IsNaN" executed="True" result="Success" success="True" time="0.001" asserts="1" />
+                          <test-case name="NUnit.Framework.Tests.ConditionAssertTests.IsNaNFails" executed="True" result="Success" success="True" time="0.001" asserts="2" />
+                          <test-case name="NUnit.Framework.Tests.ConditionAssertTests.IsNotEmpty" executed="True" result="Success" success="True" time="0.001" asserts="5" />
+                          <test-case name="NUnit.Framework.Tests.ConditionAssertTests.IsNotEmptyFailsOnEmptyArray" executed="True" result="Success" success="True" time="0.001" asserts="2" />
+                          <test-case name="NUnit.Framework.Tests.ConditionAssertTests.IsNotEmptyFailsOnEmptyArrayList" executed="True" result="Success" success="True" time="0.000" asserts="2" />
+                          <test-case name="NUnit.Framework.Tests.ConditionAssertTests.IsNotEmptyFailsOnEmptyHashTable" executed="True" result="Success" success="True" time="0.001" asserts="2" />
+                          <test-case name="NUnit.Framework.Tests.ConditionAssertTests.IsNotEmptyFailsOnEmptyIEnumerable" executed="True" result="Success" success="True" time="0.001" asserts="2" />
+                          <test-case name="NUnit.Framework.Tests.ConditionAssertTests.IsNotEmptyFailsOnEmptyString" executed="True" result="Success" success="True" time="0.001" asserts="2" />
+                          <test-case name="NUnit.Framework.Tests.ConditionAssertTests.IsNotNull" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Framework.Tests.ConditionAssertTests.IsNotNullFails" executed="True" result="Success" success="True" time="0.000" asserts="2" />
+                          <test-case name="NUnit.Framework.Tests.ConditionAssertTests.IsNull" executed="True" result="Success" success="True" time="0.001" asserts="1" />
+                          <test-case name="NUnit.Framework.Tests.ConditionAssertTests.IsNullFails" executed="True" result="Success" success="True" time="0.001" asserts="2" />
+                          <test-case name="NUnit.Framework.Tests.ConditionAssertTests.IsTrue" executed="True" result="Success" success="True" time="0.001" asserts="1" />
+                          <test-case name="NUnit.Framework.Tests.ConditionAssertTests.IsTrueFails" executed="True" result="Success" success="True" time="0.001" asserts="2" />
+                        </results>
+                      </test-suite>
+                      <test-suite type="TestFixture" name="DirectoryAssertTests" executed="True" result="Success" success="True" time="0.269" asserts="0">
+                        <results>
+                          <test-case name="NUnit.Framework.Tests.DirectoryAssertTests.AreEqualFailsWhenOneDoesNotExist" executed="True" result="Success" success="True" time="0.007" asserts="1" />
+                          <test-case name="NUnit.Framework.Tests.DirectoryAssertTests.AreEqualFailsWhenOneIsNull" executed="True" result="Success" success="True" time="0.006" asserts="1" />
+                          <test-case name="NUnit.Framework.Tests.DirectoryAssertTests.AreEqualFailsWithDirectoryInfos" executed="True" result="Success" success="True" time="0.013" asserts="1" />
+                          <test-case name="NUnit.Framework.Tests.DirectoryAssertTests.AreEqualFailsWithStringPath" executed="True" result="Success" success="True" time="0.011" asserts="1" />
+                          <test-case name="NUnit.Framework.Tests.DirectoryAssertTests.AreEqualPassesWhenBothAreNull" executed="True" result="Success" success="True" time="0.001" asserts="1" />
+                          <test-case name="NUnit.Framework.Tests.DirectoryAssertTests.AreEqualPassesWithDirectoryInfos" executed="True" result="Success" success="True" time="0.005" asserts="1" />
+                          <test-case name="NUnit.Framework.Tests.DirectoryAssertTests.AreEqualPassesWithStringPath" executed="True" result="Success" success="True" time="0.005" asserts="1" />
+                          <test-case name="NUnit.Framework.Tests.DirectoryAssertTests.AreNotEqualFailsWhenBothAreNull" executed="True" result="Success" success="True" time="0.001" asserts="2" />
+                          <test-case name="NUnit.Framework.Tests.DirectoryAssertTests.AreNotEqualFailsWithDirectoryInfos" executed="True" result="Success" success="True" time="0.006" asserts="1" />
+                          <test-case name="NUnit.Framework.Tests.DirectoryAssertTests.AreNotEqualFailsWithStringPath" executed="True" result="Success" success="True" time="0.007" asserts="1" />
+                          <test-case name="NUnit.Framework.Tests.DirectoryAssertTests.AreNotEqualPassesIfOneIsNull" executed="True" result="Success" success="True" time="0.006" asserts="1" />
+                          <test-case name="NUnit.Framework.Tests.DirectoryAssertTests.AreNotEqualPassesWhenOneDoesNotExist" executed="True" result="Success" success="True" time="0.006" asserts="1" />
+                          <test-case name="NUnit.Framework.Tests.DirectoryAssertTests.AreNotEqualPassesWithStringPath" executed="True" result="Success" success="True" time="0.012" asserts="1" />
+                          <test-case name="NUnit.Framework.Tests.DirectoryAssertTests.IsEmptyFailsWithInvalidDirectory" executed="True" result="Success" success="True" time="0.025" asserts="1" />
+                          <test-case name="NUnit.Framework.Tests.DirectoryAssertTests.IsEmptyFailsWithNonEmptyDirectoryUsingDirectoryInfo" executed="True" result="Success" success="True" time="0.007" asserts="1" />
+                          <test-case name="NUnit.Framework.Tests.DirectoryAssertTests.IsEmptyFailsWithNonEmptyDirectoryUsingStringPath" executed="True" result="Success" success="True" time="0.007" asserts="1" />
+                          <test-case name="NUnit.Framework.Tests.DirectoryAssertTests.IsEmptyPassesWithEmptyDirectoryUsingDirectoryInfo" executed="True" result="Success" success="True" time="0.003" asserts="2" />
+                          <test-case name="NUnit.Framework.Tests.DirectoryAssertTests.IsEmptyPassesWithEmptyDirectoryUsingStringPath" executed="True" result="Success" success="True" time="0.002" asserts="1" />
+                          <test-case name="NUnit.Framework.Tests.DirectoryAssertTests.IsEmptyThrowsUsingNull" executed="True" result="Success" success="True" time="0.001" asserts="1" />
+                          <test-case name="NUnit.Framework.Tests.DirectoryAssertTests.IsNotEmptyFailsWithEmptyDirectoryUsingDirectoryInfo" executed="True" result="Success" success="True" time="0.004" asserts="1" />
+                          <test-case name="NUnit.Framework.Tests.DirectoryAssertTests.IsNotEmptyFailsWithEmptyDirectoryUsingStringPath" executed="True" result="Success" success="True" time="0.003" asserts="1" />
+                          <test-case name="NUnit.Framework.Tests.DirectoryAssertTests.IsNotEmptyFailsWithInvalidDirectory" executed="True" result="Success" success="True" time="0.003" asserts="1" />
+                          <test-case name="NUnit.Framework.Tests.DirectoryAssertTests.IsNotEmptyPassesWithNonEmptyDirectoryUsingDirectoryInfo" executed="True" result="Success" success="True" time="0.007" asserts="2" />
+                          <test-case name="NUnit.Framework.Tests.DirectoryAssertTests.IsNotEmptyPassesWithNonEmptyDirectoryUsingStringPath" executed="True" result="Success" success="True" time="0.005" asserts="1" />
+                          <test-case name="NUnit.Framework.Tests.DirectoryAssertTests.IsNotEmptyThrowsUsingNull" executed="True" result="Success" success="True" time="0.001" asserts="1" />
+                          <test-case name="NUnit.Framework.Tests.DirectoryAssertTests.IsNotWithinFailsWithDirectoryInfo" executed="True" result="Success" success="True" time="0.006" asserts="1" />
+                          <test-case name="NUnit.Framework.Tests.DirectoryAssertTests.IsNotWithinFailsWithStringPath" executed="True" result="Success" success="True" time="0.006" asserts="1" />
+                          <test-case name="NUnit.Framework.Tests.DirectoryAssertTests.IsNotWithinPassesWhenOutsidePathUsingDirectoryInfo" executed="True" result="Success" success="True" time="0.006" asserts="1" />
+                          <test-case name="NUnit.Framework.Tests.DirectoryAssertTests.IsNotWithinPassesWhenOutsidePathUsingStringPath" executed="True" result="Success" success="True" time="0.005" asserts="1" />
+                          <test-case name="NUnit.Framework.Tests.DirectoryAssertTests.IsNotWithinThrowsWhenBothAreNull" executed="True" result="Success" success="True" time="0.001" asserts="0" />
+                          <test-case name="NUnit.Framework.Tests.DirectoryAssertTests.IsWithinFailsWhenOutsidePathUsingDirectoryInfo" executed="True" result="Success" success="True" time="0.006" asserts="1" />
+                          <test-case name="NUnit.Framework.Tests.DirectoryAssertTests.IsWithinFailsWhenOutsidePathUsingStringPath" executed="True" result="Success" success="True" time="0.006" asserts="1" />
+                          <test-case name="NUnit.Framework.Tests.DirectoryAssertTests.IsWithinPassesWithDirectoryInfo" executed="True" result="Success" success="True" time="0.006" asserts="1" />
+                          <test-case name="NUnit.Framework.Tests.DirectoryAssertTests.IsWithinPassesWithStringPath" executed="True" result="Success" success="True" time="0.006" asserts="1" />
+                          <test-case name="NUnit.Framework.Tests.DirectoryAssertTests.IsWithinPassesWithTempPath" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Framework.Tests.DirectoryAssertTests.IsWithinThrowsWhenBothAreNull" executed="True" result="Success" success="True" time="0.000" asserts="0" />
+                        </results>
+                      </test-suite>
+                      <test-suite type="TestFixture" name="EqualsFixture" executed="True" result="Success" success="True" time="0.091" asserts="0">
+                        <results>
+                          <test-case name="NUnit.Framework.Tests.EqualsFixture.Bug575936Int32Int64Comparison" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Framework.Tests.EqualsFixture.Byte" executed="True" result="Success" success="True" time="0.000" asserts="2" />
+                          <test-case name="NUnit.Framework.Tests.EqualsFixture.DateTimeEqual" executed="True" result="Success" success="True" time="0.001" asserts="1" />
+                          <test-case name="NUnit.Framework.Tests.EqualsFixture.DateTimeNotEqual" executed="True" result="Success" success="True" time="0.002" asserts="2" />
+                          <test-case name="NUnit.Framework.Tests.EqualsFixture.Decimal" executed="True" result="Success" success="True" time="0.002" asserts="6" />
+                          <test-case name="NUnit.Framework.Tests.EqualsFixture.DirectoryInfoEquality" executed="True" result="Success" success="True" time="0.001" asserts="1" />
+                          <test-case name="NUnit.Framework.Tests.EqualsFixture.DirectoryInfoEqualityIgnoresTrailingDirectorySeparator" executed="True" result="Success" success="True" time="0.001" asserts="1" />
+                          <test-case name="NUnit.Framework.Tests.EqualsFixture.DoubleNotEqualMessageDisplaysAllDigits" executed="True" result="Success" success="True" time="0.000" asserts="2" />
+                          <test-case name="NUnit.Framework.Tests.EqualsFixture.DoubleNotEqualMessageDisplaysDefaultTolerance" executed="True" result="Success" success="True" time="0.001" asserts="2" />
+                          <test-case name="NUnit.Framework.Tests.EqualsFixture.DoubleNotEqualMessageDisplaysTolerance" executed="True" result="Success" success="True" time="0.001" asserts="2" />
+                          <test-case name="NUnit.Framework.Tests.EqualsFixture.DoubleNotEqualWithNanDoesNotDisplayDefaultTolerance" executed="True" result="Success" success="True" time="0.001" asserts="2" />
+                          <test-case name="NUnit.Framework.Tests.EqualsFixture.EnumsEqual" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Framework.Tests.EqualsFixture.EnumsNotEqual" executed="True" result="Success" success="True" time="0.001" asserts="2" />
+                          <test-case name="NUnit.Framework.Tests.EqualsFixture.Equals" executed="True" result="Success" success="True" time="0.000" asserts="2" />
+                          <test-case name="NUnit.Framework.Tests.EqualsFixture.EqualsFail" executed="True" result="Success" success="True" time="0.001" asserts="2" />
+                          <test-case name="NUnit.Framework.Tests.EqualsFixture.EqualsNaNFails" executed="True" result="Success" success="True" time="0.000" asserts="2" />
+                          <test-case name="NUnit.Framework.Tests.EqualsFixture.EqualsNull" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Framework.Tests.EqualsFixture.EqualsSameTypes" executed="True" result="Success" success="True" time="0.003" asserts="31" />
+                          <test-case name="NUnit.Framework.Tests.EqualsFixture.EqualsThrowsException" executed="True" result="Success" success="True" time="0.001" asserts="0" />
+                          <test-case name="NUnit.Framework.Tests.EqualsFixture.Float" executed="True" result="Success" success="True" time="0.000" asserts="2" />
+                          <test-case name="NUnit.Framework.Tests.EqualsFixture.FloatNotEqualMessageDisplaysAllDigits" executed="True" result="Success" success="True" time="0.000" asserts="2" />
+                          <test-case name="NUnit.Framework.Tests.EqualsFixture.FloatNotEqualMessageDisplaysTolerance" executed="True" result="Success" success="True" time="0.001" asserts="2" />
+                          <test-case name="NUnit.Framework.Tests.EqualsFixture.IEquatableSuccess_ConstraintSyntax" executed="True" result="Success" success="True" time="0.001" asserts="2" />
+                          <test-case name="NUnit.Framework.Tests.EqualsFixture.IEquatableSuccess_OldSyntax" executed="True" result="Success" success="True" time="0.001" asserts="2" />
+                          <test-case name="NUnit.Framework.Tests.EqualsFixture.Int" executed="True" result="Success" success="True" time="0.000" asserts="2" />
+                          <test-case name="NUnit.Framework.Tests.EqualsFixture.IntegerEquals" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Framework.Tests.EqualsFixture.IntegerLongComparison" executed="True" result="Success" success="True" time="0.000" asserts="2" />
+                          <test-case name="NUnit.Framework.Tests.EqualsFixture.NanEqualsFails" executed="True" result="Success" success="True" time="0.001" asserts="2" />
+                          <test-case name="NUnit.Framework.Tests.EqualsFixture.NanEqualsNaNSucceeds" executed="True" result="Success" success="True" time="0.001" asserts="1" />
+                          <test-case name="NUnit.Framework.Tests.EqualsFixture.NegInfinityEqualsInfinity" executed="True" result="Success" success="True" time="0.001" asserts="1" />
+                          <test-case name="NUnit.Framework.Tests.EqualsFixture.PosInfinityEqualsInfinity" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Framework.Tests.EqualsFixture.PosInfinityNotEquals" executed="True" result="Success" success="True" time="0.001" asserts="2" />
+                          <test-case name="NUnit.Framework.Tests.EqualsFixture.PosInfinityNotEqualsNegInfinity" executed="True" result="Success" success="True" time="0.000" asserts="2" />
+                          <test-case name="NUnit.Framework.Tests.EqualsFixture.ReferenceEqualsThrowsException" executed="True" result="Success" success="True" time="0.001" asserts="0" />
+                          <test-case name="NUnit.Framework.Tests.EqualsFixture.Short" executed="True" result="Success" success="True" time="0.000" asserts="2" />
+                          <test-case name="NUnit.Framework.Tests.EqualsFixture.SinglePosInfinityNotEqualsNegInfinity" executed="True" result="Success" success="True" time="0.000" asserts="2" />
+                          <test-case name="NUnit.Framework.Tests.EqualsFixture.String" executed="True" result="Success" success="True" time="0.000" asserts="2" />
+                          <test-case name="NUnit.Framework.Tests.EqualsFixture.UInt" executed="True" result="Success" success="True" time="0.000" asserts="2" />
+                        </results>
+                      </test-suite>
+                      <test-suite type="TestFixture" name="FileAssertTests" executed="True" result="Success" success="True" time="0.128" asserts="0">
+                        <results>
+                          <test-case name="NUnit.Framework.Tests.FileAssertTests.AreEqualFailsWhenOneIsNull" executed="True" result="Success" success="True" time="0.004" asserts="2" />
+                          <test-case name="NUnit.Framework.Tests.FileAssertTests.AreEqualFailsWithFileInfos" executed="True" result="Success" success="True" time="0.006" asserts="2" />
+                          <test-case name="NUnit.Framework.Tests.FileAssertTests.AreEqualFailsWithFiles" executed="True" result="Success" success="True" time="0.004" asserts="2" />
+                          <test-case name="NUnit.Framework.Tests.FileAssertTests.AreEqualFailsWithStreams" executed="True" result="Success" success="True" time="0.005" asserts="2" />
+                          <test-case name="NUnit.Framework.Tests.FileAssertTests.AreEqualFailsWithTextFilesAfterReadingBothFiles" executed="True" result="Success" success="True" time="0.005" asserts="1" />
+                          <test-case name="NUnit.Framework.Tests.FileAssertTests.AreEqualPassesUsingSameFileTwice" executed="True" result="Success" success="True" time="0.002" asserts="1" />
+                          <test-case name="NUnit.Framework.Tests.FileAssertTests.AreEqualPassesWhenBothAreNull" executed="True" result="Success" success="True" time="0.001" asserts="1" />
+                          <test-case name="NUnit.Framework.Tests.FileAssertTests.AreEqualPassesWithEqualStreams" executed="True" result="Success" success="True" time="0.004" asserts="1" />
+                          <test-case name="NUnit.Framework.Tests.FileAssertTests.AreEqualPassesWithFileInfos" executed="True" result="Success" success="True" time="0.004" asserts="2" />
+                          <test-case name="NUnit.Framework.Tests.FileAssertTests.AreEqualPassesWithFiles" executed="True" result="Success" success="True" time="0.003" asserts="1" />
+                          <test-case name="NUnit.Framework.Tests.FileAssertTests.AreEqualPassesWithSameStream" executed="True" result="Success" success="True" time="0.001" asserts="1" />
+                          <test-case name="NUnit.Framework.Tests.FileAssertTests.AreEqualPassesWithTextFiles" executed="True" result="Success" success="True" time="0.004" asserts="1" />
+                          <test-case name="NUnit.Framework.Tests.FileAssertTests.AreNotEqualFailsWhenBothAreNull" executed="True" result="Success" success="True" time="0.001" asserts="2" />
+                          <test-case name="NUnit.Framework.Tests.FileAssertTests.AreNotEqualFailsWithFileInfos" executed="True" result="Success" success="True" time="0.005" asserts="2" />
+                          <test-case name="NUnit.Framework.Tests.FileAssertTests.AreNotEqualFailsWithFiles" executed="True" result="Success" success="True" time="0.004" asserts="2" />
+                          <test-case name="NUnit.Framework.Tests.FileAssertTests.AreNotEqualFailsWithStreams" executed="True" result="Success" success="True" time="0.004" asserts="2" />
+                          <test-case name="NUnit.Framework.Tests.FileAssertTests.AreNotEqualIteratesOverTheEntireFile" executed="True" result="Success" success="True" time="0.004" asserts="1" />
+                          <test-case name="NUnit.Framework.Tests.FileAssertTests.AreNotEqualIteratesOverTheEntireFileAndFails" executed="True" result="Success" success="True" time="0.004" asserts="2" />
+                          <test-case name="NUnit.Framework.Tests.FileAssertTests.AreNotEqualPassesIfOneIsNull" executed="True" result="Success" success="True" time="0.002" asserts="1" />
+                          <test-case name="NUnit.Framework.Tests.FileAssertTests.AreNotEqualPassesWithFileInfos" executed="True" result="Success" success="True" time="0.004" asserts="1" />
+                          <test-case name="NUnit.Framework.Tests.FileAssertTests.AreNotEqualPassesWithFiles" executed="True" result="Success" success="True" time="0.003" asserts="1" />
+                          <test-case name="NUnit.Framework.Tests.FileAssertTests.AreNotEqualPassesWithStreams" executed="True" result="Success" success="True" time="0.004" asserts="1" />
+                          <test-case name="NUnit.Framework.Tests.FileAssertTests.NonReadableStreamGivesException" executed="True" result="Success" success="True" time="0.005" asserts="1" />
+                          <test-case name="NUnit.Framework.Tests.FileAssertTests.NonSeekableStreamGivesException" executed="True" result="Success" success="True" time="0.003" asserts="1" />
+                        </results>
+                      </test-suite>
+                      <test-suite type="TestFixture" name="GreaterEqualFixture" executed="True" result="Success" success="True" time="0.084" asserts="0">
+                        <results>
+                          <test-case name="NUnit.Framework.Tests.GreaterEqualFixture.FailureMessage" executed="True" result="Success" success="True" time="0.000" asserts="3" />
+                          <test-case name="NUnit.Framework.Tests.GreaterEqualFixture.GreaterOrEqual_Decimal" executed="True" result="Success" success="True" time="0.001" asserts="2" />
+                          <test-case name="NUnit.Framework.Tests.GreaterEqualFixture.GreaterOrEqual_Double" executed="True" result="Success" success="True" time="0.000" asserts="2" />
+                          <test-case name="NUnit.Framework.Tests.GreaterEqualFixture.GreaterOrEqual_Float" executed="True" result="Success" success="True" time="0.000" asserts="2" />
+                          <test-case name="NUnit.Framework.Tests.GreaterEqualFixture.GreaterOrEqual_Int32" executed="True" result="Success" success="True" time="0.000" asserts="2" />
+                          <test-case name="NUnit.Framework.Tests.GreaterEqualFixture.GreaterOrEqual_Long" executed="True" result="Success" success="True" time="0.000" asserts="2" />
+                          <test-case name="NUnit.Framework.Tests.GreaterEqualFixture.GreaterOrEqual_UInt32" executed="True" result="Success" success="True" time="0.000" asserts="2" />
+                          <test-case name="NUnit.Framework.Tests.GreaterEqualFixture.GreaterOrEqual_ULong" executed="True" result="Success" success="True" time="0.001" asserts="2" />
+                          <test-case name="NUnit.Framework.Tests.GreaterEqualFixture.MixedTypes" executed="True" result="Success" success="True" time="0.003" asserts="42" />
+                          <test-case name="NUnit.Framework.Tests.GreaterEqualFixture.NotGreaterEqualIComparable" executed="True" result="Success" success="True" time="0.001" asserts="2" />
+                          <test-case name="NUnit.Framework.Tests.GreaterEqualFixture.NotGreaterOrEqual" executed="True" result="Success" success="True" time="0.000" asserts="2" />
+                        </results>
+                      </test-suite>
+                      <test-suite type="TestFixture" name="GreaterFixture" executed="True" result="Success" success="True" time="0.022" asserts="0">
+                        <results>
+                          <test-case name="NUnit.Framework.Tests.GreaterFixture.FailureMessage" executed="True" result="Success" success="True" time="0.002" asserts="2" />
+                          <test-case name="NUnit.Framework.Tests.GreaterFixture.Greater" executed="True" result="Success" success="True" time="0.002" asserts="7" />
+                          <test-case name="NUnit.Framework.Tests.GreaterFixture.MixedTypes" executed="True" result="Success" success="True" time="0.003" asserts="42" />
+                          <test-case name="NUnit.Framework.Tests.GreaterFixture.NotGreater" executed="True" result="Success" success="True" time="0.001" asserts="2" />
+                          <test-case name="NUnit.Framework.Tests.GreaterFixture.NotGreaterIComparable" executed="True" result="Success" success="True" time="0.002" asserts="2" />
+                          <test-case name="NUnit.Framework.Tests.GreaterFixture.NotGreaterWhenEqual" executed="True" result="Success" success="True" time="0.001" asserts="2" />
+                        </results>
+                      </test-suite>
+                      <test-suite type="TestFixture" name="LessEqualFixture" executed="True" result="Success" success="True" time="0.024" asserts="0">
+                        <results>
+                          <test-case name="NUnit.Framework.Tests.LessEqualFixture.FailureMessage" executed="True" result="Success" success="True" time="0.001" asserts="2" />
+                          <test-case name="NUnit.Framework.Tests.LessEqualFixture.LessOrEqual" executed="True" result="Success" success="True" time="0.007" asserts="42" />
+                          <test-case name="NUnit.Framework.Tests.LessEqualFixture.MixedTypes" executed="True" result="Success" success="True" time="0.003" asserts="42" />
+                          <test-case name="NUnit.Framework.Tests.LessEqualFixture.NotLessEqualIComparable" executed="True" result="Success" success="True" time="0.001" asserts="2" />
+                          <test-case name="NUnit.Framework.Tests.LessEqualFixture.NotLessOrEqual" executed="True" result="Success" success="True" time="0.001" asserts="2" />
+                        </results>
+                      </test-suite>
+                      <test-suite type="TestFixture" name="LessFixture" executed="True" result="Success" success="True" time="0.024" asserts="0">
+                        <results>
+                          <test-case name="NUnit.Framework.Tests.LessFixture.FailureMessage" executed="True" result="Success" success="True" time="0.000" asserts="3" />
+                          <test-case name="NUnit.Framework.Tests.LessFixture.Less" executed="True" result="Success" success="True" time="0.004" asserts="18" />
+                          <test-case name="NUnit.Framework.Tests.LessFixture.MixedTypes" executed="True" result="Success" success="True" time="0.002" asserts="42" />
+                          <test-case name="NUnit.Framework.Tests.LessFixture.NotLess" executed="True" result="Success" success="True" time="0.001" asserts="2" />
+                          <test-case name="NUnit.Framework.Tests.LessFixture.NotLessIComparable" executed="True" result="Success" success="True" time="0.001" asserts="2" />
+                          <test-case name="NUnit.Framework.Tests.LessFixture.NotLessWhenEqual" executed="True" result="Success" success="True" time="0.001" asserts="2" />
+                        </results>
+                      </test-suite>
+                      <test-suite type="TestFixture" name="ListContentsTests" executed="True" result="Success" success="True" time="0.018" asserts="0">
+                        <results>
+                          <test-case name="NUnit.Framework.Tests.ListContentsTests.ArrayFails" executed="True" result="Success" success="True" time="0.001" asserts="2" />
+                          <test-case name="NUnit.Framework.Tests.ListContentsTests.ArrayListFails" executed="True" result="Success" success="True" time="0.000" asserts="2" />
+                          <test-case name="NUnit.Framework.Tests.ListContentsTests.ArrayListSucceeds" executed="True" result="Success" success="True" time="0.000" asserts="3" />
+                          <test-case name="NUnit.Framework.Tests.ListContentsTests.ArraySucceeds" executed="True" result="Success" success="True" time="0.000" asserts="3" />
+                          <test-case name="NUnit.Framework.Tests.ListContentsTests.DifferentTypesMayBeEqual" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Framework.Tests.ListContentsTests.EmptyArrayFails" executed="True" result="Success" success="True" time="0.001" asserts="2" />
+                          <test-case name="NUnit.Framework.Tests.ListContentsTests.NullArrayIsError" executed="True" result="Success" success="True" time="0.001" asserts="1" />
+                        </results>
+                      </test-suite>
+                      <test-suite type="TestFixture" name="NotEqualFixture" executed="True" result="Success" success="True" time="0.020" asserts="0">
+                        <results>
+                          <test-case name="NUnit.Framework.Tests.NotEqualFixture.ArraysNotEqual" executed="True" result="Success" success="True" time="0.001" asserts="1" />
+                          <test-case name="NUnit.Framework.Tests.NotEqualFixture.ArraysNotEqualFails" executed="True" result="Success" success="True" time="0.002" asserts="2" />
+                          <test-case name="NUnit.Framework.Tests.NotEqualFixture.NotEqual" executed="True" result="Success" success="True" time="0.001" asserts="1" />
+                          <test-case name="NUnit.Framework.Tests.NotEqualFixture.NotEqualFails" executed="True" result="Success" success="True" time="0.000" asserts="2" />
+                          <test-case name="NUnit.Framework.Tests.NotEqualFixture.NotEqualSameTypes" executed="True" result="Success" success="True" time="0.002" asserts="21" />
+                          <test-case name="NUnit.Framework.Tests.NotEqualFixture.NullEqualsNull" executed="True" result="Success" success="True" time="0.001" asserts="2" />
+                          <test-case name="NUnit.Framework.Tests.NotEqualFixture.NullNotEqualToNonNull" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Framework.Tests.NotEqualFixture.UInt" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                        </results>
+                      </test-suite>
+                      <test-suite type="TestFixture" name="NotSameFixture" executed="True" result="Success" success="True" time="0.005" asserts="0">
+                        <results>
+                          <test-case name="NUnit.Framework.Tests.NotSameFixture.NotSame" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Framework.Tests.NotSameFixture.NotSameFails" executed="True" result="Success" success="True" time="0.000" asserts="2" />
+                        </results>
+                      </test-suite>
+                      <test-suite type="TestFixture" name="NullableTypesTests" executed="True" result="Success" success="True" time="0.021" asserts="0">
+                        <categories>
+                          <category name="Generics" />
+                        </categories>
+                        <results>
+                          <test-case name="NUnit.Framework.Tests.NullableTypesTests.CanCompareNullableEnums" executed="True" result="Success" success="True" time="0.000" asserts="3" />
+                          <test-case name="NUnit.Framework.Tests.NullableTypesTests.CanCompareNullableMixedNumerics" executed="True" result="Success" success="True" time="0.003" asserts="36" />
+                          <test-case name="NUnit.Framework.Tests.NullableTypesTests.CanCompareNullableStructs" executed="True" result="Success" success="True" time="0.001" asserts="4" />
+                          <test-case name="NUnit.Framework.Tests.NullableTypesTests.CanCompareWithTolerance" executed="True" result="Success" success="True" time="0.001" asserts="4" />
+                          <test-case name="NUnit.Framework.Tests.NullableTypesTests.CanTestForNaN" executed="True" result="Success" success="True" time="0.000" asserts="2" />
+                          <test-case name="NUnit.Framework.Tests.NullableTypesTests.CanTestForNull" executed="True" result="Success" success="True" time="0.000" asserts="4" />
+                        </results>
+                      </test-suite>
+                      <test-suite type="TestFixture" name="RandomizerTests" executed="True" result="Success" success="True" time="0.019" asserts="0">
+                        <results>
+                          <test-case name="NUnit.Framework.Tests.RandomizerTests.RandomDoublesAreUnique" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Framework.Tests.RandomizerTests.RandomIntsAreUnique" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Framework.Tests.RandomizerTests.RandomizersWithDifferentSeedsReturnDifferentValues" executed="True" result="Success" success="True" time="0.001" asserts="10" />
+                          <test-case name="NUnit.Framework.Tests.RandomizerTests.RandomizersWithSameSeedsReturnSameValues" executed="True" result="Success" success="True" time="0.001" asserts="10" />
+                          <test-case name="NUnit.Framework.Tests.RandomizerTests.RandomSeedsAreUnique" executed="True" result="Success" success="True" time="0.001" asserts="1" />
+                          <test-case name="NUnit.Framework.Tests.RandomizerTests.ReturnsDifferentRandomizersForDifferentMethods" executed="True" result="Success" success="True" time="0.001" asserts="1" />
+                          <test-case name="NUnit.Framework.Tests.RandomizerTests.ReturnsSameRandomizerForDifferentParametersOfSameMethod" executed="True" result="Success" success="True" time="0.001" asserts="1" />
+                          <test-case name="NUnit.Framework.Tests.RandomizerTests.ReturnsSameRandomizerForSameMethod" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Framework.Tests.RandomizerTests.ReturnsSameRandomizerForSameParameter" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                        </results>
+                      </test-suite>
+                      <test-suite type="TestFixture" name="RangeTests" executed="True" result="Success" success="True" time="0.014" asserts="0">
+                        <results>
+                          <test-case name="NUnit.Framework.Tests.RangeTests.InRangeFails" executed="True" result="Success" success="True" time="0.001" asserts="2" />
+                          <test-case name="NUnit.Framework.Tests.RangeTests.InRangeSucceeds" executed="True" result="Success" success="True" time="0.005" asserts="3" />
+                          <test-case name="NUnit.Framework.Tests.RangeTests.NotInRangeFails" executed="True" result="Success" success="True" time="0.001" asserts="2" />
+                          <test-case name="NUnit.Framework.Tests.RangeTests.NotInRangeSucceeds" executed="True" result="Success" success="True" time="0.000" asserts="2" />
+                        </results>
+                      </test-suite>
+                      <test-suite type="TestFixture" name="SameFixture" executed="True" result="Success" success="True" time="0.005" asserts="0">
+                        <results>
+                          <test-case name="NUnit.Framework.Tests.SameFixture.Same" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Framework.Tests.SameFixture.SameFails" executed="True" result="Success" success="True" time="0.001" asserts="2" />
+                          <test-case name="NUnit.Framework.Tests.SameFixture.SameValueTypes" executed="True" result="Success" success="True" time="0.001" asserts="2" />
+                        </results>
+                      </test-suite>
+                      <test-suite type="TestFixture" name="StringAssertTests" executed="True" result="Success" success="True" time="0.052" asserts="0">
+                        <results>
+                          <test-case name="NUnit.Framework.Tests.StringAssertTests.CaseInsensitiveCompare" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Framework.Tests.StringAssertTests.CaseInsensitiveCompareFails" executed="True" result="Success" success="True" time="0.002" asserts="2" />
+                          <test-case name="NUnit.Framework.Tests.StringAssertTests.Contains" executed="True" result="Success" success="True" time="0.001" asserts="3" />
+                          <test-case name="NUnit.Framework.Tests.StringAssertTests.ContainsFails" executed="True" result="Success" success="True" time="0.001" asserts="2" />
+                          <test-case name="NUnit.Framework.Tests.StringAssertTests.DifferentEncodingsOfSameStringAreNotEqual" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Framework.Tests.StringAssertTests.DoesNotContain" executed="True" result="Success" success="True" time="0.001" asserts="1" />
+                          <test-case name="NUnit.Framework.Tests.StringAssertTests.DoesNotContainFails" executed="True" result="Success" success="True" time="0.001" asserts="1" />
+                          <test-case name="NUnit.Framework.Tests.StringAssertTests.DoesNotEndWith" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Framework.Tests.StringAssertTests.DoesNotEndWithFails" executed="True" result="Success" success="True" time="0.004" asserts="1" />
+                          <test-case name="NUnit.Framework.Tests.StringAssertTests.DoesNotStartWith" executed="True" result="Success" success="True" time="0.001" asserts="1" />
+                          <test-case name="NUnit.Framework.Tests.StringAssertTests.DoesNotStartWithFails" executed="True" result="Success" success="True" time="0.003" asserts="1" />
+                          <test-case name="NUnit.Framework.Tests.StringAssertTests.EndsWith" executed="True" result="Success" success="True" time="0.000" asserts="2" />
+                          <test-case name="NUnit.Framework.Tests.StringAssertTests.EndsWithFails" executed="True" result="Success" success="True" time="0.001" asserts="2" />
+                          <test-case name="NUnit.Framework.Tests.StringAssertTests.IsMatch" executed="True" result="Success" success="True" time="0.003" asserts="1" />
+                          <test-case name="NUnit.Framework.Tests.StringAssertTests.IsMatchFails" executed="True" result="Success" success="True" time="0.001" asserts="2" />
+                          <test-case name="NUnit.Framework.Tests.StringAssertTests.StartsWith" executed="True" result="Success" success="True" time="0.000" asserts="2" />
+                          <test-case name="NUnit.Framework.Tests.StringAssertTests.StartsWithFails" executed="True" result="Success" success="True" time="0.000" asserts="2" />
+                        </results>
+                      </test-suite>
+                      <test-suite type="TestFixture" name="TestFixtureAttributeTests" executed="True" result="Success" success="True" time="0.011" asserts="0">
+                        <results>
+                          <test-case name="NUnit.Framework.Tests.TestFixtureAttributeTests.ConstructWithCombinedArgs" executed="True" result="Success" success="True" time="0.000" asserts="2">
+                            <categories>
+                              <category name="Generics" />
+                            </categories>
+                          </test-case>
+                          <test-case name="NUnit.Framework.Tests.TestFixtureAttributeTests.ConstructWithFixtureArgs" executed="True" result="Success" success="True" time="0.000" asserts="2" />
+                          <test-case name="NUnit.Framework.Tests.TestFixtureAttributeTests.ConstructWithFixtureArgsAndSetTypeArgs" executed="True" result="Success" success="True" time="0.001" asserts="2">
+                            <categories>
+                              <category name="Generics" />
+                            </categories>
+                          </test-case>
+                          <test-case name="NUnit.Framework.Tests.TestFixtureAttributeTests.ConstructWithJustTypeArgs" executed="True" result="Success" success="True" time="0.001" asserts="2">
+                            <categories>
+                              <category name="Generics" />
+                            </categories>
+                          </test-case>
+                          <test-case name="NUnit.Framework.Tests.TestFixtureAttributeTests.ConstructWithNoArgumentsAndSetTypeArgs" executed="True" result="Success" success="True" time="0.001" asserts="2">
+                            <categories>
+                              <category name="Generics" />
+                            </categories>
+                          </test-case>
+                          <test-case name="NUnit.Framework.Tests.TestFixtureAttributeTests.ConstructWithoutArguments" executed="True" result="Success" success="True" time="0.000" asserts="2" />
+                        </results>
+                      </test-suite>
+                      <test-suite type="TestFixture" name="TextMessageWriterTests" executed="True" result="Success" success="True" time="0.026" asserts="0">
+                        <results>
+                          <test-case name="NUnit.Framework.Tests.TextMessageWriterTests.ConnectorIsWrittenWithSurroundingSpaces" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Framework.Tests.TextMessageWriterTests.DateTimeTest" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Framework.Tests.TextMessageWriterTests.DecimalIsWrittenToTwentyNineDigits" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Framework.Tests.TextMessageWriterTests.DecimalIsWrittenWithTrailingM" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Framework.Tests.TextMessageWriterTests.DisplayStringDifferences" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Framework.Tests.TextMessageWriterTests.DisplayStringDifferences_NoClipping" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Framework.Tests.TextMessageWriterTests.DoubleIsWrittenToSeventeenDigits" executed="True" result="Success" success="True" time="0.001" asserts="1" />
+                          <test-case name="NUnit.Framework.Tests.TextMessageWriterTests.DoubleIsWrittenWithTrailingD" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Framework.Tests.TextMessageWriterTests.FloatIsWrittenToNineDigits" executed="True" result="Success" success="True" time="0.000" asserts="2" />
+                          <test-case name="NUnit.Framework.Tests.TextMessageWriterTests.FloatIsWrittenWithTrailingF" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Framework.Tests.TextMessageWriterTests.IntegerIsWrittenAsIs" executed="True" result="Success" success="True" time="0.001" asserts="1" />
+                          <test-case name="NUnit.Framework.Tests.TextMessageWriterTests.PredicateIsWrittenWithTrailingSpace" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Framework.Tests.TextMessageWriterTests.StringIsWrittenWithQuotes" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                        </results>
+                      </test-suite>
+                      <test-suite type="TestFixture" name="TypeAssertTests" executed="True" result="Success" success="True" time="0.025" asserts="0">
+                        <results>
+                          <test-case name="NUnit.Framework.Tests.TypeAssertTests.ExactType" executed="True" result="Success" success="True" time="0.001" asserts="1" />
+                          <test-case name="NUnit.Framework.Tests.TypeAssertTests.ExactTypeFails" executed="True" result="Success" success="True" time="0.001" asserts="2" />
+                          <test-case name="NUnit.Framework.Tests.TypeAssertTests.IsAssignableFrom" executed="True" result="Success" success="True" time="0.001" asserts="3" />
+                          <test-case name="NUnit.Framework.Tests.TypeAssertTests.IsAssignableFromFails" executed="True" result="Success" success="True" time="0.002" asserts="2" />
+                          <test-case name="NUnit.Framework.Tests.TypeAssertTests.IsInstanceOf" executed="True" result="Success" success="True" time="0.000" asserts="3" />
+                          <test-case name="NUnit.Framework.Tests.TypeAssertTests.IsInstanceOfFails" executed="True" result="Success" success="True" time="0.001" asserts="2" />
+                          <test-case name="NUnit.Framework.Tests.TypeAssertTests.IsNotAssignableFrom" executed="True" result="Success" success="True" time="0.001" asserts="3" />
+                          <test-case name="NUnit.Framework.Tests.TypeAssertTests.IsNotAssignableFromFails" executed="True" result="Success" success="True" time="0.000" asserts="2" />
+                          <test-case name="NUnit.Framework.Tests.TypeAssertTests.IsNotInstanceOf" executed="True" result="Success" success="True" time="0.001" asserts="3" />
+                          <test-case name="NUnit.Framework.Tests.TypeAssertTests.IsNotInstanceOfFails" executed="True" result="Success" success="True" time="0.001" asserts="2" />
+                        </results>
+                      </test-suite>
+                      <test-suite type="TestFixture" name="ValuesAttributeTests" executed="True" result="Success" success="True" time="0.101" asserts="0">
+                        <results>
+                          <test-suite type="ParameterizedTest" name="CanConverDoubleToDecimal" executed="True" result="Success" success="True" time="0.001" asserts="0">
+                            <results>
+                              <test-case name="NUnit.Framework.Tests.ValuesAttributeTests.CanConverDoubleToDecimal(12.5m)" executed="True" result="Success" success="True" time="0.000" asserts="0" />
+                            </results>
+                          </test-suite>
+                          <test-suite type="ParameterizedTest" name="CanConvertDoubleRangeToDecimal" executed="True" result="Success" success="True" time="0.006" asserts="0">
+                            <results>
+                              <test-case name="NUnit.Framework.Tests.ValuesAttributeTests.CanConvertDoubleRangeToDecimal(1m)" executed="True" result="Success" success="True" time="0.000" asserts="0" />
+                              <test-case name="NUnit.Framework.Tests.ValuesAttributeTests.CanConvertDoubleRangeToDecimal(1.1m)" executed="True" result="Success" success="True" time="0.001" asserts="0" />
+                              <test-case name="NUnit.Framework.Tests.ValuesAttributeTests.CanConvertDoubleRangeToDecimal(1.2m)" executed="True" result="Success" success="True" time="0.000" asserts="0" />
+                              <test-case name="NUnit.Framework.Tests.ValuesAttributeTests.CanConvertDoubleRangeToDecimal(1.3m)" executed="True" result="Success" success="True" time="0.000" asserts="0" />
+                            </results>
+                          </test-suite>
+                          <test-suite type="ParameterizedTest" name="CanConvertIntRangeToByte" executed="True" result="Success" success="True" time="0.006" asserts="0">
+                            <results>
+                              <test-case name="NUnit.Framework.Tests.ValuesAttributeTests.CanConvertIntRangeToByte(1)" executed="True" result="Success" success="True" time="0.000" asserts="0" />
+                              <test-case name="NUnit.Framework.Tests.ValuesAttributeTests.CanConvertIntRangeToByte(2)" executed="True" result="Success" success="True" time="0.000" asserts="0" />
+                              <test-case name="NUnit.Framework.Tests.ValuesAttributeTests.CanConvertIntRangeToByte(3)" executed="True" result="Success" success="True" time="0.000" asserts="0" />
+                            </results>
+                          </test-suite>
+                          <test-suite type="ParameterizedTest" name="CanConvertIntRangeToDecimal" executed="True" result="Success" success="True" time="0.004" asserts="0">
+                            <results>
+                              <test-case name="NUnit.Framework.Tests.ValuesAttributeTests.CanConvertIntRangeToDecimal(1m)" executed="True" result="Success" success="True" time="0.001" asserts="0" />
+                              <test-case name="NUnit.Framework.Tests.ValuesAttributeTests.CanConvertIntRangeToDecimal(2m)" executed="True" result="Success" success="True" time="0.000" asserts="0" />
+                              <test-case name="NUnit.Framework.Tests.ValuesAttributeTests.CanConvertIntRangeToDecimal(3m)" executed="True" result="Success" success="True" time="0.000" asserts="0" />
+                            </results>
+                          </test-suite>
+                          <test-suite type="ParameterizedTest" name="CanConvertIntRangeToSByte" executed="True" result="Success" success="True" time="0.004" asserts="0">
+                            <results>
+                              <test-case name="NUnit.Framework.Tests.ValuesAttributeTests.CanConvertIntRangeToSByte(1)" executed="True" result="Success" success="True" time="0.001" asserts="0" />
+                              <test-case name="NUnit.Framework.Tests.ValuesAttributeTests.CanConvertIntRangeToSByte(2)" executed="True" result="Success" success="True" time="0.000" asserts="0" />
+                              <test-case name="NUnit.Framework.Tests.ValuesAttributeTests.CanConvertIntRangeToSByte(3)" executed="True" result="Success" success="True" time="0.000" asserts="0" />
+                            </results>
+                          </test-suite>
+                          <test-suite type="ParameterizedTest" name="CanConvertIntRangeToShort" executed="True" result="Success" success="True" time="0.004" asserts="0">
+                            <results>
+                              <test-case name="NUnit.Framework.Tests.ValuesAttributeTests.CanConvertIntRangeToShort(1)" executed="True" result="Success" success="True" time="0.000" asserts="0" />
+                              <test-case name="NUnit.Framework.Tests.ValuesAttributeTests.CanConvertIntRangeToShort(2)" executed="True" result="Success" success="True" time="0.000" asserts="0" />
+                              <test-case name="NUnit.Framework.Tests.ValuesAttributeTests.CanConvertIntRangeToShort(3)" executed="True" result="Success" success="True" time="0.000" asserts="0" />
+                            </results>
+                          </test-suite>
+                          <test-suite type="ParameterizedTest" name="CanConvertIntToDecimal" executed="True" result="Success" success="True" time="0.001" asserts="0">
+                            <results>
+                              <test-case name="NUnit.Framework.Tests.ValuesAttributeTests.CanConvertIntToDecimal(12m)" executed="True" result="Success" success="True" time="0.000" asserts="0" />
+                            </results>
+                          </test-suite>
+                          <test-suite type="ParameterizedTest" name="CanConvertRandomDoubleToDecimal" executed="True" result="Success" success="True" time="0.004" asserts="0">
+                            <results>
+                              <test-case name="NUnit.Framework.Tests.ValuesAttributeTests.CanConvertRandomDoubleToDecimal(8.14633362188299m)" executed="True" result="Success" success="True" time="0.000" asserts="0" />
+                              <test-case name="NUnit.Framework.Tests.ValuesAttributeTests.CanConvertRandomDoubleToDecimal(5.50450880383351m)" executed="True" result="Success" success="True" time="0.000" asserts="0" />
+                              <test-case name="NUnit.Framework.Tests.ValuesAttributeTests.CanConvertRandomDoubleToDecimal(5.0549624255183m)" executed="True" result="Success" success="True" time="0.000" asserts="0" />
+                            </results>
+                          </test-suite>
+                          <test-suite type="ParameterizedTest" name="CanConvertRandomIntToByte" executed="True" result="Success" success="True" time="0.004" asserts="0">
+                            <results>
+                              <test-case name="NUnit.Framework.Tests.ValuesAttributeTests.CanConvertRandomIntToByte(9)" executed="True" result="Success" success="True" time="0.001" asserts="0" />
+                              <test-case name="NUnit.Framework.Tests.ValuesAttributeTests.CanConvertRandomIntToByte(4)" executed="True" result="Success" success="True" time="0.000" asserts="0" />
+                              <test-case name="NUnit.Framework.Tests.ValuesAttributeTests.CanConvertRandomIntToByte(9)" executed="True" result="Success" success="True" time="0.000" asserts="0" />
+                            </results>
+                          </test-suite>
+                          <test-suite type="ParameterizedTest" name="CanConvertRandomIntToDecimal" executed="True" result="Success" success="True" time="0.005" asserts="0">
+                            <results>
+                              <test-case name="NUnit.Framework.Tests.ValuesAttributeTests.CanConvertRandomIntToDecimal(8m)" executed="True" result="Success" success="True" time="0.000" asserts="0" />
+                              <test-case name="NUnit.Framework.Tests.ValuesAttributeTests.CanConvertRandomIntToDecimal(7m)" executed="True" result="Success" success="True" time="0.000" asserts="0" />
+                              <test-case name="NUnit.Framework.Tests.ValuesAttributeTests.CanConvertRandomIntToDecimal(7m)" executed="True" result="Success" success="True" time="0.001" asserts="0" />
+                            </results>
+                          </test-suite>
+                          <test-suite type="ParameterizedTest" name="CanConvertRandomIntToSByte" executed="True" result="Success" success="True" time="0.005" asserts="0">
+                            <results>
+                              <test-case name="NUnit.Framework.Tests.ValuesAttributeTests.CanConvertRandomIntToSByte(3)" executed="True" result="Success" success="True" time="0.000" asserts="0" />
+                              <test-case name="NUnit.Framework.Tests.ValuesAttributeTests.CanConvertRandomIntToSByte(5)" executed="True" result="Success" success="True" time="0.000" asserts="0" />
+                              <test-case name="NUnit.Framework.Tests.ValuesAttributeTests.CanConvertRandomIntToSByte(7)" executed="True" result="Success" success="True" time="0.000" asserts="0" />
+                            </results>
+                          </test-suite>
+                          <test-suite type="ParameterizedTest" name="CanConvertRandomIntToShort" executed="True" result="Success" success="True" time="0.005" asserts="0">
+                            <results>
+                              <test-case name="NUnit.Framework.Tests.ValuesAttributeTests.CanConvertRandomIntToShort(1)" executed="True" result="Success" success="True" time="0.000" asserts="0" />
+                              <test-case name="NUnit.Framework.Tests.ValuesAttributeTests.CanConvertRandomIntToShort(2)" executed="True" result="Success" success="True" time="0.000" asserts="0" />
+                              <test-case name="NUnit.Framework.Tests.ValuesAttributeTests.CanConvertRandomIntToShort(7)" executed="True" result="Success" success="True" time="0.000" asserts="0" />
+                            </results>
+                          </test-suite>
+                          <test-suite type="ParameterizedTest" name="CanConvertSmallIntsToByte" executed="True" result="Success" success="True" time="0.001" asserts="0">
+                            <results>
+                              <test-case name="NUnit.Framework.Tests.ValuesAttributeTests.CanConvertSmallIntsToByte(5)" executed="True" result="Success" success="True" time="0.000" asserts="0" />
+                            </results>
+                          </test-suite>
+                          <test-suite type="ParameterizedTest" name="CanConvertSmallIntsToSByte" executed="True" result="Success" success="True" time="0.001" asserts="0">
+                            <results>
+                              <test-case name="NUnit.Framework.Tests.ValuesAttributeTests.CanConvertSmallIntsToSByte(5)" executed="True" result="Success" success="True" time="0.000" asserts="0" />
+                            </results>
+                          </test-suite>
+                          <test-suite type="ParameterizedTest" name="CanConvertSmallIntsToShort" executed="True" result="Success" success="True" time="0.001" asserts="0">
+                            <results>
+                              <test-case name="NUnit.Framework.Tests.ValuesAttributeTests.CanConvertSmallIntsToShort(5)" executed="True" result="Success" success="True" time="0.000" asserts="0" />
+                            </results>
+                          </test-suite>
+                          <test-suite type="ParameterizedTest" name="CanConvertStringToDecimal" executed="True" result="Success" success="True" time="0.001" asserts="0">
+                            <results>
+                              <test-case name="NUnit.Framework.Tests.ValuesAttributeTests.CanConvertStringToDecimal(12.5m)" executed="True" result="Success" success="True" time="0.001" asserts="0" />
+                            </results>
+                          </test-suite>
+                          <test-case name="NUnit.Framework.Tests.ValuesAttributeTests.RangeAttributeWithDoubleRangeAndStep" executed="True" result="Success" success="True" time="0.001" asserts="1" />
+                          <test-case name="NUnit.Framework.Tests.ValuesAttributeTests.RangeAttributeWithFloatRangeAndStep" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Framework.Tests.ValuesAttributeTests.RangeAttributeWithIntRange" executed="True" result="Success" success="True" time="0.001" asserts="1" />
+                          <test-case name="NUnit.Framework.Tests.ValuesAttributeTests.RangeAttributeWithIntRangeAndStep" executed="True" result="Success" success="True" time="0.001" asserts="1" />
+                          <test-case name="NUnit.Framework.Tests.ValuesAttributeTests.RangeAttributeWithLongRangeAndStep" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Framework.Tests.ValuesAttributeTests.ValuesAttributeProvidesSpecifiedValues" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                        </results>
+                      </test-suite>
+                    </results>
+                  </test-suite>
+                </results>
+              </test-suite>
+            </results>
+          </test-suite>
+        </results>
+      </test-suite>
+      <test-suite type="Assembly" name="C:\Program Files\NUnit 2.6.2\bin\tests/nunit.core.tests.dll" executed="True" result="Success" success="True" time="11.618" asserts="0">
+        <results>
+          <test-suite type="Namespace" name="NUnit" executed="True" result="Success" success="True" time="11.618" asserts="0">
+            <results>
+              <test-suite type="Namespace" name="Core" executed="True" result="Success" success="True" time="11.617" asserts="0">
+                <results>
+                  <test-suite type="Namespace" name="Tests" executed="True" result="Success" success="True" time="11.617" asserts="0">
+                    <results>
+                      <test-suite type="TestFixture" name="ActionAttributeExceptionTests" executed="True" result="Success" success="True" time="0.333" asserts="0">
+                        <results>
+                          <test-case name="NUnit.Core.Tests.ActionAttributeExceptionTests.AfterTestException" executed="True" result="Success" success="True" time="0.009" asserts="2" />
+                          <test-case name="NUnit.Core.Tests.ActionAttributeExceptionTests.BeforeTestException" executed="True" result="Success" success="True" time="0.003" asserts="2" />
+                        </results>
+                      </test-suite>
+                      <test-suite type="TestFixture" name="ActionAttributeTests" executed="True" result="Success" success="True" time="0.026" asserts="0">
+                        <results>
+                          <test-case name="NUnit.Core.Tests.ActionAttributeTests.ExpectedOutput_InCorrectOrder" executed="True" result="Success" success="True" time="0.001" asserts="1" />
+                          <test-case name="NUnit.Core.Tests.ActionAttributeTests.TestsRunsSuccessfully" executed="True" result="Success" success="True" time="0.003" asserts="1" />
+                        </results>
+                      </test-suite>
+                      <test-suite type="TestFixture" name="AssemblyHelperTests" executed="True" result="Success" success="True" time="0.055" asserts="0">
+                        <results>
+                          <test-suite type="ParameterizedTest" name="GetAssemblyPathFromEscapedCodeBase_Linux" executed="False" result="Skipped">
+                            <reason>
+                              <message><![CDATA[Only supported on Linux]]></message>
+                            </reason>
+                            <results>
+                              <test-case name="NUnit.Core.Tests.AssemblyHelperTests.GetAssemblyPathFromEscapedCodeBase_Linux(&quot;file:///path/to/assembly.dll&quot;)" executed="False" result="Skipped">
+                                <reason>
+                                  <message><![CDATA[Only supported on Linux]]></message>
+                                </reason>
+                              </test-case>
+                              <test-case name="NUnit.Core.Tests.AssemblyHelperTests.GetAssemblyPathFromEscapedCodeBase_Linux(&quot;file://path/to/assembly.dll&quot;)" executed="False" result="Skipped">
+                                <reason>
+                                  <message><![CDATA[Only supported on Linux]]></message>
+                                </reason>
+                              </test-case>
+                              <test-case name="NUnit.Core.Tests.AssemblyHelperTests.GetAssemblyPathFromEscapedCodeBase_Linux(&quot;file:///dev/C#/assembly.dll&quot;)" executed="False" result="Skipped">
+                                <reason>
+                                  <message><![CDATA[Only supported on Linux]]></message>
+                                </reason>
+                              </test-case>
+                              <test-case name="NUnit.Core.Tests.AssemblyHelperTests.GetAssemblyPathFromEscapedCodeBase_Linux(&quot;file:///dev/funnychars?:=/assembly.dll&quot;)" executed="False" result="Skipped">
+                                <reason>
+                                  <message><![CDATA[Only supported on Linux]]></message>
+                                </reason>
+                              </test-case>
+                              <test-case name="NUnit.Core.Tests.AssemblyHelperTests.GetAssemblyPathFromEscapedCodeBase_Linux(&quot;file:///my path/to my/assembly.dll&quot;)" executed="False" result="Skipped">
+                                <reason>
+                                  <message><![CDATA[Only supported on Linux]]></message>
+                                </reason>
+                              </test-case>
+                              <test-case name="NUnit.Core.Tests.AssemblyHelperTests.GetAssemblyPathFromEscapedCodeBase_Linux(&quot;file://my path/to my/assembly.dll&quot;)" executed="False" result="Skipped">
+                                <reason>
+                                  <message><![CDATA[Only supported on Linux]]></message>
+                                </reason>
+                              </test-case>
+                            </results>
+                          </test-suite>
+                          <test-suite type="ParameterizedTest" name="GetAssemblyPathFromEscapedCodeBase_Windows" executed="True" result="Success" success="True" time="0.035" asserts="0">
+                            <results>
+                              <test-case name="NUnit.Core.Tests.AssemblyHelperTests.GetAssemblyPathFromEscapedCodeBase_Windows(&quot;file:///C:/dev/C%23/assembly.dll&quot;,&quot;C:\\dev\\C#\\assembly.dll&quot;)" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                              <test-case name="NUnit.Core.Tests.AssemblyHelperTests.GetAssemblyPathFromEscapedCodeBase_Windows(&quot;file:///dev/funnychars?:=/assembly.dll&quot;,&quot;/dev/funnychars?:=/assembly.dll&quot;)" executed="True" result="Success" success="True" time="0.011" asserts="1" />
+                              <test-case name="NUnit.Core.Tests.AssemblyHelperTests.GetAssemblyPathFromEscapedCodeBase_Windows(&quot;file:///dev/C%23/assembly.dll&quot;,&quot;/dev/C#/assembly.dll&quot;)" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                              <test-case name="NUnit.Core.Tests.AssemblyHelperTests.GetAssemblyPathFromEscapedCodeBase_Windows(&quot;file://C:/my%20path/to%20my/assembly.dll&quot;,&quot;C:\\my path\\to my\\assembly.dll&quot;)" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                              <test-case name="NUnit.Core.Tests.AssemblyHelperTests.GetAssemblyPathFromEscapedCodeBase_Windows(&quot;file:///my%20path/to%20my/assembly.dll&quot;,&quot;/my path/to my/assembly.dll&quot;)" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                              <test-case name="NUnit.Core.Tests.AssemblyHelperTests.GetAssemblyPathFromEscapedCodeBase_Windows(&quot;file:///C:/path/to/assembly.dll&quot;,&quot;C:\\path\\to\\assembly.dll&quot;)" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                              <test-case name="NUnit.Core.Tests.AssemblyHelperTests.GetAssemblyPathFromEscapedCodeBase_Windows(&quot;file://C:/path/to/assembly.dll&quot;,&quot;C:\\path\\to\\assembly.dll&quot;)" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                              <test-case name="NUnit.Core.Tests.AssemblyHelperTests.GetAssemblyPathFromEscapedCodeBase_Windows(&quot;file:///C:/dev/funnychars?:=/assembly.dll&quot;,&quot;C:\\dev\\funnychars?:=\\assembly.dll&quot;)" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                              <test-case name="NUnit.Core.Tests.AssemblyHelperTests.GetAssemblyPathFromEscapedCodeBase_Windows(&quot;file:///path/to/assembly.dll&quot;,&quot;/path/to/assembly.dll&quot;)" executed="True" result="Success" success="True" time="0.004" asserts="1" />
+                              <test-case name="NUnit.Core.Tests.AssemblyHelperTests.GetAssemblyPathFromEscapedCodeBase_Windows(&quot;file://server/path/to/assembly.dll&quot;,&quot;\\\\server\\path\\to\\assembly.dll&quot;)" executed="True" result="Success" success="True" time="0.001" asserts="1" />
+                            </results>
+                          </test-suite>
+                          <test-case name="NUnit.Core.Tests.AssemblyHelperTests.GetPathForAssembly" executed="True" result="Success" success="True" time="0.001" asserts="2" />
+                          <test-case name="NUnit.Core.Tests.AssemblyHelperTests.GetPathForType" executed="True" result="Success" success="True" time="0.001" asserts="2" />
+                        </results>
+                      </test-suite>
+                      <test-suite type="TestFixture" name="AssemblyReaderTests" executed="True" result="Success" success="True" time="0.027" asserts="0">
+                        <results>
+                          <test-case name="NUnit.Core.Tests.AssemblyReaderTests.CreateFromAssembly" executed="True" result="Success" success="True" time="0.001" asserts="1" />
+                          <test-case name="NUnit.Core.Tests.AssemblyReaderTests.CreateFromPath" executed="True" result="Success" success="True" time="0.001" asserts="1" />
+                          <test-case name="NUnit.Core.Tests.AssemblyReaderTests.ImageRuntimeVersion" executed="True" result="Success" success="True" time="0.002" asserts="1" />
+                          <test-case name="NUnit.Core.Tests.AssemblyReaderTests.IsDotNetFile" executed="True" result="Success" success="True" time="0.001" asserts="1" />
+                          <test-case name="NUnit.Core.Tests.AssemblyReaderTests.IsValidPeFile" executed="True" result="Success" success="True" time="0.001" asserts="1" />
+                          <test-case name="NUnit.Core.Tests.AssemblyReaderTests.IsValidPeFile_Fails" executed="True" result="Success" success="True" time="0.001" asserts="1" />
+                        </results>
+                      </test-suite>
+                      <test-suite type="TestFixture" name="AssemblyResolverTests" executed="True" result="Success" success="True" time="0.130" asserts="0">
+                        <results>
+                          <test-case name="NUnit.Core.Tests.AssemblyResolverTests.AddFile" executed="True" result="Success" success="True" time="0.127" asserts="0" />
+                        </results>
+                      </test-suite>
+                      <test-suite type="TestFixture" name="AssemblyTests" executed="True" result="Success" success="True" time="0.616" asserts="0">
+                        <results>
+                          <test-case name="NUnit.Core.Tests.AssemblyTests.AppSettingsLoaded" executed="True" result="Success" success="True" time="0.052" asserts="3" />
+                          <test-case name="NUnit.Core.Tests.AssemblyTests.LoadAssembly" executed="True" result="Success" success="True" time="0.383" asserts="2" />
+                          <test-case name="NUnit.Core.Tests.AssemblyTests.LoadAssemblyNotFound" executed="True" result="Success" success="True" time="0.119" asserts="0" />
+                          <test-case name="NUnit.Core.Tests.AssemblyTests.LoadAssemblyWithoutTestFixtures" executed="True" result="Success" success="True" time="0.032" asserts="3" />
+                          <test-case name="NUnit.Core.Tests.AssemblyTests.LoadTestFixtureFromAssembly" executed="True" result="Success" success="True" time="0.014" asserts="1" />
+                          <test-case name="NUnit.Core.Tests.AssemblyTests.RunSetsCurrentDirectory" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                        </results>
+                      </test-suite>
+                      <test-suite type="TestFixture" name="AssemblyVersionFixture" executed="True" result="Success" success="True" time="0.003" asserts="0">
+                        <results>
+                          <test-case name="NUnit.Core.Tests.AssemblyVersionFixture.Version" executed="True" result="Success" success="True" time="0.002" asserts="1" />
+                        </results>
+                      </test-suite>
+                      <test-suite type="TestFixture" name="AssertInconclusiveFixture" executed="True" result="Success" success="True" time="0.001" asserts="0">
+                        <results>
+                          <test-case name="NUnit.Core.Tests.AssertInconclusiveFixture.AssertInconclusiveThrowsException" executed="True" result="Success" success="True" time="0.001" asserts="2" />
+                        </results>
+                      </test-suite>
+                      <test-suite type="TestFixture" name="AssertPassFixture" executed="True" result="Success" success="True" time="0.006" asserts="0">
+                        <results>
+                          <test-case name="NUnit.Core.Tests.AssertPassFixture.AssertPassReturnsSuccess" executed="True" result="Success" success="True" time="0.002" asserts="0">
+                            <reason>
+                              <message><![CDATA[This test is OK!]]></message>
+                            </reason>
+                          </test-case>
+                          <test-case name="NUnit.Core.Tests.AssertPassFixture.SubsequentFailureIsIrrelevant" executed="True" result="Success" success="True" time="0.001" asserts="0">
+                            <reason>
+                              <message><![CDATA[This test is OK!]]></message>
+                            </reason>
+                          </test-case>
+                        </results>
+                      </test-suite>
+                      <test-suite type="TestFixture" name="AttributeInheritance" executed="True" result="Success" success="True" time="0.013" asserts="0">
+                        <results>
+                          <test-case name="NUnit.Core.Tests.AttributeInheritance.InheritedExplicitAttributeIsRecognized" executed="True" result="Success" success="True" time="0.002" asserts="2" />
+                          <test-case name="NUnit.Core.Tests.AttributeInheritance.InheritedFixtureAttributeIsRecognized" executed="True" result="Success" success="True" time="0.001" asserts="1" />
+                          <test-case name="NUnit.Core.Tests.AttributeInheritance.InheritedIgnoreAttributeIsRecognized" executed="True" result="Success" success="True" time="0.001" asserts="2" />
+                          <test-case name="NUnit.Core.Tests.AttributeInheritance.InheritedTestAttributeIsRecognized" executed="True" result="Success" success="True" time="0.002" asserts="1" />
+                        </results>
+                      </test-suite>
+                      <test-suite type="TestFixture" name="CallContextTests" executed="True" result="Success" success="True" time="0.012" asserts="0">
+                        <results>
+                          <test-case name="NUnit.Core.Tests.CallContextTests.GenericPrincipalTest" executed="True" result="Success" success="True" time="0.000" asserts="0" />
+                          <test-case name="NUnit.Core.Tests.CallContextTests.ILogicalThreadAffinativeTest" executed="True" result="Success" success="True" time="0.000" asserts="0" />
+                          <test-case name="NUnit.Core.Tests.CallContextTests.ILogicalThreadAffinativeTestConsole" executed="True" result="Success" success="True" time="0.000" asserts="0" />
+                          <test-case name="NUnit.Core.Tests.CallContextTests.SetCustomPrincipalOnThread" executed="True" result="Success" success="True" time="0.000" asserts="0" />
+                          <test-case name="NUnit.Core.Tests.CallContextTests.SetGenericPrincipalOnThread" executed="True" result="Success" success="True" time="0.000" asserts="0" />
+                          <test-case name="NUnit.Core.Tests.CallContextTests.UseCustomIdentity" executed="True" result="Success" success="True" time="0.000" asserts="0" />
+                        </results>
+                      </test-suite>
+                      <test-suite type="TestFixture" name="CategoryAttributeTests" executed="True" result="Success" success="True" time="0.033" asserts="0">
+                        <results>
+                          <test-case name="NUnit.Core.Tests.CategoryAttributeTests.CanDeriveFromCategoryAttribute" executed="True" result="Success" success="True" time="0.003" asserts="1" />
+                          <test-case name="NUnit.Core.Tests.CategoryAttributeTests.CategoryOnFixture" executed="True" result="Success" success="True" time="0.003" asserts="1" />
+                          <test-case name="NUnit.Core.Tests.CategoryAttributeTests.CategoryOnTestCase" executed="True" result="Success" success="True" time="0.002" asserts="1" />
+                          <test-suite type="ParameterizedTest" name="CountTestsUsingCategoryFilter" executed="True" result="Success" success="True" time="0.011" asserts="0">
+                            <results>
+                              <test-case name="NUnit.Core.Tests.CategoryAttributeTests.CountTestsUsingCategoryFilter(&quot;Critical&quot;)" executed="True" result="Success" success="True" time="0.003" asserts="1" />
+                              <test-case name="NUnit.Core.Tests.CategoryAttributeTests.CountTestsUsingCategoryFilter(&quot;Long&quot;)" executed="True" result="Success" success="True" time="0.002" asserts="1" />
+                              <test-case name="NUnit.Core.Tests.CategoryAttributeTests.CountTestsUsingCategoryFilter(&quot;Database&quot;)" executed="True" result="Success" success="True" time="0.001" asserts="1" />
+                            </results>
+                          </test-suite>
+                          <test-case name="NUnit.Core.Tests.CategoryAttributeTests.CountTestsWithoutCategoryFilter" executed="True" result="Success" success="True" time="0.001" asserts="1" />
+                          <test-case name="NUnit.Core.Tests.CategoryAttributeTests.DerivedCategoryMayBeInherited" executed="True" result="Success" success="True" time="0.002" asserts="1" />
+                        </results>
+                      </test-suite>
+                      <test-suite type="TestFixture" name="CombinatorialTests" executed="True" result="Success" success="True" time="0.093" asserts="0">
+                        <results>
+                          <test-suite type="ParameterizedTest" name="RandomArgsAreIndependent" executed="True" result="Success" success="True" time="0.001" asserts="0">
+                            <results>
+                              <test-case name="NUnit.Core.Tests.CombinatorialTests.RandomArgsAreIndependent(0.709089772174642d,0.572929527877332d)" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                            </results>
+                          </test-suite>
+                          <test-suite type="ParameterizedTest" name="RandomTest" executed="True" result="Success" success="True" time="0.009" asserts="0">
+                            <results>
+                              <test-case name="NUnit.Core.Tests.CombinatorialTests.RandomTest(61,0.399936584476352d)" executed="True" result="Success" success="True" time="0.000" asserts="2" />
+                              <test-case name="NUnit.Core.Tests.CombinatorialTests.RandomTest(180,0.673102904890246d)" executed="True" result="Success" success="True" time="0.000" asserts="2" />
+                              <test-case name="NUnit.Core.Tests.CombinatorialTests.RandomTest(119,0.118893442265174d)" executed="True" result="Success" success="True" time="0.000" asserts="2" />
+                              <test-case name="NUnit.Core.Tests.CombinatorialTests.RandomTest(211,0.688360472995956d)" executed="True" result="Success" success="True" time="0.000" asserts="2" />
+                              <test-case name="NUnit.Core.Tests.CombinatorialTests.RandomTest(170,0.417889132359013d)" executed="True" result="Success" success="True" time="0.000" asserts="2" />
+                            </results>
+                          </test-suite>
+                          <test-suite type="ParameterizedTest" name="RangeTest" executed="True" result="Success" success="True" time="0.017" asserts="0">
+                            <results>
+                              <test-case name="NUnit.Core.Tests.CombinatorialTests.RangeTest(0.2d,10)" executed="True" result="Success" success="True" time="0.000" asserts="0" />
+                              <test-case name="NUnit.Core.Tests.CombinatorialTests.RangeTest(0.2d,15)" executed="True" result="Success" success="True" time="0.000" asserts="0" />
+                              <test-case name="NUnit.Core.Tests.CombinatorialTests.RangeTest(0.2d,20)" executed="True" result="Success" success="True" time="0.000" asserts="0" />
+                              <test-case name="NUnit.Core.Tests.CombinatorialTests.RangeTest(0.4d,10)" executed="True" result="Success" success="True" time="0.000" asserts="0" />
+                              <test-case name="NUnit.Core.Tests.CombinatorialTests.RangeTest(0.4d,15)" executed="True" result="Success" success="True" time="0.000" asserts="0" />
+                              <test-case name="NUnit.Core.Tests.CombinatorialTests.RangeTest(0.4d,20)" executed="True" result="Success" success="True" time="0.000" asserts="0" />
+                              <test-case name="NUnit.Core.Tests.CombinatorialTests.RangeTest(0.6d,10)" executed="True" result="Success" success="True" time="0.000" asserts="0" />
+                              <test-case name="NUnit.Core.Tests.CombinatorialTests.RangeTest(0.6d,15)" executed="True" result="Success" success="True" time="0.000" asserts="0" />
+                              <test-case name="NUnit.Core.Tests.CombinatorialTests.RangeTest(0.6d,20)" executed="True" result="Success" success="True" time="0.000" asserts="0" />
+                            </results>
+                          </test-suite>
+                          <test-suite type="ParameterizedTest" name="SingleArgument" executed="True" result="Success" success="True" time="0.004" asserts="0">
+                            <results>
+                              <test-case name="NUnit.Core.Tests.CombinatorialTests.SingleArgument(1.3d)" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                              <test-case name="NUnit.Core.Tests.CombinatorialTests.SingleArgument(1.7d)" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                              <test-case name="NUnit.Core.Tests.CombinatorialTests.SingleArgument(1.5d)" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                            </results>
+                          </test-suite>
+                          <test-suite type="ParameterizedTest" name="ThreeArguments_Combinatorial" executed="True" result="Success" success="True" time="0.030" asserts="0">
+                            <results>
+                              <test-case name="NUnit.Core.Tests.CombinatorialTests.ThreeArguments_Combinatorial(1,10,&quot;Charlie&quot;)" executed="True" result="Success" success="True" time="0.001" asserts="2" />
+                              <test-case name="NUnit.Core.Tests.CombinatorialTests.ThreeArguments_Combinatorial(1,10,&quot;Joe&quot;)" executed="True" result="Success" success="True" time="0.000" asserts="2" />
+                              <test-case name="NUnit.Core.Tests.CombinatorialTests.ThreeArguments_Combinatorial(1,10,&quot;Frank&quot;)" executed="True" result="Success" success="True" time="0.000" asserts="2" />
+                              <test-case name="NUnit.Core.Tests.CombinatorialTests.ThreeArguments_Combinatorial(1,20,&quot;Charlie&quot;)" executed="True" result="Success" success="True" time="0.000" asserts="2" />
+                              <test-case name="NUnit.Core.Tests.CombinatorialTests.ThreeArguments_Combinatorial(1,20,&quot;Joe&quot;)" executed="True" result="Success" success="True" time="0.000" asserts="2" />
+                              <test-case name="NUnit.Core.Tests.CombinatorialTests.ThreeArguments_Combinatorial(1,20,&quot;Frank&quot;)" executed="True" result="Success" success="True" time="0.000" asserts="2" />
+                              <test-case name="NUnit.Core.Tests.CombinatorialTests.ThreeArguments_Combinatorial(2,10,&quot;Charlie&quot;)" executed="True" result="Success" success="True" time="0.000" asserts="2" />
+                              <test-case name="NUnit.Core.Tests.CombinatorialTests.ThreeArguments_Combinatorial(2,10,&quot;Joe&quot;)" executed="True" result="Success" success="True" time="0.000" asserts="2" />
+                              <test-case name="NUnit.Core.Tests.CombinatorialTests.ThreeArguments_Combinatorial(2,10,&quot;Frank&quot;)" executed="True" result="Success" success="True" time="0.000" asserts="2" />
+                              <test-case name="NUnit.Core.Tests.CombinatorialTests.ThreeArguments_Combinatorial(2,20,&quot;Charlie&quot;)" executed="True" result="Success" success="True" time="0.000" asserts="2" />
+                              <test-case name="NUnit.Core.Tests.CombinatorialTests.ThreeArguments_Combinatorial(2,20,&quot;Joe&quot;)" executed="True" result="Success" success="True" time="0.000" asserts="2" />
+                              <test-case name="NUnit.Core.Tests.CombinatorialTests.ThreeArguments_Combinatorial(2,20,&quot;Frank&quot;)" executed="True" result="Success" success="True" time="0.000" asserts="2" />
+                              <test-case name="NUnit.Core.Tests.CombinatorialTests.ThreeArguments_Combinatorial(3,10,&quot;Charlie&quot;)" executed="True" result="Success" success="True" time="0.000" asserts="2" />
+                              <test-case name="NUnit.Core.Tests.CombinatorialTests.ThreeArguments_Combinatorial(3,10,&quot;Joe&quot;)" executed="True" result="Success" success="True" time="0.000" asserts="2" />
+                              <test-case name="NUnit.Core.Tests.CombinatorialTests.ThreeArguments_Combinatorial(3,10,&quot;Frank&quot;)" executed="True" result="Success" success="True" time="0.000" asserts="2" />
+                              <test-case name="NUnit.Core.Tests.CombinatorialTests.ThreeArguments_Combinatorial(3,20,&quot;Charlie&quot;)" executed="True" result="Success" success="True" time="0.000" asserts="2" />
+                              <test-case name="NUnit.Core.Tests.CombinatorialTests.ThreeArguments_Combinatorial(3,20,&quot;Joe&quot;)" executed="True" result="Success" success="True" time="0.000" asserts="2" />
+                              <test-case name="NUnit.Core.Tests.CombinatorialTests.ThreeArguments_Combinatorial(3,20,&quot;Frank&quot;)" executed="True" result="Success" success="True" time="0.001" asserts="2" />
+                            </results>
+                          </test-suite>
+                          <test-suite type="ParameterizedTest" name="ThreeArguments_Sequential" executed="True" result="Success" success="True" time="0.003" asserts="0">
+                            <results>
+                              <test-case name="NUnit.Core.Tests.CombinatorialTests.ThreeArguments_Sequential(1,10,&quot;Charlie&quot;)" executed="True" result="Success" success="True" time="0.000" asserts="2" />
+                              <test-case name="NUnit.Core.Tests.CombinatorialTests.ThreeArguments_Sequential(2,20,&quot;Joe&quot;)" executed="True" result="Success" success="True" time="0.000" asserts="2" />
+                              <test-case name="NUnit.Core.Tests.CombinatorialTests.ThreeArguments_Sequential(3,null,&quot;Frank&quot;)" executed="True" result="Success" success="True" time="0.000" asserts="2" />
+                            </results>
+                          </test-suite>
+                          <test-suite type="ParameterizedTest" name="TwoArguments_Combinatorial" executed="True" result="Success" success="True" time="0.009" asserts="0">
+                            <results>
+                              <test-case name="NUnit.Core.Tests.CombinatorialTests.TwoArguments_Combinatorial(1,10)" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                              <test-case name="NUnit.Core.Tests.CombinatorialTests.TwoArguments_Combinatorial(1,20)" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                              <test-case name="NUnit.Core.Tests.CombinatorialTests.TwoArguments_Combinatorial(2,10)" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                              <test-case name="NUnit.Core.Tests.CombinatorialTests.TwoArguments_Combinatorial(2,20)" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                              <test-case name="NUnit.Core.Tests.CombinatorialTests.TwoArguments_Combinatorial(3,10)" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                              <test-case name="NUnit.Core.Tests.CombinatorialTests.TwoArguments_Combinatorial(3,20)" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                            </results>
+                          </test-suite>
+                          <test-suite type="ParameterizedTest" name="TwoArguments_Sequential" executed="True" result="Success" success="True" time="0.004" asserts="0">
+                            <results>
+                              <test-case name="NUnit.Core.Tests.CombinatorialTests.TwoArguments_Sequential(1,10)" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                              <test-case name="NUnit.Core.Tests.CombinatorialTests.TwoArguments_Sequential(2,20)" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                              <test-case name="NUnit.Core.Tests.CombinatorialTests.TwoArguments_Sequential(3,null)" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                            </results>
+                          </test-suite>
+                        </results>
+                      </test-suite>
+                      <test-suite type="TestFixture" name="CoreExtensionsTests" executed="True" result="Success" success="True" time="0.985" asserts="0">
+                        <results>
+                          <test-case name="NUnit.Core.Tests.CoreExtensionsTests.CanAddDecorator" executed="True" result="Success" success="True" time="0.834" asserts="0" />
+                          <test-case name="NUnit.Core.Tests.CoreExtensionsTests.CanAddEventListener" executed="True" result="Success" success="True" time="0.097" asserts="0" />
+                          <test-case name="NUnit.Core.Tests.CoreExtensionsTests.CanAddSuiteBuilder" executed="True" result="Success" success="True" time="0.011" asserts="0" />
+                          <test-case name="NUnit.Core.Tests.CoreExtensionsTests.CanAddTestCaseBuilder" executed="True" result="Success" success="True" time="0.006" asserts="0" />
+                          <test-case name="NUnit.Core.Tests.CoreExtensionsTests.CanAddTestCaseBuilder2" executed="True" result="Success" success="True" time="0.012" asserts="0" />
+                          <test-case name="NUnit.Core.Tests.CoreExtensionsTests.DecoratorsRunInOrderOfPriorities" executed="True" result="Success" success="True" time="0.001" asserts="2" />
+                          <test-case name="NUnit.Core.Tests.CoreExtensionsTests.HasEventListenerExtensionPoint" executed="True" result="Success" success="True" time="0.000" asserts="3" />
+                          <test-case name="NUnit.Core.Tests.CoreExtensionsTests.HasSuiteBuildersExtensionPoint" executed="True" result="Success" success="True" time="0.001" asserts="3" />
+                          <test-case name="NUnit.Core.Tests.CoreExtensionsTests.HasTestCaseBuildersExtensionPoint" executed="True" result="Success" success="True" time="0.001" asserts="3" />
+                          <test-case name="NUnit.Core.Tests.CoreExtensionsTests.HasTestDecoratorsExtensionPoint" executed="True" result="Success" success="True" time="0.000" asserts="3" />
+                          <test-case name="NUnit.Core.Tests.CoreExtensionsTests.HasTestFrameworkRegistry" executed="True" result="Success" success="True" time="0.000" asserts="3" />
+                        </results>
+                      </test-suite>
+                      <test-suite type="TestFixture" name="CultureSettingAndDetectionTests" executed="True" result="Success" success="True" time="0.135" asserts="0">
+                        <results>
+                          <test-case name="NUnit.Core.Tests.CultureSettingAndDetectionTests.CanMatchAttributeWithExclude" executed="True" result="Success" success="True" time="0.001" asserts="2" />
+                          <test-case name="NUnit.Core.Tests.CultureSettingAndDetectionTests.CanMatchAttributeWithInclude" executed="True" result="Success" success="True" time="0.001" asserts="2" />
+                          <test-case name="NUnit.Core.Tests.CultureSettingAndDetectionTests.CanMatchAttributeWithIncludeAndExclude" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Core.Tests.CultureSettingAndDetectionTests.CanMatchStrings" executed="True" result="Success" success="True" time="0.001" asserts="5" />
+                          <test-case name="NUnit.Core.Tests.CultureSettingAndDetectionTests.LoadWithFrenchCanadianCulture" executed="True" result="Success" success="True" time="0.060" asserts="5" />
+                          <test-case name="NUnit.Core.Tests.CultureSettingAndDetectionTests.LoadWithFrenchCulture" executed="True" result="Success" success="True" time="0.007" asserts="5" />
+                          <test-case name="NUnit.Core.Tests.CultureSettingAndDetectionTests.LoadWithRussianCulture" executed="True" result="Success" success="True" time="0.006" asserts="5" />
+                          <test-case name="NUnit.Core.Tests.CultureSettingAndDetectionTests.SettingInvalidCultureGivesError" executed="True" result="Success" success="True" time="0.027" asserts="3" />
+                          <test-suite type="ParameterizedTest" name="UseWithParameterizedTest" executed="True" result="Success" success="True" time="0.002" asserts="0">
+                            <results>
+                              <test-case name="NUnit.Core.Tests.CultureSettingAndDetectionTests.UseWithParameterizedTest()" executed="True" result="Success" success="True" time="0.001" asserts="1" />
+                            </results>
+                          </test-suite>
+                        </results>
+                      </test-suite>
+                      <test-suite type="TestFixture" name="CultureSettingAndDetectionTests+NestedFixture" executed="True" result="Success" success="True" time="0.002" asserts="0">
+                        <results>
+                          <test-case name="NUnit.Core.Tests.CultureSettingAndDetectionTests+NestedFixture.CanSetCultureOnFixture" executed="True" result="Success" success="True" time="0.001" asserts="1" />
+                        </results>
+                      </test-suite>
+                      <test-suite type="TestFixture" name="DatapointTests" executed="True" result="Success" success="True" time="0.054" asserts="0">
+                        <results>
+                          <test-case name="NUnit.Core.Tests.DatapointTests.WorksOnArray" executed="True" result="Success" success="True" time="0.006" asserts="3" />
+                          <test-case name="NUnit.Core.Tests.DatapointTests.WorksOnField" executed="True" result="Success" success="True" time="0.005" asserts="3" />
+                          <test-case name="NUnit.Core.Tests.DatapointTests.WorksOnIEnumerableOfT" executed="True" result="Success" success="True" time="0.005" asserts="3" />
+                          <test-case name="NUnit.Core.Tests.DatapointTests.WorksOnIteratorReturningIEnumerableOfT" executed="True" result="Success" success="True" time="0.004" asserts="3" />
+                          <test-case name="NUnit.Core.Tests.DatapointTests.WorksOnMethodReturningArray" executed="True" result="Success" success="True" time="0.005" asserts="3" />
+                          <test-case name="NUnit.Core.Tests.DatapointTests.WorksOnMethodReturningIEnumerableOfT" executed="True" result="Success" success="True" time="0.004" asserts="3" />
+                          <test-case name="NUnit.Core.Tests.DatapointTests.WorksOnPropertyReturningArray" executed="True" result="Success" success="True" time="0.005" asserts="3" />
+                          <test-case name="NUnit.Core.Tests.DatapointTests.WorksOnPropertyReturningIEnumerableOfT" executed="True" result="Success" success="True" time="0.005" asserts="3" />
+                        </results>
+                      </test-suite>
+                      <test-suite type="TestFixture" name="DirectoryChangeTests" executed="True" result="Success" success="True" time="0.002" asserts="0">
+                        <results>
+                          <test-case name="NUnit.Core.Tests.DirectoryChangeTests.ChangingCurrentDirectoryGivesWarning" executed="True" result="Success" success="True" time="0.001" asserts="2" />
+                        </results>
+                      </test-suite>
+                      <test-suite type="TestFixture" name="DirectorySwapperTests" executed="True" result="Success" success="True" time="0.004" asserts="0">
+                        <results>
+                          <test-case name="NUnit.Core.Tests.DirectorySwapperTests.ChangeAndRestore" executed="True" result="Success" success="True" time="0.001" asserts="3" />
+                          <test-case name="NUnit.Core.Tests.DirectorySwapperTests.SwapAndRestore" executed="True" result="Success" success="True" time="0.000" asserts="2" />
+                        </results>
+                      </test-suite>
+                      <test-suite type="TestFixture" name="EventQueueTests" executed="True" result="Success" success="True" time="0.338" asserts="0">
+                        <results>
+                          <test-case name="NUnit.Core.Tests.EventQueueTests.DequeueEmpty" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Core.Tests.EventQueueTests.PumpAutoStopsOnRunFinished" executed="True" result="Success" success="True" time="0.102" asserts="3" />
+                          <test-case name="NUnit.Core.Tests.EventQueueTests.PumpEvents" executed="True" result="Success" success="True" time="0.008" asserts="12">
+                            <properties>
+                              <property name="Timeout" value="3000" />
+                            </properties>
+                          </test-case>
+                          <test-case name="NUnit.Core.Tests.EventQueueTests.PumpEventsWithAutoStop" executed="True" result="Success" success="True" time="0.003" asserts="1">
+                            <properties>
+                              <property name="Timeout" value="2000" />
+                            </properties>
+                          </test-case>
+                          <test-case name="NUnit.Core.Tests.EventQueueTests.PumpPendingEventsAfterAutoStop" executed="True" result="Success" success="True" time="0.102" asserts="2">
+                            <properties>
+                              <property name="Timeout" value="2000" />
+                            </properties>
+                          </test-case>
+                          <test-case name="NUnit.Core.Tests.EventQueueTests.PumpSynchronousAndAsynchronousEvents" executed="True" result="Success" success="True" time="0.004" asserts="6">
+                            <properties>
+                              <property name="Timeout" value="1000" />
+                            </properties>
+                          </test-case>
+                          <test-case name="NUnit.Core.Tests.EventQueueTests.QueueEvents" executed="True" result="Success" success="True" time="0.000" asserts="9" />
+                          <test-case name="NUnit.Core.Tests.EventQueueTests.SendEvents" executed="True" result="Success" success="True" time="0.001" asserts="9" />
+                          <test-case name="NUnit.Core.Tests.EventQueueTests.StartAndStopPumpOnEmptyQueue" executed="True" result="Success" success="True" time="0.002" asserts="2" />
+                          <test-case name="NUnit.Core.Tests.EventQueueTests.TracingEventListenerDoesNotDeadlock" executed="True" result="Success" success="True" time="0.082" asserts="0">
+                            <properties>
+                              <property name="Timeout" value="1000" />
+                            </properties>
+                          </test-case>
+                        </results>
+                      </test-suite>
+                      <test-suite type="TestFixture" name="EventQueueTests+DequeueBlocking_StopTest" executed="True" result="Success" success="True" time="0.034" asserts="0">
+                        <results>
+                          <test-case name="NUnit.Core.Tests.EventQueueTests+DequeueBlocking_StopTest.DequeueBlocking_Stop" executed="True" result="Success" success="True" time="0.033" asserts="3">
+                            <properties>
+                              <property name="Timeout" value="1000" />
+                            </properties>
+                          </test-case>
+                        </results>
+                      </test-suite>
+                      <test-suite type="TestFixture" name="EventQueueTests+SetWaitHandle_Enqueue_AsynchronousTest" executed="True" result="Success" success="True" time="0.033" asserts="0">
+                        <results>
+                          <test-case name="NUnit.Core.Tests.EventQueueTests+SetWaitHandle_Enqueue_AsynchronousTest.SetWaitHandle_Enqueue_Asynchronous" executed="True" result="Success" success="True" time="0.031" asserts="4">
+                            <properties>
+                              <property name="Timeout" value="1000" />
+                            </properties>
+                          </test-case>
+                        </results>
+                      </test-suite>
+                      <test-suite type="TestFixture" name="EventQueueTests+SetWaitHandle_Enqueue_SynchronousTest" executed="True" result="Success" success="True" time="0.064" asserts="0">
+                        <results>
+                          <test-case name="NUnit.Core.Tests.EventQueueTests+SetWaitHandle_Enqueue_SynchronousTest.SetWaitHandle_Enqueue_Synchronous" executed="True" result="Success" success="True" time="0.062" asserts="5">
+                            <properties>
+                              <property name="Timeout" value="1000" />
+                            </properties>
+                          </test-case>
+                        </results>
+                      </test-suite>
+                      <test-suite type="TestFixture" name="EventTestFixture" description="Tests that proper events are generated when running  test" executed="True" result="Success" success="True" time="0.117" asserts="0">
+                        <results>
+                          <test-case name="NUnit.Core.Tests.EventTestFixture.CheckEventListening" executed="True" result="Success" success="True" time="0.050" asserts="4" />
+                        </results>
+                      </test-suite>
+                      <test-suite type="TestFixture" name="ExpectExceptionTest" executed="True" result="Success" success="True" time="0.144" asserts="0">
+                        <results>
+                          <test-case name="NUnit.Core.Tests.ExpectExceptionTest.AssertFailBeforeException" executed="True" result="Success" success="True" time="0.003" asserts="2" />
+                          <test-case name="NUnit.Core.Tests.ExpectExceptionTest.CanExpectUnspecifiedException" executed="True" result="Success" success="True" time="0.001" asserts="0" />
+                          <test-case name="NUnit.Core.Tests.ExpectExceptionTest.ExceptionHandlerIsCalledWhenExceptionMatches" executed="True" result="Success" success="True" time="0.001" asserts="2" />
+                          <test-case name="NUnit.Core.Tests.ExpectExceptionTest.ExceptionHandlerIsCalledWhenExceptionMatches_AlternateHandler" executed="True" result="Success" success="True" time="0.002" asserts="2" />
+                          <test-case name="NUnit.Core.Tests.ExpectExceptionTest.ExceptionHandlerIsNotCalledWhenExceptionDoesNotMatch" executed="True" result="Success" success="True" time="0.002" asserts="2" />
+                          <test-case name="NUnit.Core.Tests.ExpectExceptionTest.ExceptionHandlerIsNotCalledWhenExceptionDoesNotMatch_AlternateHandler" executed="True" result="Success" success="True" time="0.001" asserts="2" />
+                          <test-case name="NUnit.Core.Tests.ExpectExceptionTest.MethodThrowsArgumentOutOfRange" executed="True" result="Success" success="True" time="0.003" asserts="1" />
+                          <test-case name="NUnit.Core.Tests.ExpectExceptionTest.MethodThrowsException" executed="True" result="Success" success="True" time="0.002" asserts="1" />
+                          <test-case name="NUnit.Core.Tests.ExpectExceptionTest.MethodThrowsRightExceptionMessage" executed="True" result="Success" success="True" time="0.003" asserts="1" />
+                          <test-case name="NUnit.Core.Tests.ExpectExceptionTest.MethodThrowsWrongExceptionMessage" executed="True" result="Success" success="True" time="0.005" asserts="1" />
+                          <test-case name="NUnit.Core.Tests.ExpectExceptionTest.SetUpThrowsSameException" executed="True" result="Success" success="True" time="0.003" asserts="1" />
+                          <test-case name="NUnit.Core.Tests.ExpectExceptionTest.TearDownThrowsSameException" executed="True" result="Success" success="True" time="0.004" asserts="1" />
+                          <test-case name="NUnit.Core.Tests.ExpectExceptionTest.TestExceptionNameNotThrown" executed="True" result="Success" success="True" time="0.000" asserts="2" />
+                          <test-case name="NUnit.Core.Tests.ExpectExceptionTest.TestExceptionNameNotThrownWithUserMessage" executed="True" result="Success" success="True" time="0.001" asserts="2" />
+                          <test-case name="NUnit.Core.Tests.ExpectExceptionTest.TestExceptionTypeNotThrown" executed="True" result="Success" success="True" time="0.001" asserts="2" />
+                          <test-case name="NUnit.Core.Tests.ExpectExceptionTest.TestExceptionTypeNotThrownWithUserMessage" executed="True" result="Success" success="True" time="0.001" asserts="2" />
+                          <test-case name="NUnit.Core.Tests.ExpectExceptionTest.TestFailsWhenBaseExceptionIsThrown" executed="True" result="Success" success="True" time="0.002" asserts="2" />
+                          <test-case name="NUnit.Core.Tests.ExpectExceptionTest.TestFailsWhenDerivedExceptionIsThrown" executed="True" result="Success" success="True" time="0.001" asserts="2" />
+                          <test-case name="NUnit.Core.Tests.ExpectExceptionTest.TestIsNotRunnableWhenAlternateHandlerIsNotFound" executed="True" result="Success" success="True" time="0.001" asserts="2" />
+                          <test-case name="NUnit.Core.Tests.ExpectExceptionTest.TestMismatchedExceptionMessage" executed="True" result="Success" success="True" time="0.001" asserts="2" />
+                          <test-case name="NUnit.Core.Tests.ExpectExceptionTest.TestMismatchedExceptionMessageWithUserMessage" executed="True" result="Success" success="True" time="0.001" asserts="2" />
+                          <test-case name="NUnit.Core.Tests.ExpectExceptionTest.TestMismatchedExceptionName" executed="True" result="Success" success="True" time="0.001" asserts="2" />
+                          <test-case name="NUnit.Core.Tests.ExpectExceptionTest.TestMismatchedExceptionNameWithUserMessage" executed="True" result="Success" success="True" time="0.001" asserts="2" />
+                          <test-case name="NUnit.Core.Tests.ExpectExceptionTest.TestMismatchedExceptionType" executed="True" result="Success" success="True" time="0.001" asserts="2" />
+                          <test-case name="NUnit.Core.Tests.ExpectExceptionTest.TestMismatchedExceptionTypeAsNamedParameter" executed="True" result="Success" success="True" time="0.001" asserts="2" />
+                          <test-case name="NUnit.Core.Tests.ExpectExceptionTest.TestMismatchedExceptionTypeWithUserMessage" executed="True" result="Success" success="True" time="0.001" asserts="2" />
+                          <test-case name="NUnit.Core.Tests.ExpectExceptionTest.TestSucceedsWhenSpecifiedExceptionNameAndContainsMatch" executed="True" result="Success" success="True" time="0.000" asserts="0" />
+                          <test-case name="NUnit.Core.Tests.ExpectExceptionTest.TestSucceedsWhenSpecifiedExceptionNameAndRegexMatch" executed="True" result="Success" success="True" time="0.003" asserts="0" />
+                          <test-case name="NUnit.Core.Tests.ExpectExceptionTest.TestSucceedsWithSpecifiedExceptionName" executed="True" result="Success" success="True" time="0.001" asserts="0" />
+                          <test-case name="NUnit.Core.Tests.ExpectExceptionTest.TestSucceedsWithSpecifiedExceptionNameAndExactMatch" executed="True" result="Success" success="True" time="0.001" asserts="0" />
+                          <test-case name="NUnit.Core.Tests.ExpectExceptionTest.TestSucceedsWithSpecifiedExceptionNameAndMessage_NewFormat" executed="True" result="Success" success="True" time="0.001" asserts="0" />
+                          <test-case name="NUnit.Core.Tests.ExpectExceptionTest.TestSucceedsWithSpecifiedExceptionNameAsNamedParameter" executed="True" result="Success" success="True" time="0.000" asserts="0" />
+                          <test-case name="NUnit.Core.Tests.ExpectExceptionTest.TestSucceedsWithSpecifiedExceptionType" executed="True" result="Success" success="True" time="0.001" asserts="0" />
+                          <test-case name="NUnit.Core.Tests.ExpectExceptionTest.TestSucceedsWithSpecifiedExceptionTypeAndContainsMatch" executed="True" result="Success" success="True" time="0.001" asserts="0" />
+                          <test-case name="NUnit.Core.Tests.ExpectExceptionTest.TestSucceedsWithSpecifiedExceptionTypeAndExactMatch" executed="True" result="Success" success="True" time="0.000" asserts="0" />
+                          <test-case name="NUnit.Core.Tests.ExpectExceptionTest.TestSucceedsWithSpecifiedExceptionTypeAndMessage" executed="True" result="Success" success="True" time="0.000" asserts="0" />
+                          <test-case name="NUnit.Core.Tests.ExpectExceptionTest.TestSucceedsWithSpecifiedExceptionTypeAndRegexMatch" executed="True" result="Success" success="True" time="0.002" asserts="0" />
+                          <test-case name="NUnit.Core.Tests.ExpectExceptionTest.TestSucceedsWithSpecifiedExceptionTypeAndStartsWithMatch" executed="True" result="Success" success="True" time="0.000" asserts="0" />
+                          <test-case name="NUnit.Core.Tests.ExpectExceptionTest.TestSucceedsWithSpecifiedExceptionTypeAsNamedParameter" executed="True" result="Success" success="True" time="0.001" asserts="0" />
+                          <test-case name="NUnit.Core.Tests.ExpectExceptionTest.TestUnspecifiedExceptionNotThrown" executed="True" result="Success" success="True" time="0.001" asserts="2" />
+                          <test-case name="NUnit.Core.Tests.ExpectExceptionTest.TestUnspecifiedExceptionNotThrownWithUserMessage" executed="True" result="Success" success="True" time="0.001" asserts="2" />
+                          <test-case name="NUnit.Core.Tests.ExpectExceptionTest.ThrowingMyAppException" executed="True" result="Success" success="True" time="0.001" asserts="0" />
+                          <test-case name="NUnit.Core.Tests.ExpectExceptionTest.ThrowingMyAppExceptionWithMessage" executed="True" result="Success" success="True" time="0.000" asserts="0" />
+                          <test-case name="NUnit.Core.Tests.ExpectExceptionTest.ThrowNUnitException" executed="True" result="Success" success="True" time="0.001" asserts="0" />
+                        </results>
+                      </test-suite>
+                      <test-suite type="TestFixture" name="FailFixture" executed="True" result="Success" success="True" time="0.015" asserts="0">
+                        <results>
+                          <test-case name="NUnit.Core.Tests.FailFixture.BadStackTraceIsHandled" executed="True" result="Success" success="True" time="0.001" asserts="3" />
+                          <test-case name="NUnit.Core.Tests.FailFixture.CustomExceptionIsHandled" executed="True" result="Success" success="True" time="0.001" asserts="2" />
+                          <test-case name="NUnit.Core.Tests.FailFixture.FailInheritsFromSystemException" executed="True" result="Success" success="True" time="0.000" asserts="0" />
+                          <test-case name="NUnit.Core.Tests.FailFixture.FailRecordsInnerException" executed="True" result="Success" success="True" time="0.001" asserts="2" />
+                          <test-case name="NUnit.Core.Tests.FailFixture.FailThrowsAssertionException" executed="True" result="Success" success="True" time="0.000" asserts="0" />
+                          <test-case name="NUnit.Core.Tests.FailFixture.VerifyFailWorks" executed="True" result="Success" success="True" time="0.001" asserts="2" />
+                        </results>
+                      </test-suite>
+                      <test-suite type="TestFixture" name="FixtureSetupTearDownTest" executed="True" result="Success" success="True" time="0.093" asserts="0">
+                        <results>
+                          <test-case name="NUnit.Core.Tests.FixtureSetupTearDownTest.BaseSetUpCalledFirstAndTearDownCalledLast" executed="True" result="Success" success="True" time="0.004" asserts="6" />
+                          <test-case name="NUnit.Core.Tests.FixtureSetupTearDownTest.CheckInheritedSetUpAndTearDownAreCalled" executed="True" result="Success" success="True" time="0.003" asserts="2" />
+                          <test-case name="NUnit.Core.Tests.FixtureSetupTearDownTest.DisposeCalledWhenFixtureImplementsIDisposable" executed="True" result="Success" success="True" time="0.002" asserts="1" />
+                          <test-case name="NUnit.Core.Tests.FixtureSetupTearDownTest.FixtureWithNoTestsCallsFixtureSetUpAndTearDown" executed="True" result="Success" success="True" time="0.002" asserts="2" />
+                          <test-case name="NUnit.Core.Tests.FixtureSetupTearDownTest.HandleErrorInFixtureSetup" executed="True" result="Success" success="True" time="0.004" asserts="11" />
+                          <test-case name="NUnit.Core.Tests.FixtureSetupTearDownTest.HandleErrorInFixtureTearDown" executed="True" result="Success" success="True" time="0.003" asserts="9" />
+                          <test-case name="NUnit.Core.Tests.FixtureSetupTearDownTest.HandleExceptionInFixtureConstructor" executed="True" result="Success" success="True" time="0.003" asserts="9" />
+                          <test-case name="NUnit.Core.Tests.FixtureSetupTearDownTest.HandleIgnoreInFixtureSetup" executed="True" result="Success" success="True" time="0.003" asserts="7" />
+                          <test-case name="NUnit.Core.Tests.FixtureSetupTearDownTest.HandleSetUpAndTearDownWithTestInName" executed="True" result="Success" success="True" time="0.002" asserts="2" />
+                          <test-case name="NUnit.Core.Tests.FixtureSetupTearDownTest.IgnoredFixtureShouldNotCallFixtureSetUpOrTearDown" executed="True" result="Success" success="True" time="0.003" asserts="6" />
+                          <test-case name="NUnit.Core.Tests.FixtureSetupTearDownTest.MakeSureSetUpAndTearDownAreCalled" executed="True" result="Success" success="True" time="0.003" asserts="2" />
+                          <test-case name="NUnit.Core.Tests.FixtureSetupTearDownTest.MakeSureSetUpAndTearDownAreCalledOnExplicitFixture" executed="True" result="Success" success="True" time="0.002" asserts="2" />
+                          <test-case name="NUnit.Core.Tests.FixtureSetupTearDownTest.OverriddenSetUpAndTearDownAreNotCalled" executed="True" result="Success" success="True" time="0.003" asserts="4" />
+                          <test-case name="NUnit.Core.Tests.FixtureSetupTearDownTest.RerunFixtureAfterSetUpFixed" executed="True" result="Success" success="True" time="0.004" asserts="4" />
+                          <test-case name="NUnit.Core.Tests.FixtureSetupTearDownTest.RerunFixtureAfterTearDownFixed" executed="True" result="Success" success="True" time="0.005" asserts="4" />
+                          <test-case name="NUnit.Core.Tests.FixtureSetupTearDownTest.RunningSingleMethodCallsSetUpAndTearDown" executed="True" result="Success" success="True" time="0.004" asserts="2" />
+                          <test-case name="NUnit.Core.Tests.FixtureSetupTearDownTest.StaticBaseSetUpCalledFirstAndTearDownCalledLast" executed="True" result="Success" success="True" time="0.003" asserts="6" />
+                          <test-case name="NUnit.Core.Tests.FixtureSetupTearDownTest.StaticClassSetUpAndTearDownAreCalled" executed="True" result="Success" success="True" time="0.002" asserts="2" />
+                          <test-case name="NUnit.Core.Tests.FixtureSetupTearDownTest.StaticSetUpAndTearDownAreCalled" executed="True" result="Success" success="True" time="0.001" asserts="2" />
+                        </results>
+                      </test-suite>
+                      <test-suite type="TestFixture" name="FixtureSetupTearDownTest+ChangesMadeInFixtureSetUp" executed="True" result="Success" success="True" time="0.005" asserts="0">
+                        <results>
+                          <test-case name="NUnit.Core.Tests.FixtureSetupTearDownTest+ChangesMadeInFixtureSetUp.TestThatChangesPersistUsingSameThread" executed="True" result="Success" success="True" time="0.001" asserts="3" />
+                          <test-case name="NUnit.Core.Tests.FixtureSetupTearDownTest+ChangesMadeInFixtureSetUp.TestThatChangesPersistUsingSeparateThread" executed="True" result="Success" success="True" time="0.001" asserts="3">
+                            <properties>
+                              <property name="RequiresThread" value="True" />
+                            </properties>
+                          </test-case>
+                        </results>
+                      </test-suite>
+                      <test-suite type="Namespace" name="Generic" executed="True" result="Success" success="True" time="0.053" asserts="0">
+                        <results>
+                          <test-suite type="GenericFixture" name="DeduceTypeArgsFromArgs&lt;T1,T2&gt;" executed="True" result="Success" success="True" time="0.006" asserts="0">
+                            <results>
+                              <test-suite type="TestFixture" name="DeduceTypeArgsFromArgs&lt;Double,Int32&gt;(100.0d,42)" executed="True" result="Success" success="True" time="0.003" asserts="0">
+                                <categories>
+                                  <category name="Generics" />
+                                </categories>
+                                <results>
+                                  <test-suite type="ParameterizedTest" name="TestMyArgTypes" executed="True" result="Success" success="True" time="0.001" asserts="0">
+                                    <results>
+                                      <test-case name="NUnit.Core.Tests.Generic.DeduceTypeArgsFromArgs&lt;Double,Int32&gt;(100.0d,42).TestMyArgTypes(5,7)" executed="True" result="Success" success="True" time="0.001" asserts="2" />
+                                    </results>
+                                  </test-suite>
+                                </results>
+                              </test-suite>
+                              <test-suite type="TestFixture" name="DeduceTypeArgsFromArgs&lt;Int32,Double&gt;(42,100.0d)" executed="True" result="Success" success="True" time="0.001" asserts="0">
+                                <categories>
+                                  <category name="Generics" />
+                                </categories>
+                                <results>
+                                  <test-suite type="ParameterizedTest" name="TestMyArgTypes" executed="True" result="Success" success="True" time="0.001" asserts="0">
+                                    <results>
+                                      <test-case name="NUnit.Core.Tests.Generic.DeduceTypeArgsFromArgs&lt;Int32,Double&gt;(42,100.0d).TestMyArgTypes(5,7)" executed="True" result="Success" success="True" time="0.001" asserts="2" />
+                                    </results>
+                                  </test-suite>
+                                </results>
+                              </test-suite>
+                            </results>
+                          </test-suite>
+                          <test-suite type="GenericFixture" name="SimpleGenericFixture&lt;TList&gt;" executed="True" result="Success" success="True" time="0.006" asserts="0">
+                            <results>
+                              <test-suite type="TestFixture" name="SimpleGenericFixture&lt;ArrayList&gt;" executed="True" result="Success" success="True" time="0.002" asserts="0">
+                                <categories>
+                                  <category name="Generics" />
+                                </categories>
+                                <results>
+                                  <test-case name="NUnit.Core.Tests.Generic.SimpleGenericFixture&lt;ArrayList&gt;.TestCollectionCount" executed="True" result="Success" success="True" time="0.001" asserts="1" />
+                                </results>
+                              </test-suite>
+                              <test-suite type="TestFixture" name="SimpleGenericFixture&lt;List&lt;Int32&gt;&gt;" executed="True" result="Success" success="True" time="0.000" asserts="0">
+                                <categories>
+                                  <category name="Generics" />
+                                </categories>
+                                <results>
+                                  <test-case name="NUnit.Core.Tests.Generic.SimpleGenericFixture&lt;List&lt;Int32&gt;&gt;.TestCollectionCount" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                                </results>
+                              </test-suite>
+                            </results>
+                          </test-suite>
+                          <test-suite type="TestFixture" name="SimpleGenericMethods" executed="True" result="Success" success="True" time="0.026" asserts="0">
+                            <categories>
+                              <category name="Generics" />
+                            </categories>
+                            <results>
+                              <test-suite type="ParameterizedTest" name="GenericTestMethodWithOneTypeParameter" executed="True" result="Success" success="True" time="0.006" asserts="0">
+                                <results>
+                                  <test-case name="NUnit.Core.Tests.Generic.SimpleGenericMethods.GenericTestMethodWithOneTypeParameter&lt;Double&gt;(5.0d,2.0d,&quot;ABC&quot;)" executed="True" result="Success" success="True" time="0.001" asserts="3" />
+                                  <test-case name="NUnit.Core.Tests.Generic.SimpleGenericMethods.GenericTestMethodWithOneTypeParameter&lt;Double&gt;(5.0d,2.0d,&quot;ABC&quot;)" executed="True" result="Success" success="True" time="0.001" asserts="3" />
+                                  <test-case name="NUnit.Core.Tests.Generic.SimpleGenericMethods.GenericTestMethodWithOneTypeParameter&lt;Double&gt;(5.0d,2.0d,&quot;ABC&quot;)" executed="True" result="Success" success="True" time="0.000" asserts="3" />
+                                  <test-case name="NUnit.Core.Tests.Generic.SimpleGenericMethods.GenericTestMethodWithOneTypeParameter&lt;Int32&gt;(5,2,&quot;ABC&quot;)" executed="True" result="Success" success="True" time="0.001" asserts="3" />
+                                </results>
+                              </test-suite>
+                              <test-suite type="ParameterizedTest" name="GenericTestMethodWithTwoTypeParameters" executed="True" result="Success" success="True" time="0.007" asserts="0">
+                                <results>
+                                  <test-case name="NUnit.Core.Tests.Generic.SimpleGenericMethods.GenericTestMethodWithTwoTypeParameters&lt;Double,Int64&gt;(5.0d,2L,&quot;ABC&quot;)" executed="True" result="Success" success="True" time="0.001" asserts="3" />
+                                  <test-case name="NUnit.Core.Tests.Generic.SimpleGenericMethods.GenericTestMethodWithTwoTypeParameters&lt;Int32,Int32&gt;(5,2,&quot;ABC&quot;)" executed="True" result="Success" success="True" time="0.001" asserts="3" />
+                                  <test-case name="NUnit.Core.Tests.Generic.SimpleGenericMethods.GenericTestMethodWithTwoTypeParameters&lt;Double,Double&gt;(5.0d,2.0d,&quot;ABC&quot;)" executed="True" result="Success" success="True" time="0.000" asserts="3" />
+                                  <test-case name="NUnit.Core.Tests.Generic.SimpleGenericMethods.GenericTestMethodWithTwoTypeParameters&lt;Int32,Double&gt;(5,2.0d,&quot;ABC&quot;)" executed="True" result="Success" success="True" time="0.000" asserts="3" />
+                                </results>
+                              </test-suite>
+                              <test-suite type="ParameterizedTest" name="GenericTestMethodWithTwoTypeParameters_Reversed" executed="True" result="Success" success="True" time="0.008" asserts="0">
+                                <results>
+                                  <test-case name="NUnit.Core.Tests.Generic.SimpleGenericMethods.GenericTestMethodWithTwoTypeParameters_Reversed&lt;Double,Int32&gt;(5,2.0d,&quot;ABC&quot;)" executed="True" result="Success" success="True" time="0.000" asserts="3" />
+                                  <test-case name="NUnit.Core.Tests.Generic.SimpleGenericMethods.GenericTestMethodWithTwoTypeParameters_Reversed&lt;Int32,Int32&gt;(5,2,&quot;ABC&quot;)" executed="True" result="Success" success="True" time="0.001" asserts="3" />
+                                  <test-case name="NUnit.Core.Tests.Generic.SimpleGenericMethods.GenericTestMethodWithTwoTypeParameters_Reversed&lt;Double,Double&gt;(5.0d,2.0d,&quot;ABC&quot;)" executed="True" result="Success" success="True" time="0.001" asserts="3" />
+                                  <test-case name="NUnit.Core.Tests.Generic.SimpleGenericMethods.GenericTestMethodWithTwoTypeParameters_Reversed&lt;Int64,Double&gt;(5.0d,2L,&quot;ABC&quot;)" executed="True" result="Success" success="True" time="0.001" asserts="3" />
+                                </results>
+                              </test-suite>
+                            </results>
+                          </test-suite>
+                          <test-suite type="GenericFixture" name="TypeParameterUsedWithTestMethod&lt;T&gt;" executed="True" result="Success" success="True" time="0.004" asserts="0">
+                            <results>
+                              <test-suite type="TestFixture" name="TypeParameterUsedWithTestMethod&lt;Double&gt;" executed="True" result="Success" success="True" time="0.004" asserts="0">
+                                <categories>
+                                  <category name="Generics" />
+                                </categories>
+                                <results>
+                                  <test-suite type="ParameterizedTest" name="TestMyArgType" executed="True" result="Success" success="True" time="0.003" asserts="0">
+                                    <results>
+                                      <test-case name="NUnit.Core.Tests.Generic.TypeParameterUsedWithTestMethod&lt;Double&gt;.TestMyArgType(1.23d)" executed="True" result="Success" success="True" time="0.001" asserts="1" />
+                                      <test-case name="NUnit.Core.Tests.Generic.TypeParameterUsedWithTestMethod&lt;Double&gt;.TestMyArgType(5)" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                                    </results>
+                                  </test-suite>
+                                </results>
+                              </test-suite>
+                            </results>
+                          </test-suite>
+                        </results>
+                      </test-suite>
+                      <test-suite type="TestFixture" name="IgnoreFixture" executed="True" result="Success" success="True" time="0.025" asserts="0">
+                        <results>
+                          <test-case name="NUnit.Core.Tests.IgnoreFixture.IgnoreTakesPrecedenceOverExpectedException" executed="True" result="Success" success="True" time="0.002" asserts="2" />
+                          <test-case name="NUnit.Core.Tests.IgnoreFixture.IgnoreThrowsIgnoreException" executed="True" result="Success" success="True" time="0.001" asserts="1" />
+                          <test-case name="NUnit.Core.Tests.IgnoreFixture.IgnoreWithUserMessage" executed="True" result="Success" success="True" time="0.001" asserts="1" />
+                          <test-case name="NUnit.Core.Tests.IgnoreFixture.IgnoreWithUserMessage_ArrayOfArgs" executed="True" result="Success" success="True" time="0.001" asserts="1" />
+                          <test-case name="NUnit.Core.Tests.IgnoreFixture.IgnoreWithUserMessage_OneArg" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Core.Tests.IgnoreFixture.IgnoreWithUserMessage_ThreeArgs" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Core.Tests.IgnoreFixture.IgnoreWorksForTestCase" executed="True" result="Success" success="True" time="0.001" asserts="2" />
+                          <test-case name="NUnit.Core.Tests.IgnoreFixture.IgnoreWorksForTestSuite" executed="True" result="Success" success="True" time="0.004" asserts="3" />
+                          <test-case name="NUnit.Core.Tests.IgnoreFixture.IgnoreWorksFromSetUp" executed="True" result="Success" success="True" time="0.003" asserts="2" />
+                        </results>
+                      </test-suite>
+                      <test-suite type="TestFixture" name="LegacySuiteTests" executed="True" result="Success" success="True" time="0.114" asserts="0">
+                        <results>
+                          <test-case name="NUnit.Core.Tests.LegacySuiteTests.SetUpAndTearDownAreCalled" executed="True" result="Success" success="True" time="0.004" asserts="3" />
+                          <test-case name="NUnit.Core.Tests.LegacySuiteTests.SuitePropertyWithInvalidType" executed="True" result="Success" success="True" time="0.001" asserts="1" />
+                          <test-case name="NUnit.Core.Tests.LegacySuiteTests.SuiteReturningFixtures" executed="True" result="Success" success="True" time="0.074" asserts="3" />
+                          <test-case name="NUnit.Core.Tests.LegacySuiteTests.SuiteReturningFixtureWithArguments" executed="True" result="Success" success="True" time="0.005" asserts="3" />
+                          <test-case name="NUnit.Core.Tests.LegacySuiteTests.SuiteReturningTestSuite" executed="True" result="Success" success="True" time="0.009" asserts="3" />
+                          <test-case name="NUnit.Core.Tests.LegacySuiteTests.SuiteReturningTypes" executed="True" result="Success" success="True" time="0.007" asserts="3" />
+                        </results>
+                      </test-suite>
+                      <test-suite type="TestFixture" name="MaxTimeTests" executed="True" result="Success" success="True" time="0.085" asserts="0">
+                        <results>
+                          <test-case name="NUnit.Core.Tests.MaxTimeTests.ErrorReport" executed="True" result="Success" success="True" time="0.001" asserts="0">
+                            <properties>
+                              <property name="MaxTime" value="1000" />
+                            </properties>
+                          </test-case>
+                          <test-case name="NUnit.Core.Tests.MaxTimeTests.ErrorReportHasPriorityOverMaxTime" executed="True" result="Success" success="True" time="0.023" asserts="3" />
+                          <test-case name="NUnit.Core.Tests.MaxTimeTests.FailureReport" executed="True" result="Success" success="True" time="0.001" asserts="0">
+                            <properties>
+                              <property name="MaxTime" value="1000" />
+                            </properties>
+                          </test-case>
+                          <test-case name="NUnit.Core.Tests.MaxTimeTests.FailureReportHasPriorityOverMaxTime" executed="True" result="Success" success="True" time="0.023" asserts="3" />
+                          <test-case name="NUnit.Core.Tests.MaxTimeTests.MaxTimeExceeded" executed="True" result="Success" success="True" time="0.022" asserts="2" />
+                          <test-case name="NUnit.Core.Tests.MaxTimeTests.MaxTimeNotExceeded" executed="True" result="Success" success="True" time="0.000" asserts="0">
+                            <properties>
+                              <property name="MaxTime" value="1000" />
+                            </properties>
+                          </test-case>
+                        </results>
+                      </test-suite>
+                      <test-suite type="TestFixture" name="NameFilterTest" executed="True" result="Success" success="True" time="0.062" asserts="0">
+                        <results>
+                          <test-case name="NUnit.Core.Tests.NameFilterTest.ExplicitTestCaseDoesNotMatchWhenNotSelectedDirectly" executed="True" result="Success" success="True" time="0.005" asserts="1" />
+                          <test-case name="NUnit.Core.Tests.NameFilterTest.ExplicitTestCaseMatchesWhenSelectedDirectly" executed="True" result="Success" success="True" time="0.005" asserts="2" />
+                          <test-case name="NUnit.Core.Tests.NameFilterTest.ExplicitTestSuiteDoesNotMatchWhenNotSelectedDirectly" executed="True" result="Success" success="True" time="0.005" asserts="2" />
+                          <test-case name="NUnit.Core.Tests.NameFilterTest.ExplicitTestSuiteMatchesWhenSelectedDirectly" executed="True" result="Success" success="True" time="0.007" asserts="3" />
+                          <test-case name="NUnit.Core.Tests.NameFilterTest.HighLevelSuite" executed="True" result="Success" success="True" time="0.005" asserts="3" />
+                          <test-case name="NUnit.Core.Tests.NameFilterTest.MultipleNameMatch" executed="True" result="Success" success="True" time="0.004" asserts="3" />
+                          <test-case name="NUnit.Core.Tests.NameFilterTest.SingleNameMatch" executed="True" result="Success" success="True" time="0.004" asserts="4" />
+                          <test-case name="NUnit.Core.Tests.NameFilterTest.SuiteNameMatch" executed="True" result="Success" success="True" time="0.004" asserts="3" />
+                          <test-case name="NUnit.Core.Tests.NameFilterTest.TestDoesNotMatch" executed="True" result="Success" success="True" time="0.003" asserts="2" />
+                        </results>
+                      </test-suite>
+                      <test-suite type="TestFixture" name="NamespaceAssemblyTests" executed="True" result="Success" success="True" time="0.092" asserts="0">
+                        <results>
+                          <test-case name="NUnit.Core.Tests.NamespaceAssemblyTests.Hierarchy" executed="True" result="Success" success="True" time="0.029" asserts="17" />
+                          <test-case name="NUnit.Core.Tests.NamespaceAssemblyTests.LoadTestFixtureFromAssembly" executed="True" result="Success" success="True" time="0.015" asserts="1" />
+                          <test-case name="NUnit.Core.Tests.NamespaceAssemblyTests.NoNamespaceInAssembly" executed="True" result="Success" success="True" time="0.013" asserts="5" />
+                          <test-case name="NUnit.Core.Tests.NamespaceAssemblyTests.TestRoot" executed="True" result="Success" success="True" time="0.028" asserts="1" />
+                        </results>
+                      </test-suite>
+                      <test-suite type="TestFixture" name="NUnitTestCaseBuilderTests" executed="True" result="Success" success="True" time="0.005" asserts="0">
+                        <results>
+                          <test-suite type="ParameterizedTest" name="TestCases" executed="True" result="Success" success="True" time="0.001" asserts="0">
+                            <results>
+                              <test-case name="NUnit.Core.Tests.NUnitTestCaseBuilderTests.TestCases(Void VoidTestCaseWithExpectedResult(Int32),NotRunnable)" executed="True" result="Success" success="True" time="0.000" asserts="2" />
+                            </results>
+                          </test-suite>
+                          <test-suite type="ParameterizedTest" name="Tests" executed="True" result="Success" success="True" time="0.001" asserts="0">
+                            <results>
+                              <test-case name="NUnit.Core.Tests.NUnitTestCaseBuilderTests.Tests(Int32 NonVoidTest(),NotRunnable)" executed="True" result="Success" success="True" time="0.000" asserts="2" />
+                            </results>
+                          </test-suite>
+                        </results>
+                      </test-suite>
+                      <test-suite type="TestFixture" name="PairwiseTest" executed="True" result="Success" success="True" time="0.020" asserts="0">
+                        <results>
+                          <test-suite type="ParameterizedTest" name="Test" executed="True" result="Success" success="True" time="0.019" asserts="0">
+                            <results>
+                              <test-case name="NUnit.Core.Tests.PairwiseTest.Test 2x4" executed="True" result="Success" success="True" time="0.002" asserts="2" />
+                              <test-case name="NUnit.Core.Tests.PairwiseTest.Test 2x2x2" executed="True" result="Success" success="True" time="0.000" asserts="2" />
+                              <test-case name="NUnit.Core.Tests.PairwiseTest.Test 3x2x2" executed="True" result="Success" success="True" time="0.000" asserts="2" />
+                              <test-case name="NUnit.Core.Tests.PairwiseTest.Test 3x2x2x2" executed="True" result="Success" success="True" time="0.001" asserts="2" />
+                              <test-case name="NUnit.Core.Tests.PairwiseTest.Test 3x2x2x2x2" executed="True" result="Success" success="True" time="0.002" asserts="2" />
+                              <test-case name="NUnit.Core.Tests.PairwiseTest.Test 3x2x2x2x2x2" executed="True" result="Success" success="True" time="0.000" asserts="2" />
+                              <test-case name="NUnit.Core.Tests.PairwiseTest.Test 3x3x3" executed="True" result="Success" success="True" time="0.000" asserts="2" />
+                              <test-case name="NUnit.Core.Tests.PairwiseTest.Test 4x4x4" executed="True" result="Success" success="True" time="0.001" asserts="2" />
+                              <test-case name="NUnit.Core.Tests.PairwiseTest.Test 5x5x5" executed="True" result="Success" success="True" time="0.001" asserts="2" />
+                            </results>
+                          </test-suite>
+                        </results>
+                      </test-suite>
+                      <test-suite type="TestFixture" name="PairwiseTest+LiveTest" executed="True" result="Success" success="True" time="0.014" asserts="1">
+                        <results>
+                          <test-suite type="ParameterizedTest" name="Test" executed="True" result="Success" success="True" time="0.013" asserts="0">
+                            <results>
+                              <test-case name="NUnit.Core.Tests.PairwiseTest+LiveTest.Test(&quot;a&quot;,&quot;-&quot;,&quot;x&quot;)" executed="True" result="Success" success="True" time="0.001" asserts="0" />
+                              <test-case name="NUnit.Core.Tests.PairwiseTest+LiveTest.Test(&quot;b&quot;,&quot;+&quot;,&quot;y&quot;)" executed="True" result="Success" success="True" time="0.000" asserts="0" />
+                              <test-case name="NUnit.Core.Tests.PairwiseTest+LiveTest.Test(&quot;c&quot;,&quot;+&quot;,&quot;x&quot;)" executed="True" result="Success" success="True" time="0.000" asserts="0" />
+                              <test-case name="NUnit.Core.Tests.PairwiseTest+LiveTest.Test(&quot;b&quot;,&quot;-&quot;,&quot;x&quot;)" executed="True" result="Success" success="True" time="0.000" asserts="0" />
+                              <test-case name="NUnit.Core.Tests.PairwiseTest+LiveTest.Test(&quot;a&quot;,&quot;-&quot;,&quot;y&quot;)" executed="True" result="Success" success="True" time="0.000" asserts="0" />
+                              <test-case name="NUnit.Core.Tests.PairwiseTest+LiveTest.Test(&quot;c&quot;,&quot;-&quot;,&quot;y&quot;)" executed="True" result="Success" success="True" time="0.000" asserts="0" />
+                              <test-case name="NUnit.Core.Tests.PairwiseTest+LiveTest.Test(&quot;a&quot;,&quot;+&quot;,&quot;x&quot;)" executed="True" result="Success" success="True" time="0.001" asserts="0" />
+                            </results>
+                          </test-suite>
+                        </results>
+                      </test-suite>
+                      <test-suite type="ParameterizedFixture" name="ParameterizedTestFixture" executed="True" result="Success" success="True" time="0.014" asserts="0">
+                        <results>
+                          <test-suite type="TestFixture" name="ParameterizedTestFixture(&quot;hello&quot;,&quot;hello&quot;,&quot;goodbye&quot;)" executed="True" result="Success" success="True" time="0.003" asserts="0">
+                            <results>
+                              <test-case name="NUnit.Core.Tests.ParameterizedTestFixture(&quot;hello&quot;,&quot;hello&quot;,&quot;goodbye&quot;).TestEquality" executed="True" result="Success" success="True" time="0.000" asserts="2" />
+                              <test-case name="NUnit.Core.Tests.ParameterizedTestFixture(&quot;hello&quot;,&quot;hello&quot;,&quot;goodbye&quot;).TestInequality" executed="True" result="Success" success="True" time="0.000" asserts="2" />
+                            </results>
+                          </test-suite>
+                          <test-suite type="TestFixture" name="ParameterizedTestFixture(&quot;zip&quot;,&quot;zip&quot;)" executed="True" result="Success" success="True" time="0.003" asserts="0">
+                            <results>
+                              <test-case name="NUnit.Core.Tests.ParameterizedTestFixture(&quot;zip&quot;,&quot;zip&quot;).TestEquality" executed="True" result="Success" success="True" time="0.000" asserts="2" />
+                              <test-case name="NUnit.Core.Tests.ParameterizedTestFixture(&quot;zip&quot;,&quot;zip&quot;).TestInequality" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                            </results>
+                          </test-suite>
+                          <test-suite type="TestFixture" name="ParameterizedTestFixture(42,42,99)" executed="True" result="Success" success="True" time="0.002" asserts="0">
+                            <results>
+                              <test-case name="NUnit.Core.Tests.ParameterizedTestFixture(42,42,99).TestEquality" executed="True" result="Success" success="True" time="0.000" asserts="2" />
+                              <test-case name="NUnit.Core.Tests.ParameterizedTestFixture(42,42,99).TestInequality" executed="True" result="Success" success="True" time="0.000" asserts="2" />
+                            </results>
+                          </test-suite>
+                        </results>
+                      </test-suite>
+                      <test-suite type="TestFixture" name="ParameterizedTestFixtureNamingTests" executed="True" result="Success" success="True" time="0.025" asserts="0">
+                        <results>
+                          <test-case name="NUnit.Core.Tests.ParameterizedTestFixtureNamingTests.FixtureInstancesAreNamedCorrectly" executed="True" result="Success" success="True" time="0.005" asserts="2" />
+                          <test-case name="NUnit.Core.Tests.ParameterizedTestFixtureNamingTests.MethodWithoutParamsIsNamedCorrectly" executed="True" result="Success" success="True" time="0.003" asserts="2" />
+                          <test-case name="NUnit.Core.Tests.ParameterizedTestFixtureNamingTests.MethodWithParamsIsNamedCorrectly" executed="True" result="Success" success="True" time="0.004" asserts="3" />
+                          <test-case name="NUnit.Core.Tests.ParameterizedTestFixtureNamingTests.SuiteHasCorrectNumberOfInstances" executed="True" result="Success" success="True" time="0.003" asserts="1" />
+                          <test-case name="NUnit.Core.Tests.ParameterizedTestFixtureNamingTests.TopLevelSuiteIsNamedCorrectly" executed="True" result="Success" success="True" time="0.004" asserts="2" />
+                        </results>
+                      </test-suite>
+                      <test-suite type="TestFixture" name="ParameterizedTestFixtureTests" executed="True" result="Success" success="True" time="0.006" asserts="0">
+                        <results>
+                          <test-case name="NUnit.Core.Tests.ParameterizedTestFixtureTests.CanSpecifyCategory" executed="True" result="Success" success="True" time="0.001" asserts="1" />
+                          <test-case name="NUnit.Core.Tests.ParameterizedTestFixtureTests.CanSpecifyMultipleCategories" executed="True" result="Success" success="True" time="0.001" asserts="1" />
+                        </results>
+                      </test-suite>
+                      <test-suite type="ParameterizedFixture" name="ParameterizedTestFixtureWithDataSources" executed="True" result="Success" success="True" time="0.024" asserts="0">
+                        <results>
+                          <test-suite type="TestFixture" name="ParameterizedTestFixtureWithDataSources(42)" executed="True" result="Success" success="True" time="0.024" asserts="0">
+                            <results>
+                              <test-suite type="ParameterizedTest" name="CanAccessTestCaseSource" executed="True" result="Success" success="True" time="0.004" asserts="0">
+                                <results>
+                                  <test-case name="NUnit.Core.Tests.ParameterizedTestFixtureWithDataSources(42).CanAccessTestCaseSource(6,7)" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                                  <test-case name="NUnit.Core.Tests.ParameterizedTestFixtureWithDataSources(42).CanAccessTestCaseSource(3,14)" executed="True" result="Success" success="True" time="0.001" asserts="1" />
+                                </results>
+                              </test-suite>
+                              <test-suite type="ParameterizedTest" name="CanAccessValueSource" executed="True" result="Success" success="True" time="0.004" asserts="0">
+                                <results>
+                                  <test-case name="NUnit.Core.Tests.ParameterizedTestFixtureWithDataSources(42).CanAccessValueSource(1)" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                                  <test-case name="NUnit.Core.Tests.ParameterizedTestFixtureWithDataSources(42).CanAccessValueSource(2)" executed="True" result="Success" success="True" time="0.001" asserts="1" />
+                                  <test-case name="NUnit.Core.Tests.ParameterizedTestFixtureWithDataSources(42).CanAccessValueSource(3)" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                                </results>
+                              </test-suite>
+                              <test-suite type="ParameterizedTest" name="CanGenerateDataFromParameter" executed="True" result="Success" success="True" time="0.012" asserts="0">
+                                <results>
+                                  <test-case name="NUnit.Core.Tests.ParameterizedTestFixtureWithDataSources(42).CanGenerateDataFromParameter(1,42)" executed="True" result="Success" success="True" time="0.001" asserts="1" />
+                                  <test-case name="NUnit.Core.Tests.ParameterizedTestFixtureWithDataSources(42).CanGenerateDataFromParameter(2,21)" executed="True" result="Success" success="True" time="0.001" asserts="1" />
+                                  <test-case name="NUnit.Core.Tests.ParameterizedTestFixtureWithDataSources(42).CanGenerateDataFromParameter(3,14)" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                                  <test-case name="NUnit.Core.Tests.ParameterizedTestFixtureWithDataSources(42).CanGenerateDataFromParameter(6,7)" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                                  <test-case name="NUnit.Core.Tests.ParameterizedTestFixtureWithDataSources(42).CanGenerateDataFromParameter(7,6)" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                                  <test-case name="NUnit.Core.Tests.ParameterizedTestFixtureWithDataSources(42).CanGenerateDataFromParameter(14,3)" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                                  <test-case name="NUnit.Core.Tests.ParameterizedTestFixtureWithDataSources(42).CanGenerateDataFromParameter(21,2)" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                                  <test-case name="NUnit.Core.Tests.ParameterizedTestFixtureWithDataSources(42).CanGenerateDataFromParameter(42,1)" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                                </results>
+                              </test-suite>
+                            </results>
+                          </test-suite>
+                        </results>
+                      </test-suite>
+                      <test-suite type="ParameterizedFixture" name="ParameterizedTestFixtureWithNullArguments" executed="True" result="Success" success="True" time="0.009" asserts="0">
+                        <results>
+                          <test-suite type="TestFixture" name="ParameterizedTestFixtureWithNullArguments(&quot;A&quot;,null)" executed="True" result="Success" success="True" time="0.001" asserts="0">
+                            <results>
+                              <test-case name="NUnit.Core.Tests.ParameterizedTestFixtureWithNullArguments(&quot;A&quot;,null).TestMethod" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                            </results>
+                          </test-suite>
+                          <test-suite type="TestFixture" name="ParameterizedTestFixtureWithNullArguments(null,&quot;A&quot;)" executed="True" result="Success" success="True" time="0.001" asserts="0">
+                            <results>
+                              <test-case name="NUnit.Core.Tests.ParameterizedTestFixtureWithNullArguments(null,&quot;A&quot;).TestMethod" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                            </results>
+                          </test-suite>
+                          <test-suite type="TestFixture" name="ParameterizedTestFixtureWithNullArguments(null,null)" executed="True" result="Success" success="True" time="0.001" asserts="0">
+                            <results>
+                              <test-case name="NUnit.Core.Tests.ParameterizedTestFixtureWithNullArguments(null,null).TestMethod" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                            </results>
+                          </test-suite>
+                        </results>
+                      </test-suite>
+                      <test-suite type="ParameterizedFixture" name="ParameterizedTestFixtureWithTypeAsArgument" executed="True" result="Success" success="True" time="0.004" asserts="0">
+                        <results>
+                          <test-suite type="TestFixture" name="ParameterizedTestFixtureWithTypeAsArgument(System.Int32)" executed="True" result="Success" success="True" time="0.002" asserts="0">
+                            <results>
+                              <test-case name="NUnit.Core.Tests.ParameterizedTestFixtureWithTypeAsArgument(System.Int32).MakeSureTypeIsInSystemNamespace" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                            </results>
+                          </test-suite>
+                          <test-suite type="TestFixture" name="ParameterizedTestFixtureWithTypeAsArgument(System.String)" executed="True" result="Success" success="True" time="0.001" asserts="0">
+                            <results>
+                              <test-case name="NUnit.Core.Tests.ParameterizedTestFixtureWithTypeAsArgument(System.String).MakeSureTypeIsInSystemNamespace" executed="True" result="Success" success="True" time="0.001" asserts="1" />
+                            </results>
+                          </test-suite>
+                        </results>
+                      </test-suite>
+                      <test-suite type="TestFixture" name="PlatformDetectionTests" executed="True" result="Success" success="True" time="0.081" asserts="0">
+                        <results>
+                          <test-case name="NUnit.Core.Tests.PlatformDetectionTests.ArrayOfPlatforms" executed="True" result="Success" success="True" time="0.001" asserts="2" />
+                          <test-case name="NUnit.Core.Tests.PlatformDetectionTests.DetectExactVersion" executed="True" result="Success" success="True" time="0.000" asserts="4" />
+                          <test-case name="NUnit.Core.Tests.PlatformDetectionTests.DetectMacOSX" executed="True" result="Success" success="True" time="0.002" asserts="25" />
+                          <test-case name="NUnit.Core.Tests.PlatformDetectionTests.DetectMono10" executed="True" result="Success" success="True" time="0.000" asserts="15" />
+                          <test-case name="NUnit.Core.Tests.PlatformDetectionTests.DetectMono20" executed="True" result="Success" success="True" time="0.000" asserts="15" />
+                          <test-case name="NUnit.Core.Tests.PlatformDetectionTests.DetectMono30" executed="True" result="Success" success="True" time="0.000" asserts="14" />
+                          <test-case name="NUnit.Core.Tests.PlatformDetectionTests.DetectMono35" executed="True" result="Success" success="True" time="0.000" asserts="13" />
+                          <test-case name="NUnit.Core.Tests.PlatformDetectionTests.DetectMono40" executed="True" result="Success" success="True" time="0.000" asserts="15" />
+                          <test-case name="NUnit.Core.Tests.PlatformDetectionTests.DetectNet10" executed="True" result="Success" success="True" time="0.000" asserts="15" />
+                          <test-case name="NUnit.Core.Tests.PlatformDetectionTests.DetectNet11" executed="True" result="Success" success="True" time="0.001" asserts="15" />
+                          <test-case name="NUnit.Core.Tests.PlatformDetectionTests.DetectNet20" executed="True" result="Success" success="True" time="0.001" asserts="15" />
+                          <test-case name="NUnit.Core.Tests.PlatformDetectionTests.DetectNet30" executed="True" result="Success" success="True" time="0.000" asserts="14" />
+                          <test-case name="NUnit.Core.Tests.PlatformDetectionTests.DetectNet35" executed="True" result="Success" success="True" time="0.000" asserts="13" />
+                          <test-case name="NUnit.Core.Tests.PlatformDetectionTests.DetectNet40" executed="True" result="Success" success="True" time="0.000" asserts="15" />
+                          <test-case name="NUnit.Core.Tests.PlatformDetectionTests.DetectNet45" executed="True" result="Success" success="True" time="0.004" asserts="14" />
+                          <test-case name="NUnit.Core.Tests.PlatformDetectionTests.DetectNetCF" executed="True" result="Success" success="True" time="0.001" asserts="16" />
+                          <test-case name="NUnit.Core.Tests.PlatformDetectionTests.DetectNT3" executed="True" result="Success" success="True" time="0.000" asserts="22" />
+                          <test-case name="NUnit.Core.Tests.PlatformDetectionTests.DetectNT4" executed="True" result="Success" success="True" time="0.000" asserts="22" />
+                          <test-case name="NUnit.Core.Tests.PlatformDetectionTests.DetectSSCLI" executed="True" result="Success" success="True" time="0.000" asserts="15" />
+                          <test-case name="NUnit.Core.Tests.PlatformDetectionTests.DetectUnixUnderMicrosoftDotNet" executed="True" result="Success" success="True" time="0.001" asserts="24" />
+                          <test-case name="NUnit.Core.Tests.PlatformDetectionTests.DetectUnixUnderMono" executed="False" result="Skipped">
+                            <reason>
+                              <message><![CDATA[Not supported on Net]]></message>
+                            </reason>
+                          </test-case>
+                          <test-case name="NUnit.Core.Tests.PlatformDetectionTests.DetectVista" executed="True" result="Success" success="True" time="0.000" asserts="21" />
+                          <test-case name="NUnit.Core.Tests.PlatformDetectionTests.DetectWin2003Server" executed="True" result="Success" success="True" time="0.000" asserts="21" />
+                          <test-case name="NUnit.Core.Tests.PlatformDetectionTests.DetectWin2008ServerOriginal" executed="True" result="Success" success="True" time="0.001" asserts="21" />
+                          <test-case name="NUnit.Core.Tests.PlatformDetectionTests.DetectWin2008ServerR2" executed="True" result="Success" success="True" time="0.000" asserts="20" />
+                          <test-case name="NUnit.Core.Tests.PlatformDetectionTests.DetectWin2K" executed="True" result="Success" success="True" time="0.000" asserts="21" />
+                          <test-case name="NUnit.Core.Tests.PlatformDetectionTests.DetectWin95" executed="True" result="Success" success="True" time="0.000" asserts="22" />
+                          <test-case name="NUnit.Core.Tests.PlatformDetectionTests.DetectWin98" executed="True" result="Success" success="True" time="0.001" asserts="22" />
+                          <test-case name="NUnit.Core.Tests.PlatformDetectionTests.DetectWinCE" executed="True" result="Success" success="True" time="0.001" asserts="23" />
+                          <test-case name="NUnit.Core.Tests.PlatformDetectionTests.DetectWindows7" executed="True" result="Success" success="True" time="0.000" asserts="21" />
+                          <test-case name="NUnit.Core.Tests.PlatformDetectionTests.DetectWinMe" executed="True" result="Success" success="True" time="0.000" asserts="22" />
+                          <test-case name="NUnit.Core.Tests.PlatformDetectionTests.DetectWinXP" executed="True" result="Success" success="True" time="0.000" asserts="21" />
+                          <test-case name="NUnit.Core.Tests.PlatformDetectionTests.DetectWinXPProfessionalX64" executed="True" result="Success" success="True" time="0.000" asserts="21" />
+                          <test-case name="NUnit.Core.Tests.PlatformDetectionTests.DetectXbox" executed="True" result="Success" success="True" time="0.000" asserts="25" />
+                          <test-case name="NUnit.Core.Tests.PlatformDetectionTests.PlatformAttribute_Exclude" executed="True" result="Success" success="True" time="0.001" asserts="3" />
+                          <test-case name="NUnit.Core.Tests.PlatformDetectionTests.PlatformAttribute_Include" executed="True" result="Success" success="True" time="0.000" asserts="3" />
+                          <test-case name="NUnit.Core.Tests.PlatformDetectionTests.PlatformAttribute_IncludeAndExclude" executed="True" result="Success" success="True" time="0.000" asserts="7" />
+                          <test-case name="NUnit.Core.Tests.PlatformDetectionTests.PlatformAttribute_InvalidPlatform" executed="True" result="Success" success="True" time="0.000" asserts="2" />
+                        </results>
+                      </test-suite>
+                      <test-suite type="TestFixture" name="PropertyAttributeTests" executed="True" result="Success" success="True" time="0.015" asserts="0">
+                        <results>
+                          <test-case name="NUnit.Core.Tests.PropertyAttributeTests.CanDeriveFromPropertyAttribute" executed="True" result="Success" success="True" time="0.003" asserts="1" />
+                          <test-case name="NUnit.Core.Tests.PropertyAttributeTests.PropertiesWithNumericValues" executed="True" result="Success" success="True" time="0.003" asserts="2" />
+                          <test-case name="NUnit.Core.Tests.PropertyAttributeTests.PropertyWithStringValue" executed="True" result="Success" success="True" time="0.002" asserts="1" />
+                          <test-case name="NUnit.Core.Tests.PropertyAttributeTests.PropertyWorksOnFixtures" executed="True" result="Success" success="True" time="0.002" asserts="1" />
+                        </results>
+                      </test-suite>
+                      <test-suite type="TestFixture" name="ReflectTests" executed="True" result="Success" success="True" time="0.034" asserts="0">
+                        <results>
+                          <test-case name="NUnit.Core.Tests.ReflectTests.CanDetectAttributes" executed="True" result="Success" success="True" time="0.000" asserts="3" />
+                          <test-case name="NUnit.Core.Tests.ReflectTests.CanDetectInheritedAttributes" executed="True" result="Success" success="True" time="0.000" asserts="3" />
+                          <test-case name="NUnit.Core.Tests.ReflectTests.Construct" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Core.Tests.ReflectTests.GetAttribute" executed="True" result="Success" success="True" time="0.001" asserts="3" />
+                          <test-case name="NUnit.Core.Tests.ReflectTests.GetAttributes" executed="True" result="Success" success="True" time="0.000" asserts="4" />
+                          <test-case name="NUnit.Core.Tests.ReflectTests.GetConstructor" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Core.Tests.ReflectTests.GetInheritedAttribute" executed="True" result="Success" success="True" time="0.001" asserts="3" />
+                          <test-case name="NUnit.Core.Tests.ReflectTests.GetInheritedAttributes" executed="True" result="Success" success="True" time="0.000" asserts="4" />
+                          <test-case name="NUnit.Core.Tests.ReflectTests.GetMethodsWithAttribute" executed="True" result="Success" success="True" time="0.001" asserts="1" />
+                          <test-case name="NUnit.Core.Tests.ReflectTests.GetNamedMethod" executed="True" result="Success" success="True" time="0.001" asserts="1" />
+                          <test-case name="NUnit.Core.Tests.ReflectTests.GetNamedMethodWithArgs" executed="True" result="Success" success="True" time="0.001" asserts="1" />
+                          <test-case name="NUnit.Core.Tests.ReflectTests.GetNamedProperty" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Core.Tests.ReflectTests.GetPropertyValue" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Core.Tests.ReflectTests.GetPropertyWithAttribute" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Core.Tests.ReflectTests.HasInterface" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Core.Tests.ReflectTests.InheritsFrom" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Core.Tests.ReflectTests.InvokeMethod" executed="True" result="Success" success="True" time="0.001" asserts="1" />
+                        </results>
+                      </test-suite>
+                      <test-suite type="TestFixture" name="RemoteRunnerTests" executed="True" result="Success" success="True" time="0.464" asserts="1">
+                        <results>
+                          <test-case name="NUnit.Core.Tests.RemoteRunnerTests.BasicRunnerTests.CheckRunnerID" executed="True" result="Success" success="True" time="0.001" asserts="1" />
+                          <test-case name="NUnit.Core.Tests.RemoteRunnerTests.BasicRunnerTests.CountTestCases" executed="True" result="Success" success="True" time="0.030" asserts="1" />
+                          <test-case name="NUnit.Core.Tests.RemoteRunnerTests.BasicRunnerTests.CountTestCasesAcrossMultipleAssemblies" executed="True" result="Success" success="True" time="0.040" asserts="1" />
+                          <test-case name="NUnit.Core.Tests.RemoteRunnerTests.BasicRunnerTests.LoadAndReloadAssembly" executed="True" result="Success" success="True" time="0.055" asserts="2" />
+                          <test-case name="NUnit.Core.Tests.RemoteRunnerTests.BasicRunnerTests.LoadAssemblyWithFixture" executed="True" result="Success" success="True" time="0.013" asserts="1" />
+                          <test-case name="NUnit.Core.Tests.RemoteRunnerTests.BasicRunnerTests.LoadAssemblyWithoutNamespaces" executed="True" result="Success" success="True" time="0.029" asserts="4" />
+                          <test-case name="NUnit.Core.Tests.RemoteRunnerTests.BasicRunnerTests.LoadAssemblyWithSuite" executed="True" result="Success" success="True" time="0.011" asserts="1" />
+                          <test-case name="NUnit.Core.Tests.RemoteRunnerTests.BasicRunnerTests.LoadMultipleAssemblies" executed="True" result="Success" success="True" time="0.038" asserts="1" />
+                          <test-case name="NUnit.Core.Tests.RemoteRunnerTests.BasicRunnerTests.LoadMultipleAssembliesWithFixture" executed="True" result="Success" success="True" time="0.022" asserts="1" />
+                          <test-case name="NUnit.Core.Tests.RemoteRunnerTests.BasicRunnerTests.LoadMultipleAssembliesWithSuite" executed="True" result="Success" success="True" time="0.019" asserts="1" />
+                          <test-case name="NUnit.Core.Tests.RemoteRunnerTests.BasicRunnerTests.RunAssembly" executed="True" result="Success" success="True" time="0.039" asserts="1" />
+                          <test-case name="NUnit.Core.Tests.RemoteRunnerTests.BasicRunnerTests.RunAssemblyUsingBeginAndEndRun" executed="True" result="Success" success="True" time="0.037" asserts="2" />
+                          <test-case name="NUnit.Core.Tests.RemoteRunnerTests.BasicRunnerTests.RunMultipleAssemblies" executed="True" result="Success" success="True" time="0.052" asserts="1" />
+                          <test-case name="NUnit.Core.Tests.RemoteRunnerTests.BasicRunnerTests.RunMultipleAssembliesUsingBeginAndEndRun" executed="True" result="Success" success="True" time="0.051" asserts="2" />
+                        </results>
+                      </test-suite>
+                      <test-suite type="TestFixture" name="RepeatedTestFixture" executed="True" result="Success" success="True" time="0.024" asserts="0">
+                        <results>
+                          <test-case name="NUnit.Core.Tests.RepeatedTestFixture.CategoryWorksWithRepeatedTest" executed="True" result="Success" success="True" time="0.003" asserts="3" />
+                          <test-case name="NUnit.Core.Tests.RepeatedTestFixture.IgnoreWorksWithRepeatedTest" executed="True" result="Success" success="True" time="0.003" asserts="3" />
+                          <test-case name="NUnit.Core.Tests.RepeatedTestFixture.RepeatFailOnFirst" executed="True" result="Success" success="True" time="0.004" asserts="4" />
+                          <test-case name="NUnit.Core.Tests.RepeatedTestFixture.RepeatFailOnThird" executed="True" result="Success" success="True" time="0.004" asserts="4" />
+                          <test-case name="NUnit.Core.Tests.RepeatedTestFixture.RepeatSuccess" executed="True" result="Success" success="True" time="0.002" asserts="6" />
+                        </results>
+                      </test-suite>
+                      <test-suite type="TestFixture" name="RuntimeFrameworkTests" executed="True" result="Success" success="True" time="0.514" asserts="0">
+                        <results>
+                          <test-suite type="ParameterizedTest" name="AnyFrameworkSupportsItself" executed="True" result="Success" success="True" time="0.035" asserts="0">
+                            <results>
+                              <test-case name="NUnit.Core.Tests.RuntimeFrameworkTests.AnyFrameworkSupportsItself(net-1.0)" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                              <test-case name="NUnit.Core.Tests.RuntimeFrameworkTests.AnyFrameworkSupportsItself(net-1.1)" executed="True" result="Success" success="True" time="0.001" asserts="1" />
+                              <test-case name="NUnit.Core.Tests.RuntimeFrameworkTests.AnyFrameworkSupportsItself(net-2.0)" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                              <test-case name="NUnit.Core.Tests.RuntimeFrameworkTests.AnyFrameworkSupportsItself(net-3.0)" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                              <test-case name="NUnit.Core.Tests.RuntimeFrameworkTests.AnyFrameworkSupportsItself(net-3.5)" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                              <test-case name="NUnit.Core.Tests.RuntimeFrameworkTests.AnyFrameworkSupportsItself(net-4.0)" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                              <test-case name="NUnit.Core.Tests.RuntimeFrameworkTests.AnyFrameworkSupportsItself(net-4.5)" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                              <test-case name="NUnit.Core.Tests.RuntimeFrameworkTests.AnyFrameworkSupportsItself(mono-1.0)" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                              <test-case name="NUnit.Core.Tests.RuntimeFrameworkTests.AnyFrameworkSupportsItself(mono-2.0)" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                              <test-case name="NUnit.Core.Tests.RuntimeFrameworkTests.AnyFrameworkSupportsItself(mono-3.0)" executed="True" result="Success" success="True" time="0.001" asserts="1" />
+                              <test-case name="NUnit.Core.Tests.RuntimeFrameworkTests.AnyFrameworkSupportsItself(mono-3.5)" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                              <test-case name="NUnit.Core.Tests.RuntimeFrameworkTests.AnyFrameworkSupportsItself(mono-4.0)" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                              <test-case name="NUnit.Core.Tests.RuntimeFrameworkTests.AnyFrameworkSupportsItself(mono-4.5)" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                              <test-case name="NUnit.Core.Tests.RuntimeFrameworkTests.AnyFrameworkSupportsItself(v1.0)" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                              <test-case name="NUnit.Core.Tests.RuntimeFrameworkTests.AnyFrameworkSupportsItself(v1.1)" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                              <test-case name="NUnit.Core.Tests.RuntimeFrameworkTests.AnyFrameworkSupportsItself(v2.0)" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                              <test-case name="NUnit.Core.Tests.RuntimeFrameworkTests.AnyFrameworkSupportsItself(v3.0)" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                              <test-case name="NUnit.Core.Tests.RuntimeFrameworkTests.AnyFrameworkSupportsItself(v3.5)" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                              <test-case name="NUnit.Core.Tests.RuntimeFrameworkTests.AnyFrameworkSupportsItself(v4.0)" executed="True" result="Success" success="True" time="0.001" asserts="1" />
+                              <test-case name="NUnit.Core.Tests.RuntimeFrameworkTests.AnyFrameworkSupportsItself(v4.5)" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                            </results>
+                          </test-suite>
+                          <test-suite type="ParameterizedTest" name="CanCreateUsingClrVersion" executed="True" result="Success" success="True" time="0.039" asserts="0">
+                            <results>
+                              <test-case name="NUnit.Core.Tests.RuntimeFrameworkTests.CanCreateUsingClrVersion(&lt;Net,1.0,1.0.3705&gt;)" executed="True" result="Success" success="True" time="0.001" asserts="3" />
+                              <test-case name="NUnit.Core.Tests.RuntimeFrameworkTests.CanCreateUsingClrVersion(&lt;Net,1.1,1.1.4322&gt;)" executed="True" result="Success" success="True" time="0.000" asserts="3" />
+                              <test-case name="NUnit.Core.Tests.RuntimeFrameworkTests.CanCreateUsingClrVersion(&lt;Net,2.0,2.0.50727&gt;)" executed="True" result="Success" success="True" time="0.000" asserts="3" />
+                              <test-case name="NUnit.Core.Tests.RuntimeFrameworkTests.CanCreateUsingClrVersion(&lt;Net,3.0,2.0.50727&gt;)" executed="True" result="Inconclusive" success="False" time="0.001" asserts="0">
+                                <reason>
+                                  <message><![CDATA[  Expected: True
+  But was:  False
+]]></message>
+                                </reason>
+                              </test-case>
+                              <test-case name="NUnit.Core.Tests.RuntimeFrameworkTests.CanCreateUsingClrVersion(&lt;Net,3.5,2.0.50727&gt;)" executed="True" result="Inconclusive" success="False" time="0.001" asserts="0">
+                                <reason>
+                                  <message><![CDATA[  Expected: True
+  But was:  False
+]]></message>
+                                </reason>
+                              </test-case>
+                              <test-case name="NUnit.Core.Tests.RuntimeFrameworkTests.CanCreateUsingClrVersion(&lt;Net,4.0,4.0.30319&gt;)" executed="True" result="Success" success="True" time="0.001" asserts="3" />
+                              <test-case name="NUnit.Core.Tests.RuntimeFrameworkTests.CanCreateUsingClrVersion(&lt;Net,4.5,4.0.30319&gt;)" executed="True" result="Inconclusive" success="False" time="0.002" asserts="0">
+                                <reason>
+                                  <message><![CDATA[  Expected: True
+  But was:  False
+]]></message>
+                                </reason>
+                              </test-case>
+                              <test-case name="NUnit.Core.Tests.RuntimeFrameworkTests.CanCreateUsingClrVersion(&lt;Net,0.0,0.0&gt;)" executed="True" result="Success" success="True" time="0.000" asserts="3" />
+                              <test-case name="NUnit.Core.Tests.RuntimeFrameworkTests.CanCreateUsingClrVersion(&lt;Mono,1.0,1.1.4322&gt;)" executed="True" result="Success" success="True" time="0.001" asserts="3" />
+                              <test-case name="NUnit.Core.Tests.RuntimeFrameworkTests.CanCreateUsingClrVersion(&lt;Mono,2.0,2.0.50727&gt;)" executed="True" result="Success" success="True" time="0.001" asserts="3" />
+                              <test-case name="NUnit.Core.Tests.RuntimeFrameworkTests.CanCreateUsingClrVersion(&lt;Mono,3.5,2.0.50727&gt;)" executed="True" result="Inconclusive" success="False" time="0.001" asserts="0">
+                                <reason>
+                                  <message><![CDATA[  Expected: True
+  But was:  False
+]]></message>
+                                </reason>
+                              </test-case>
+                              <test-case name="NUnit.Core.Tests.RuntimeFrameworkTests.CanCreateUsingClrVersion(&lt;Mono,4.0,4.0.30319&gt;)" executed="True" result="Success" success="True" time="0.000" asserts="3" />
+                              <test-case name="NUnit.Core.Tests.RuntimeFrameworkTests.CanCreateUsingClrVersion(&lt;Mono,0.0,0.0&gt;)" executed="True" result="Success" success="True" time="0.000" asserts="3" />
+                              <test-case name="NUnit.Core.Tests.RuntimeFrameworkTests.CanCreateUsingClrVersion(&lt;Any,1.1,1.1.4322&gt;)" executed="True" result="Success" success="True" time="0.000" asserts="3" />
+                              <test-case name="NUnit.Core.Tests.RuntimeFrameworkTests.CanCreateUsingClrVersion(&lt;Any,2.0,2.0.50727&gt;)" executed="True" result="Success" success="True" time="0.000" asserts="3" />
+                              <test-case name="NUnit.Core.Tests.RuntimeFrameworkTests.CanCreateUsingClrVersion(&lt;Any,3.5,2.0.50727&gt;)" executed="True" result="Inconclusive" success="False" time="0.001" asserts="0">
+                                <reason>
+                                  <message><![CDATA[  Expected: True
+  But was:  False
+]]></message>
+                                </reason>
+                              </test-case>
+                              <test-case name="NUnit.Core.Tests.RuntimeFrameworkTests.CanCreateUsingClrVersion(&lt;Any,4.0,4.0.30319&gt;)" executed="True" result="Success" success="True" time="0.000" asserts="3" />
+                              <test-case name="NUnit.Core.Tests.RuntimeFrameworkTests.CanCreateUsingClrVersion(&lt;Any,0.0,0.0&gt;)" executed="True" result="Success" success="True" time="0.000" asserts="3" />
+                            </results>
+                          </test-suite>
+                          <test-suite type="ParameterizedTest" name="CanCreateUsingFrameworkVersion" executed="True" result="Success" success="True" time="0.035" asserts="0">
+                            <results>
+                              <test-case name="NUnit.Core.Tests.RuntimeFrameworkTests.CanCreateUsingFrameworkVersion(&lt;Net,1.0,1.0.3705&gt;)" executed="True" result="Success" success="True" time="0.000" asserts="3" />
+                              <test-case name="NUnit.Core.Tests.RuntimeFrameworkTests.CanCreateUsingFrameworkVersion(&lt;Net,1.1,1.1.4322&gt;)" executed="True" result="Success" success="True" time="0.000" asserts="3" />
+                              <test-case name="NUnit.Core.Tests.RuntimeFrameworkTests.CanCreateUsingFrameworkVersion(&lt;Net,2.0,2.0.50727&gt;)" executed="True" result="Success" success="True" time="0.000" asserts="3" />
+                              <test-case name="NUnit.Core.Tests.RuntimeFrameworkTests.CanCreateUsingFrameworkVersion(&lt;Net,3.0,2.0.50727&gt;)" executed="True" result="Success" success="True" time="0.000" asserts="3" />
+                              <test-case name="NUnit.Core.Tests.RuntimeFrameworkTests.CanCreateUsingFrameworkVersion(&lt;Net,3.5,2.0.50727&gt;)" executed="True" result="Success" success="True" time="0.000" asserts="3" />
+                              <test-case name="NUnit.Core.Tests.RuntimeFrameworkTests.CanCreateUsingFrameworkVersion(&lt;Net,4.0,4.0.30319&gt;)" executed="True" result="Success" success="True" time="0.000" asserts="3" />
+                              <test-case name="NUnit.Core.Tests.RuntimeFrameworkTests.CanCreateUsingFrameworkVersion(&lt;Net,4.5,4.0.30319&gt;)" executed="True" result="Success" success="True" time="0.000" asserts="3" />
+                              <test-case name="NUnit.Core.Tests.RuntimeFrameworkTests.CanCreateUsingFrameworkVersion(&lt;Net,0.0,0.0&gt;)" executed="True" result="Success" success="True" time="0.001" asserts="3" />
+                              <test-case name="NUnit.Core.Tests.RuntimeFrameworkTests.CanCreateUsingFrameworkVersion(&lt;Mono,1.0,1.1.4322&gt;)" executed="True" result="Success" success="True" time="0.000" asserts="3" />
+                              <test-case name="NUnit.Core.Tests.RuntimeFrameworkTests.CanCreateUsingFrameworkVersion(&lt;Mono,2.0,2.0.50727&gt;)" executed="True" result="Success" success="True" time="0.000" asserts="3" />
+                              <test-case name="NUnit.Core.Tests.RuntimeFrameworkTests.CanCreateUsingFrameworkVersion(&lt;Mono,3.5,2.0.50727&gt;)" executed="True" result="Success" success="True" time="0.000" asserts="3" />
+                              <test-case name="NUnit.Core.Tests.RuntimeFrameworkTests.CanCreateUsingFrameworkVersion(&lt;Mono,4.0,4.0.30319&gt;)" executed="True" result="Success" success="True" time="0.000" asserts="3" />
+                              <test-case name="NUnit.Core.Tests.RuntimeFrameworkTests.CanCreateUsingFrameworkVersion(&lt;Mono,0.0,0.0&gt;)" executed="True" result="Success" success="True" time="0.000" asserts="3" />
+                              <test-case name="NUnit.Core.Tests.RuntimeFrameworkTests.CanCreateUsingFrameworkVersion(&lt;Any,1.1,1.1.4322&gt;)" executed="True" result="Success" success="True" time="0.000" asserts="3" />
+                              <test-case name="NUnit.Core.Tests.RuntimeFrameworkTests.CanCreateUsingFrameworkVersion(&lt;Any,2.0,2.0.50727&gt;)" executed="True" result="Success" success="True" time="0.000" asserts="3" />
+                              <test-case name="NUnit.Core.Tests.RuntimeFrameworkTests.CanCreateUsingFrameworkVersion(&lt;Any,3.5,2.0.50727&gt;)" executed="True" result="Success" success="True" time="0.001" asserts="3" />
+                              <test-case name="NUnit.Core.Tests.RuntimeFrameworkTests.CanCreateUsingFrameworkVersion(&lt;Any,4.0,4.0.30319&gt;)" executed="True" result="Success" success="True" time="0.000" asserts="3" />
+                              <test-case name="NUnit.Core.Tests.RuntimeFrameworkTests.CanCreateUsingFrameworkVersion(&lt;Any,0.0,0.0&gt;)" executed="True" result="Success" success="True" time="0.000" asserts="3" />
+                            </results>
+                          </test-suite>
+                          <test-suite type="ParameterizedTest" name="CanDisplayFrameworkAsString" executed="True" result="Success" success="True" time="0.034" asserts="0">
+                            <results>
+                              <test-case name="NUnit.Core.Tests.RuntimeFrameworkTests.CanDisplayFrameworkAsString(&lt;Net,1.0,1.0.3705&gt;)" executed="True" result="Success" success="True" time="0.000" asserts="2" />
+                              <test-case name="NUnit.Core.Tests.RuntimeFrameworkTests.CanDisplayFrameworkAsString(&lt;Net,1.1,1.1.4322&gt;)" executed="True" result="Success" success="True" time="0.000" asserts="2" />
+                              <test-case name="NUnit.Core.Tests.RuntimeFrameworkTests.CanDisplayFrameworkAsString(&lt;Net,2.0,2.0.50727&gt;)" executed="True" result="Success" success="True" time="0.000" asserts="2" />
+                              <test-case name="NUnit.Core.Tests.RuntimeFrameworkTests.CanDisplayFrameworkAsString(&lt;Net,3.0,2.0.50727&gt;)" executed="True" result="Success" success="True" time="0.001" asserts="2" />
+                              <test-case name="NUnit.Core.Tests.RuntimeFrameworkTests.CanDisplayFrameworkAsString(&lt;Net,3.5,2.0.50727&gt;)" executed="True" result="Success" success="True" time="0.000" asserts="2" />
+                              <test-case name="NUnit.Core.Tests.RuntimeFrameworkTests.CanDisplayFrameworkAsString(&lt;Net,4.0,4.0.30319&gt;)" executed="True" result="Success" success="True" time="0.000" asserts="2" />
+                              <test-case name="NUnit.Core.Tests.RuntimeFrameworkTests.CanDisplayFrameworkAsString(&lt;Net,4.5,4.0.30319&gt;)" executed="True" result="Success" success="True" time="0.000" asserts="2" />
+                              <test-case name="NUnit.Core.Tests.RuntimeFrameworkTests.CanDisplayFrameworkAsString(&lt;Net,0.0,0.0&gt;)" executed="True" result="Success" success="True" time="0.000" asserts="2" />
+                              <test-case name="NUnit.Core.Tests.RuntimeFrameworkTests.CanDisplayFrameworkAsString(&lt;Mono,1.0,1.1.4322&gt;)" executed="True" result="Success" success="True" time="0.000" asserts="2" />
+                              <test-case name="NUnit.Core.Tests.RuntimeFrameworkTests.CanDisplayFrameworkAsString(&lt;Mono,2.0,2.0.50727&gt;)" executed="True" result="Success" success="True" time="0.000" asserts="2" />
+                              <test-case name="NUnit.Core.Tests.RuntimeFrameworkTests.CanDisplayFrameworkAsString(&lt;Mono,3.5,2.0.50727&gt;)" executed="True" result="Success" success="True" time="0.000" asserts="2" />
+                              <test-case name="NUnit.Core.Tests.RuntimeFrameworkTests.CanDisplayFrameworkAsString(&lt;Mono,4.0,4.0.30319&gt;)" executed="True" result="Success" success="True" time="0.000" asserts="2" />
+                              <test-case name="NUnit.Core.Tests.RuntimeFrameworkTests.CanDisplayFrameworkAsString(&lt;Mono,0.0,0.0&gt;)" executed="True" result="Success" success="True" time="0.000" asserts="2" />
+                              <test-case name="NUnit.Core.Tests.RuntimeFrameworkTests.CanDisplayFrameworkAsString(&lt;Any,1.1,1.1.4322&gt;)" executed="True" result="Success" success="True" time="0.000" asserts="2" />
+                              <test-case name="NUnit.Core.Tests.RuntimeFrameworkTests.CanDisplayFrameworkAsString(&lt;Any,2.0,2.0.50727&gt;)" executed="True" result="Success" success="True" time="0.000" asserts="2" />
+                              <test-case name="NUnit.Core.Tests.RuntimeFrameworkTests.CanDisplayFrameworkAsString(&lt;Any,3.5,2.0.50727&gt;)" executed="True" result="Success" success="True" time="0.000" asserts="2" />
+                              <test-case name="NUnit.Core.Tests.RuntimeFrameworkTests.CanDisplayFrameworkAsString(&lt;Any,4.0,4.0.30319&gt;)" executed="True" result="Success" success="True" time="0.000" asserts="2" />
+                              <test-case name="NUnit.Core.Tests.RuntimeFrameworkTests.CanDisplayFrameworkAsString(&lt;Any,0.0,0.0&gt;)" executed="True" result="Success" success="True" time="0.000" asserts="2" />
+                            </results>
+                          </test-suite>
+                          <test-case name="NUnit.Core.Tests.RuntimeFrameworkTests.CanGetCurrentFramework" executed="True" result="Success" success="True" time="0.001" asserts="2" />
+                          <test-case name="NUnit.Core.Tests.RuntimeFrameworkTests.CanListAvailableFrameworks" executed="True" result="Success" success="True" time="0.004" asserts="2" />
+                          <test-suite type="ParameterizedTest" name="CanParseRuntimeFramework" executed="True" result="Success" success="True" time="0.030" asserts="0">
+                            <results>
+                              <test-case name="NUnit.Core.Tests.RuntimeFrameworkTests.CanParseRuntimeFramework(&lt;Net,1.0,1.0.3705&gt;)" executed="True" result="Success" success="True" time="0.000" asserts="2" />
+                              <test-case name="NUnit.Core.Tests.RuntimeFrameworkTests.CanParseRuntimeFramework(&lt;Net,1.1,1.1.4322&gt;)" executed="True" result="Success" success="True" time="0.000" asserts="2" />
+                              <test-case name="NUnit.Core.Tests.RuntimeFrameworkTests.CanParseRuntimeFramework(&lt;Net,2.0,2.0.50727&gt;)" executed="True" result="Success" success="True" time="0.000" asserts="2" />
+                              <test-case name="NUnit.Core.Tests.RuntimeFrameworkTests.CanParseRuntimeFramework(&lt;Net,3.0,2.0.50727&gt;)" executed="True" result="Success" success="True" time="0.000" asserts="2" />
+                              <test-case name="NUnit.Core.Tests.RuntimeFrameworkTests.CanParseRuntimeFramework(&lt;Net,3.5,2.0.50727&gt;)" executed="True" result="Success" success="True" time="0.000" asserts="2" />
+                              <test-case name="NUnit.Core.Tests.RuntimeFrameworkTests.CanParseRuntimeFramework(&lt;Net,4.0,4.0.30319&gt;)" executed="True" result="Success" success="True" time="0.001" asserts="2" />
+                              <test-case name="NUnit.Core.Tests.RuntimeFrameworkTests.CanParseRuntimeFramework(&lt;Net,4.5,4.0.30319&gt;)" executed="True" result="Success" success="True" time="0.000" asserts="2" />
+                              <test-case name="NUnit.Core.Tests.RuntimeFrameworkTests.CanParseRuntimeFramework(&lt;Net,0.0,0.0&gt;)" executed="True" result="Success" success="True" time="0.000" asserts="2" />
+                              <test-case name="NUnit.Core.Tests.RuntimeFrameworkTests.CanParseRuntimeFramework(&lt;Mono,1.0,1.1.4322&gt;)" executed="True" result="Success" success="True" time="0.000" asserts="2" />
+                              <test-case name="NUnit.Core.Tests.RuntimeFrameworkTests.CanParseRuntimeFramework(&lt;Mono,2.0,2.0.50727&gt;)" executed="True" result="Success" success="True" time="0.000" asserts="2" />
+                              <test-case name="NUnit.Core.Tests.RuntimeFrameworkTests.CanParseRuntimeFramework(&lt;Mono,3.5,2.0.50727&gt;)" executed="True" result="Success" success="True" time="0.000" asserts="2" />
+                              <test-case name="NUnit.Core.Tests.RuntimeFrameworkTests.CanParseRuntimeFramework(&lt;Mono,4.0,4.0.30319&gt;)" executed="True" result="Success" success="True" time="0.001" asserts="2" />
+                              <test-case name="NUnit.Core.Tests.RuntimeFrameworkTests.CanParseRuntimeFramework(&lt;Mono,0.0,0.0&gt;)" executed="True" result="Success" success="True" time="0.000" asserts="2" />
+                              <test-case name="NUnit.Core.Tests.RuntimeFrameworkTests.CanParseRuntimeFramework(&lt;Any,1.1,1.1.4322&gt;)" executed="True" result="Success" success="True" time="0.000" asserts="2" />
+                              <test-case name="NUnit.Core.Tests.RuntimeFrameworkTests.CanParseRuntimeFramework(&lt;Any,2.0,2.0.50727&gt;)" executed="True" result="Success" success="True" time="0.000" asserts="2" />
+                              <test-case name="NUnit.Core.Tests.RuntimeFrameworkTests.CanParseRuntimeFramework(&lt;Any,3.5,2.0.50727&gt;)" executed="True" result="Success" success="True" time="0.000" asserts="2" />
+                              <test-case name="NUnit.Core.Tests.RuntimeFrameworkTests.CanParseRuntimeFramework(&lt;Any,4.0,4.0.30319&gt;)" executed="True" result="Success" success="True" time="0.001" asserts="2" />
+                              <test-case name="NUnit.Core.Tests.RuntimeFrameworkTests.CanParseRuntimeFramework(&lt;Any,0.0,0.0&gt;)" executed="True" result="Success" success="True" time="0.000" asserts="2" />
+                            </results>
+                          </test-suite>
+                          <test-case name="NUnit.Core.Tests.RuntimeFrameworkTests.CurrentFrameworkHasBuildSpecified" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Core.Tests.RuntimeFrameworkTests.CurrentFrameworkMustBeAvailable" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                          <test-suite type="ParameterizedTest" name="DifferentRuntimes_NotSupported" executed="True" result="Success" success="True" time="0.010" asserts="0">
+                            <results>
+                              <test-case name="NUnit.Core.Tests.RuntimeFrameworkTests.DifferentRuntimes_NotSupported(mono-1.0)" executed="True" result="Success" success="True" time="0.000" asserts="2" />
+                              <test-case name="NUnit.Core.Tests.RuntimeFrameworkTests.DifferentRuntimes_NotSupported(mono-2.0)" executed="True" result="Success" success="True" time="0.000" asserts="2" />
+                              <test-case name="NUnit.Core.Tests.RuntimeFrameworkTests.DifferentRuntimes_NotSupported(mono-3.0)" executed="True" result="Success" success="True" time="0.000" asserts="2" />
+                              <test-case name="NUnit.Core.Tests.RuntimeFrameworkTests.DifferentRuntimes_NotSupported(mono-3.5)" executed="True" result="Success" success="True" time="0.000" asserts="2" />
+                              <test-case name="NUnit.Core.Tests.RuntimeFrameworkTests.DifferentRuntimes_NotSupported(mono-4.0)" executed="True" result="Success" success="True" time="0.000" asserts="2" />
+                              <test-case name="NUnit.Core.Tests.RuntimeFrameworkTests.DifferentRuntimes_NotSupported(mono-4.5)" executed="True" result="Success" success="True" time="0.000" asserts="2" />
+                            </results>
+                          </test-suite>
+                          <test-case name="NUnit.Core.Tests.RuntimeFrameworkTests.Mono11IsSynonymousWithMono10" executed="True" result="Success" success="True" time="0.000" asserts="6" />
+                          <test-suite type="ParameterizedTest" name="SameRuntime_HigherVersion_NotSupported" executed="True" result="Success" success="True" time="0.097" asserts="0">
+                            <results>
+                              <test-case name="NUnit.Core.Tests.RuntimeFrameworkTests.SameRuntime_HigherVersion_NotSupported(net-1.0,net-1.1)" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                              <test-case name="NUnit.Core.Tests.RuntimeFrameworkTests.SameRuntime_HigherVersion_NotSupported(net-1.0,net-2.0)" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                              <test-case name="NUnit.Core.Tests.RuntimeFrameworkTests.SameRuntime_HigherVersion_NotSupported(net-1.0,net-3.0)" executed="True" result="Success" success="True" time="0.001" asserts="1" />
+                              <test-case name="NUnit.Core.Tests.RuntimeFrameworkTests.SameRuntime_HigherVersion_NotSupported(net-1.0,net-3.5)" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                              <test-case name="NUnit.Core.Tests.RuntimeFrameworkTests.SameRuntime_HigherVersion_NotSupported(net-1.0,net-4.0)" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                              <test-case name="NUnit.Core.Tests.RuntimeFrameworkTests.SameRuntime_HigherVersion_NotSupported(net-1.0,net-4.5)" executed="True" result="Success" success="True" time="0.001" asserts="1" />
+                              <test-case name="NUnit.Core.Tests.RuntimeFrameworkTests.SameRuntime_HigherVersion_NotSupported(net-1.1,net-2.0)" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                              <test-case name="NUnit.Core.Tests.RuntimeFrameworkTests.SameRuntime_HigherVersion_NotSupported(net-1.1,net-3.0)" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                              <test-case name="NUnit.Core.Tests.RuntimeFrameworkTests.SameRuntime_HigherVersion_NotSupported(net-1.1,net-3.5)" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                              <test-case name="NUnit.Core.Tests.RuntimeFrameworkTests.SameRuntime_HigherVersion_NotSupported(net-1.1,net-4.0)" executed="True" result="Success" success="True" time="0.001" asserts="1" />
+                              <test-case name="NUnit.Core.Tests.RuntimeFrameworkTests.SameRuntime_HigherVersion_NotSupported(net-1.1,net-4.5)" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                              <test-case name="NUnit.Core.Tests.RuntimeFrameworkTests.SameRuntime_HigherVersion_NotSupported(net-2.0,net-3.0)" executed="True" result="Success" success="True" time="0.001" asserts="1" />
+                              <test-case name="NUnit.Core.Tests.RuntimeFrameworkTests.SameRuntime_HigherVersion_NotSupported(net-2.0,net-3.5)" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                              <test-case name="NUnit.Core.Tests.RuntimeFrameworkTests.SameRuntime_HigherVersion_NotSupported(net-2.0,net-4.0)" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                              <test-case name="NUnit.Core.Tests.RuntimeFrameworkTests.SameRuntime_HigherVersion_NotSupported(net-2.0,net-4.5)" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                              <test-case name="NUnit.Core.Tests.RuntimeFrameworkTests.SameRuntime_HigherVersion_NotSupported(net-3.0,net-3.5)" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                              <test-case name="NUnit.Core.Tests.RuntimeFrameworkTests.SameRuntime_HigherVersion_NotSupported(net-3.0,net-4.0)" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                              <test-case name="NUnit.Core.Tests.RuntimeFrameworkTests.SameRuntime_HigherVersion_NotSupported(net-3.0,net-4.5)" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                              <test-case name="NUnit.Core.Tests.RuntimeFrameworkTests.SameRuntime_HigherVersion_NotSupported(net-3.5,net-4.0)" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                              <test-case name="NUnit.Core.Tests.RuntimeFrameworkTests.SameRuntime_HigherVersion_NotSupported(net-3.5,net-4.5)" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                              <test-case name="NUnit.Core.Tests.RuntimeFrameworkTests.SameRuntime_HigherVersion_NotSupported(net-4.0,net-4.5)" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                              <test-case name="NUnit.Core.Tests.RuntimeFrameworkTests.SameRuntime_HigherVersion_NotSupported(mono-1.0,mono-2.0)" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                              <test-case name="NUnit.Core.Tests.RuntimeFrameworkTests.SameRuntime_HigherVersion_NotSupported(mono-1.0,mono-3.0)" executed="True" result="Success" success="True" time="0.001" asserts="1" />
+                              <test-case name="NUnit.Core.Tests.RuntimeFrameworkTests.SameRuntime_HigherVersion_NotSupported(mono-1.0,mono-3.5)" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                              <test-case name="NUnit.Core.Tests.RuntimeFrameworkTests.SameRuntime_HigherVersion_NotSupported(mono-1.0,mono-4.0)" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                              <test-case name="NUnit.Core.Tests.RuntimeFrameworkTests.SameRuntime_HigherVersion_NotSupported(mono-1.0,mono-4.5)" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                              <test-case name="NUnit.Core.Tests.RuntimeFrameworkTests.SameRuntime_HigherVersion_NotSupported(mono-2.0,mono-3.0)" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                              <test-case name="NUnit.Core.Tests.RuntimeFrameworkTests.SameRuntime_HigherVersion_NotSupported(mono-2.0,mono-3.5)" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                              <test-case name="NUnit.Core.Tests.RuntimeFrameworkTests.SameRuntime_HigherVersion_NotSupported(mono-2.0,mono-4.0)" executed="True" result="Success" success="True" time="0.001" asserts="1" />
+                              <test-case name="NUnit.Core.Tests.RuntimeFrameworkTests.SameRuntime_HigherVersion_NotSupported(mono-2.0,mono-4.5)" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                              <test-case name="NUnit.Core.Tests.RuntimeFrameworkTests.SameRuntime_HigherVersion_NotSupported(mono-3.0,mono-3.5)" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                              <test-case name="NUnit.Core.Tests.RuntimeFrameworkTests.SameRuntime_HigherVersion_NotSupported(mono-3.0,mono-4.0)" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                              <test-case name="NUnit.Core.Tests.RuntimeFrameworkTests.SameRuntime_HigherVersion_NotSupported(mono-3.0,mono-4.5)" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                              <test-case name="NUnit.Core.Tests.RuntimeFrameworkTests.SameRuntime_HigherVersion_NotSupported(mono-3.5,mono-4.0)" executed="True" result="Success" success="True" time="0.001" asserts="1" />
+                              <test-case name="NUnit.Core.Tests.RuntimeFrameworkTests.SameRuntime_HigherVersion_NotSupported(mono-3.5,mono-4.5)" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                              <test-case name="NUnit.Core.Tests.RuntimeFrameworkTests.SameRuntime_HigherVersion_NotSupported(mono-4.0,mono-4.5)" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                              <test-case name="NUnit.Core.Tests.RuntimeFrameworkTests.SameRuntime_HigherVersion_NotSupported(v1.0,v1.1)" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                              <test-case name="NUnit.Core.Tests.RuntimeFrameworkTests.SameRuntime_HigherVersion_NotSupported(v1.0,v2.0)" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                              <test-case name="NUnit.Core.Tests.RuntimeFrameworkTests.SameRuntime_HigherVersion_NotSupported(v1.0,v3.0)" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                              <test-case name="NUnit.Core.Tests.RuntimeFrameworkTests.SameRuntime_HigherVersion_NotSupported(v1.0,v3.5)" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                              <test-case name="NUnit.Core.Tests.RuntimeFrameworkTests.SameRuntime_HigherVersion_NotSupported(v1.0,v4.0)" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                              <test-case name="NUnit.Core.Tests.RuntimeFrameworkTests.SameRuntime_HigherVersion_NotSupported(v1.0,v4.5)" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                              <test-case name="NUnit.Core.Tests.RuntimeFrameworkTests.SameRuntime_HigherVersion_NotSupported(v1.1,v2.0)" executed="True" result="Success" success="True" time="0.001" asserts="1" />
+                              <test-case name="NUnit.Core.Tests.RuntimeFrameworkTests.SameRuntime_HigherVersion_NotSupported(v1.1,v3.0)" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                              <test-case name="NUnit.Core.Tests.RuntimeFrameworkTests.SameRuntime_HigherVersion_NotSupported(v1.1,v3.5)" executed="True" result="Success" success="True" time="0.001" asserts="1" />
+                              <test-case name="NUnit.Core.Tests.RuntimeFrameworkTests.SameRuntime_HigherVersion_NotSupported(v1.1,v4.0)" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                              <test-case name="NUnit.Core.Tests.RuntimeFrameworkTests.SameRuntime_HigherVersion_NotSupported(v1.1,v4.5)" executed="True" result="Success" success="True" time="0.001" asserts="1" />
+                              <test-case name="NUnit.Core.Tests.RuntimeFrameworkTests.SameRuntime_HigherVersion_NotSupported(v2.0,v3.0)" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                              <test-case name="NUnit.Core.Tests.RuntimeFrameworkTests.SameRuntime_HigherVersion_NotSupported(v2.0,v3.5)" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                              <test-case name="NUnit.Core.Tests.RuntimeFrameworkTests.SameRuntime_HigherVersion_NotSupported(v2.0,v4.0)" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                              <test-case name="NUnit.Core.Tests.RuntimeFrameworkTests.SameRuntime_HigherVersion_NotSupported(v2.0,v4.5)" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                              <test-case name="NUnit.Core.Tests.RuntimeFrameworkTests.SameRuntime_HigherVersion_NotSupported(v3.0,v3.5)" executed="True" result="Success" success="True" time="0.001" asserts="1" />
+                              <test-case name="NUnit.Core.Tests.RuntimeFrameworkTests.SameRuntime_HigherVersion_NotSupported(v3.0,v4.0)" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                              <test-case name="NUnit.Core.Tests.RuntimeFrameworkTests.SameRuntime_HigherVersion_NotSupported(v3.0,v4.5)" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                              <test-case name="NUnit.Core.Tests.RuntimeFrameworkTests.SameRuntime_HigherVersion_NotSupported(v3.5,v4.0)" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                              <test-case name="NUnit.Core.Tests.RuntimeFrameworkTests.SameRuntime_HigherVersion_NotSupported(v3.5,v4.5)" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                              <test-case name="NUnit.Core.Tests.RuntimeFrameworkTests.SameRuntime_HigherVersion_NotSupported(v4.0,v4.5)" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                            </results>
+                          </test-suite>
+                          <test-suite type="ParameterizedTest" name="SameRuntime_LowerVersion_DifferentCLR_NotSupported" executed="True" result="Success" success="True" time="0.077" asserts="0">
+                            <results>
+                              <test-case name="NUnit.Core.Tests.RuntimeFrameworkTests.SameRuntime_LowerVersion_DifferentCLR_NotSupported(net-1.1,net-1.0)" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                              <test-case name="NUnit.Core.Tests.RuntimeFrameworkTests.SameRuntime_LowerVersion_DifferentCLR_NotSupported(net-2.0,net-1.0)" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                              <test-case name="NUnit.Core.Tests.RuntimeFrameworkTests.SameRuntime_LowerVersion_DifferentCLR_NotSupported(net-3.0,net-1.0)" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                              <test-case name="NUnit.Core.Tests.RuntimeFrameworkTests.SameRuntime_LowerVersion_DifferentCLR_NotSupported(net-3.5,net-1.0)" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                              <test-case name="NUnit.Core.Tests.RuntimeFrameworkTests.SameRuntime_LowerVersion_DifferentCLR_NotSupported(net-4.0,net-1.0)" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                              <test-case name="NUnit.Core.Tests.RuntimeFrameworkTests.SameRuntime_LowerVersion_DifferentCLR_NotSupported(net-4.5,net-1.0)" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                              <test-case name="NUnit.Core.Tests.RuntimeFrameworkTests.SameRuntime_LowerVersion_DifferentCLR_NotSupported(net-2.0,net-1.1)" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                              <test-case name="NUnit.Core.Tests.RuntimeFrameworkTests.SameRuntime_LowerVersion_DifferentCLR_NotSupported(net-3.0,net-1.1)" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                              <test-case name="NUnit.Core.Tests.RuntimeFrameworkTests.SameRuntime_LowerVersion_DifferentCLR_NotSupported(net-3.5,net-1.1)" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                              <test-case name="NUnit.Core.Tests.RuntimeFrameworkTests.SameRuntime_LowerVersion_DifferentCLR_NotSupported(net-4.0,net-1.1)" executed="True" result="Success" success="True" time="0.001" asserts="1" />
+                              <test-case name="NUnit.Core.Tests.RuntimeFrameworkTests.SameRuntime_LowerVersion_DifferentCLR_NotSupported(net-4.5,net-1.1)" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                              <test-case name="NUnit.Core.Tests.RuntimeFrameworkTests.SameRuntime_LowerVersion_DifferentCLR_NotSupported(net-4.0,net-2.0)" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                              <test-case name="NUnit.Core.Tests.RuntimeFrameworkTests.SameRuntime_LowerVersion_DifferentCLR_NotSupported(net-4.5,net-2.0)" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                              <test-case name="NUnit.Core.Tests.RuntimeFrameworkTests.SameRuntime_LowerVersion_DifferentCLR_NotSupported(net-4.0,net-3.0)" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                              <test-case name="NUnit.Core.Tests.RuntimeFrameworkTests.SameRuntime_LowerVersion_DifferentCLR_NotSupported(net-4.5,net-3.0)" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                              <test-case name="NUnit.Core.Tests.RuntimeFrameworkTests.SameRuntime_LowerVersion_DifferentCLR_NotSupported(net-4.0,net-3.5)" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                              <test-case name="NUnit.Core.Tests.RuntimeFrameworkTests.SameRuntime_LowerVersion_DifferentCLR_NotSupported(net-4.5,net-3.5)" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                              <test-case name="NUnit.Core.Tests.RuntimeFrameworkTests.SameRuntime_LowerVersion_DifferentCLR_NotSupported(mono-2.0,mono-1.0)" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                              <test-case name="NUnit.Core.Tests.RuntimeFrameworkTests.SameRuntime_LowerVersion_DifferentCLR_NotSupported(mono-3.0,mono-1.0)" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                              <test-case name="NUnit.Core.Tests.RuntimeFrameworkTests.SameRuntime_LowerVersion_DifferentCLR_NotSupported(mono-3.5,mono-1.0)" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                              <test-case name="NUnit.Core.Tests.RuntimeFrameworkTests.SameRuntime_LowerVersion_DifferentCLR_NotSupported(mono-4.0,mono-1.0)" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                              <test-case name="NUnit.Core.Tests.RuntimeFrameworkTests.SameRuntime_LowerVersion_DifferentCLR_NotSupported(mono-4.5,mono-1.0)" executed="True" result="Success" success="True" time="0.001" asserts="1" />
+                              <test-case name="NUnit.Core.Tests.RuntimeFrameworkTests.SameRuntime_LowerVersion_DifferentCLR_NotSupported(mono-4.0,mono-2.0)" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                              <test-case name="NUnit.Core.Tests.RuntimeFrameworkTests.SameRuntime_LowerVersion_DifferentCLR_NotSupported(mono-4.5,mono-2.0)" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                              <test-case name="NUnit.Core.Tests.RuntimeFrameworkTests.SameRuntime_LowerVersion_DifferentCLR_NotSupported(mono-4.0,mono-3.0)" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                              <test-case name="NUnit.Core.Tests.RuntimeFrameworkTests.SameRuntime_LowerVersion_DifferentCLR_NotSupported(mono-4.5,mono-3.0)" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                              <test-case name="NUnit.Core.Tests.RuntimeFrameworkTests.SameRuntime_LowerVersion_DifferentCLR_NotSupported(mono-4.0,mono-3.5)" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                              <test-case name="NUnit.Core.Tests.RuntimeFrameworkTests.SameRuntime_LowerVersion_DifferentCLR_NotSupported(mono-4.5,mono-3.5)" executed="True" result="Success" success="True" time="0.001" asserts="1" />
+                              <test-case name="NUnit.Core.Tests.RuntimeFrameworkTests.SameRuntime_LowerVersion_DifferentCLR_NotSupported(v1.1,v1.0)" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                              <test-case name="NUnit.Core.Tests.RuntimeFrameworkTests.SameRuntime_LowerVersion_DifferentCLR_NotSupported(v2.0,v1.0)" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                              <test-case name="NUnit.Core.Tests.RuntimeFrameworkTests.SameRuntime_LowerVersion_DifferentCLR_NotSupported(v3.0,v1.0)" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                              <test-case name="NUnit.Core.Tests.RuntimeFrameworkTests.SameRuntime_LowerVersion_DifferentCLR_NotSupported(v3.5,v1.0)" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                              <test-case name="NUnit.Core.Tests.RuntimeFrameworkTests.SameRuntime_LowerVersion_DifferentCLR_NotSupported(v4.0,v1.0)" executed="True" result="Success" success="True" time="0.001" asserts="1" />
+                              <test-case name="NUnit.Core.Tests.RuntimeFrameworkTests.SameRuntime_LowerVersion_DifferentCLR_NotSupported(v4.5,v1.0)" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                              <test-case name="NUnit.Core.Tests.RuntimeFrameworkTests.SameRuntime_LowerVersion_DifferentCLR_NotSupported(v2.0,v1.1)" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                              <test-case name="NUnit.Core.Tests.RuntimeFrameworkTests.SameRuntime_LowerVersion_DifferentCLR_NotSupported(v3.0,v1.1)" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                              <test-case name="NUnit.Core.Tests.RuntimeFrameworkTests.SameRuntime_LowerVersion_DifferentCLR_NotSupported(v3.5,v1.1)" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                              <test-case name="NUnit.Core.Tests.RuntimeFrameworkTests.SameRuntime_LowerVersion_DifferentCLR_NotSupported(v4.0,v1.1)" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                              <test-case name="NUnit.Core.Tests.RuntimeFrameworkTests.SameRuntime_LowerVersion_DifferentCLR_NotSupported(v4.5,v1.1)" executed="True" result="Success" success="True" time="0.001" asserts="1" />
+                              <test-case name="NUnit.Core.Tests.RuntimeFrameworkTests.SameRuntime_LowerVersion_DifferentCLR_NotSupported(v4.0,v2.0)" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                              <test-case name="NUnit.Core.Tests.RuntimeFrameworkTests.SameRuntime_LowerVersion_DifferentCLR_NotSupported(v4.5,v2.0)" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                              <test-case name="NUnit.Core.Tests.RuntimeFrameworkTests.SameRuntime_LowerVersion_DifferentCLR_NotSupported(v4.0,v3.0)" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                              <test-case name="NUnit.Core.Tests.RuntimeFrameworkTests.SameRuntime_LowerVersion_DifferentCLR_NotSupported(v4.5,v3.0)" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                              <test-case name="NUnit.Core.Tests.RuntimeFrameworkTests.SameRuntime_LowerVersion_DifferentCLR_NotSupported(v4.0,v3.5)" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                              <test-case name="NUnit.Core.Tests.RuntimeFrameworkTests.SameRuntime_LowerVersion_DifferentCLR_NotSupported(v4.5,v3.5)" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                            </results>
+                          </test-suite>
+                          <test-suite type="ParameterizedTest" name="SameRuntime_LowerVersion_SameCLR_Supported" executed="True" result="Success" success="True" time="0.022" asserts="0">
+                            <results>
+                              <test-case name="NUnit.Core.Tests.RuntimeFrameworkTests.SameRuntime_LowerVersion_SameCLR_Supported(net-3.0,net-2.0)" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                              <test-case name="NUnit.Core.Tests.RuntimeFrameworkTests.SameRuntime_LowerVersion_SameCLR_Supported(net-3.5,net-2.0)" executed="True" result="Success" success="True" time="0.001" asserts="1" />
+                              <test-case name="NUnit.Core.Tests.RuntimeFrameworkTests.SameRuntime_LowerVersion_SameCLR_Supported(net-3.5,net-3.0)" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                              <test-case name="NUnit.Core.Tests.RuntimeFrameworkTests.SameRuntime_LowerVersion_SameCLR_Supported(net-4.5,net-4.0)" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                              <test-case name="NUnit.Core.Tests.RuntimeFrameworkTests.SameRuntime_LowerVersion_SameCLR_Supported(mono-3.0,mono-2.0)" executed="True" result="Success" success="True" time="0.001" asserts="1" />
+                              <test-case name="NUnit.Core.Tests.RuntimeFrameworkTests.SameRuntime_LowerVersion_SameCLR_Supported(mono-3.5,mono-2.0)" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                              <test-case name="NUnit.Core.Tests.RuntimeFrameworkTests.SameRuntime_LowerVersion_SameCLR_Supported(mono-3.5,mono-3.0)" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                              <test-case name="NUnit.Core.Tests.RuntimeFrameworkTests.SameRuntime_LowerVersion_SameCLR_Supported(mono-4.5,mono-4.0)" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                              <test-case name="NUnit.Core.Tests.RuntimeFrameworkTests.SameRuntime_LowerVersion_SameCLR_Supported(v3.0,v2.0)" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                              <test-case name="NUnit.Core.Tests.RuntimeFrameworkTests.SameRuntime_LowerVersion_SameCLR_Supported(v3.5,v2.0)" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                              <test-case name="NUnit.Core.Tests.RuntimeFrameworkTests.SameRuntime_LowerVersion_SameCLR_Supported(v3.5,v3.0)" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                              <test-case name="NUnit.Core.Tests.RuntimeFrameworkTests.SameRuntime_LowerVersion_SameCLR_Supported(v4.5,v4.0)" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                            </results>
+                          </test-suite>
+                          <test-case name="NUnit.Core.Tests.RuntimeFrameworkTests.SameRuntimes_DifferentBuilds_NotSupported" executed="True" result="Success" success="True" time="0.001" asserts="2" />
+                          <test-suite type="ParameterizedTest" name="UnspecifiedRuntime_SameVersion_Supported" executed="True" result="Success" success="True" time="0.022" asserts="0">
+                            <results>
+                              <test-case name="NUnit.Core.Tests.RuntimeFrameworkTests.UnspecifiedRuntime_SameVersion_Supported(mono-1.0)" executed="True" result="Inconclusive" success="False" time="0.001" asserts="0">
+                                <reason>
+                                  <message><![CDATA[  Expected: True
+  But was:  False
+]]></message>
+                                </reason>
+                              </test-case>
+                              <test-case name="NUnit.Core.Tests.RuntimeFrameworkTests.UnspecifiedRuntime_SameVersion_Supported(mono-2.0)" executed="True" result="Success" success="True" time="0.000" asserts="2" />
+                              <test-case name="NUnit.Core.Tests.RuntimeFrameworkTests.UnspecifiedRuntime_SameVersion_Supported(mono-3.0)" executed="True" result="Success" success="True" time="0.001" asserts="2" />
+                              <test-case name="NUnit.Core.Tests.RuntimeFrameworkTests.UnspecifiedRuntime_SameVersion_Supported(mono-3.5)" executed="True" result="Success" success="True" time="0.000" asserts="2" />
+                              <test-case name="NUnit.Core.Tests.RuntimeFrameworkTests.UnspecifiedRuntime_SameVersion_Supported(mono-4.0)" executed="True" result="Success" success="True" time="0.000" asserts="2" />
+                              <test-case name="NUnit.Core.Tests.RuntimeFrameworkTests.UnspecifiedRuntime_SameVersion_Supported(mono-4.5)" executed="True" result="Success" success="True" time="0.000" asserts="2" />
+                              <test-case name="NUnit.Core.Tests.RuntimeFrameworkTests.UnspecifiedRuntime_SameVersion_Supported(net-1.0)" executed="True" result="Success" success="True" time="0.000" asserts="2" />
+                              <test-case name="NUnit.Core.Tests.RuntimeFrameworkTests.UnspecifiedRuntime_SameVersion_Supported(net-1.1)" executed="True" result="Success" success="True" time="0.000" asserts="2" />
+                              <test-case name="NUnit.Core.Tests.RuntimeFrameworkTests.UnspecifiedRuntime_SameVersion_Supported(net-2.0)" executed="True" result="Success" success="True" time="0.000" asserts="2" />
+                              <test-case name="NUnit.Core.Tests.RuntimeFrameworkTests.UnspecifiedRuntime_SameVersion_Supported(net-3.0)" executed="True" result="Success" success="True" time="0.000" asserts="2" />
+                              <test-case name="NUnit.Core.Tests.RuntimeFrameworkTests.UnspecifiedRuntime_SameVersion_Supported(net-3.5)" executed="True" result="Success" success="True" time="0.000" asserts="2" />
+                              <test-case name="NUnit.Core.Tests.RuntimeFrameworkTests.UnspecifiedRuntime_SameVersion_Supported(net-4.0)" executed="True" result="Success" success="True" time="0.000" asserts="2" />
+                              <test-case name="NUnit.Core.Tests.RuntimeFrameworkTests.UnspecifiedRuntime_SameVersion_Supported(net-4.5)" executed="True" result="Success" success="True" time="0.000" asserts="2" />
+                            </results>
+                          </test-suite>
+                          <test-suite type="ParameterizedTest" name="UnspecifiedRuntimeAndVersion_Supported" executed="True" result="Success" success="True" time="0.021" asserts="0">
+                            <results>
+                              <test-case name="NUnit.Core.Tests.RuntimeFrameworkTests.UnspecifiedRuntimeAndVersion_Supported(net-1.0)" executed="True" result="Success" success="True" time="0.000" asserts="2" />
+                              <test-case name="NUnit.Core.Tests.RuntimeFrameworkTests.UnspecifiedRuntimeAndVersion_Supported(net-1.1)" executed="True" result="Success" success="True" time="0.000" asserts="2" />
+                              <test-case name="NUnit.Core.Tests.RuntimeFrameworkTests.UnspecifiedRuntimeAndVersion_Supported(net-2.0)" executed="True" result="Success" success="True" time="0.000" asserts="2" />
+                              <test-case name="NUnit.Core.Tests.RuntimeFrameworkTests.UnspecifiedRuntimeAndVersion_Supported(net-3.0)" executed="True" result="Success" success="True" time="0.001" asserts="2" />
+                              <test-case name="NUnit.Core.Tests.RuntimeFrameworkTests.UnspecifiedRuntimeAndVersion_Supported(net-3.5)" executed="True" result="Success" success="True" time="0.000" asserts="2" />
+                              <test-case name="NUnit.Core.Tests.RuntimeFrameworkTests.UnspecifiedRuntimeAndVersion_Supported(net-4.0)" executed="True" result="Success" success="True" time="0.000" asserts="2" />
+                              <test-case name="NUnit.Core.Tests.RuntimeFrameworkTests.UnspecifiedRuntimeAndVersion_Supported(net-4.5)" executed="True" result="Success" success="True" time="0.000" asserts="2" />
+                              <test-case name="NUnit.Core.Tests.RuntimeFrameworkTests.UnspecifiedRuntimeAndVersion_Supported(mono-1.0)" executed="True" result="Success" success="True" time="0.001" asserts="2" />
+                              <test-case name="NUnit.Core.Tests.RuntimeFrameworkTests.UnspecifiedRuntimeAndVersion_Supported(mono-2.0)" executed="True" result="Success" success="True" time="0.000" asserts="2" />
+                              <test-case name="NUnit.Core.Tests.RuntimeFrameworkTests.UnspecifiedRuntimeAndVersion_Supported(mono-3.0)" executed="True" result="Success" success="True" time="0.001" asserts="2" />
+                              <test-case name="NUnit.Core.Tests.RuntimeFrameworkTests.UnspecifiedRuntimeAndVersion_Supported(mono-3.5)" executed="True" result="Success" success="True" time="0.000" asserts="2" />
+                              <test-case name="NUnit.Core.Tests.RuntimeFrameworkTests.UnspecifiedRuntimeAndVersion_Supported(mono-4.0)" executed="True" result="Success" success="True" time="0.000" asserts="2" />
+                              <test-case name="NUnit.Core.Tests.RuntimeFrameworkTests.UnspecifiedRuntimeAndVersion_Supported(mono-4.5)" executed="True" result="Success" success="True" time="0.000" asserts="2" />
+                            </results>
+                          </test-suite>
+                          <test-suite type="ParameterizedTest" name="UnspecifiedVersion_SameRuntime_Supported" executed="True" result="Success" success="True" time="0.021" asserts="0">
+                            <results>
+                              <test-case name="NUnit.Core.Tests.RuntimeFrameworkTests.UnspecifiedVersion_SameRuntime_Supported(mono-1.0)" executed="True" result="Success" success="True" time="0.001" asserts="2" />
+                              <test-case name="NUnit.Core.Tests.RuntimeFrameworkTests.UnspecifiedVersion_SameRuntime_Supported(mono-2.0)" executed="True" result="Success" success="True" time="0.000" asserts="2" />
+                              <test-case name="NUnit.Core.Tests.RuntimeFrameworkTests.UnspecifiedVersion_SameRuntime_Supported(mono-3.0)" executed="True" result="Success" success="True" time="0.001" asserts="2" />
+                              <test-case name="NUnit.Core.Tests.RuntimeFrameworkTests.UnspecifiedVersion_SameRuntime_Supported(mono-3.5)" executed="True" result="Success" success="True" time="0.000" asserts="2" />
+                              <test-case name="NUnit.Core.Tests.RuntimeFrameworkTests.UnspecifiedVersion_SameRuntime_Supported(mono-4.0)" executed="True" result="Success" success="True" time="0.000" asserts="2" />
+                              <test-case name="NUnit.Core.Tests.RuntimeFrameworkTests.UnspecifiedVersion_SameRuntime_Supported(mono-4.5)" executed="True" result="Success" success="True" time="0.000" asserts="2" />
+                              <test-case name="NUnit.Core.Tests.RuntimeFrameworkTests.UnspecifiedVersion_SameRuntime_Supported(net-1.0)" executed="True" result="Success" success="True" time="0.000" asserts="2" />
+                              <test-case name="NUnit.Core.Tests.RuntimeFrameworkTests.UnspecifiedVersion_SameRuntime_Supported(net-1.1)" executed="True" result="Success" success="True" time="0.000" asserts="2" />
+                              <test-case name="NUnit.Core.Tests.RuntimeFrameworkTests.UnspecifiedVersion_SameRuntime_Supported(net-2.0)" executed="True" result="Success" success="True" time="0.000" asserts="2" />
+                              <test-case name="NUnit.Core.Tests.RuntimeFrameworkTests.UnspecifiedVersion_SameRuntime_Supported(net-3.0)" executed="True" result="Success" success="True" time="0.000" asserts="2" />
+                              <test-case name="NUnit.Core.Tests.RuntimeFrameworkTests.UnspecifiedVersion_SameRuntime_Supported(net-3.5)" executed="True" result="Success" success="True" time="0.000" asserts="2" />
+                              <test-case name="NUnit.Core.Tests.RuntimeFrameworkTests.UnspecifiedVersion_SameRuntime_Supported(net-4.0)" executed="True" result="Success" success="True" time="0.000" asserts="2" />
+                              <test-case name="NUnit.Core.Tests.RuntimeFrameworkTests.UnspecifiedVersion_SameRuntime_Supported(net-4.5)" executed="True" result="Success" success="True" time="0.000" asserts="2" />
+                            </results>
+                          </test-suite>
+                          <test-suite type="ParameterizedTest" name="WellKnownClrVersions_SupportEquivalentFrameworkVersions" executed="True" result="Success" success="True" time="0.007" asserts="0">
+                            <results>
+                              <test-case name="NUnit.Core.Tests.RuntimeFrameworkTests.WellKnownClrVersions_SupportEquivalentFrameworkVersions(&quot;net-4.0.30319&quot;)" executed="True" result="Success" success="True" time="0.001" asserts="5" />
+                              <test-case name="NUnit.Core.Tests.RuntimeFrameworkTests.WellKnownClrVersions_SupportEquivalentFrameworkVersions(&quot;net-1.0.3705&quot;)" executed="True" result="Success" success="True" time="0.000" asserts="5" />
+                              <test-case name="NUnit.Core.Tests.RuntimeFrameworkTests.WellKnownClrVersions_SupportEquivalentFrameworkVersions(&quot;net-1.1.4322&quot;)" executed="True" result="Success" success="True" time="0.000" asserts="5" />
+                              <test-case name="NUnit.Core.Tests.RuntimeFrameworkTests.WellKnownClrVersions_SupportEquivalentFrameworkVersions(&quot;net-2.0.50727&quot;)" executed="True" result="Success" success="True" time="0.001" asserts="5" />
+                            </results>
+                          </test-suite>
+                        </results>
+                      </test-suite>
+                      <test-suite type="TestFixture" name="SerializationBug" executed="True" result="Success" success="True" time="0.005" asserts="0">
+                        <results>
+                          <test-case name="NUnit.Core.Tests.SerializationBug.SaveAndLoad" executed="True" result="Success" success="True" time="0.003" asserts="3" />
+                        </results>
+                      </test-suite>
+                      <test-suite type="TestFixture" name="SetCultureAttributeTests" executed="True" result="Success" success="True" time="0.014" asserts="0">
+                        <results>
+                          <test-case name="NUnit.Core.Tests.SetCultureAttributeTests.SetBothCulturesToFrench" executed="True" result="Success" success="True" time="0.001" asserts="2" />
+                          <test-case name="NUnit.Core.Tests.SetCultureAttributeTests.SetBothCulturesToFrenchCanadian" executed="True" result="Success" success="True" time="0.001" asserts="2" />
+                          <test-case name="NUnit.Core.Tests.SetCultureAttributeTests.SetBothCulturesToRussian" executed="True" result="Success" success="True" time="0.001" asserts="2" />
+                          <test-case name="NUnit.Core.Tests.SetCultureAttributeTests.SetMixedCulturesToFrenchAndUIFrenchCanadian" executed="True" result="Success" success="True" time="0.001" asserts="2" />
+                          <test-case name="NUnit.Core.Tests.SetCultureAttributeTests.SetMixedCulturesToRussianAndUIEnglishUS" executed="True" result="Success" success="True" time="0.001" asserts="2" />
+                          <test-case name="NUnit.Core.Tests.SetCultureAttributeTests.SetUICultureOnlyToFrench" executed="True" result="Success" success="True" time="0.000" asserts="2" />
+                          <test-case name="NUnit.Core.Tests.SetCultureAttributeTests.SetUICultureOnlyToFrenchCanadian" executed="True" result="Success" success="True" time="0.000" asserts="2" />
+                          <test-case name="NUnit.Core.Tests.SetCultureAttributeTests.SetUICultureOnlyToRussian" executed="True" result="Success" success="True" time="0.000" asserts="2" />
+                        </results>
+                      </test-suite>
+                      <test-suite type="TestFixture" name="SetCultureAttributeTests+NestedBehavior" executed="True" result="Success" success="True" time="0.003" asserts="0">
+                        <results>
+                          <test-case name="NUnit.Core.Tests.SetCultureAttributeTests+NestedBehavior.InheritedRussian" executed="True" result="Success" success="True" time="0.000" asserts="2" />
+                          <test-case name="NUnit.Core.Tests.SetCultureAttributeTests+NestedBehavior.InheritedRussianWithUIFrench" executed="True" result="Success" success="True" time="0.001" asserts="2" />
+                        </results>
+                      </test-suite>
+                      <test-suite type="TestFixture" name="SetUpFixtureTests" executed="True" result="Success" success="True" time="0.735" asserts="0">
+                        <results>
+                          <test-case name="NUnit.Core.Tests.SetUpFixtureTests.AssemblySetUpFixtureReplacesAssemblyNodeInTree" executed="True" result="Success" success="True" time="0.319" asserts="4" />
+                          <test-case name="NUnit.Core.Tests.SetUpFixtureTests.AssemblySetupFixtureWrapsExecutionOfTest" executed="True" result="Success" success="True" time="0.307" asserts="5" />
+                          <test-case name="NUnit.Core.Tests.SetUpFixtureTests.NamespaceSetUpFixtureReplacesNamespaceNodeInTree" executed="True" result="Success" success="True" time="0.013" asserts="14" />
+                          <test-case name="NUnit.Core.Tests.SetUpFixtureTests.NamespaceSetUpFixtureWrapsExecutionOfSingleTest" executed="True" result="Success" success="True" time="0.014" asserts="8" />
+                          <test-case name="NUnit.Core.Tests.SetUpFixtureTests.NamespaceSetUpFixtureWrapsExecutionOfTwoTests" executed="True" result="Success" success="True" time="0.015" asserts="13" />
+                          <test-case name="NUnit.Core.Tests.SetUpFixtureTests.NamespaceSetUpFixtureWrapsNestedNamespaceSetUpFixture" executed="True" result="Success" success="True" time="0.017" asserts="15" />
+                          <test-case name="NUnit.Core.Tests.SetUpFixtureTests.NamespaceSetUpMethodsMayBeStatic" executed="True" result="Success" success="True" time="0.018" asserts="8" />
+                          <test-case name="NUnit.Core.Tests.SetUpFixtureTests.WithTwoSetUpFixtuesOnlyOneIsUsed" executed="True" result="Success" success="True" time="0.014" asserts="8" />
+                        </results>
+                      </test-suite>
+                      <test-suite type="TestFixture" name="SetUpTest" executed="True" result="Success" success="True" time="0.035" asserts="0">
+                        <results>
+                          <test-case name="NUnit.Core.Tests.SetUpTest.BaseSetUpIsCalledFirstTearDownLast" executed="True" result="Success" success="True" time="0.003" asserts="6" />
+                          <test-case name="NUnit.Core.Tests.SetUpTest.CheckInheritedSetUpAndTearDownAreCalled" executed="True" result="Success" success="True" time="0.002" asserts="2" />
+                          <test-case name="NUnit.Core.Tests.SetUpTest.CheckOverriddenSetUpAndTearDownAreNotCalled" executed="True" result="Success" success="True" time="0.002" asserts="4" />
+                          <test-case name="NUnit.Core.Tests.SetUpTest.MakeSureSetUpAndTearDownAreCalled" executed="True" result="Success" success="True" time="0.002" asserts="2" />
+                          <test-case name="NUnit.Core.Tests.SetUpTest.MultipleSetUpAndTearDownMethodsAreCalled" executed="True" result="Success" success="True" time="0.002" asserts="5" />
+                          <test-case name="NUnit.Core.Tests.SetUpTest.SetUpAndTearDownCounter" executed="True" result="Success" success="True" time="0.002" asserts="2" />
+                          <test-case name="NUnit.Core.Tests.SetUpTest.SetupRecordsOriginalExceptionThownByTestCase" executed="True" result="Success" success="True" time="0.003" asserts="4" />
+                          <test-case name="NUnit.Core.Tests.SetUpTest.TearDownRecordsOriginalExceptionThownByTestCase" executed="True" result="Success" success="True" time="0.003" asserts="4" />
+                        </results>
+                      </test-suite>
+                      <test-suite type="TestFixture" name="SetUpTest+SetupCallDerived" executed="True" result="Success" success="True" time="0.002" asserts="0">
+                        <results>
+                          <test-case name="NUnit.Core.Tests.SetUpTest+SetupCallDerived.AssertCount" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                        </results>
+                      </test-suite>
+                      <test-suite type="TestFixture" name="SimpleNameFilterTests" executed="True" result="Success" success="True" time="0.056" asserts="0">
+                        <results>
+                          <test-case name="NUnit.Core.Tests.SimpleNameFilterTests.ExplicitTestCaseDoesNotMatchWhenNotSelectedDirectly" executed="True" result="Success" success="True" time="0.005" asserts="1" />
+                          <test-case name="NUnit.Core.Tests.SimpleNameFilterTests.ExplicitTestCaseMatchesWhenSelectedDirectly" executed="True" result="Success" success="True" time="0.007" asserts="2" />
+                          <test-case name="NUnit.Core.Tests.SimpleNameFilterTests.ExplicitTestSuiteDoesNotMatchWhenNotSelectedDirectly" executed="True" result="Success" success="True" time="0.004" asserts="2" />
+                          <test-case name="NUnit.Core.Tests.SimpleNameFilterTests.ExplicitTestSuiteMatchesWhenSelectedDirectly" executed="True" result="Success" success="True" time="0.004" asserts="3" />
+                          <test-case name="NUnit.Core.Tests.SimpleNameFilterTests.HighLevelSuite" executed="True" result="Success" success="True" time="0.004" asserts="3" />
+                          <test-case name="NUnit.Core.Tests.SimpleNameFilterTests.MultipleNameMatch" executed="True" result="Success" success="True" time="0.005" asserts="3" />
+                          <test-case name="NUnit.Core.Tests.SimpleNameFilterTests.SingleNameMatch" executed="True" result="Success" success="True" time="0.004" asserts="4" />
+                          <test-case name="NUnit.Core.Tests.SimpleNameFilterTests.SuiteNameMatch" executed="True" result="Success" success="True" time="0.004" asserts="3" />
+                          <test-case name="NUnit.Core.Tests.SimpleNameFilterTests.TestDoesNotMatch" executed="True" result="Success" success="True" time="0.004" asserts="2" />
+                        </results>
+                      </test-suite>
+                      <test-suite type="TestFixture" name="SimpleTestRunnerTests" executed="True" result="Success" success="True" time="0.435" asserts="1">
+                        <results>
+                          <test-case name="NUnit.Core.Tests.SimpleTestRunnerTests.BasicRunnerTests.CheckRunnerID" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Core.Tests.SimpleTestRunnerTests.BasicRunnerTests.CountTestCases" executed="True" result="Success" success="True" time="0.030" asserts="1" />
+                          <test-case name="NUnit.Core.Tests.SimpleTestRunnerTests.BasicRunnerTests.CountTestCasesAcrossMultipleAssemblies" executed="True" result="Success" success="True" time="0.038" asserts="1" />
+                          <test-case name="NUnit.Core.Tests.SimpleTestRunnerTests.BasicRunnerTests.LoadAndReloadAssembly" executed="True" result="Success" success="True" time="0.055" asserts="2" />
+                          <test-case name="NUnit.Core.Tests.SimpleTestRunnerTests.BasicRunnerTests.LoadAssemblyWithFixture" executed="True" result="Success" success="True" time="0.013" asserts="1" />
+                          <test-case name="NUnit.Core.Tests.SimpleTestRunnerTests.BasicRunnerTests.LoadAssemblyWithoutNamespaces" executed="True" result="Success" success="True" time="0.027" asserts="4" />
+                          <test-case name="NUnit.Core.Tests.SimpleTestRunnerTests.BasicRunnerTests.LoadAssemblyWithSuite" executed="True" result="Success" success="True" time="0.009" asserts="1" />
+                          <test-case name="NUnit.Core.Tests.SimpleTestRunnerTests.BasicRunnerTests.LoadMultipleAssemblies" executed="True" result="Success" success="True" time="0.039" asserts="1" />
+                          <test-case name="NUnit.Core.Tests.SimpleTestRunnerTests.BasicRunnerTests.LoadMultipleAssembliesWithFixture" executed="True" result="Success" success="True" time="0.021" asserts="1" />
+                          <test-case name="NUnit.Core.Tests.SimpleTestRunnerTests.BasicRunnerTests.LoadMultipleAssembliesWithSuite" executed="True" result="Success" success="True" time="0.016" asserts="1" />
+                          <test-case name="NUnit.Core.Tests.SimpleTestRunnerTests.BasicRunnerTests.RunAssembly" executed="True" result="Success" success="True" time="0.034" asserts="1" />
+                          <test-case name="NUnit.Core.Tests.SimpleTestRunnerTests.BasicRunnerTests.RunAssemblyUsingBeginAndEndRun" executed="True" result="Success" success="True" time="0.036" asserts="2" />
+                          <test-case name="NUnit.Core.Tests.SimpleTestRunnerTests.BasicRunnerTests.RunMultipleAssemblies" executed="True" result="Success" success="True" time="0.046" asserts="1" />
+                          <test-case name="NUnit.Core.Tests.SimpleTestRunnerTests.BasicRunnerTests.RunMultipleAssembliesUsingBeginAndEndRun" executed="True" result="Success" success="True" time="0.042" asserts="2" />
+                        </results>
+                      </test-suite>
+                      <test-suite type="TestFixture" name="StackOverflowTestFixture" executed="False" result="Skipped">
+                        <reason>
+                          <message><![CDATA[Cannot handle StackOverflowException in managed code]]></message>
+                        </reason>
+                        <results>
+                          <test-case name="NUnit.Core.Tests.StackOverflowTestFixture.SimpleOverflow" executed="False" result="Skipped">
+                            <reason>
+                              <message><![CDATA[Cannot handle StackOverflowException in managed code]]></message>
+                            </reason>
+                          </test-case>
+                        </results>
+                      </test-suite>
+                      <test-suite type="TestFixture" name="SuiteBuilderTests" executed="True" result="Success" success="True" time="1.463" asserts="0">
+                        <results>
+                          <test-case name="NUnit.Core.Tests.SuiteBuilderTests.DiscoverSuite" executed="True" result="Success" success="True" time="0.012" asserts="1" />
+                          <test-case name="NUnit.Core.Tests.SuiteBuilderTests.FileNotFound" executed="True" result="Success" success="True" time="0.034" asserts="0" />
+                          <test-case name="NUnit.Core.Tests.SuiteBuilderTests.FixtureNotFound" executed="True" result="Success" success="True" time="0.011" asserts="1" />
+                          <test-case name="NUnit.Core.Tests.SuiteBuilderTests.InvalidAssembly" executed="True" result="Success" success="True" time="0.092" asserts="0" />
+                          <test-case name="NUnit.Core.Tests.SuiteBuilderTests.LoadAssembly" executed="True" result="Success" success="True" time="0.424" asserts="3" />
+                          <test-case name="NUnit.Core.Tests.SuiteBuilderTests.LoadAssemblyWithoutNamespaces" executed="True" result="Success" success="True" time="0.410" asserts="3" />
+                          <test-case name="NUnit.Core.Tests.SuiteBuilderTests.LoadFixture" executed="True" result="Success" success="True" time="0.026" asserts="1" />
+                          <test-case name="NUnit.Core.Tests.SuiteBuilderTests.LoadNamespaceAsSuite" executed="True" result="Success" success="True" time="0.402" asserts="3" />
+                          <test-case name="NUnit.Core.Tests.SuiteBuilderTests.LoadSuite" executed="True" result="Success" success="True" time="0.017" asserts="2" />
+                          <test-case name="NUnit.Core.Tests.SuiteBuilderTests.WrongReturnTypeSuite" executed="True" result="Success" success="True" time="0.011" asserts="2" />
+                        </results>
+                      </test-suite>
+                      <test-suite type="TestFixture" name="SuiteBuilderTests_Multiple" executed="True" result="Success" success="True" time="0.175" asserts="0">
+                        <results>
+                          <test-case name="NUnit.Core.Tests.SuiteBuilderTests_Multiple.BuildSuite" executed="True" result="Success" success="True" time="0.038" asserts="1" />
+                          <test-case name="NUnit.Core.Tests.SuiteBuilderTests_Multiple.LoadFixture" executed="True" result="Success" success="True" time="0.056" asserts="2" />
+                          <test-case name="NUnit.Core.Tests.SuiteBuilderTests_Multiple.RootNode" executed="True" result="Success" success="True" time="0.035" asserts="1" />
+                          <test-case name="NUnit.Core.Tests.SuiteBuilderTests_Multiple.TestCaseCount" executed="True" result="Success" success="True" time="0.038" asserts="1" />
+                        </results>
+                      </test-suite>
+                      <test-suite type="TestFixture" name="TestAttributeFixture" executed="True" result="Success" success="True" time="0.025" asserts="0">
+                        <results>
+                          <test-case name="NUnit.Core.Tests.TestAttributeFixture.Description" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Core.Tests.TestAttributeFixture.DescriptionInResult" executed="True" result="Success" success="True" time="0.004" asserts="2" />
+                          <test-case name="NUnit.Core.Tests.TestAttributeFixture.FixtureDescription" executed="True" result="Success" success="True" time="0.002" asserts="1" />
+                          <test-case name="NUnit.Core.Tests.TestAttributeFixture.FixtureDescriptionInResult" executed="True" result="Success" success="True" time="0.003" asserts="1" />
+                          <test-case name="NUnit.Core.Tests.TestAttributeFixture.NoDescription" executed="True" result="Success" success="True" time="0.001" asserts="1" />
+                          <test-case name="NUnit.Core.Tests.TestAttributeFixture.ReflectionTest" executed="True" result="Success" success="True" time="0.001" asserts="1" />
+                          <test-case name="NUnit.Core.Tests.TestAttributeFixture.SeparateDescriptionAttribute" executed="True" result="Success" success="True" time="0.001" asserts="1" />
+                          <test-case name="NUnit.Core.Tests.TestAttributeFixture.SeparateDescriptionInResult" executed="True" result="Success" success="True" time="0.003" asserts="1" />
+                        </results>
+                      </test-suite>
+                      <test-suite type="TestFixture" name="TestCaseAttributeTests" executed="True" result="Success" success="True" time="0.138" asserts="0">
+                        <results>
+                          <test-suite type="ParameterizedTest" name="ArgumentsAreCoalescedInObjectArray" executed="True" result="Success" success="True" time="0.001" asserts="0">
+                            <results>
+                              <test-case name="NUnit.Core.Tests.TestCaseAttributeTests.ArgumentsAreCoalescedInObjectArray(&quot;a&quot;,&quot;b&quot;)" executed="True" result="Success" success="True" time="0.001" asserts="2" />
+                            </results>
+                          </test-suite>
+                          <test-suite type="ParameterizedTest" name="ArgumentsOfDifferentTypeAreCoalescedInObjectArray" executed="True" result="Success" success="True" time="0.001" asserts="0">
+                            <results>
+                              <test-case name="NUnit.Core.Tests.TestCaseAttributeTests.ArgumentsOfDifferentTypeAreCoalescedInObjectArray(1,&quot;b&quot;)" executed="True" result="Success" success="True" time="0.000" asserts="2" />
+                            </results>
+                          </test-suite>
+                          <test-suite type="ParameterizedTest" name="CanConvertDoubleToDecimal" executed="True" result="Success" success="True" time="0.002" asserts="0">
+                            <results>
+                              <test-case name="NUnit.Core.Tests.TestCaseAttributeTests.CanConvertDoubleToDecimal(2.2m,3.3m)" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                            </results>
+                          </test-suite>
+                          <test-suite type="ParameterizedTest" name="CanConvertIntToDecimal" executed="True" result="Success" success="True" time="0.001" asserts="0">
+                            <results>
+                              <test-case name="NUnit.Core.Tests.TestCaseAttributeTests.CanConvertIntToDecimal(5m,2m)" executed="True" result="Success" success="True" time="0.001" asserts="1" />
+                            </results>
+                          </test-suite>
+                          <test-suite type="ParameterizedTest" name="CanConvertIntToDouble" executed="True" result="Success" success="True" time="0.001" asserts="0">
+                            <results>
+                              <test-case name="NUnit.Core.Tests.TestCaseAttributeTests.CanConvertIntToDouble(2,2)" executed="True" result="Success" success="True" time="0.001" asserts="1" />
+                            </results>
+                          </test-suite>
+                          <test-suite type="ParameterizedTest" name="CanConvertSmallIntsToByte" executed="True" result="Success" success="True" time="0.001" asserts="0">
+                            <results>
+                              <test-case name="NUnit.Core.Tests.TestCaseAttributeTests.CanConvertSmallIntsToByte(5,2)" executed="True" result="Success" success="True" time="0.001" asserts="1" />
+                            </results>
+                          </test-suite>
+                          <test-suite type="ParameterizedTest" name="CanConvertSmallIntsToSByte" executed="True" result="Success" success="True" time="0.001" asserts="0">
+                            <results>
+                              <test-case name="NUnit.Core.Tests.TestCaseAttributeTests.CanConvertSmallIntsToSByte(5,2)" executed="True" result="Success" success="True" time="0.001" asserts="1" />
+                            </results>
+                          </test-suite>
+                          <test-suite type="ParameterizedTest" name="CanConvertSmallIntsToShort" executed="True" result="Success" success="True" time="0.000" asserts="0">
+                            <results>
+                              <test-case name="NUnit.Core.Tests.TestCaseAttributeTests.CanConvertSmallIntsToShort(5,2)" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                            </results>
+                          </test-suite>
+                          <test-suite type="ParameterizedTest" name="CanConvertStringToDateTime" executed="True" result="Success" success="True" time="0.001" asserts="0">
+                            <results>
+                              <test-case name="NUnit.Core.Tests.TestCaseAttributeTests.CanConvertStringToDateTime(10/12/1942 00:00:00)" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                            </results>
+                          </test-suite>
+                          <test-suite type="ParameterizedTest" name="CanConvertStringToDecimal" executed="True" result="Success" success="True" time="0.001" asserts="0">
+                            <results>
+                              <test-case name="NUnit.Core.Tests.TestCaseAttributeTests.CanConvertStringToDecimal(2.2m,3.3m)" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                            </results>
+                          </test-suite>
+                          <test-case name="NUnit.Core.Tests.TestCaseAttributeTests.CanIgnoreIndividualTestCases" executed="True" result="Success" success="True" time="0.002" asserts="4" />
+                          <test-case name="NUnit.Core.Tests.TestCaseAttributeTests.CanMarkIndividualTestCasesExplicit" executed="True" result="Success" success="True" time="0.001" asserts="4" />
+                          <test-suite type="ParameterizedTest" name="CanPassArrayAsArgument" executed="True" result="Success" success="True" time="0.001" asserts="0">
+                            <results>
+                              <test-case name="NUnit.Core.Tests.TestCaseAttributeTests.CanPassArrayAsArgument(&quot;a&quot;,&quot;b&quot;)" executed="True" result="Success" success="True" time="0.001" asserts="2" />
+                            </results>
+                          </test-suite>
+                          <test-suite type="ParameterizedTest" name="CanPassNullAsArgument" executed="True" result="Success" success="True" time="0.001" asserts="0">
+                            <results>
+                              <test-case name="NUnit.Core.Tests.TestCaseAttributeTests.CanPassNullAsArgument(null,null)" executed="True" result="Success" success="True" time="0.000" asserts="2" />
+                            </results>
+                          </test-suite>
+                          <test-suite type="ParameterizedTest" name="CanPassNullAsSoleArgument" executed="True" result="Success" success="True" time="0.001" asserts="0">
+                            <results>
+                              <test-case name="NUnit.Core.Tests.TestCaseAttributeTests.CanPassNullAsSoleArgument(null)" executed="True" result="Success" success="True" time="0.001" asserts="1" />
+                            </results>
+                          </test-suite>
+                          <test-suite type="ParameterizedTest" name="CanPassObjectArrayAsFirstArgument" executed="True" result="Success" success="True" time="0.002" asserts="0">
+                            <results>
+                              <test-case name="NUnit.Core.Tests.TestCaseAttributeTests.CanPassObjectArrayAsFirstArgument(1,&quot;two&quot;,3.0d)" executed="True" result="Success" success="True" time="0.000" asserts="0" />
+                              <test-case name="NUnit.Core.Tests.TestCaseAttributeTests.CanPassObjectArrayAsFirstArgument(&quot;zip&quot;)" executed="True" result="Success" success="True" time="0.000" asserts="0" />
+                            </results>
+                          </test-suite>
+                          <test-case name="NUnit.Core.Tests.TestCaseAttributeTests.CanSpecifyCategory" executed="True" result="Success" success="True" time="0.001" asserts="1" />
+                          <test-case name="NUnit.Core.Tests.TestCaseAttributeTests.CanSpecifyDescription" executed="True" result="Success" success="True" time="0.001" asserts="1" />
+                          <test-suite type="ParameterizedTest" name="CanSpecifyExceptionMessage" executed="True" result="Success" success="True" time="0.001" asserts="0">
+                            <results>
+                              <test-case name="NUnit.Core.Tests.TestCaseAttributeTests.CanSpecifyExceptionMessage(42)" executed="True" result="Success" success="True" time="0.001" asserts="0" />
+                            </results>
+                          </test-suite>
+                          <test-suite type="ParameterizedTest" name="CanSpecifyExceptionMessageAndMatchType" executed="True" result="Success" success="True" time="0.002" asserts="0">
+                            <results>
+                              <test-case name="NUnit.Core.Tests.TestCaseAttributeTests.CanSpecifyExceptionMessageAndMatchType(42)" executed="True" result="Success" success="True" time="0.001" asserts="0" />
+                            </results>
+                          </test-suite>
+                          <test-case name="NUnit.Core.Tests.TestCaseAttributeTests.CanSpecifyExpectedException" executed="True" result="Success" success="True" time="0.003" asserts="1" />
+                          <test-case name="NUnit.Core.Tests.TestCaseAttributeTests.CanSpecifyExpectedException_NoneThrown" executed="True" result="Success" success="True" time="0.001" asserts="2" />
+                          <test-case name="NUnit.Core.Tests.TestCaseAttributeTests.CanSpecifyExpectedException_WrongException" executed="True" result="Success" success="True" time="0.002" asserts="2" />
+                          <test-case name="NUnit.Core.Tests.TestCaseAttributeTests.CanSpecifyExpectedException_WrongMessage" executed="True" result="Success" success="True" time="0.002" asserts="2" />
+                          <test-case name="NUnit.Core.Tests.TestCaseAttributeTests.CanSpecifyMultipleCategories" executed="True" result="Success" success="True" time="0.001" asserts="1" />
+                          <test-case name="NUnit.Core.Tests.TestCaseAttributeTests.CanSpecifyTestName" executed="True" result="Success" success="True" time="0.001" asserts="2" />
+                          <test-case name="NUnit.Core.Tests.TestCaseAttributeTests.ConversionOverflowMakesTestNonRunnable" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                          <test-suite type="ParameterizedTest" name="ExpectedResultCanBeNull" executed="True" result="Success" success="True" time="0.001" asserts="0">
+                            <results>
+                              <test-case name="NUnit.Core.Tests.TestCaseAttributeTests.ExpectedResultCanBeNull()" executed="True" result="Success" success="True" time="0.001" asserts="1" />
+                            </results>
+                          </test-suite>
+                          <test-suite type="ParameterizedTest" name="HandlesParamsArrayAsLastArgument" executed="True" result="Success" success="True" time="0.001" asserts="0">
+                            <results>
+                              <test-case name="NUnit.Core.Tests.TestCaseAttributeTests.HandlesParamsArrayAsLastArgument(&quot;a&quot;,&quot;b&quot;,&quot;c&quot;,&quot;d&quot;)" executed="True" result="Success" success="True" time="0.001" asserts="4" />
+                            </results>
+                          </test-suite>
+                          <test-suite type="ParameterizedTest" name="HandlesParamsArrayAsLastArgumentWithNoValues" executed="True" result="Success" success="True" time="0.001" asserts="0">
+                            <results>
+                              <test-case name="NUnit.Core.Tests.TestCaseAttributeTests.HandlesParamsArrayAsLastArgumentWithNoValues(&quot;a&quot;,&quot;b&quot;)" executed="True" result="Success" success="True" time="0.000" asserts="3" />
+                            </results>
+                          </test-suite>
+                          <test-suite type="ParameterizedTest" name="HandlesParamsArrayAsSoleArgument" executed="True" result="Success" success="True" time="0.001" asserts="0">
+                            <results>
+                              <test-case name="NUnit.Core.Tests.TestCaseAttributeTests.HandlesParamsArrayAsSoleArgument(&quot;a&quot;,&quot;b&quot;)" executed="True" result="Success" success="True" time="0.001" asserts="2" />
+                            </results>
+                          </test-suite>
+                          <test-suite type="ParameterizedTest" name="HandlesParamsArrayWithOneItemAsLastArgument" executed="True" result="Success" success="True" time="0.001" asserts="0">
+                            <results>
+                              <test-case name="NUnit.Core.Tests.TestCaseAttributeTests.HandlesParamsArrayWithOneItemAsLastArgument(&quot;a&quot;,&quot;b&quot;,System.Object[])" executed="True" result="Success" success="True" time="0.000" asserts="3" />
+                            </results>
+                          </test-suite>
+                          <test-suite type="ParameterizedTest" name="HandlesParamsArrayWithOneItemAsSoleArgument" executed="True" result="Success" success="True" time="0.001" asserts="0">
+                            <results>
+                              <test-case name="NUnit.Core.Tests.TestCaseAttributeTests.HandlesParamsArrayWithOneItemAsSoleArgument(System.String[])" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                            </results>
+                          </test-suite>
+                          <test-case name="NUnit.Core.Tests.TestCaseAttributeTests.IgnoreTakesPrecedenceOverExpectedException" executed="True" result="Success" success="True" time="0.002" asserts="2" />
+                          <test-suite type="ParameterizedTest" name="IntegerDivisionWithResultCheckedByNUnit" executed="True" result="Success" success="True" time="0.010" asserts="0">
+                            <results>
+                              <test-case name="NUnit.Core.Tests.TestCaseAttributeTests.IntegerDivisionWithResultCheckedByNUnit(12,2)" executed="True" result="Success" success="True" time="0.001" asserts="1" />
+                              <test-case name="NUnit.Core.Tests.TestCaseAttributeTests.IntegerDivisionWithResultCheckedByNUnit(12,3)" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                              <test-case name="NUnit.Core.Tests.TestCaseAttributeTests.IntegerDivisionWithResultCheckedByNUnit(12,4)" executed="True" result="Success" success="True" time="0.001" asserts="1" />
+                              <test-case name="NUnit.Core.Tests.TestCaseAttributeTests.IntegerDivisionWithResultCheckedByNUnit(12,0)" executed="True" result="Success" success="True" time="0.001" asserts="0" />
+                              <test-case name="NUnit.Core.Tests.TestCaseAttributeTests.DivisionByZeroThrowsException" executed="True" result="Success" success="True" time="0.000" asserts="0" />
+                            </results>
+                          </test-suite>
+                          <test-suite type="ParameterizedTest" name="IntegerDivisionWithResultPassedToTest" executed="True" result="Success" success="True" time="0.010" asserts="0">
+                            <results>
+                              <test-case name="NUnit.Core.Tests.TestCaseAttributeTests.IntegerDivisionWithResultPassedToTest(12,2,6)" executed="True" result="Success" success="True" time="0.001" asserts="1" />
+                              <test-case name="NUnit.Core.Tests.TestCaseAttributeTests.IntegerDivisionWithResultPassedToTest(12,3,4)" executed="True" result="Success" success="True" time="0.001" asserts="1" />
+                              <test-case name="NUnit.Core.Tests.TestCaseAttributeTests.IntegerDivisionWithResultPassedToTest(12,4,3)" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                              <test-case name="NUnit.Core.Tests.TestCaseAttributeTests.IntegerDivisionWithResultPassedToTest(12,0,0)" executed="True" result="Success" success="True" time="0.001" asserts="0" />
+                              <test-case name="NUnit.Core.Tests.TestCaseAttributeTests.IntegerDivisionWithResultPassedToTest(12,0,0)" executed="True" result="Success" success="True" time="0.001" asserts="0" />
+                            </results>
+                          </test-suite>
+                        </results>
+                      </test-suite>
+                      <test-suite type="TestFixture" name="TestCaseResultFixture" executed="True" result="Success" success="True" time="0.009" asserts="0">
+                        <results>
+                          <test-case name="NUnit.Core.Tests.TestCaseResultFixture.TestCaseDefault" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Core.Tests.TestCaseResultFixture.TestCaseFailure" executed="True" result="Success" success="True" time="0.000" asserts="4" />
+                          <test-case name="NUnit.Core.Tests.TestCaseResultFixture.TestCaseNotRun" executed="True" result="Success" success="True" time="0.000" asserts="2" />
+                          <test-case name="NUnit.Core.Tests.TestCaseResultFixture.TestCaseSuccess" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                        </results>
+                      </test-suite>
+                      <test-suite type="TestFixture" name="TestCaseSourceTests" executed="True" result="Success" success="True" time="0.122" asserts="0">
+                        <results>
+                          <test-case name="NUnit.Core.Tests.TestCaseSourceTests.CanIgnoreIndividualTestCases" executed="True" result="Success" success="True" time="0.003" asserts="4" />
+                          <test-case name="NUnit.Core.Tests.TestCaseSourceTests.CanMarkIndividualTestCasesExplicit" executed="True" result="Success" success="True" time="0.001" asserts="4" />
+                          <test-case name="NUnit.Core.Tests.TestCaseSourceTests.CanSpecifyExpectedException" executed="True" result="Success" success="True" time="0.002" asserts="1" />
+                          <test-case name="NUnit.Core.Tests.TestCaseSourceTests.CanSpecifyExpectedException_NoneThrown" executed="True" result="Success" success="True" time="0.000" asserts="2" />
+                          <test-case name="NUnit.Core.Tests.TestCaseSourceTests.CanSpecifyExpectedException_NoneThrown_ExpectedResultReturned" executed="True" result="Success" success="True" time="0.001" asserts="2" />
+                          <test-case name="NUnit.Core.Tests.TestCaseSourceTests.CanSpecifyExpectedException_WrongException" executed="True" result="Success" success="True" time="0.001" asserts="2" />
+                          <test-suite type="ParameterizedTest" name="ExpectedResultCanBeNull" executed="True" result="Success" success="True" time="0.001" asserts="0">
+                            <results>
+                              <test-case name="NUnit.Core.Tests.TestCaseSourceTests.ExpectedResultCanBeNull()" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                            </results>
+                          </test-suite>
+                          <test-case name="NUnit.Core.Tests.TestCaseSourceTests.HandlesExceptionInTestCaseSource" executed="True" result="Success" success="True" time="0.001" asserts="3" />
+                          <test-case name="NUnit.Core.Tests.TestCaseSourceTests.IgnoreTakesPrecedenceOverExpectedException" executed="True" result="Success" success="True" time="0.001" asserts="2" />
+                          <test-suite type="ParameterizedTest" name="MethodTakingTwoStringArrays" executed="True" result="Success" success="True" time="0.001" asserts="0">
+                            <results>
+                              <test-case name="NUnit.Core.Tests.TestCaseSourceTests.MethodTakingTwoStringArrays(System.String[],System.String[])" executed="True" result="Success" success="True" time="0.001" asserts="2" />
+                            </results>
+                          </test-suite>
+                          <test-suite type="ParameterizedTest" name="SourceCanBeInstanceField" executed="True" result="Success" success="True" time="0.001" asserts="0">
+                            <results>
+                              <test-case name="NUnit.Core.Tests.TestCaseSourceTests.SourceCanBeInstanceField(&quot;InstanceField&quot;)" executed="True" result="Success" success="True" time="0.001" asserts="1" />
+                            </results>
+                          </test-suite>
+                          <test-suite type="ParameterizedTest" name="SourceCanBeInstanceMethod" executed="True" result="Success" success="True" time="0.001" asserts="0">
+                            <results>
+                              <test-case name="NUnit.Core.Tests.TestCaseSourceTests.SourceCanBeInstanceMethod(&quot;InstanceMethod&quot;)" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                            </results>
+                          </test-suite>
+                          <test-suite type="ParameterizedTest" name="SourceCanBeInstanceProperty" executed="True" result="Success" success="True" time="0.001" asserts="0">
+                            <results>
+                              <test-case name="NUnit.Core.Tests.TestCaseSourceTests.SourceCanBeInstanceProperty(&quot;InstanceProperty&quot;)" executed="True" result="Success" success="True" time="0.001" asserts="1" />
+                            </results>
+                          </test-suite>
+                          <test-suite type="ParameterizedTest" name="SourceCanBeStaticField" executed="True" result="Success" success="True" time="0.000" asserts="0">
+                            <results>
+                              <test-case name="NUnit.Core.Tests.TestCaseSourceTests.SourceCanBeStaticField(&quot;StaticField&quot;)" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                            </results>
+                          </test-suite>
+                          <test-suite type="ParameterizedTest" name="SourceCanBeStaticMethod" executed="True" result="Success" success="True" time="0.001" asserts="0">
+                            <results>
+                              <test-case name="NUnit.Core.Tests.TestCaseSourceTests.SourceCanBeStaticMethod(&quot;StaticMethod&quot;)" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                            </results>
+                          </test-suite>
+                          <test-suite type="ParameterizedTest" name="SourceCanBeStaticProperty" executed="True" result="Success" success="True" time="0.001" asserts="0">
+                            <results>
+                              <test-case name="NUnit.Core.Tests.TestCaseSourceTests.SourceCanBeStaticProperty(&quot;StaticProperty&quot;)" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                            </results>
+                          </test-suite>
+                          <test-suite type="ParameterizedTest" name="SourceIsInvokedWithCorrectCurrentDirectory" executed="True" result="Success" success="True" time="0.001" asserts="0">
+                            <results>
+                              <test-case name="NUnit.Core.Tests.TestCaseSourceTests.SourceIsInvokedWithCorrectCurrentDirectory(True)" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                            </results>
+                          </test-suite>
+                          <test-suite type="ParameterizedTest" name="SourceMayBeInAnotherClass" executed="True" result="Success" success="True" time="0.005" asserts="0">
+                            <categories>
+                              <category name="Top" />
+                            </categories>
+                            <results>
+                              <test-case name="NUnit.Core.Tests.TestCaseSourceTests.ThisOneShouldThrow" description="Demonstrates use of ExpectedException" executed="True" result="Success" success="True" time="0.001" asserts="0">
+                                <categories>
+                                  <category name="Junk" />
+                                </categories>
+                                <properties>
+                                  <property name="MyProp" value="zip" />
+                                </properties>
+                              </test-case>
+                              <test-case name="NUnit.Core.Tests.TestCaseSourceTests.SourceMayBeInAnotherClass(100,20,5)" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                              <test-case name="NUnit.Core.Tests.TestCaseSourceTests.SourceMayBeInAnotherClass(100,4,25)" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                            </results>
+                          </test-suite>
+                          <test-suite type="ParameterizedTest" name="SourceMayBeInAnotherClassWithExpectedResult" executed="True" result="Success" success="True" time="0.009" asserts="0">
+                            <results>
+                              <test-case name="NUnit.Core.Tests.TestCaseSourceTests.SourceMayBeInAnotherClassWithExpectedResult(12,0)" executed="True" result="Success" success="True" time="0.000" asserts="0" />
+                              <test-case name="NUnit.Core.Tests.TestCaseSourceTests.TC1" executed="True" result="Success" success="True" time="0.001" asserts="1" />
+                              <test-case name="NUnit.Core.Tests.TestCaseSourceTests.TC2" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                              <test-case name="NUnit.Core.Tests.TestCaseSourceTests.TC3" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                            </results>
+                          </test-suite>
+                          <test-suite type="ParameterizedTest" name="SourceMayReturnArgumentsAsIntArray" executed="True" result="Success" success="True" time="0.004" asserts="0">
+                            <results>
+                              <test-case name="NUnit.Core.Tests.TestCaseSourceTests.SourceMayReturnArgumentsAsIntArray(12,3,4)" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                              <test-case name="NUnit.Core.Tests.TestCaseSourceTests.SourceMayReturnArgumentsAsIntArray(12,4,3)" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                              <test-case name="NUnit.Core.Tests.TestCaseSourceTests.SourceMayReturnArgumentsAsIntArray(12,6,2)" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                            </results>
+                          </test-suite>
+                          <test-suite type="ParameterizedTest" name="SourceMayReturnArgumentsAsObjectArray" executed="True" result="Success" success="True" time="0.005" asserts="0">
+                            <results>
+                              <test-case name="NUnit.Core.Tests.TestCaseSourceTests.SourceMayReturnArgumentsAsObjectArray(12,3,4)" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                              <test-case name="NUnit.Core.Tests.TestCaseSourceTests.SourceMayReturnArgumentsAsObjectArray(12,4,3)" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                              <test-case name="NUnit.Core.Tests.TestCaseSourceTests.SourceMayReturnArgumentsAsObjectArray(12,6,2)" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                            </results>
+                          </test-suite>
+                          <test-suite type="ParameterizedTest" name="SourceMayReturnArgumentsAsParamSet" executed="True" result="Success" success="True" time="0.003" asserts="0">
+                            <results>
+                              <test-case name="NUnit.Core.Tests.TestCaseSourceTests.SourceMayReturnArgumentsAsParamSet(24,3)" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                              <test-case name="NUnit.Core.Tests.TestCaseSourceTests.SourceMayReturnArgumentsAsParamSet(24,2)" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                            </results>
+                          </test-suite>
+                          <test-suite type="ParameterizedTest" name="SourceMayReturnSinglePrimitiveArgumentAlone" executed="True" result="Success" success="True" time="0.005" asserts="0">
+                            <results>
+                              <test-case name="NUnit.Core.Tests.TestCaseSourceTests.SourceMayReturnSinglePrimitiveArgumentAlone(2)" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                              <test-case name="NUnit.Core.Tests.TestCaseSourceTests.SourceMayReturnSinglePrimitiveArgumentAlone(4)" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                              <test-case name="NUnit.Core.Tests.TestCaseSourceTests.SourceMayReturnSinglePrimitiveArgumentAlone(6)" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                              <test-case name="NUnit.Core.Tests.TestCaseSourceTests.SourceMayReturnSinglePrimitiveArgumentAlone(8)" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                            </results>
+                          </test-suite>
+                          <test-suite type="ParameterizedTest" name="TestAttributeIsOptional" executed="True" result="Success" success="True" time="0.004" asserts="0">
+                            <results>
+                              <test-case name="NUnit.Core.Tests.TestCaseSourceTests.TestAttributeIsOptional(12,3,4)" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                              <test-case name="NUnit.Core.Tests.TestCaseSourceTests.TestAttributeIsOptional(12,4,3)" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                              <test-case name="NUnit.Core.Tests.TestCaseSourceTests.TestAttributeIsOptional(12,6,2)" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                            </results>
+                          </test-suite>
+                          <test-suite type="ParameterizedTest" name="TestMayUseMultipleSourceAttributes" executed="True" result="Success" success="True" time="0.012" asserts="0">
+                            <results>
+                              <test-case name="NUnit.Core.Tests.TestCaseSourceTests.TestMayUseMultipleSourceAttributes(12,1,12)" executed="True" result="Success" success="True" time="0.001" asserts="1">
+                                <categories>
+                                  <category name="Extra" />
+                                </categories>
+                              </test-case>
+                              <test-case name="NUnit.Core.Tests.TestCaseSourceTests.TestMayUseMultipleSourceAttributes(12,2,6)" executed="True" result="Success" success="True" time="0.000" asserts="1">
+                                <categories>
+                                  <category name="Extra" />
+                                </categories>
+                              </test-case>
+                              <test-case name="NUnit.Core.Tests.TestCaseSourceTests.TestMayUseMultipleSourceAttributes(12,3,4)" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                              <test-case name="NUnit.Core.Tests.TestCaseSourceTests.TestMayUseMultipleSourceAttributes(12,4,3)" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                              <test-case name="NUnit.Core.Tests.TestCaseSourceTests.TestMayUseMultipleSourceAttributes(12,6,2)" executed="True" result="Success" success="True" time="0.001" asserts="1" />
+                              <test-case name="NUnit.Core.Tests.TestCaseSourceTests.TestMayUseMultipleSourceAttributes(12,0,0)" executed="True" result="Success" success="True" time="0.001" asserts="0" />
+                            </results>
+                          </test-suite>
+                          <test-suite type="ParameterizedTest" name="TestWithFourArguments" executed="True" result="Success" success="True" time="0.004" asserts="0">
+                            <results>
+                              <test-case name="NUnit.Core.Tests.TestCaseSourceTests.TestWithFourArguments(12,3,4,0)" executed="True" result="Success" success="True" time="0.000" asserts="2" />
+                              <test-case name="NUnit.Core.Tests.TestCaseSourceTests.TestWithFourArguments(12,4,3,0)" executed="True" result="Success" success="True" time="0.000" asserts="2" />
+                              <test-case name="NUnit.Core.Tests.TestCaseSourceTests.TestWithFourArguments(12,5,2,2)" executed="True" result="Success" success="True" time="0.001" asserts="2" />
+                            </results>
+                          </test-suite>
+                        </results>
+                      </test-suite>
+                      <test-suite type="TestFixture" name="TestCaseTest" executed="True" result="Success" success="True" time="0.007" asserts="0">
+                        <results>
+                          <test-case name="NUnit.Core.Tests.TestCaseTest.CreateIgnoredTestCase" executed="True" result="Success" success="True" time="0.001" asserts="3" />
+                          <test-case name="NUnit.Core.Tests.TestCaseTest.LoadMethodCategories" executed="True" result="Success" success="True" time="0.000" asserts="3" />
+                          <test-case name="NUnit.Core.Tests.TestCaseTest.RunIgnoredTestCase" executed="True" result="Success" success="True" time="0.000" asserts="3" />
+                        </results>
+                      </test-suite>
+                      <test-suite type="TestFixture" name="TestConsole" executed="True" result="Success" success="True" time="0.010" asserts="0">
+                        <results>
+                          <test-case name="NUnit.Core.Tests.TestConsole.ConsoleWrite" executed="True" result="Success" success="True" time="0.001" asserts="0" />
+                          <test-case name="NUnit.Core.Tests.TestConsole.ConsoleWriteLine" executed="True" result="Success" success="True" time="0.000" asserts="0" />
+                        </results>
+                      </test-suite>
+                      <test-suite type="TestFixture" name="TestContextTests" executed="True" result="Success" success="True" time="0.064" asserts="4">
+                        <properties>
+                          <property name="Question" value="Why?" />
+                        </properties>
+                        <results>
+                          <test-case name="NUnit.Core.Tests.TestContextTests.CanAccessTestContextFromThreadSpawnedWithinTest" executed="True" result="Success" success="True" time="0.003" asserts="3" />
+                          <test-case name="NUnit.Core.Tests.TestContextTests.CanAccessTestContextWhenRunningTestOnSeparateThread" executed="True" result="Success" success="True" time="0.000" asserts="3">
+                            <properties>
+                              <property name="RequiresThread" value="True" />
+                            </properties>
+                          </test-case>
+                          <test-case name="NUnit.Core.Tests.TestContextTests.FixtureSetUpCanAccessFixtureFullName" executed="True" result="Success" success="True" time="0.000" asserts="3" />
+                          <test-case name="NUnit.Core.Tests.TestContextTests.FixtureSetUpCanAccessFixtureName" executed="True" result="Success" success="True" time="0.000" asserts="3" />
+                          <test-case name="NUnit.Core.Tests.TestContextTests.FixtureSetUpCanAccessFixtureProperties" executed="True" result="Success" success="True" time="0.000" asserts="3">
+                            <properties>
+                              <property name="Answer" value="37" />
+                            </properties>
+                          </test-case>
+                          <test-case name="NUnit.Core.Tests.TestContextTests.FixtureSetUpCanAccessFixtureResultState" executed="True" result="Success" success="True" time="0.001" asserts="4" />
+                          <test-case name="NUnit.Core.Tests.TestContextTests.FixtureSetUpCanAccessTestDirectory" executed="True" result="Success" success="True" time="0.001" asserts="5" />
+                          <test-case name="NUnit.Core.Tests.TestContextTests.FixtureSetUpCanAccessWorkDirectory" executed="True" result="Success" success="True" time="0.000" asserts="4" />
+                          <test-case name="NUnit.Core.Tests.TestContextTests.SetUpCanAccessTestDirectory" executed="True" result="Success" success="True" time="0.000" asserts="5" />
+                          <test-case name="NUnit.Core.Tests.TestContextTests.SetUpCanAccessTestFullName" executed="True" result="Success" success="True" time="0.000" asserts="3" />
+                          <test-case name="NUnit.Core.Tests.TestContextTests.SetUpCanAccessTestName" executed="True" result="Success" success="True" time="0.000" asserts="3" />
+                          <test-case name="NUnit.Core.Tests.TestContextTests.SetUpCanAccessTestProperties" executed="True" result="Success" success="True" time="0.001" asserts="3">
+                            <properties>
+                              <property name="Answer" value="99" />
+                            </properties>
+                          </test-case>
+                          <test-case name="NUnit.Core.Tests.TestContextTests.SetUpCanAccessTestResultState" executed="True" result="Success" success="True" time="0.001" asserts="4" />
+                          <test-case name="NUnit.Core.Tests.TestContextTests.SetUpCanAccessWorkDirectory" executed="True" result="Success" success="True" time="0.000" asserts="4" />
+                          <test-case name="NUnit.Core.Tests.TestContextTests.TestCanAccessItsOwnFullName" executed="True" result="Success" success="True" time="0.000" asserts="3" />
+                          <test-case name="NUnit.Core.Tests.TestContextTests.TestCanAccessItsOwnName" executed="True" result="Success" success="True" time="0.000" asserts="3" />
+                          <test-case name="NUnit.Core.Tests.TestContextTests.TestCanAccessItsOwnProperties" executed="True" result="Success" success="True" time="0.001" asserts="3">
+                            <properties>
+                              <property name="Answer" value="42" />
+                            </properties>
+                          </test-case>
+                          <test-case name="NUnit.Core.Tests.TestContextTests.TestCanAccessItsOwnResultState" executed="True" result="Success" success="True" time="0.001" asserts="4" />
+                          <test-case name="NUnit.Core.Tests.TestContextTests.TestCanAccessTestDirectory" executed="True" result="Success" success="True" time="0.001" asserts="5" />
+                          <test-case name="NUnit.Core.Tests.TestContextTests.TestCanAccessTestState_FailingTest" executed="True" result="Success" success="True" time="0.004" asserts="4" />
+                          <test-case name="NUnit.Core.Tests.TestContextTests.TestCanAccessTestState_FailureInSetUp" executed="True" result="Success" success="True" time="0.003" asserts="4" />
+                          <test-case name="NUnit.Core.Tests.TestContextTests.TestCanAccessTestState_IgnoredInSetUp" executed="True" result="Success" success="True" time="0.003" asserts="4" />
+                          <test-case name="NUnit.Core.Tests.TestContextTests.TestCanAccessTestState_PassingTest" executed="True" result="Success" success="True" time="0.002" asserts="4" />
+                          <test-case name="NUnit.Core.Tests.TestContextTests.TestCanAccessWorkDirectory" executed="True" result="Success" success="True" time="0.001" asserts="4" />
+                        </results>
+                      </test-suite>
+                      <test-suite type="TestFixture" name="TestDelegateFixture" executed="True" result="Success" success="True" time="0.001" asserts="0">
+                        <results>
+                          <test-case name="NUnit.Core.Tests.TestDelegateFixture.DelegateTest" executed="True" result="Success" success="True" time="0.001" asserts="1" />
+                        </results>
+                      </test-suite>
+                      <test-suite type="TestFixture" name="TestExecutionContextTests" executed="True" result="Success" success="True" time="0.029" asserts="3">
+                        <properties>
+                          <property name="Question" value="Why?" />
+                        </properties>
+                        <results>
+                          <test-case name="NUnit.Core.Tests.TestExecutionContextTests.FixtureSetUpCanAccessFixtureFullName" executed="True" result="Success" success="True" time="0.001" asserts="2" />
+                          <test-case name="NUnit.Core.Tests.TestExecutionContextTests.FixtureSetUpCanAccessFixtureName" executed="True" result="Success" success="True" time="0.001" asserts="2" />
+                          <test-case name="NUnit.Core.Tests.TestExecutionContextTests.FixtureSetUpCanAccessFixtureProperties" executed="True" result="Success" success="True" time="0.001" asserts="2" />
+                          <test-case name="NUnit.Core.Tests.TestExecutionContextTests.SetAndRestoreCurrentCulture" executed="True" result="Success" success="True" time="0.001" asserts="6" />
+                          <test-case name="NUnit.Core.Tests.TestExecutionContextTests.SetAndRestoreCurrentDirectory" executed="True" result="Success" success="True" time="0.001" asserts="6" />
+                          <test-case name="NUnit.Core.Tests.TestExecutionContextTests.SetAndRestoreCurrentPrincipal" executed="True" result="Success" success="True" time="0.000" asserts="6" />
+                          <test-case name="NUnit.Core.Tests.TestExecutionContextTests.SetAndRestoreCurrentUICulture" executed="True" result="Success" success="True" time="0.001" asserts="6" />
+                          <test-case name="NUnit.Core.Tests.TestExecutionContextTests.SetUpCanAccessTestFullName" executed="True" result="Success" success="True" time="0.001" asserts="2" />
+                          <test-case name="NUnit.Core.Tests.TestExecutionContextTests.SetUpCanAccessTestName" executed="True" result="Success" success="True" time="0.000" asserts="2" />
+                          <test-case name="NUnit.Core.Tests.TestExecutionContextTests.SetUpCanAccessTestProperties" executed="True" result="Success" success="True" time="0.000" asserts="2">
+                            <properties>
+                              <property name="Answer" value="42" />
+                            </properties>
+                          </test-case>
+                          <test-case name="NUnit.Core.Tests.TestExecutionContextTests.TestCanAccessItsOwnFullName" executed="True" result="Success" success="True" time="0.000" asserts="2" />
+                          <test-case name="NUnit.Core.Tests.TestExecutionContextTests.TestCanAccessItsOwnName" executed="True" result="Success" success="True" time="0.001" asserts="2" />
+                          <test-case name="NUnit.Core.Tests.TestExecutionContextTests.TestCanAccessItsOwnProperties" executed="True" result="Success" success="True" time="0.001" asserts="2">
+                            <properties>
+                              <property name="Answer" value="42" />
+                            </properties>
+                          </test-case>
+                        </results>
+                      </test-suite>
+                      <test-suite type="TestFixture" name="TestFixtureBuilderTests" executed="True" result="Success" success="True" time="0.007" asserts="0">
+                        <results>
+                          <test-case name="NUnit.Core.Tests.TestFixtureBuilderTests.GoodSignature" executed="True" result="Success" success="True" time="0.003" asserts="2" />
+                          <test-case name="NUnit.Core.Tests.TestFixtureBuilderTests.LoadCategories" executed="True" result="Success" success="True" time="0.001" asserts="2" />
+                        </results>
+                      </test-suite>
+                      <test-suite type="TestFixture" name="TestFixtureExtension" executed="True" result="Success" success="True" time="0.057" asserts="0">
+                        <results>
+                          <test-case name="NUnit.Core.Tests.TestFixtureExtension.CheckMultipleSetUp" executed="True" result="Success" success="True" time="0.014" asserts="1" />
+                          <test-case name="NUnit.Core.Tests.TestFixtureExtension.DerivedTest" executed="True" result="Success" success="True" time="0.012" asserts="1" />
+                          <test-case name="NUnit.Core.Tests.TestFixtureExtension.InheritSetup" executed="True" result="Success" success="True" time="0.012" asserts="1" />
+                          <test-case name="NUnit.Core.Tests.TestFixtureExtension.InheritTearDown" executed="True" result="Success" success="True" time="0.013" asserts="1" />
+                        </results>
+                      </test-suite>
+                      <test-suite type="TestFixture" name="TestFixtureTests" executed="True" result="Success" success="True" time="0.171" asserts="0">
+                        <results>
+                          <test-case name="NUnit.Core.Tests.TestFixtureTests.CannotRunBadConstructor" executed="True" result="Success" success="True" time="0.002" asserts="3" />
+                          <test-case name="NUnit.Core.Tests.TestFixtureTests.CannotRunConstructorWithArgsNotSupplied" executed="True" result="Success" success="True" time="0.001" asserts="3" />
+                          <test-case name="NUnit.Core.Tests.TestFixtureTests.CannotRunFixtureSetupWithParameters" executed="True" result="Success" success="True" time="0.001" asserts="3" />
+                          <test-case name="NUnit.Core.Tests.TestFixtureTests.CannotRunFixtureSetupWithReturnValue" executed="True" result="Success" success="True" time="0.002" asserts="3" />
+                          <test-case name="NUnit.Core.Tests.TestFixtureTests.CannotRunFixtureTearDownWithParameters" executed="True" result="Success" success="True" time="0.002" asserts="3" />
+                          <test-case name="NUnit.Core.Tests.TestFixtureTests.CannotRunFixtureTearDownWithReturnValue" executed="True" result="Success" success="True" time="0.002" asserts="3" />
+                          <test-case name="NUnit.Core.Tests.TestFixtureTests.CannotRunGenericFixtureDerivedFromAbstractFixtureWithNoArgsProvided" executed="True" result="Success" success="True" time="0.004" asserts="2" />
+                          <test-case name="NUnit.Core.Tests.TestFixtureTests.CannotRunGenericFixtureWithNoArgsProvided" executed="True" result="Success" success="True" time="0.001" asserts="2" />
+                          <test-case name="NUnit.Core.Tests.TestFixtureTests.CannotRunGenericFixtureWithNoTestFixtureAttribute" executed="True" result="Success" success="True" time="0.000" asserts="3" />
+                          <test-case name="NUnit.Core.Tests.TestFixtureTests.CannotRunGenericFixtureWithOpenTypeAsArgument" executed="True" result="Success" success="True" time="0.001" asserts="2" />
+                          <test-case name="NUnit.Core.Tests.TestFixtureTests.CannotRunIgnoredFixture" executed="True" result="Success" success="True" time="0.001" asserts="2" />
+                          <test-case name="NUnit.Core.Tests.TestFixtureTests.CannotRunPrivateFixtureSetUp" executed="True" result="Success" success="True" time="0.001" asserts="3" />
+                          <test-case name="NUnit.Core.Tests.TestFixtureTests.CannotRunPrivateFixtureTearDown" executed="True" result="Success" success="True" time="0.002" asserts="3" />
+                          <test-case name="NUnit.Core.Tests.TestFixtureTests.CannotRunPrivateSetUp" executed="True" result="Success" success="True" time="0.002" asserts="3" />
+                          <test-case name="NUnit.Core.Tests.TestFixtureTests.CannotRunPrivateTearDown" executed="True" result="Success" success="True" time="0.002" asserts="3" />
+                          <test-case name="NUnit.Core.Tests.TestFixtureTests.CannotRunSetupWithParameters" executed="True" result="Success" success="True" time="0.001" asserts="3" />
+                          <test-case name="NUnit.Core.Tests.TestFixtureTests.CannotRunSetupWithReturnValue" executed="True" result="Success" success="True" time="0.001" asserts="3" />
+                          <test-case name="NUnit.Core.Tests.TestFixtureTests.CannotRunTearDownWithParameters" executed="True" result="Success" success="True" time="0.001" asserts="3" />
+                          <test-case name="NUnit.Core.Tests.TestFixtureTests.CannotRunTearDownWithReturnValue" executed="True" result="Success" success="True" time="0.001" asserts="3" />
+                          <test-case name="NUnit.Core.Tests.TestFixtureTests.CanRunConstructorWithArgsSupplied" executed="True" result="Success" success="True" time="0.002" asserts="1" />
+                          <test-case name="NUnit.Core.Tests.TestFixtureTests.CanRunFixtureDerivedFromAbstractDerivedTestFixture" executed="True" result="Success" success="True" time="0.002" asserts="1" />
+                          <test-case name="NUnit.Core.Tests.TestFixtureTests.CanRunFixtureDerivedFromAbstractFixture" executed="True" result="Success" success="True" time="0.002" asserts="1" />
+                          <test-case name="NUnit.Core.Tests.TestFixtureTests.CanRunGenericFixtureDerivedFromAbstractFixtureWithArgsProvided" executed="True" result="Success" success="True" time="0.003" asserts="3" />
+                          <test-case name="NUnit.Core.Tests.TestFixtureTests.CanRunGenericFixtureWithProperArgsProvided" executed="True" result="Success" success="True" time="0.003" asserts="3" />
+                          <test-case name="NUnit.Core.Tests.TestFixtureTests.CanRunMultipleSetUp" executed="True" result="Success" success="True" time="0.002" asserts="1" />
+                          <test-case name="NUnit.Core.Tests.TestFixtureTests.CanRunMultipleTearDown" executed="True" result="Success" success="True" time="0.002" asserts="1" />
+                          <test-case name="NUnit.Core.Tests.TestFixtureTests.CanRunMultipleTestFixtureSetUp" executed="True" result="Success" success="True" time="0.002" asserts="1" />
+                          <test-case name="NUnit.Core.Tests.TestFixtureTests.CanRunMultipleTestFixtureTearDown" executed="True" result="Success" success="True" time="0.002" asserts="1" />
+                          <test-case name="NUnit.Core.Tests.TestFixtureTests.CanRunProtectedFixtureSetUp" executed="True" result="Success" success="True" time="0.001" asserts="1" />
+                          <test-case name="NUnit.Core.Tests.TestFixtureTests.CanRunProtectedFixtureTearDown" executed="True" result="Success" success="True" time="0.002" asserts="1" />
+                          <test-case name="NUnit.Core.Tests.TestFixtureTests.CanRunProtectedSetUp" executed="True" result="Success" success="True" time="0.002" asserts="1" />
+                          <test-case name="NUnit.Core.Tests.TestFixtureTests.CanRunProtectedTearDown" executed="True" result="Success" success="True" time="0.002" asserts="1" />
+                          <test-case name="NUnit.Core.Tests.TestFixtureTests.CanRunStaticFixture" executed="True" result="Success" success="True" time="0.001" asserts="1" />
+                          <test-case name="NUnit.Core.Tests.TestFixtureTests.CanRunStaticFixtureSetUp" executed="True" result="Success" success="True" time="0.002" asserts="1" />
+                          <test-case name="NUnit.Core.Tests.TestFixtureTests.CanRunStaticFixtureTearDown" executed="True" result="Success" success="True" time="0.004" asserts="1" />
+                          <test-case name="NUnit.Core.Tests.TestFixtureTests.CanRunStaticSetUp" executed="True" result="Success" success="True" time="0.002" asserts="1" />
+                          <test-case name="NUnit.Core.Tests.TestFixtureTests.CanRunStaticTearDown" executed="True" result="Success" success="True" time="0.002" asserts="1" />
+                          <test-case name="NUnit.Core.Tests.TestFixtureTests.ConstructFromDoublyNestedType" executed="True" result="Success" success="True" time="0.001" asserts="2" />
+                          <test-case name="NUnit.Core.Tests.TestFixtureTests.ConstructFromNestedType" executed="True" result="Success" success="True" time="0.001" asserts="2" />
+                          <test-case name="NUnit.Core.Tests.TestFixtureTests.ConstructFromStaticTypeWithoutTestFixtureAttribute" executed="True" result="Success" success="True" time="0.002" asserts="3" />
+                          <test-case name="NUnit.Core.Tests.TestFixtureTests.ConstructFromType" executed="True" result="Success" success="True" time="0.005" asserts="2" />
+                          <test-case name="NUnit.Core.Tests.TestFixtureTests.ConstructFromTypeWithoutNamespace" executed="True" result="Success" success="True" time="0.002" asserts="2" />
+                          <test-case name="NUnit.Core.Tests.TestFixtureTests.ConstructFromTypeWithoutTestFixtureAttributeContainingTest" executed="True" result="Success" success="True" time="0.002" asserts="3" />
+                          <test-case name="NUnit.Core.Tests.TestFixtureTests.ConstructFromTypeWithoutTestFixtureAttributeContainingTestCase" executed="True" result="Success" success="True" time="0.003" asserts="3" />
+                          <test-case name="NUnit.Core.Tests.TestFixtureTests.ConstructFromTypeWithoutTestFixtureAttributeContainingTestCaseSource" executed="True" result="Success" success="True" time="0.002" asserts="3" />
+                          <test-case name="NUnit.Core.Tests.TestFixtureTests.ConstructFromTypeWithoutTestFixtureAttributeContainingTheory" executed="True" result="Success" success="True" time="0.002" asserts="3" />
+                          <test-case name="NUnit.Core.Tests.TestFixtureTests.FixtureInheritingTwoTestFixtureAttributesIsLoadedOnlyOnce" executed="True" result="Success" success="True" time="0.002" asserts="2" />
+                        </results>
+                      </test-suite>
+                      <test-suite type="TestFixture" name="TestFixtureTests+InternalTestFixture" executed="True" result="Success" success="True" time="0.002" asserts="0">
+                        <results>
+                          <test-case name="NUnit.Core.Tests.TestFixtureTests+InternalTestFixture.CanRunTestInInternalTestFixture" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                        </results>
+                      </test-suite>
+                      <test-suite type="TestFixture" name="TestFixtureTests+PrivateTestFixture" executed="True" result="Success" success="True" time="0.001" asserts="0">
+                        <results>
+                          <test-case name="NUnit.Core.Tests.TestFixtureTests+PrivateTestFixture.CanRunTestInPrivateTestFixture" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                        </results>
+                      </test-suite>
+                      <test-suite type="TestFixture" name="TestFixtureTests+ProtectedTestFixture" executed="True" result="Success" success="True" time="0.001" asserts="0">
+                        <results>
+                          <test-case name="NUnit.Core.Tests.TestFixtureTests+ProtectedTestFixture.CanRunTestInProtectedTestFixture" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                        </results>
+                      </test-suite>
+                      <test-suite type="TestFixture" name="TestFrameworkTests" executed="True" result="Success" success="True" time="0.002" asserts="0">
+                        <results>
+                          <test-case name="NUnit.Core.Tests.TestFrameworkTests.NUnitFrameworkIsKnownAndReferenced" executed="True" result="Success" success="True" time="0.001" asserts="0" />
+                        </results>
+                      </test-suite>
+                      <test-suite type="TestFixture" name="TestIDTests" executed="True" result="Success" success="True" time="0.005" asserts="0">
+                        <results>
+                          <test-case name="NUnit.Core.Tests.TestIDTests.ClonedTestIDsAreEqual" executed="True" result="Success" success="True" time="0.001" asserts="3" />
+                          <test-case name="NUnit.Core.Tests.TestIDTests.DifferentTestIDsAreNotEqual" executed="True" result="Success" success="True" time="0.000" asserts="3" />
+                          <test-case name="NUnit.Core.Tests.TestIDTests.DifferentTestIDsDisplayDifferentStrings" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                        </results>
+                      </test-suite>
+                      <test-suite type="TestFixture" name="TestInfoTests" executed="True" result="Success" success="True" time="0.018" asserts="0">
+                        <results>
+                          <test-case name="NUnit.Core.Tests.TestInfoTests.ConstructFromFixture" executed="True" result="Success" success="True" time="0.006" asserts="10" />
+                          <test-case name="NUnit.Core.Tests.TestInfoTests.ConstructFromSuite" executed="True" result="Success" success="True" time="0.004" asserts="9" />
+                          <test-case name="NUnit.Core.Tests.TestInfoTests.ConstructFromTestCase" executed="True" result="Success" success="True" time="0.004" asserts="9" />
+                        </results>
+                      </test-suite>
+                      <test-suite type="TestFixture" name="TestMethodSignatureTests" executed="True" result="Success" success="True" time="0.227" asserts="0">
+                        <results>
+                          <test-case name="NUnit.Core.Tests.TestMethodSignatureTests.InstanceTestMethodIsRunnable" executed="True" result="Success" success="True" time="0.008" asserts="1" />
+                          <test-case name="NUnit.Core.Tests.TestMethodSignatureTests.PrivateTestMethodIsNotRunnable" executed="True" result="Success" success="True" time="0.007" asserts="2" />
+                          <test-case name="NUnit.Core.Tests.TestMethodSignatureTests.ProtectedTestMethodIsNotRunnable" executed="True" result="Success" success="True" time="0.008" asserts="2" />
+                          <test-case name="NUnit.Core.Tests.TestMethodSignatureTests.RunningTestsThroughFixtureGivesCorrectResults" executed="True" result="Success" success="True" time="0.010" asserts="6" />
+                          <test-case name="NUnit.Core.Tests.TestMethodSignatureTests.StaticTestMethodIsRunnable" executed="True" result="Success" success="True" time="0.007" asserts="1" />
+                          <test-case name="NUnit.Core.Tests.TestMethodSignatureTests.StaticTestMethodWithArgumentsNotProvidedIsNotRunnable" executed="True" result="Success" success="True" time="0.006" asserts="2" />
+                          <test-case name="NUnit.Core.Tests.TestMethodSignatureTests.StaticTestMethodWithArgumentsProvidedIsRunnable" executed="True" result="Success" success="True" time="0.007" asserts="1" />
+                          <test-case name="NUnit.Core.Tests.TestMethodSignatureTests.StaticTestMethodWithWrongArgumentTypesProvidedGivesError" executed="True" result="Success" success="True" time="0.007" asserts="1" />
+                          <test-case name="NUnit.Core.Tests.TestMethodSignatureTests.StaticTestMethodWithWrongNumberOfArgumentsProvidedIsNotRunnable" executed="True" result="Success" success="True" time="0.007" asserts="2" />
+                          <test-case name="NUnit.Core.Tests.TestMethodSignatureTests.TestMethodWithArgumentsNotProvidedIsNotRunnable" executed="True" result="Success" success="True" time="0.009" asserts="2" />
+                          <test-case name="NUnit.Core.Tests.TestMethodSignatureTests.TestMethodWithArgumentsProvidedIsRunnable" executed="True" result="Success" success="True" time="0.007" asserts="1" />
+                          <test-case name="NUnit.Core.Tests.TestMethodSignatureTests.TestMethodWithConvertibleArgumentsIsRunnable" executed="True" result="Success" success="True" time="0.006" asserts="1" />
+                          <test-case name="NUnit.Core.Tests.TestMethodSignatureTests.TestMethodWithMultipleTestCasesExecutesMultipleTimes" executed="True" result="Success" success="True" time="0.006" asserts="2" />
+                          <test-case name="NUnit.Core.Tests.TestMethodSignatureTests.TestMethodWithMultipleTestCasesUsesCorrectNames" executed="True" result="Success" success="True" time="0.007" asserts="7" />
+                          <test-case name="NUnit.Core.Tests.TestMethodSignatureTests.TestMethodWithNonConvertibleArgumentsGivesError" executed="True" result="Success" success="True" time="0.006" asserts="1" />
+                          <test-case name="NUnit.Core.Tests.TestMethodSignatureTests.TestMethodWithoutParametersWithArgumentsProvidedIsNotRunnable" executed="True" result="Success" success="True" time="0.009" asserts="2" />
+                          <test-case name="NUnit.Core.Tests.TestMethodSignatureTests.TestMethodWithParamsArgumentIsRunnable" executed="True" result="Success" success="True" time="0.007" asserts="1" />
+                          <test-case name="NUnit.Core.Tests.TestMethodSignatureTests.TestMethodWithReturnTypeIsNotRunnable" executed="True" result="Success" success="True" time="0.006" asserts="2" />
+                          <test-case name="NUnit.Core.Tests.TestMethodSignatureTests.TestMethodWithWrongArgumentTypesProvidedGivesError" executed="True" result="Success" success="True" time="0.007" asserts="1" />
+                          <test-case name="NUnit.Core.Tests.TestMethodSignatureTests.TestMethodWithWrongNumberOfArgumentsProvidedIsNotRunnable" executed="True" result="Success" success="True" time="0.006" asserts="2" />
+                          <test-suite type="ParameterizedTest" name="TestParams" executed="True" result="Success" success="True" time="0.041" asserts="0">
+                            <results>
+                              <test-case name="NUnit.Core.Tests.TestMethodSignatureTests.TestParams(&quot;one&quot;,&quot;two&quot;,&quot;three&quot;)" executed="True" result="Success" success="True" time="0.006" asserts="1" />
+                              <test-case name="NUnit.Core.Tests.TestMethodSignatureTests.TestParams(&quot;one&quot;,&quot;two&quot;)" executed="True" result="Success" success="True" time="0.006" asserts="1" />
+                              <test-case name="NUnit.Core.Tests.TestMethodSignatureTests.TestParams(&quot;one&quot;,&quot;two&quot;,&quot;three&quot;,&quot;four&quot;)" executed="True" result="Success" success="True" time="0.007" asserts="1" />
+                              <test-case name="NUnit.Core.Tests.TestMethodSignatureTests.TestParams(System.String[])" executed="True" result="Success" success="True" time="0.006" asserts="1" />
+                              <test-case name="NUnit.Core.Tests.TestMethodSignatureTests.TestParams()" executed="True" result="Success" success="True" time="0.006" asserts="1" />
+                            </results>
+                          </test-suite>
+                        </results>
+                      </test-suite>
+                      <test-suite type="TestFixture" name="TestNameTests" executed="True" result="Success" success="True" time="0.028" asserts="0">
+                        <results>
+                          <test-case name="NUnit.Core.Tests.TestNameTests.CanCompareStrongTestNames" executed="True" result="Success" success="True" time="0.001" asserts="9" />
+                          <test-case name="NUnit.Core.Tests.TestNameTests.CanCompareWeakAndStrongTestNames" executed="True" result="Success" success="True" time="0.000" asserts="3" />
+                          <test-case name="NUnit.Core.Tests.TestNameTests.CanCompareWeakTestNames" executed="True" result="Success" success="True" time="0.000" asserts="6" />
+                          <test-case name="NUnit.Core.Tests.TestNameTests.CanDisplayUniqueNames" executed="True" result="Success" success="True" time="0.000" asserts="2" />
+                          <test-case name="NUnit.Core.Tests.TestNameTests.CanParseSimpleTestNames" executed="True" result="Success" success="True" time="0.001" asserts="1" />
+                          <test-case name="NUnit.Core.Tests.TestNameTests.CanParseStrongTestNames" executed="True" result="Success" success="True" time="0.000" asserts="2" />
+                          <test-case name="NUnit.Core.Tests.TestNameTests.CanParseWeakTestNames" executed="True" result="Success" success="True" time="0.000" asserts="2" />
+                          <test-case name="NUnit.Core.Tests.TestNameTests.ClonedTestNamesAreEqual" executed="True" result="Success" success="True" time="0.001" asserts="6" />
+                          <test-case name="NUnit.Core.Tests.TestNameTests.TestNamesWithDifferentRunnerIDsAreNotEqual" executed="True" result="Success" success="True" time="0.001" asserts="7" />
+                        </results>
+                      </test-suite>
+                      <test-suite type="TestFixture" name="TestNodeTests" executed="True" result="Success" success="True" time="0.019" asserts="0">
+                        <results>
+                          <test-case name="NUnit.Core.Tests.TestNodeTests.ConstructFromMultipleTests" executed="True" result="Success" success="True" time="0.006" asserts="8" />
+                          <test-case name="NUnit.Core.Tests.TestNodeTests.ConstructFromSuite" executed="True" result="Success" success="True" time="0.005" asserts="3" />
+                          <test-case name="NUnit.Core.Tests.TestNodeTests.ConstructFromTestCase" executed="True" result="Success" success="True" time="0.003" asserts="1" />
+                        </results>
+                      </test-suite>
+                      <test-suite type="TestFixture" name="TestRunnerThreadTests" executed="True" result="Success" success="True" time="0.103" asserts="0">
+                        <results>
+                          <test-case name="NUnit.Core.Tests.TestRunnerThreadTests.RunMultipleTests" executed="True" result="Success" success="True" time="0.092" asserts="0" />
+                          <test-case name="NUnit.Core.Tests.TestRunnerThreadTests.RunNamedTest" executed="True" result="Success" success="True" time="0.003" asserts="0" />
+                          <test-case name="NUnit.Core.Tests.TestRunnerThreadTests.RunTestSuite" executed="True" result="Success" success="True" time="0.001" asserts="0" />
+                        </results>
+                      </test-suite>
+                      <test-suite type="TestFixture" name="TestSuiteTest" executed="True" result="Success" success="True" time="0.195" asserts="0">
+                        <results>
+                          <test-case name="NUnit.Core.Tests.TestSuiteTest.CanSortUsingExternalComparer" executed="True" result="Success" success="True" time="0.008" asserts="1" />
+                          <test-case name="NUnit.Core.Tests.TestSuiteTest.CountTestCasesFilteredByName" executed="True" result="Success" success="True" time="0.007" asserts="4" />
+                          <test-case name="NUnit.Core.Tests.TestSuiteTest.DefaultSortIsByName" executed="True" result="Success" success="True" time="0.005" asserts="1" />
+                          <test-case name="NUnit.Core.Tests.TestSuiteTest.ExcludingCategoryDoesNotRunExplicitTestCases" executed="True" result="Success" success="True" time="0.008" asserts="1" />
+                          <test-case name="NUnit.Core.Tests.TestSuiteTest.ExcludingCategoryDoesNotRunExplicitTestFixtures" executed="True" result="Success" success="True" time="0.038" asserts="1" />
+                          <test-case name="NUnit.Core.Tests.TestSuiteTest.InheritedTestCount" executed="True" result="Success" success="True" time="0.006" asserts="1" />
+                          <test-case name="NUnit.Core.Tests.TestSuiteTest.RunExplicitTestByCategory" executed="True" result="Success" success="True" time="0.005" asserts="1" />
+                          <test-case name="NUnit.Core.Tests.TestSuiteTest.RunExplicitTestByName" executed="True" result="Success" success="True" time="0.005" asserts="1" />
+                          <test-case name="NUnit.Core.Tests.TestSuiteTest.RunExplicitTestDirectly" executed="True" result="Success" success="True" time="0.006" asserts="1" />
+                          <test-case name="NUnit.Core.Tests.TestSuiteTest.RunNoTestSuite" executed="True" result="Success" success="True" time="0.005" asserts="2" />
+                          <test-case name="NUnit.Core.Tests.TestSuiteTest.RunSingleTest" executed="True" result="Success" success="True" time="0.009" asserts="1" />
+                          <test-case name="NUnit.Core.Tests.TestSuiteTest.RunSuiteByCategory" executed="True" result="Success" success="True" time="0.008" asserts="1" />
+                          <test-case name="NUnit.Core.Tests.TestSuiteTest.RunSuiteByName" executed="True" result="Success" success="True" time="0.008" asserts="2" />
+                          <test-case name="NUnit.Core.Tests.TestSuiteTest.RunTestByCategory" executed="True" result="Success" success="True" time="0.006" asserts="1" />
+                          <test-case name="NUnit.Core.Tests.TestSuiteTest.RunTestByName" executed="True" result="Success" success="True" time="0.006" asserts="2" />
+                          <test-case name="NUnit.Core.Tests.TestSuiteTest.RunTestExcludingCategory" executed="True" result="Success" success="True" time="0.008" asserts="1" />
+                          <test-case name="NUnit.Core.Tests.TestSuiteTest.RunTestsInFixture" executed="True" result="Success" success="True" time="0.008" asserts="6" />
+                          <test-case name="NUnit.Core.Tests.TestSuiteTest.SuiteRunInitialized" executed="True" result="Success" success="True" time="0.005" asserts="1" />
+                          <test-case name="NUnit.Core.Tests.TestSuiteTest.SuiteWithNoTests" executed="True" result="Success" success="True" time="0.005" asserts="2" />
+                        </results>
+                      </test-suite>
+                      <test-suite type="TestFixture" name="TheoryTests" executed="True" result="Success" success="True" time="0.081" asserts="0">
+                        <results>
+                          <test-suite type="Theory" name="ArrayWithDatapointsAttributeIsUsed" executed="True" result="Success" success="True" time="0.004" asserts="0">
+                            <results>
+                              <test-case name="NUnit.Core.Tests.TheoryTests.ArrayWithDatapointsAttributeIsUsed(&quot;xyz1&quot;)" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                              <test-case name="NUnit.Core.Tests.TheoryTests.ArrayWithDatapointsAttributeIsUsed(&quot;xyz2&quot;)" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                              <test-case name="NUnit.Core.Tests.TheoryTests.ArrayWithDatapointsAttributeIsUsed(&quot;xyz3&quot;)" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                            </results>
+                          </test-suite>
+                          <test-case name="NUnit.Core.Tests.TheoryTests.BooleanArgumentsAreSuppliedAutomatically" executed="True" result="Success" success="True" time="0.001" asserts="2" />
+                          <test-case name="NUnit.Core.Tests.TheoryTests.EnumArgumentsAreSuppliedAutomatically" executed="True" result="Success" success="True" time="0.001" asserts="2" />
+                          <test-suite type="Theory" name="NullDatapointIsOK" executed="True" result="Success" success="True" time="0.001" asserts="0">
+                            <results>
+                              <test-case name="NUnit.Core.Tests.TheoryTests.NullDatapointIsOK(null)" executed="True" result="Success" success="True" time="0.000" asserts="0" />
+                            </results>
+                          </test-suite>
+                          <test-case name="NUnit.Core.Tests.TheoryTests.SimpleTestIgnoresDataPoints" executed="True" result="Success" success="True" time="0.001" asserts="1" />
+                          <test-suite type="Theory" name="SquareRootWithAllGoodValues" executed="True" result="Success" success="True" time="0.006" asserts="0">
+                            <results>
+                              <test-case name="NUnit.Core.Tests.TheoryTests.SquareRootWithAllGoodValues(12.0d)" executed="True" result="Success" success="True" time="0.001" asserts="2" />
+                              <test-case name="NUnit.Core.Tests.TheoryTests.SquareRootWithAllGoodValues(4.0d)" executed="True" result="Success" success="True" time="0.001" asserts="2" />
+                              <test-case name="NUnit.Core.Tests.TheoryTests.SquareRootWithAllGoodValues(9.0d)" executed="True" result="Success" success="True" time="0.001" asserts="2" />
+                            </results>
+                          </test-suite>
+                          <test-suite type="Theory" name="SquareRootWithOneBadValue" executed="True" result="Success" success="True" time="0.006" asserts="0">
+                            <results>
+                              <test-case name="NUnit.Core.Tests.TheoryTests.SquareRootWithOneBadValue(12.0d)" executed="True" result="Success" success="True" time="0.000" asserts="2" />
+                              <test-case name="NUnit.Core.Tests.TheoryTests.SquareRootWithOneBadValue(-4.0d)" executed="True" result="Inconclusive" success="False" time="0.001" asserts="0">
+                                <reason>
+                                  <message><![CDATA[  Expected: True
+  But was:  False
+]]></message>
+                                </reason>
+                              </test-case>
+                              <test-case name="NUnit.Core.Tests.TheoryTests.SquareRootWithOneBadValue(9.0d)" executed="True" result="Success" success="True" time="0.000" asserts="2" />
+                            </results>
+                          </test-suite>
+                          <test-case name="NUnit.Core.Tests.TheoryTests.TheoryFailsIfAllTestsAreInconclusive" executed="True" result="Success" success="True" time="0.004" asserts="2" />
+                          <test-case name="NUnit.Core.Tests.TheoryTests.TheoryWithDatapointsIsRunnable" executed="True" result="Success" success="True" time="0.003" asserts="2" />
+                          <test-case name="NUnit.Core.Tests.TheoryTests.TheoryWithNoArgumentsIsTreatedAsTest" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Core.Tests.TheoryTests.TheoryWithNoDatapointsIsNotRunnable" executed="True" result="Success" success="True" time="0.001" asserts="2" />
+                        </results>
+                      </test-suite>
+                      <test-suite type="TestFixture" name="TheoryTests+SqrtTests_DisplayResults" executed="True" result="Success" success="True" time="0.011" asserts="0">
+                        <results>
+                          <test-suite type="Theory" name="SqrtTimesItselfGivesOriginal" executed="True" result="Success" success="True" time="0.011" asserts="0">
+                            <results>
+                              <test-case name="NUnit.Core.Tests.TheoryTests+SqrtTests_DisplayResults.SqrtTimesItselfGivesOriginal(0.0d)" executed="True" result="Success" success="True" time="0.000" asserts="2" />
+                              <test-case name="NUnit.Core.Tests.TheoryTests+SqrtTests_DisplayResults.SqrtTimesItselfGivesOriginal(1.0d)" executed="True" result="Success" success="True" time="0.000" asserts="2" />
+                              <test-case name="NUnit.Core.Tests.TheoryTests+SqrtTests_DisplayResults.SqrtTimesItselfGivesOriginal(-1.0d)" executed="True" result="Inconclusive" success="False" time="0.001" asserts="0">
+                                <reason>
+                                  <message><![CDATA[  Expected: True
+  But was:  False
+]]></message>
+                                </reason>
+                              </test-case>
+                              <test-case name="NUnit.Core.Tests.TheoryTests+SqrtTests_DisplayResults.SqrtTimesItselfGivesOriginal(double.MaxValue)" executed="True" result="Inconclusive" success="False" time="0.001" asserts="0">
+                                <reason>
+                                  <message><![CDATA[  Expected: True
+  But was:  False
+]]></message>
+                                </reason>
+                              </test-case>
+                              <test-case name="NUnit.Core.Tests.TheoryTests+SqrtTests_DisplayResults.SqrtTimesItselfGivesOriginal(double.PositiveInfinity)" executed="True" result="Inconclusive" success="False" time="0.001" asserts="0">
+                                <reason>
+                                  <message><![CDATA[  Expected: True
+  But was:  False
+]]></message>
+                                </reason>
+                              </test-case>
+                            </results>
+                          </test-suite>
+                        </results>
+                      </test-suite>
+                      <test-suite type="TestFixture" name="ThreadedTestRunnerTests" executed="True" result="Success" success="True" time="0.428" asserts="1">
+                        <results>
+                          <test-case name="NUnit.Core.Tests.ThreadedTestRunnerTests.BasicRunnerTests.CheckRunnerID" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Core.Tests.ThreadedTestRunnerTests.BasicRunnerTests.CountTestCases" executed="True" result="Success" success="True" time="0.028" asserts="1" />
+                          <test-case name="NUnit.Core.Tests.ThreadedTestRunnerTests.BasicRunnerTests.CountTestCasesAcrossMultipleAssemblies" executed="True" result="Success" success="True" time="0.035" asserts="1" />
+                          <test-case name="NUnit.Core.Tests.ThreadedTestRunnerTests.BasicRunnerTests.LoadAndReloadAssembly" executed="True" result="Success" success="True" time="0.054" asserts="2" />
+                          <test-case name="NUnit.Core.Tests.ThreadedTestRunnerTests.BasicRunnerTests.LoadAssemblyWithFixture" executed="True" result="Success" success="True" time="0.012" asserts="1" />
+                          <test-case name="NUnit.Core.Tests.ThreadedTestRunnerTests.BasicRunnerTests.LoadAssemblyWithoutNamespaces" executed="True" result="Success" success="True" time="0.025" asserts="4" />
+                          <test-case name="NUnit.Core.Tests.ThreadedTestRunnerTests.BasicRunnerTests.LoadAssemblyWithSuite" executed="True" result="Success" success="True" time="0.009" asserts="1" />
+                          <test-case name="NUnit.Core.Tests.ThreadedTestRunnerTests.BasicRunnerTests.LoadMultipleAssemblies" executed="True" result="Success" success="True" time="0.038" asserts="1" />
+                          <test-case name="NUnit.Core.Tests.ThreadedTestRunnerTests.BasicRunnerTests.LoadMultipleAssembliesWithFixture" executed="True" result="Success" success="True" time="0.020" asserts="1" />
+                          <test-case name="NUnit.Core.Tests.ThreadedTestRunnerTests.BasicRunnerTests.LoadMultipleAssembliesWithSuite" executed="True" result="Success" success="True" time="0.017" asserts="1" />
+                          <test-case name="NUnit.Core.Tests.ThreadedTestRunnerTests.BasicRunnerTests.RunAssembly" executed="True" result="Success" success="True" time="0.036" asserts="1" />
+                          <test-case name="NUnit.Core.Tests.ThreadedTestRunnerTests.BasicRunnerTests.RunAssemblyUsingBeginAndEndRun" executed="True" result="Success" success="True" time="0.035" asserts="2" />
+                          <test-case name="NUnit.Core.Tests.ThreadedTestRunnerTests.BasicRunnerTests.RunMultipleAssemblies" executed="True" result="Success" success="True" time="0.047" asserts="1" />
+                          <test-case name="NUnit.Core.Tests.ThreadedTestRunnerTests.BasicRunnerTests.RunMultipleAssembliesUsingBeginAndEndRun" executed="True" result="Success" success="True" time="0.045" asserts="2" />
+                        </results>
+                      </test-suite>
+                      <test-suite type="TestFixture" name="ThreadingTests" executed="True" result="Success" success="True" time="0.163" asserts="0">
+                        <results>
+                          <test-case name="NUnit.Core.Tests.ThreadingTests.TestOnSeparateThreadReportsAssertCountCorrectly" executed="True" result="Success" success="True" time="0.002" asserts="1" />
+                          <test-case name="NUnit.Core.Tests.ThreadingTests.TestWithInfiniteLoopTimesOut" executed="True" result="Success" success="True" time="0.063" asserts="3" />
+                          <test-case name="NUnit.Core.Tests.ThreadingTests.TestWithMTAThreadRunsInMTA" executed="True" result="Success" success="True" time="0.000" asserts="2">
+                            <properties>
+                              <property name="APARTMENT_STATE" value="MTA" />
+                            </properties>
+                          </test-case>
+                          <test-case name="NUnit.Core.Tests.ThreadingTests.TestWithRequiresMTARunsInMTA" executed="True" result="Success" success="True" time="0.000" asserts="2">
+                            <properties>
+                              <property name="APARTMENT_STATE" value="MTA" />
+                            </properties>
+                          </test-case>
+                          <test-case name="NUnit.Core.Tests.ThreadingTests.TestWithRequiresSTARunsInSTA" executed="True" result="Success" success="True" time="0.001" asserts="1">
+                            <properties>
+                              <property name="APARTMENT_STATE" value="STA" />
+                            </properties>
+                          </test-case>
+                          <test-case name="NUnit.Core.Tests.ThreadingTests.TestWithRequiresThreadRunsInSeparateThread" executed="True" result="Success" success="True" time="0.001" asserts="1">
+                            <properties>
+                              <property name="RequiresThread" value="True" />
+                            </properties>
+                          </test-case>
+                          <test-case name="NUnit.Core.Tests.ThreadingTests.TestWithRequiresThreadRunsSetUpAndTestOnSameThread" executed="True" result="Success" success="True" time="0.001" asserts="1">
+                            <properties>
+                              <property name="RequiresThread" value="True" />
+                            </properties>
+                          </test-case>
+                          <test-case name="NUnit.Core.Tests.ThreadingTests.TestWithRequiresThreadWithMTAArgRunsOnSeparateThreadInMTA" executed="True" result="Success" success="True" time="0.001" asserts="2">
+                            <properties>
+                              <property name="RequiresThread" value="True" />
+                              <property name="APARTMENT_STATE" value="MTA" />
+                            </properties>
+                          </test-case>
+                          <test-case name="NUnit.Core.Tests.ThreadingTests.TestWithRequiresThreadWithSTAArgRunsOnSeparateThreadInSTA" executed="True" result="Success" success="True" time="0.001" asserts="2">
+                            <properties>
+                              <property name="RequiresThread" value="True" />
+                              <property name="APARTMENT_STATE" value="STA" />
+                            </properties>
+                          </test-case>
+                          <test-case name="NUnit.Core.Tests.ThreadingTests.TestWithSTAThreadRunsInSTA" executed="True" result="Success" success="True" time="0.001" asserts="1">
+                            <properties>
+                              <property name="APARTMENT_STATE" value="STA" />
+                            </properties>
+                          </test-case>
+                          <test-case name="NUnit.Core.Tests.ThreadingTests.TestWithTimeoutRunsOnSeparateThread" executed="True" result="Success" success="True" time="0.001" asserts="1">
+                            <properties>
+                              <property name="Timeout" value="50" />
+                            </properties>
+                          </test-case>
+                          <test-case name="NUnit.Core.Tests.ThreadingTests.TestWithTimeoutRunsSetUpAndTestOnSameThread" executed="True" result="Success" success="True" time="0.000" asserts="1">
+                            <properties>
+                              <property name="Timeout" value="50" />
+                            </properties>
+                          </test-case>
+                          <test-case name="NUnit.Core.Tests.ThreadingTests.TimeoutCanBeSetOnTestFixture" executed="True" result="Success" success="True" time="0.066" asserts="3" />
+                        </results>
+                      </test-suite>
+                      <test-suite type="TestFixture" name="ThreadingTests+FixtureRequiresMTA" executed="True" result="Success" success="True" time="0.001" asserts="0">
+                        <properties>
+                          <property name="APARTMENT_STATE" value="MTA" />
+                        </properties>
+                        <results>
+                          <test-case name="NUnit.Core.Tests.ThreadingTests+FixtureRequiresMTA.RequiresMTACanBeSetOnTestFixture" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                        </results>
+                      </test-suite>
+                      <test-suite type="TestFixture" name="ThreadingTests+FixtureRequiresSTA" executed="True" result="Success" success="True" time="0.002" asserts="0">
+                        <properties>
+                          <property name="APARTMENT_STATE" value="STA" />
+                        </properties>
+                        <results>
+                          <test-case name="NUnit.Core.Tests.ThreadingTests+FixtureRequiresSTA.RequiresSTACanBeSetOnTestFixture" executed="True" result="Success" success="True" time="0.001" asserts="1" />
+                        </results>
+                      </test-suite>
+                      <test-suite type="TestFixture" name="ThreadingTests+FixtureRequiresThread" executed="True" result="Success" success="True" time="0.022" asserts="0">
+                        <properties>
+                          <property name="RequiresThread" value="True" />
+                        </properties>
+                        <results>
+                          <test-case name="NUnit.Core.Tests.ThreadingTests+FixtureRequiresThread.RequiresThreadCanBeSetOnTestFixture" executed="True" result="Success" success="True" time="0.019" asserts="1" />
+                        </results>
+                      </test-suite>
+                      <test-suite type="TestFixture" name="TypeHelperTests" executed="True" result="Success" success="True" time="0.050" asserts="0">
+                        <results>
+                          <test-suite type="ParameterizedTest" name="GetDisplayName" executed="True" result="Success" success="True" time="0.049" asserts="0">
+                            <results>
+                              <test-case name="NUnit.Core.Tests.TypeHelperTests.GetDisplayName(NUnit.TestData.TypeHelperFixture.GenericContainerClass`1+NestedClass[System.String],&quot;GenericContainerClass+NestedClass&lt;String&gt;&quot;)" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                              <test-case name="NUnit.Core.Tests.TypeHelperTests.GetDisplayName(NUnit.TestData.TypeHelperFixture.ContainerClass+NestedGeneric`1+DoublyNestedGeneric`1[System.String,System.Int32],&quot;ContainerClass+NestedGeneric+DoublyNestedGeneric&lt;String,Int32&gt;&quot;)" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                              <test-case name="NUnit.Core.Tests.TypeHelperTests.GetDisplayName(System.Int32,&quot;Int32&quot;)" executed="True" result="Success" success="True" time="0.001" asserts="1" />
+                              <test-case name="NUnit.Core.Tests.TypeHelperTests.GetDisplayName(NUnit.TestData.TypeHelperFixture.SimpleClass,&quot;SimpleClass&quot;)" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                              <test-case name="NUnit.Core.Tests.TypeHelperTests.GetDisplayName(MyNoNamespaceClass,&quot;MyNoNamespaceClass&quot;)" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                              <test-case name="NUnit.Core.Tests.TypeHelperTests.GetDisplayName(NUnit.TestData.TypeHelperFixture.GenericClass`3[System.Int32,System.Decimal,System.String],&quot;GenericClass&lt;Int32,Decimal,String&gt;&quot;)" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                              <test-case name="NUnit.Core.Tests.TypeHelperTests.GetDisplayName(NUnit.TestData.TypeHelperFixture.ListTester`1[System.Collections.Generic.List`1[System.Collections.Generic.List`1[System.Int32]]],&quot;ListTester&lt;List&lt;List&lt;Int32&gt;&gt;&gt;&quot;)" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                              <test-case name="NUnit.Core.Tests.TypeHelperTests.GetDisplayName(NUnit.TestData.TypeHelperFixture.ContainerClass+NestedClass,&quot;ContainerClass+NestedClass&quot;)" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                              <test-case name="NUnit.Core.Tests.TypeHelperTests.GetDisplayName(NUnit.TestData.TypeHelperFixture.ContainerClass+NestedClass+DoublyNestedClass,&quot;ContainerClass+NestedClass+DoublyNestedClass&quot;)" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                              <test-case name="NUnit.Core.Tests.TypeHelperTests.GetDisplayName(NUnit.TestData.TypeHelperFixture.ContainerClass+NestedClass+DoublyNestedGeneric`1[System.Int32],&quot;ContainerClass+NestedClass+DoublyNestedGeneric&lt;Int32&gt;&quot;)" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                              <test-case name="NUnit.Core.Tests.TypeHelperTests.GetDisplayName(NUnit.TestData.TypeHelperFixture.ContainerClass+NestedGeneric`1[System.Int32],&quot;ContainerClass+NestedGeneric&lt;Int32&gt;&quot;)" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                              <test-case name="NUnit.Core.Tests.TypeHelperTests.GetDisplayName(NUnit.TestData.TypeHelperFixture.ContainerClass+NestedGeneric`1+DoublyNestedClass[System.Int32],&quot;ContainerClass+NestedGeneric+DoublyNestedClass&lt;Int32&gt;&quot;)" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                              <test-case name="NUnit.Core.Tests.TypeHelperTests.GetDisplayName(NUnit.TestData.TypeHelperFixture.GenericClass`3[System.Int32[],System.Decimal[],System.String[]],&quot;GenericClass&lt;Int32[],Decimal[],String[]&gt;&quot;)" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                              <test-case name="NUnit.Core.Tests.TypeHelperTests.GetDisplayName(NUnit.TestData.TypeHelperFixture.GenericContainerClass`1+NestedClass+DoublyNestedClass[System.String],&quot;GenericContainerClass+NestedClass+DoublyNestedClass&lt;String&gt;&quot;)" executed="True" result="Success" success="True" time="0.001" asserts="1" />
+                              <test-case name="NUnit.Core.Tests.TypeHelperTests.GetDisplayName(NUnit.TestData.TypeHelperFixture.GenericContainerClass`1+NestedClass+DoublyNestedGeneric`1[System.String,System.Boolean],&quot;GenericContainerClass+NestedClass+DoublyNestedGeneric&lt;String,Boolean&gt;&quot;)" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                              <test-case name="NUnit.Core.Tests.TypeHelperTests.GetDisplayName(NUnit.TestData.TypeHelperFixture.GenericContainerClass`1+NestedGeneric`1[System.String,System.Int32],&quot;GenericContainerClass+NestedGeneric&lt;String,Int32&gt;&quot;)" executed="True" result="Success" success="True" time="0.001" asserts="1" />
+                              <test-case name="NUnit.Core.Tests.TypeHelperTests.GetDisplayName(NUnit.TestData.TypeHelperFixture.GenericContainerClass`1+NestedGeneric`1+DoublyNestedClass[System.String,System.Int32],&quot;GenericContainerClass+NestedGeneric+DoublyNestedClass&lt;String,Int32&gt;&quot;)" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                              <test-case name="NUnit.Core.Tests.TypeHelperTests.GetDisplayName(NUnit.TestData.TypeHelperFixture.GenericContainerClass`1+NestedGeneric`1+DoublyNestedGeneric`1[System.String,System.Int32,System.Boolean],&quot;GenericContainerClass+NestedGeneric+DoublyNestedGeneric&lt;String,Int32,Boolean&gt;&quot;)" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                              <test-case name="NUnit.Core.Tests.TypeHelperTests.GetDisplayName(NUnit.TestData.TypeHelperFixture.ListTester`1[System.Collections.Generic.List`1[System.Int32]],&quot;ListTester&lt;List&lt;Int32&gt;&gt;&quot;)" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                            </results>
+                          </test-suite>
+                        </results>
+                      </test-suite>
+                      <test-suite type="TestFixture" name="ValueSourceTests" executed="True" result="Success" success="True" time="0.041" asserts="0">
+                        <results>
+                          <test-suite type="ParameterizedTest" name="MultipleArguments" executed="True" result="Success" success="True" time="0.005" asserts="0">
+                            <results>
+                              <test-case name="NUnit.Core.Tests.ValueSourceTests.MultipleArguments(12,3,4)" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                              <test-case name="NUnit.Core.Tests.ValueSourceTests.MultipleArguments(12,4,3)" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                              <test-case name="NUnit.Core.Tests.ValueSourceTests.MultipleArguments(12,6,2)" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                            </results>
+                          </test-suite>
+                          <test-suite type="ParameterizedTest" name="ValueSourceCanBeInstanceField" executed="True" result="Success" success="True" time="0.001" asserts="0">
+                            <results>
+                              <test-case name="NUnit.Core.Tests.ValueSourceTests.ValueSourceCanBeInstanceField(&quot;InstanceField&quot;)" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                            </results>
+                          </test-suite>
+                          <test-suite type="ParameterizedTest" name="ValueSourceCanBeInstanceMethod" executed="True" result="Success" success="True" time="0.001" asserts="0">
+                            <results>
+                              <test-case name="NUnit.Core.Tests.ValueSourceTests.ValueSourceCanBeInstanceMethod(&quot;InstanceMethod&quot;)" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                            </results>
+                          </test-suite>
+                          <test-suite type="ParameterizedTest" name="ValueSourceCanBeInstanceProperty" executed="True" result="Success" success="True" time="0.001" asserts="0">
+                            <results>
+                              <test-case name="NUnit.Core.Tests.ValueSourceTests.ValueSourceCanBeInstanceProperty(&quot;InstanceProperty&quot;)" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                            </results>
+                          </test-suite>
+                          <test-suite type="ParameterizedTest" name="ValueSourceCanBeStaticField" executed="True" result="Success" success="True" time="0.001" asserts="0">
+                            <results>
+                              <test-case name="NUnit.Core.Tests.ValueSourceTests.ValueSourceCanBeStaticField(&quot;StaticField&quot;)" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                            </results>
+                          </test-suite>
+                          <test-suite type="ParameterizedTest" name="ValueSourceCanBeStaticMethod" executed="True" result="Success" success="True" time="0.001" asserts="0">
+                            <results>
+                              <test-case name="NUnit.Core.Tests.ValueSourceTests.ValueSourceCanBeStaticMethod(&quot;StaticMethod&quot;)" executed="True" result="Success" success="True" time="0.001" asserts="1" />
+                            </results>
+                          </test-suite>
+                          <test-suite type="ParameterizedTest" name="ValueSourceCanBeStaticProperty" executed="True" result="Success" success="True" time="0.001" asserts="0">
+                            <results>
+                              <test-case name="NUnit.Core.Tests.ValueSourceTests.ValueSourceCanBeStaticProperty(&quot;StaticProperty&quot;)" executed="True" result="Success" success="True" time="0.001" asserts="1" />
+                            </results>
+                          </test-suite>
+                          <test-suite type="ParameterizedTest" name="ValueSourceIsInvokedWithCorrectCurrentDirectory" executed="True" result="Success" success="True" time="0.001" asserts="0">
+                            <results>
+                              <test-case name="NUnit.Core.Tests.ValueSourceTests.ValueSourceIsInvokedWithCorrectCurrentDirectory(True)" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                            </results>
+                          </test-suite>
+                          <test-suite type="ParameterizedTest" name="ValueSourceMayBeGeneric" executed="True" result="Success" success="True" time="0.007" asserts="0">
+                            <results>
+                              <test-case name="NUnit.Core.Tests.ValueSourceTests.ValueSourceMayBeGeneric(1)" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                              <test-case name="NUnit.Core.Tests.ValueSourceTests.ValueSourceMayBeGeneric(2)" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                              <test-case name="NUnit.Core.Tests.ValueSourceTests.ValueSourceMayBeGeneric(4)" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                              <test-case name="NUnit.Core.Tests.ValueSourceTests.ValueSourceMayBeGeneric(8)" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                            </results>
+                          </test-suite>
+                          <test-suite type="ParameterizedTest" name="ValueSourceMayBeInAnotherClass" executed="True" result="Success" success="True" time="0.005" asserts="0">
+                            <results>
+                              <test-case name="NUnit.Core.Tests.ValueSourceTests.ValueSourceMayBeInAnotherClass(12,3,4)" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                              <test-case name="NUnit.Core.Tests.ValueSourceTests.ValueSourceMayBeInAnotherClass(12,4,3)" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                              <test-case name="NUnit.Core.Tests.ValueSourceTests.ValueSourceMayBeInAnotherClass(12,6,2)" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                            </results>
+                          </test-suite>
+                        </results>
+                      </test-suite>
+                      <test-suite type="TestFixture" name="XmlTest" executed="True" result="Success" success="True" time="1.195" asserts="0">
+                        <results>
+                          <test-case name="NUnit.Core.Tests.XmlTest.removeTime" executed="True" result="Success" success="True" time="0.713" asserts="1" />
+                          <test-case name="NUnit.Core.Tests.XmlTest.TestSchemaValidatorFrenchCulture" executed="True" result="Success" success="True" time="0.289" asserts="1" />
+                          <test-case name="NUnit.Core.Tests.XmlTest.TestSchemaValidatorInvariantCulture" executed="True" result="Success" success="True" time="0.043" asserts="1" />
+                          <test-case name="NUnit.Core.Tests.XmlTest.TestSchemaValidatorUnitedStatesCulture" executed="True" result="Success" success="True" time="0.044" asserts="1" />
+                          <test-case name="NUnit.Core.Tests.XmlTest.TestStream" executed="True" result="Success" success="True" time="0.089" asserts="1" />
+                        </results>
+                      </test-suite>
+                    </results>
+                  </test-suite>
+                </results>
+              </test-suite>
+            </results>
+          </test-suite>
+        </results>
+      </test-suite>
+      <test-suite type="Assembly" name="C:\Program Files\NUnit 2.6.2\bin\tests/nunit.util.tests.dll" executed="True" result="Success" success="True" time="31.780" asserts="0">
+        <results>
+          <test-suite type="Namespace" name="NUnit" executed="True" result="Success" success="True" time="31.777" asserts="0">
+            <results>
+              <test-suite type="Namespace" name="Util" executed="True" result="Success" success="True" time="31.777" asserts="0">
+                <results>
+                  <test-suite type="SetUpFixture" name="Tests" executed="True" result="Success" success="True" time="31.777" asserts="0">
+                    <results>
+                      <test-suite type="TestFixture" name="AssemblyListTests" executed="True" result="Success" success="True" time="0.018" asserts="0">
+                        <results>
+                          <test-case name="NUnit.Util.Tests.AssemblyListTests.AddFiresChangedEvent" executed="True" result="Success" success="True" time="0.001" asserts="1" />
+                          <test-case name="NUnit.Util.Tests.AssemblyListTests.CanAddAssemblies" executed="True" result="Success" success="True" time="0.001" asserts="3" />
+                          <test-case name="NUnit.Util.Tests.AssemblyListTests.CanRemoveAssemblies" executed="True" result="Success" success="True" time="0.000" asserts="3" />
+                          <test-case name="NUnit.Util.Tests.AssemblyListTests.EmptyList" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Util.Tests.AssemblyListTests.MustAddAbsolutePath" executed="True" result="Success" success="True" time="0.001" asserts="0" />
+                          <test-case name="NUnit.Util.Tests.AssemblyListTests.RemoveAtFiresChangedEvent" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Util.Tests.AssemblyListTests.RemoveFiresChangedEvent" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Util.Tests.AssemblyListTests.SettingFullPathFiresChangedEvent" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                        </results>
+                      </test-suite>
+                      <test-suite type="TestFixture" name="AssemblyWatcherTests" executed="True" result="Success" success="True" time="0.927" asserts="0">
+                        <results>
+                          <test-case name="NUnit.Util.Tests.AssemblyWatcherTests.ChangingAttributesDoesNotTriggerWatcher" executed="True" result="Success" success="True" time="0.239" asserts="1" />
+                          <test-case name="NUnit.Util.Tests.AssemblyWatcherTests.ChangingFileTriggersWatcher" executed="True" result="Success" success="True" time="0.204" asserts="2" />
+                          <test-case name="NUnit.Util.Tests.AssemblyWatcherTests.CopyingFileDoesNotTriggerWatcher" executed="True" result="Success" success="True" time="0.207" asserts="1" />
+                          <test-case name="NUnit.Util.Tests.AssemblyWatcherTests.MultipleCloselySpacedChangesTriggerWatcherOnlyOnce" executed="True" result="Success" success="True" time="0.265" asserts="2" />
+                        </results>
+                      </test-suite>
+                      <test-suite type="TestFixture" name="CategoryManagerTest" executed="True" result="Success" success="True" time="0.088" asserts="0">
+                        <results>
+                          <test-case name="NUnit.Util.Tests.CategoryManagerTest.CanAddAllAvailableCategoriesInTestTree" executed="True" result="Success" success="True" time="0.050" asserts="1" />
+                          <test-case name="NUnit.Util.Tests.CategoryManagerTest.CanAddStrings" executed="True" result="Success" success="True" time="0.001" asserts="1" />
+                          <test-case name="NUnit.Util.Tests.CategoryManagerTest.CanAddStringsWithoutDuplicating" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Util.Tests.CategoryManagerTest.CanAddTestCategories" executed="True" result="Success" success="True" time="0.026" asserts="1" />
+                          <test-case name="NUnit.Util.Tests.CategoryManagerTest.CanClearEntries" executed="True" result="Success" success="True" time="0.001" asserts="1" />
+                        </results>
+                      </test-suite>
+                      <test-suite type="TestFixture" name="CategoryParseTests" executed="True" result="Success" success="True" time="0.027" asserts="0">
+                        <results>
+                          <test-case name="NUnit.Util.Tests.CategoryParseTests.CanParseCompoundCategory" executed="True" result="Success" success="True" time="0.003" asserts="1" />
+                          <test-case name="NUnit.Util.Tests.CategoryParseTests.CanParseExcludedCategories" executed="True" result="Success" success="True" time="0.001" asserts="1" />
+                          <test-case name="NUnit.Util.Tests.CategoryParseTests.CanParseMultipleAlternatives" executed="True" result="Success" success="True" time="0.001" asserts="4" />
+                          <test-case name="NUnit.Util.Tests.CategoryParseTests.CanParseMultipleCategoriesWithAnd" executed="True" result="Success" success="True" time="0.001" asserts="4" />
+                          <test-case name="NUnit.Util.Tests.CategoryParseTests.CanParseSimpleCategory" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Util.Tests.CategoryParseTests.EmptyStringReturnsEmptyFilter" executed="True" result="Success" success="True" time="0.001" asserts="1" />
+                          <test-case name="NUnit.Util.Tests.CategoryParseTests.OrAndMinusCombined" executed="True" result="Success" success="True" time="0.001" asserts="5" />
+                          <test-case name="NUnit.Util.Tests.CategoryParseTests.PlusAndMinusCombined" executed="True" result="Success" success="True" time="0.000" asserts="6" />
+                          <test-case name="NUnit.Util.Tests.CategoryParseTests.PrecedenceTest" executed="True" result="Success" success="True" time="0.001" asserts="4" />
+                          <test-case name="NUnit.Util.Tests.CategoryParseTests.PrecedenceTestWithParentheses" executed="True" result="Success" success="True" time="0.001" asserts="5" />
+                        </results>
+                      </test-suite>
+                      <test-suite type="TestFixture" name="DomainManagerTests" executed="True" result="Success" success="True" time="0.019" asserts="0">
+                        <results>
+                          <test-case name="NUnit.Util.Tests.DomainManagerTests.GetCommonAppBase_OneElement" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Util.Tests.DomainManagerTests.GetCommonAppBase_ThreeElements_DiferentDirectories" executed="True" result="Success" success="True" time="0.002" asserts="1" />
+                          <test-case name="NUnit.Util.Tests.DomainManagerTests.GetCommonAppBase_TwoElements_DifferentDirectories" executed="True" result="Success" success="True" time="0.001" asserts="1" />
+                          <test-case name="NUnit.Util.Tests.DomainManagerTests.GetCommonAppBase_TwoElements_SameDirectory" executed="True" result="Success" success="True" time="0.001" asserts="1" />
+                          <test-case name="NUnit.Util.Tests.DomainManagerTests.GetPrivateBinPath" executed="True" result="Success" success="True" time="0.003" asserts="1" />
+                          <test-case name="NUnit.Util.Tests.DomainManagerTests.UnloadUnloadedDomain" executed="True" result="Success" success="True" time="0.004" asserts="0" />
+                        </results>
+                      </test-suite>
+                      <test-suite type="TestFixture" name="EventDispatcherTests" executed="True" result="Success" success="True" time="0.051" asserts="0">
+                        <results>
+                          <test-case name="NUnit.Util.Tests.EventDispatcherTests.ProjectLoaded" executed="True" result="Success" success="True" time="0.005" asserts="3" />
+                          <test-case name="NUnit.Util.Tests.EventDispatcherTests.ProjectLoadFailed" executed="True" result="Success" success="True" time="0.001" asserts="4" />
+                          <test-case name="NUnit.Util.Tests.EventDispatcherTests.ProjectLoading" executed="True" result="Success" success="True" time="0.000" asserts="3" />
+                          <test-case name="NUnit.Util.Tests.EventDispatcherTests.ProjectUnloaded" executed="True" result="Success" success="True" time="0.000" asserts="3" />
+                          <test-case name="NUnit.Util.Tests.EventDispatcherTests.ProjectUnloadFailed" executed="True" result="Success" success="True" time="0.000" asserts="4" />
+                          <test-case name="NUnit.Util.Tests.EventDispatcherTests.ProjectUnloading" executed="True" result="Success" success="True" time="0.000" asserts="3" />
+                          <test-case name="NUnit.Util.Tests.EventDispatcherTests.RunFailed" executed="True" result="Success" success="True" time="0.001" asserts="3" />
+                          <test-case name="NUnit.Util.Tests.EventDispatcherTests.RunFinished" executed="True" result="Success" success="True" time="0.000" asserts="3" />
+                          <test-case name="NUnit.Util.Tests.EventDispatcherTests.RunStarting" executed="True" result="Success" success="True" time="0.001" asserts="4" />
+                          <test-case name="NUnit.Util.Tests.EventDispatcherTests.SuiteFinished" executed="True" result="Success" success="True" time="0.000" asserts="3" />
+                          <test-case name="NUnit.Util.Tests.EventDispatcherTests.SuiteStarting" executed="True" result="Success" success="True" time="0.001" asserts="3" />
+                          <test-case name="NUnit.Util.Tests.EventDispatcherTests.TestFinished" executed="True" result="Success" success="True" time="0.001" asserts="3" />
+                          <test-case name="NUnit.Util.Tests.EventDispatcherTests.TestLoaded" executed="True" result="Success" success="True" time="0.001" asserts="4" />
+                          <test-case name="NUnit.Util.Tests.EventDispatcherTests.TestLoadFailed" executed="True" result="Success" success="True" time="0.001" asserts="4" />
+                          <test-case name="NUnit.Util.Tests.EventDispatcherTests.TestLoading" executed="True" result="Success" success="True" time="0.001" asserts="3" />
+                          <test-case name="NUnit.Util.Tests.EventDispatcherTests.TestReloaded" executed="True" result="Success" success="True" time="0.000" asserts="4" />
+                          <test-case name="NUnit.Util.Tests.EventDispatcherTests.TestReloadFailed" executed="True" result="Success" success="True" time="0.000" asserts="4" />
+                          <test-case name="NUnit.Util.Tests.EventDispatcherTests.TestReloading" executed="True" result="Success" success="True" time="0.001" asserts="3" />
+                          <test-case name="NUnit.Util.Tests.EventDispatcherTests.TestStarting" executed="True" result="Success" success="True" time="0.001" asserts="3" />
+                          <test-case name="NUnit.Util.Tests.EventDispatcherTests.TestUnloaded" executed="True" result="Success" success="True" time="0.000" asserts="3" />
+                          <test-case name="NUnit.Util.Tests.EventDispatcherTests.TestUnloadFailed" executed="True" result="Success" success="True" time="0.000" asserts="4" />
+                          <test-case name="NUnit.Util.Tests.EventDispatcherTests.TestUnloading" executed="True" result="Success" success="True" time="0.001" asserts="3" />
+                        </results>
+                      </test-suite>
+                      <test-suite type="TestFixture" name="FileWatcherTests" executed="True" result="Success" success="True" time="0.892" asserts="0">
+                        <results>
+                          <test-case name="NUnit.Util.Tests.FileWatcherTests.ChangingAttributesDoesNotTriggerWatcher" executed="True" result="Success" success="True" time="0.204" asserts="1" />
+                          <test-case name="NUnit.Util.Tests.FileWatcherTests.ChangingFileTriggersWatcher" executed="True" result="Success" success="True" time="0.205" asserts="2" />
+                          <test-case name="NUnit.Util.Tests.FileWatcherTests.CopyingFileDoesNotTriggerWatcher" executed="True" result="Success" success="True" time="0.206" asserts="1" />
+                          <test-case name="NUnit.Util.Tests.FileWatcherTests.MultipleCloselySpacedChangesTriggerWatcherOnlyOnce" executed="True" result="Success" success="True" time="0.265" asserts="2" />
+                        </results>
+                      </test-suite>
+                      <test-suite type="TestFixture" name="MemorySettingsStorageTests" executed="True" result="Success" success="True" time="0.027" asserts="0">
+                        <results>
+                          <test-case name="NUnit.Util.Tests.MemorySettingsStorageTests.MakeStorage" executed="True" result="Success" success="True" time="0.001" asserts="1" />
+                          <test-case name="NUnit.Util.Tests.MemorySettingsStorageTests.MakeSubStorages" executed="True" result="Success" success="True" time="0.001" asserts="2" />
+                          <test-case name="NUnit.Util.Tests.MemorySettingsStorageTests.RemoveSettings" executed="True" result="Success" success="True" time="0.002" asserts="3" />
+                          <test-case name="NUnit.Util.Tests.MemorySettingsStorageTests.SaveAndLoadSettings" executed="True" result="Success" success="True" time="0.001" asserts="4" />
+                          <test-case name="NUnit.Util.Tests.MemorySettingsStorageTests.SubstorageSettings" executed="True" result="Success" success="True" time="0.001" asserts="5" />
+                          <test-case name="NUnit.Util.Tests.MemorySettingsStorageTests.TypeSafeSettings" executed="True" result="Success" success="True" time="0.001" asserts="3" />
+                        </results>
+                      </test-suite>
+                      <test-suite type="TestFixture" name="NUnitProjectLoad" executed="True" result="Success" success="True" time="0.042" asserts="0">
+                        <results>
+                          <test-case name="NUnit.Util.Tests.NUnitProjectLoad.FromAssembly" executed="True" result="Success" success="True" time="0.006" asserts="5" />
+                          <test-case name="NUnit.Util.Tests.NUnitProjectLoad.LoadEmptyConfigs" executed="True" result="Success" success="True" time="0.007" asserts="3" />
+                          <test-case name="NUnit.Util.Tests.NUnitProjectLoad.LoadEmptyProject" executed="True" result="Success" success="True" time="0.001" asserts="1" />
+                          <test-case name="NUnit.Util.Tests.NUnitProjectLoad.LoadNormalProject" executed="True" result="Success" success="True" time="0.004" asserts="7" />
+                          <test-case name="NUnit.Util.Tests.NUnitProjectLoad.LoadProjectWithManualBinPath" executed="True" result="Success" success="True" time="0.002" asserts="2" />
+                          <test-case name="NUnit.Util.Tests.NUnitProjectLoad.SaveClearsAssemblyWrapper" executed="True" result="Success" success="True" time="0.004" asserts="1" />
+                        </results>
+                      </test-suite>
+                      <test-suite type="TestFixture" name="NUnitProjectSave" executed="True" result="Success" success="True" time="0.011" asserts="0">
+                        <results>
+                          <test-case name="NUnit.Util.Tests.NUnitProjectSave.SaveEmptyConfigs" executed="True" result="Success" success="True" time="0.002" asserts="1" />
+                          <test-case name="NUnit.Util.Tests.NUnitProjectSave.SaveEmptyProject" executed="True" result="Success" success="True" time="0.002" asserts="1" />
+                          <test-case name="NUnit.Util.Tests.NUnitProjectSave.SaveNormalProject" executed="True" result="Success" success="True" time="0.003" asserts="1" />
+                        </results>
+                      </test-suite>
+                      <test-suite type="TestFixture" name="NUnitProjectTests" executed="True" result="Success" success="True" time="0.079" asserts="0">
+                        <results>
+                          <test-case name="NUnit.Util.Tests.NUnitProjectTests.AddConfigMakesProjectDirty" executed="True" result="Success" success="True" time="0.001" asserts="1" />
+                          <test-case name="NUnit.Util.Tests.NUnitProjectTests.CanAddAssemblies" executed="True" result="Success" success="True" time="0.001" asserts="3" />
+                          <test-case name="NUnit.Util.Tests.NUnitProjectTests.CanAddConfigs" executed="True" result="Success" success="True" time="0.001" asserts="1" />
+                          <test-case name="NUnit.Util.Tests.NUnitProjectTests.CanSetActiveConfig" executed="True" result="Success" success="True" time="0.001" asserts="1" />
+                          <test-case name="NUnit.Util.Tests.NUnitProjectTests.CanSetAppBase" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Util.Tests.NUnitProjectTests.ConfigurationFileFromAssemblies" executed="True" result="Success" success="True" time="0.001" asserts="1" />
+                          <test-case name="NUnit.Util.Tests.NUnitProjectTests.ConfigurationFileFromAssembly" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Util.Tests.NUnitProjectTests.DefaultActiveConfig" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Util.Tests.NUnitProjectTests.DefaultApplicationBase" executed="True" result="Success" success="True" time="0.001" asserts="1" />
+                          <test-case name="NUnit.Util.Tests.NUnitProjectTests.DefaultConfigurationFile" executed="True" result="Success" success="True" time="0.002" asserts="2" />
+                          <test-case name="NUnit.Util.Tests.NUnitProjectTests.DefaultProjectName" executed="True" result="Success" success="True" time="0.002" asserts="1" />
+                          <test-case name="NUnit.Util.Tests.NUnitProjectTests.IsProjectFile" executed="True" result="Success" success="True" time="0.001" asserts="2" />
+                          <test-case name="NUnit.Util.Tests.NUnitProjectTests.LoadMakesProjectNotDirty" executed="True" result="Success" success="True" time="0.001" asserts="1" />
+                          <test-case name="NUnit.Util.Tests.NUnitProjectTests.NewProjectDefaultPath" executed="True" result="Success" success="True" time="0.001" asserts="3" />
+                          <test-case name="NUnit.Util.Tests.NUnitProjectTests.NewProjectIsEmpty" executed="True" result="Success" success="True" time="0.000" asserts="2" />
+                          <test-case name="NUnit.Util.Tests.NUnitProjectTests.NewProjectIsNotDirty" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Util.Tests.NUnitProjectTests.NewProjectNotLoadable" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Util.Tests.NUnitProjectTests.RemoveActiveConfig" executed="True" result="Success" success="True" time="0.001" asserts="1" />
+                          <test-case name="NUnit.Util.Tests.NUnitProjectTests.RemoveConfigMakesProjectDirty" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Util.Tests.NUnitProjectTests.RenameActiveConfig" executed="True" result="Success" success="True" time="0.001" asserts="1" />
+                          <test-case name="NUnit.Util.Tests.NUnitProjectTests.RenameConfigMakesProjectDirty" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Util.Tests.NUnitProjectTests.SaveAndLoadConfigsWithAssemblies" executed="True" result="Success" success="True" time="0.002" asserts="8" />
+                          <test-case name="NUnit.Util.Tests.NUnitProjectTests.SaveAndLoadEmptyConfigs" executed="True" result="Success" success="True" time="0.002" asserts="4" />
+                          <test-case name="NUnit.Util.Tests.NUnitProjectTests.SaveAndLoadEmptyProject" executed="True" result="Success" success="True" time="0.002" asserts="2" />
+                          <test-case name="NUnit.Util.Tests.NUnitProjectTests.SaveMakesProjectNotDirty" executed="True" result="Success" success="True" time="0.002" asserts="1" />
+                          <test-case name="NUnit.Util.Tests.NUnitProjectTests.SaveSetsProjectPath" executed="True" result="Success" success="True" time="0.001" asserts="2" />
+                          <test-case name="NUnit.Util.Tests.NUnitProjectTests.SettingActiveConfigMakesProjectDirty" executed="True" result="Success" success="True" time="0.001" asserts="1" />
+                        </results>
+                      </test-suite>
+                      <test-suite type="TestFixture" name="NUnitRegistryTests" executed="True" result="Success" success="True" time="0.037" asserts="0">
+                        <results>
+                          <test-case name="NUnit.Util.Tests.NUnitRegistryTests.CurrentUser" executed="True" result="Success" success="True" time="0.001" asserts="2" />
+                          <test-case name="NUnit.Util.Tests.NUnitRegistryTests.CurrentUserTestMode" executed="True" result="Success" success="True" time="0.000" asserts="2" />
+                          <test-case name="NUnit.Util.Tests.NUnitRegistryTests.TestClearRoutines" executed="True" result="Success" success="True" time="0.031" asserts="2" />
+                        </results>
+                      </test-suite>
+                      <test-suite type="TestFixture" name="PathUtilTests" executed="True" result="Success" success="True" time="0.000" asserts="0">
+                        <results>
+                          <test-case name="NUnit.Util.Tests.PathUtilTests.CheckDefaults" executed="True" result="Success" success="True" time="0.000" asserts="2" />
+                        </results>
+                      </test-suite>
+                      <test-suite type="TestFixture" name="PathUtilTests_Unix" executed="True" result="Success" success="True" time="0.013" asserts="0">
+                        <results>
+                          <test-case name="NUnit.Util.Tests.PathUtilTests_Unix.Canonicalize" executed="True" result="Success" success="True" time="0.000" asserts="5" />
+                          <test-case name="NUnit.Util.Tests.PathUtilTests_Unix.IsAssemblyFileType" executed="True" result="Success" success="True" time="0.001" asserts="3" />
+                          <test-case name="NUnit.Util.Tests.PathUtilTests_Unix.PathFromUri" executed="True" result="Success" success="True" time="0.001" asserts="2" />
+                          <test-case name="NUnit.Util.Tests.PathUtilTests_Unix.RelativePath" executed="True" result="Success" success="True" time="0.000" asserts="10" />
+                          <test-case name="NUnit.Util.Tests.PathUtilTests_Unix.SamePath" executed="True" result="Success" success="True" time="0.001" asserts="4" />
+                          <test-case name="NUnit.Util.Tests.PathUtilTests_Unix.SamePathOrUnder" executed="True" result="Success" success="True" time="0.001" asserts="7" />
+                        </results>
+                      </test-suite>
+                      <test-suite type="TestFixture" name="PathUtilTests_Windows" executed="True" result="Success" success="True" time="0.013" asserts="0">
+                        <results>
+                          <test-case name="NUnit.Util.Tests.PathUtilTests_Windows.Canonicalize" executed="True" result="Success" success="True" time="0.000" asserts="5" />
+                          <test-case name="NUnit.Util.Tests.PathUtilTests_Windows.IsAssemblyFileType" executed="True" result="Success" success="True" time="0.000" asserts="3" />
+                          <test-case name="NUnit.Util.Tests.PathUtilTests_Windows.PathFromUri" executed="True" result="Success" success="True" time="0.001" asserts="2" />
+                          <test-case name="NUnit.Util.Tests.PathUtilTests_Windows.RelativePath" executed="True" result="Success" success="True" time="0.000" asserts="12" />
+                          <test-case name="NUnit.Util.Tests.PathUtilTests_Windows.SamePath" executed="True" result="Success" success="True" time="0.001" asserts="4" />
+                          <test-case name="NUnit.Util.Tests.PathUtilTests_Windows.SamePathOrUnder" executed="True" result="Success" success="True" time="0.001" asserts="9" />
+                        </results>
+                      </test-suite>
+                      <test-suite type="TestFixture" name="ProcessRunnerTests" executed="True" result="Success" success="True" time="11.527" asserts="1">
+                        <properties>
+                          <property name="Timeout" value="30000" />
+                        </properties>
+                        <results>
+                          <test-case name="NUnit.Util.Tests.ProcessRunnerTests.BasicRunnerTests.CheckRunnerID" executed="True" result="Success" success="True" time="0.001" asserts="1" />
+                          <test-case name="NUnit.Util.Tests.ProcessRunnerTests.BasicRunnerTests.CountTestCases" executed="True" result="Success" success="True" time="1.520" asserts="1" />
+                          <test-case name="NUnit.Util.Tests.ProcessRunnerTests.BasicRunnerTests.CountTestCasesAcrossMultipleAssemblies" executed="True" result="Success" success="True" time="0.714" asserts="1" />
+                          <test-case name="NUnit.Util.Tests.ProcessRunnerTests.BasicRunnerTests.LoadAndReloadAssembly" executed="True" result="Success" success="True" time="1.369" asserts="2" />
+                          <test-case name="NUnit.Util.Tests.ProcessRunnerTests.BasicRunnerTests.LoadAssemblyWithFixture" executed="True" result="Success" success="True" time="0.562" asserts="1" />
+                          <test-case name="NUnit.Util.Tests.ProcessRunnerTests.BasicRunnerTests.LoadAssemblyWithoutNamespaces" executed="True" result="Success" success="True" time="0.603" asserts="4" />
+                          <test-case name="NUnit.Util.Tests.ProcessRunnerTests.BasicRunnerTests.LoadAssemblyWithSuite" executed="True" result="Success" success="True" time="0.535" asserts="1" />
+                          <test-case name="NUnit.Util.Tests.ProcessRunnerTests.BasicRunnerTests.LoadMultipleAssemblies" executed="True" result="Success" success="True" time="0.741" asserts="1" />
+                          <test-case name="NUnit.Util.Tests.ProcessRunnerTests.BasicRunnerTests.LoadMultipleAssembliesWithFixture" executed="True" result="Success" success="True" time="0.664" asserts="1" />
+                          <test-case name="NUnit.Util.Tests.ProcessRunnerTests.BasicRunnerTests.LoadMultipleAssembliesWithSuite" executed="True" result="Success" success="True" time="0.597" asserts="1" />
+                          <test-case name="NUnit.Util.Tests.ProcessRunnerTests.BasicRunnerTests.RunAssembly" executed="True" result="Success" success="True" time="0.670" asserts="1" />
+                          <test-case name="NUnit.Util.Tests.ProcessRunnerTests.BasicRunnerTests.RunAssemblyUsingBeginAndEndRun" executed="True" result="Success" success="True" time="0.670" asserts="2" />
+                          <test-case name="NUnit.Util.Tests.ProcessRunnerTests.BasicRunnerTests.RunMultipleAssemblies" executed="True" result="Success" success="True" time="0.822" asserts="1" />
+                          <test-case name="NUnit.Util.Tests.ProcessRunnerTests.BasicRunnerTests.RunMultipleAssembliesUsingBeginAndEndRun" executed="True" result="Success" success="True" time="0.727" asserts="2" />
+                          <test-case name="NUnit.Util.Tests.ProcessRunnerTests.TestProcessIsReused" executed="True" result="Success" success="True" time="1.251" asserts="2" />
+                        </results>
+                      </test-suite>
+                      <test-suite type="TestFixture" name="ProjectConfigTests" executed="True" result="Success" success="True" time="0.087" asserts="0">
+                        <results>
+                          <test-case name="NUnit.Util.Tests.ProjectConfigTests.AbsoluteBasePath" executed="True" result="Success" success="True" time="0.001" asserts="1" />
+                          <test-case name="NUnit.Util.Tests.ProjectConfigTests.AbsoluteConfigurationFile" executed="True" result="Success" success="True" time="0.001" asserts="1" />
+                          <test-case name="NUnit.Util.Tests.ProjectConfigTests.AddingConfigMarksProjectDirty" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Util.Tests.ProjectConfigTests.AddingInitialConfigRequiresReload" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Util.Tests.ProjectConfigTests.AddingSubsequentConfigDoesNotRequireReload" executed="True" result="Success" success="True" time="0.001" asserts="1" />
+                          <test-case name="NUnit.Util.Tests.ProjectConfigTests.AddToActiveConfigMarksProjectDirty" executed="True" result="Success" success="True" time="0.001" asserts="1" />
+                          <test-case name="NUnit.Util.Tests.ProjectConfigTests.AddToActiveConfigRequiresReload" executed="True" result="Success" success="True" time="0.001" asserts="1" />
+                          <test-case name="NUnit.Util.Tests.ProjectConfigTests.AddToInactiveConfigDoesNotRequireReload" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Util.Tests.ProjectConfigTests.AddToInactiveConfigMarksProjectDirty" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Util.Tests.ProjectConfigTests.CanAddAssemblies" executed="True" result="Success" success="True" time="0.000" asserts="3" />
+                          <test-case name="NUnit.Util.Tests.ProjectConfigTests.DefaultConfigurationFile" executed="True" result="Success" success="True" time="0.000" asserts="2" />
+                          <test-case name="NUnit.Util.Tests.ProjectConfigTests.EmptyConfig" executed="True" result="Success" success="True" time="0.001" asserts="2" />
+                          <test-case name="NUnit.Util.Tests.ProjectConfigTests.ManualPrivateBinPath" executed="True" result="Success" success="True" time="0.001" asserts="1" />
+                          <test-case name="NUnit.Util.Tests.ProjectConfigTests.NoBasePathSet" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Util.Tests.ProjectConfigTests.NoPrivateBinPath" executed="True" result="Success" success="True" time="0.001" asserts="1" />
+                          <test-case name="NUnit.Util.Tests.ProjectConfigTests.RelativeBasePath" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Util.Tests.ProjectConfigTests.RelativeConfigurationFile" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Util.Tests.ProjectConfigTests.RemoveActiveConfigMarksProjectDirty" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Util.Tests.ProjectConfigTests.RemoveActiveConfigRequiresReload" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Util.Tests.ProjectConfigTests.RemoveInactiveConfigDoesNotRequireReload" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Util.Tests.ProjectConfigTests.RemoveInactiveConfigMarksProjectDirty" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Util.Tests.ProjectConfigTests.RenameActiveConfigMarksProjectDirty" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Util.Tests.ProjectConfigTests.RenameActiveConfigRequiresReload" executed="True" result="Success" success="True" time="0.001" asserts="1" />
+                          <test-case name="NUnit.Util.Tests.ProjectConfigTests.RenameInactiveConfigDoesNotRequireReload" executed="True" result="Success" success="True" time="0.001" asserts="1" />
+                          <test-case name="NUnit.Util.Tests.ProjectConfigTests.RenameInctiveConfigMarksProjectDirty" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Util.Tests.ProjectConfigTests.SettingActiveConfigApplicationBaseMarksProjectDirty" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Util.Tests.ProjectConfigTests.SettingActiveConfigApplicationBaseRequiresReload" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Util.Tests.ProjectConfigTests.SettingActiveConfigBinPathTypeMarksProjectDirty" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Util.Tests.ProjectConfigTests.SettingActiveConfigBinPathTypeRequiresReload" executed="True" result="Success" success="True" time="0.001" asserts="1" />
+                          <test-case name="NUnit.Util.Tests.ProjectConfigTests.SettingActiveConfigConfigurationFileMarksProjectDirty" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Util.Tests.ProjectConfigTests.SettingActiveConfigConfigurationFileRequiresReload" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Util.Tests.ProjectConfigTests.SettingActiveConfigPrivateBinPathMarksProjectDirty" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Util.Tests.ProjectConfigTests.SettingActiveConfigPrivateBinPathRequiresReload" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Util.Tests.ProjectConfigTests.SettingInactiveConfigApplicationBaseDoesNotRequireReload" executed="True" result="Success" success="True" time="0.001" asserts="1" />
+                          <test-case name="NUnit.Util.Tests.ProjectConfigTests.SettingInactiveConfigApplicationBaseMarksProjectDirty" executed="True" result="Success" success="True" time="0.001" asserts="1" />
+                          <test-case name="NUnit.Util.Tests.ProjectConfigTests.SettingInactiveConfigBinPathTypeDoesNotRequireReload" executed="True" result="Success" success="True" time="0.001" asserts="1" />
+                          <test-case name="NUnit.Util.Tests.ProjectConfigTests.SettingInactiveConfigBinPathTypeMarksProjectDirty" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Util.Tests.ProjectConfigTests.SettingInactiveConfigConfigurationFileDoesNotRequireReload" executed="True" result="Success" success="True" time="0.001" asserts="1" />
+                          <test-case name="NUnit.Util.Tests.ProjectConfigTests.SettingInactiveConfigConfigurationFileMarksProjectDirty" executed="True" result="Success" success="True" time="0.001" asserts="1" />
+                          <test-case name="NUnit.Util.Tests.ProjectConfigTests.SettingInactiveConfigPrivateBinPathDoesNotRequireReload" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Util.Tests.ProjectConfigTests.SettingInactiveConfigPrivateBinPathMarksProjectDirty" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Util.Tests.ProjectConfigTests.ToArray" executed="True" result="Success" success="True" time="0.000" asserts="2" />
+                        </results>
+                      </test-suite>
+                      <test-suite type="TestFixture" name="RecentFileEntryTests" executed="True" result="Success" success="True" time="0.017" asserts="0">
+                        <results>
+                          <test-case name="NUnit.Util.Tests.RecentFileEntryTests.CanCreateFromFileNameAndVersion" executed="True" result="Success" success="True" time="0.002" asserts="2" />
+                          <test-case name="NUnit.Util.Tests.RecentFileEntryTests.CanCreateFromSimpleFileName" executed="True" result="Success" success="True" time="0.000" asserts="2" />
+                          <test-case name="NUnit.Util.Tests.RecentFileEntryTests.CanParseFileNamePlusVersionString" executed="True" result="Success" success="True" time="0.001" asserts="2" />
+                          <test-case name="NUnit.Util.Tests.RecentFileEntryTests.CanParseFileNameWithCommaPlusVersionString" executed="True" result="Success" success="True" time="0.000" asserts="2" />
+                          <test-case name="NUnit.Util.Tests.RecentFileEntryTests.CanParseSimpleFileName" executed="True" result="Success" success="True" time="0.000" asserts="2" />
+                          <test-case name="NUnit.Util.Tests.RecentFileEntryTests.CanParseSimpleFileNameWithComma" executed="True" result="Success" success="True" time="0.001" asserts="2" />
+                          <test-case name="NUnit.Util.Tests.RecentFileEntryTests.EntryCanDisplayItself" executed="True" result="Success" success="True" time="0.001" asserts="1" />
+                        </results>
+                      </test-suite>
+                      <test-suite type="TestFixture" name="RecentFilesTests" executed="True" result="Success" success="True" time="0.053" asserts="0">
+                        <results>
+                          <test-case name="NUnit.Util.Tests.RecentFilesTests.AddMaxItems" executed="True" result="Success" success="True" time="0.004" asserts="7" />
+                          <test-case name="NUnit.Util.Tests.RecentFilesTests.AddSingleItem" executed="True" result="Success" success="True" time="0.000" asserts="3" />
+                          <test-case name="NUnit.Util.Tests.RecentFilesTests.AddTooManyItems" executed="True" result="Success" success="True" time="0.000" asserts="7" />
+                          <test-case name="NUnit.Util.Tests.RecentFilesTests.CountAtMax" executed="True" result="Success" success="True" time="0.001" asserts="1" />
+                          <test-case name="NUnit.Util.Tests.RecentFilesTests.CountAtMin" executed="True" result="Success" success="True" time="0.001" asserts="1" />
+                          <test-case name="NUnit.Util.Tests.RecentFilesTests.CountDefault" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Util.Tests.RecentFilesTests.CountOverMax" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Util.Tests.RecentFilesTests.CountUnderMin" executed="True" result="Success" success="True" time="0.001" asserts="1" />
+                          <test-case name="NUnit.Util.Tests.RecentFilesTests.EmptyList" executed="True" result="Success" success="True" time="0.001" asserts="3" />
+                          <test-case name="NUnit.Util.Tests.RecentFilesTests.IncreaseSize" executed="True" result="Success" success="True" time="0.001" asserts="12" />
+                          <test-case name="NUnit.Util.Tests.RecentFilesTests.IncreaseSizeAfterAdd" executed="True" result="Success" success="True" time="0.001" asserts="8" />
+                          <test-case name="NUnit.Util.Tests.RecentFilesTests.ReduceSize" executed="True" result="Success" success="True" time="0.000" asserts="5" />
+                          <test-case name="NUnit.Util.Tests.RecentFilesTests.ReduceSizeAfterAdd" executed="True" result="Success" success="True" time="0.000" asserts="4" />
+                          <test-case name="NUnit.Util.Tests.RecentFilesTests.RemoveFirstProject" executed="True" result="Success" success="True" time="0.001" asserts="3" />
+                          <test-case name="NUnit.Util.Tests.RecentFilesTests.RemoveLastProject" executed="True" result="Success" success="True" time="0.001" asserts="5" />
+                          <test-case name="NUnit.Util.Tests.RecentFilesTests.RemoveMultipleProjects" executed="True" result="Success" success="True" time="0.001" asserts="3" />
+                          <test-case name="NUnit.Util.Tests.RecentFilesTests.RemoveOneProject" executed="True" result="Success" success="True" time="0.000" asserts="4" />
+                          <test-case name="NUnit.Util.Tests.RecentFilesTests.ReorderLastProject" executed="True" result="Success" success="True" time="0.000" asserts="6" />
+                          <test-case name="NUnit.Util.Tests.RecentFilesTests.ReorderMultipleProjects" executed="True" result="Success" success="True" time="0.001" asserts="6" />
+                          <test-case name="NUnit.Util.Tests.RecentFilesTests.ReorderSameProject" executed="True" result="Success" success="True" time="0.001" asserts="6" />
+                          <test-case name="NUnit.Util.Tests.RecentFilesTests.ReorderSingleProject" executed="True" result="Success" success="True" time="0.000" asserts="6" />
+                          <test-case name="NUnit.Util.Tests.RecentFilesTests.ReorderWithListNotFull" executed="True" result="Success" success="True" time="0.000" asserts="4" />
+                        </results>
+                      </test-suite>
+                      <test-suite type="TestFixture" name="RegistrySettingsStorageTests" executed="True" result="Success" success="True" time="0.018" asserts="0">
+                        <results>
+                          <test-case name="NUnit.Util.Tests.RegistrySettingsStorageTests.MakeSubStorages" executed="True" result="Success" success="True" time="0.002" asserts="4" />
+                          <test-case name="NUnit.Util.Tests.RegistrySettingsStorageTests.RemoveSettings" executed="True" result="Success" success="True" time="0.002" asserts="3" />
+                          <test-case name="NUnit.Util.Tests.RegistrySettingsStorageTests.SaveAndLoadSettings" executed="True" result="Success" success="True" time="0.001" asserts="6" />
+                          <test-case name="NUnit.Util.Tests.RegistrySettingsStorageTests.StorageHasCorrectKey" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Util.Tests.RegistrySettingsStorageTests.SubstorageSettings" executed="True" result="Success" success="True" time="0.001" asserts="5" />
+                          <test-case name="NUnit.Util.Tests.RegistrySettingsStorageTests.TypeSafeSettings" executed="True" result="Success" success="True" time="0.001" asserts="3" />
+                        </results>
+                      </test-suite>
+                      <test-suite type="TestFixture" name="RemoteTestAgentTests" executed="True" result="Success" success="True" time="0.002" asserts="0">
+                        <results>
+                          <test-case name="NUnit.Util.Tests.RemoteTestAgentTests.AgentReturnsProcessId" executed="True" result="Success" success="True" time="0.001" asserts="1" />
+                        </results>
+                      </test-suite>
+                      <test-suite type="TestFixture" name="RemoteTestResultTest" executed="True" result="Success" success="True" time="0.473" asserts="0">
+                        <results>
+                          <test-case name="NUnit.Util.Tests.RemoteTestResultTest.ResultStillValidAfterDomainUnload" executed="True" result="Success" success="True" time="0.473" asserts="2" />
+                        </results>
+                      </test-suite>
+                      <test-suite type="TestFixture" name="RuntimeFrameworkSelectorTests" executed="True" result="Success" success="True" time="0.055" asserts="0">
+                        <results>
+                          <test-suite type="Theory" name="RequestForSpecificFrameworkIsHonored" executed="True" result="Success" success="True" time="0.024" asserts="0">
+                            <results>
+                              <test-case name="NUnit.Util.Tests.RuntimeFrameworkSelectorTests.RequestForSpecificFrameworkIsHonored(net-1.0)" executed="True" result="Success" success="True" time="0.002" asserts="2" />
+                              <test-case name="NUnit.Util.Tests.RuntimeFrameworkSelectorTests.RequestForSpecificFrameworkIsHonored(net-1.1)" executed="True" result="Success" success="True" time="0.001" asserts="2" />
+                              <test-case name="NUnit.Util.Tests.RuntimeFrameworkSelectorTests.RequestForSpecificFrameworkIsHonored(net-2.0)" executed="True" result="Success" success="True" time="0.001" asserts="2" />
+                              <test-case name="NUnit.Util.Tests.RuntimeFrameworkSelectorTests.RequestForSpecificFrameworkIsHonored(net-4.0)" executed="True" result="Success" success="True" time="0.000" asserts="2" />
+                              <test-case name="NUnit.Util.Tests.RuntimeFrameworkSelectorTests.RequestForSpecificFrameworkIsHonored(mono-1.0)" executed="True" result="Success" success="True" time="0.000" asserts="2" />
+                              <test-case name="NUnit.Util.Tests.RuntimeFrameworkSelectorTests.RequestForSpecificFrameworkIsHonored(mono-2.0)" executed="True" result="Success" success="True" time="0.001" asserts="2" />
+                              <test-case name="NUnit.Util.Tests.RuntimeFrameworkSelectorTests.RequestForSpecificFrameworkIsHonored(v1.1)" executed="True" result="Inconclusive" success="False" time="0.004" asserts="0">
+                                <reason>
+                                  <message><![CDATA[  Expected: not Any
+  But was:  Any
+]]></message>
+                                </reason>
+                              </test-case>
+                              <test-case name="NUnit.Util.Tests.RuntimeFrameworkSelectorTests.RequestForSpecificFrameworkIsHonored(v2.0)" executed="True" result="Inconclusive" success="False" time="0.001" asserts="0">
+                                <reason>
+                                  <message><![CDATA[  Expected: not Any
+  But was:  Any
+]]></message>
+                                </reason>
+                              </test-case>
+                              <test-case name="NUnit.Util.Tests.RuntimeFrameworkSelectorTests.RequestForSpecificFrameworkIsHonored(v4.0)" executed="True" result="Inconclusive" success="False" time="0.001" asserts="0">
+                                <reason>
+                                  <message><![CDATA[  Expected: not Any
+  But was:  Any
+]]></message>
+                                </reason>
+                              </test-case>
+                            </results>
+                          </test-suite>
+                          <test-suite type="Theory" name="RequestForSpecificVersionIsHonored" executed="True" result="Success" success="True" time="0.025" asserts="0">
+                            <results>
+                              <test-case name="NUnit.Util.Tests.RuntimeFrameworkSelectorTests.RequestForSpecificVersionIsHonored(net-1.0)" executed="True" result="Inconclusive" success="False" time="0.001" asserts="0">
+                                <reason>
+                                  <message><![CDATA[  Expected: Any
+  But was:  Net
+]]></message>
+                                </reason>
+                              </test-case>
+                              <test-case name="NUnit.Util.Tests.RuntimeFrameworkSelectorTests.RequestForSpecificVersionIsHonored(net-1.1)" executed="True" result="Inconclusive" success="False" time="0.001" asserts="0">
+                                <reason>
+                                  <message><![CDATA[  Expected: Any
+  But was:  Net
+]]></message>
+                                </reason>
+                              </test-case>
+                              <test-case name="NUnit.Util.Tests.RuntimeFrameworkSelectorTests.RequestForSpecificVersionIsHonored(net-2.0)" executed="True" result="Inconclusive" success="False" time="0.001" asserts="0">
+                                <reason>
+                                  <message><![CDATA[  Expected: Any
+  But was:  Net
+]]></message>
+                                </reason>
+                              </test-case>
+                              <test-case name="NUnit.Util.Tests.RuntimeFrameworkSelectorTests.RequestForSpecificVersionIsHonored(net-4.0)" executed="True" result="Inconclusive" success="False" time="0.001" asserts="0">
+                                <reason>
+                                  <message><![CDATA[  Expected: Any
+  But was:  Net
+]]></message>
+                                </reason>
+                              </test-case>
+                              <test-case name="NUnit.Util.Tests.RuntimeFrameworkSelectorTests.RequestForSpecificVersionIsHonored(mono-1.0)" executed="True" result="Inconclusive" success="False" time="0.001" asserts="0">
+                                <reason>
+                                  <message><![CDATA[  Expected: Any
+  But was:  Mono
+]]></message>
+                                </reason>
+                              </test-case>
+                              <test-case name="NUnit.Util.Tests.RuntimeFrameworkSelectorTests.RequestForSpecificVersionIsHonored(mono-2.0)" executed="True" result="Inconclusive" success="False" time="0.001" asserts="0">
+                                <reason>
+                                  <message><![CDATA[  Expected: Any
+  But was:  Mono
+]]></message>
+                                </reason>
+                              </test-case>
+                              <test-case name="NUnit.Util.Tests.RuntimeFrameworkSelectorTests.RequestForSpecificVersionIsHonored(v1.1)" executed="True" result="Success" success="True" time="0.000" asserts="2" />
+                              <test-case name="NUnit.Util.Tests.RuntimeFrameworkSelectorTests.RequestForSpecificVersionIsHonored(v2.0)" executed="True" result="Success" success="True" time="0.000" asserts="2" />
+                              <test-case name="NUnit.Util.Tests.RuntimeFrameworkSelectorTests.RequestForSpecificVersionIsHonored(v4.0)" executed="True" result="Success" success="True" time="0.000" asserts="2" />
+                            </results>
+                          </test-suite>
+                        </results>
+                      </test-suite>
+                      <test-suite type="TestFixture" name="ServerUtilityTests" executed="True" result="Success" success="True" time="0.023" asserts="0">
+                        <results>
+                          <test-case name="NUnit.Util.Tests.ServerUtilityTests.CanGetTcpChannelOnSpecifiedPort" executed="True" result="Success" success="True" time="0.019" asserts="5" />
+                          <test-case name="NUnit.Util.Tests.ServerUtilityTests.CanGetTcpChannelOnUnpecifiedPort" executed="True" result="Success" success="True" time="0.001" asserts="4" />
+                        </results>
+                      </test-suite>
+                      <test-suite type="TestFixture" name="SettingsGroupTests" executed="True" result="Success" success="True" time="0.013" asserts="0">
+                        <results>
+                          <test-case name="NUnit.Util.Tests.SettingsGroupTests.BadSetting" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Util.Tests.SettingsGroupTests.DefaultSettings" executed="True" result="Success" success="True" time="0.001" asserts="7" />
+                          <test-case name="NUnit.Util.Tests.SettingsGroupTests.SubGroupSettings" executed="True" result="Success" success="True" time="0.000" asserts="7" />
+                          <test-case name="NUnit.Util.Tests.SettingsGroupTests.TopLevelSettings" executed="True" result="Success" success="True" time="0.000" asserts="5" />
+                          <test-case name="NUnit.Util.Tests.SettingsGroupTests.TypeSafeSettings" executed="True" result="Success" success="True" time="0.000" asserts="3" />
+                        </results>
+                      </test-suite>
+                      <test-suite type="TestFixture" name="SummaryResultFixture" executed="True" result="Success" success="True" time="0.010" asserts="0">
+                        <results>
+                          <test-case name="NUnit.Util.Tests.SummaryResultFixture.SummaryMatchesResult" executed="True" result="Success" success="True" time="0.009" asserts="9" />
+                        </results>
+                      </test-suite>
+                      <test-suite type="TestFixture" name="TestAgencyTests" executed="True" result="Success" success="True" time="0.544" asserts="0">
+                        <results>
+                          <test-case name="NUnit.Util.Tests.TestAgencyTests.CanConnectToAgency" executed="True" result="Success" success="True" time="0.002" asserts="2" />
+                          <test-case name="NUnit.Util.Tests.TestAgencyTests.CanLaunchAndConnectToAgent" executed="True" result="Success" success="True" time="0.532" asserts="1" />
+                        </results>
+                      </test-suite>
+                      <test-suite type="TestFixture" name="TestDomainFixture" executed="True" result="Success" success="True" time="0.434" asserts="0">
+                        <results>
+                          <test-case name="NUnit.Util.Tests.TestDomainFixture.AppDomainIsSetUpCorrectly" executed="True" result="Success" success="True" time="0.003" asserts="8" />
+                          <test-case name="NUnit.Util.Tests.TestDomainFixture.AssemblyIsLoadedCorrectly" executed="True" result="Success" success="True" time="0.000" asserts="2" />
+                          <test-case name="NUnit.Util.Tests.TestDomainFixture.CanRunMockAssemblyTests" executed="True" result="Success" success="True" time="0.061" asserts="5" />
+                        </results>
+                      </test-suite>
+                      <test-suite type="TestFixture" name="TestDomainRunnerTests" executed="True" result="Success" success="True" time="6.155" asserts="1">
+                        <results>
+                          <test-case name="NUnit.Util.Tests.TestDomainRunnerTests.BasicRunnerTests.CheckRunnerID" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Util.Tests.TestDomainRunnerTests.BasicRunnerTests.CountTestCases" executed="True" result="Success" success="True" time="0.424" asserts="1" />
+                          <test-case name="NUnit.Util.Tests.TestDomainRunnerTests.BasicRunnerTests.CountTestCasesAcrossMultipleAssemblies" executed="True" result="Success" success="True" time="0.434" asserts="1" />
+                          <test-case name="NUnit.Util.Tests.TestDomainRunnerTests.BasicRunnerTests.LoadAndReloadAssembly" executed="True" result="Success" success="True" time="0.749" asserts="2" />
+                          <test-case name="NUnit.Util.Tests.TestDomainRunnerTests.BasicRunnerTests.LoadAssemblyWithFixture" executed="True" result="Success" success="True" time="0.340" asserts="1" />
+                          <test-case name="NUnit.Util.Tests.TestDomainRunnerTests.BasicRunnerTests.LoadAssemblyWithoutNamespaces" executed="True" result="Success" success="True" time="0.414" asserts="4" />
+                          <test-case name="NUnit.Util.Tests.TestDomainRunnerTests.BasicRunnerTests.LoadAssemblyWithSuite" executed="True" result="Success" success="True" time="0.327" asserts="1" />
+                          <test-case name="NUnit.Util.Tests.TestDomainRunnerTests.BasicRunnerTests.LoadMultipleAssemblies" executed="True" result="Success" success="True" time="0.439" asserts="1" />
+                          <test-case name="NUnit.Util.Tests.TestDomainRunnerTests.BasicRunnerTests.LoadMultipleAssembliesWithFixture" executed="True" result="Success" success="True" time="0.471" asserts="1" />
+                          <test-case name="NUnit.Util.Tests.TestDomainRunnerTests.BasicRunnerTests.LoadMultipleAssembliesWithSuite" executed="True" result="Success" success="True" time="0.592" asserts="1" />
+                          <test-case name="NUnit.Util.Tests.TestDomainRunnerTests.BasicRunnerTests.RunAssembly" executed="True" result="Success" success="True" time="0.486" asserts="1" />
+                          <test-case name="NUnit.Util.Tests.TestDomainRunnerTests.BasicRunnerTests.RunAssemblyUsingBeginAndEndRun" executed="True" result="Success" success="True" time="0.470" asserts="2" />
+                          <test-case name="NUnit.Util.Tests.TestDomainRunnerTests.BasicRunnerTests.RunMultipleAssemblies" executed="True" result="Success" success="True" time="0.475" asserts="1" />
+                          <test-case name="NUnit.Util.Tests.TestDomainRunnerTests.BasicRunnerTests.RunMultipleAssembliesUsingBeginAndEndRun" executed="True" result="Success" success="True" time="0.480" asserts="2" />
+                        </results>
+                      </test-suite>
+                      <test-suite type="TestFixture" name="TestDomainTests" executed="True" result="Success" success="True" time="3.419" asserts="0">
+                        <results>
+                          <test-case name="NUnit.Util.Tests.TestDomainTests.BasePathOverrideIsHonored" executed="True" result="Success" success="True" time="0.750" asserts="1" />
+                          <test-case name="NUnit.Util.Tests.TestDomainTests.BinPathOverrideIsHonored" executed="True" result="Success" success="True" time="0.381" asserts="1" />
+                          <test-case name="NUnit.Util.Tests.TestDomainTests.ConfigFileOverrideIsHonored" executed="True" result="Success" success="True" time="0.390" asserts="1" />
+                          <test-case name="NUnit.Util.Tests.TestDomainTests.FileNotFound" executed="True" result="Success" success="True" time="0.703" asserts="0" />
+                          <test-case name="NUnit.Util.Tests.TestDomainTests.InvalidTestFixture" executed="True" result="Success" success="True" time="0.335" asserts="1" />
+                          <test-case name="NUnit.Util.Tests.TestDomainTests.SpecificTestFixture" executed="True" result="Success" success="True" time="0.514" asserts="4" />
+                          <test-case name="NUnit.Util.Tests.TestDomainTests.TurnOffShadowCopy" executed="True" result="Success" success="True" time="0.329" asserts="1" />
+                        </results>
+                      </test-suite>
+                      <test-suite type="TestFixture" name="TestDomainTests_Multiple" executed="True" result="Success" success="True" time="0.508" asserts="0">
+                        <results>
+                          <test-case name="NUnit.Util.Tests.TestDomainTests_Multiple.AssemblyNodes" executed="True" result="Success" success="True" time="0.001" asserts="2" />
+                          <test-case name="NUnit.Util.Tests.TestDomainTests_Multiple.BuildSuite" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Util.Tests.TestDomainTests_Multiple.RootNode" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Util.Tests.TestDomainTests_Multiple.RunMultipleAssemblies" executed="True" result="Success" success="True" time="0.067" asserts="1" />
+                          <test-case name="NUnit.Util.Tests.TestDomainTests_Multiple.TestCaseCount" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                        </results>
+                      </test-suite>
+                      <test-suite type="TestFixture" name="TestDomainTests_MultipleFixture" executed="True" result="Success" success="True" time="0.391" asserts="0">
+                        <results>
+                          <test-case name="NUnit.Util.Tests.TestDomainTests_MultipleFixture.LoadFixture" executed="True" result="Success" success="True" time="0.391" asserts="1" />
+                        </results>
+                      </test-suite>
+                      <test-suite type="TestFixture" name="TestLoaderAssemblyTests" executed="True" result="Success" success="True" time="2.359" asserts="0">
+                        <results>
+                          <test-case name="NUnit.Util.Tests.TestLoaderAssemblyTests.AssemblyWithNoTests" executed="True" result="Success" success="True" time="0.577" asserts="4" />
+                          <test-case name="NUnit.Util.Tests.TestLoaderAssemblyTests.FileNotFound" executed="True" result="Success" success="True" time="0.004" asserts="5" />
+                          <test-case name="NUnit.Util.Tests.TestLoaderAssemblyTests.LoadProject" executed="True" result="Success" success="True" time="0.001" asserts="5" />
+                          <test-case name="NUnit.Util.Tests.TestLoaderAssemblyTests.LoadTest" executed="True" result="Success" success="True" time="0.387" asserts="6" />
+                          <test-case name="NUnit.Util.Tests.TestLoaderAssemblyTests.RunTest" executed="True" result="Success" success="True" time="0.995" asserts="9" />
+                          <test-case name="NUnit.Util.Tests.TestLoaderAssemblyTests.UnloadProject" executed="True" result="Success" success="True" time="0.001" asserts="5" />
+                          <test-case name="NUnit.Util.Tests.TestLoaderAssemblyTests.UnloadTest" executed="True" result="Success" success="True" time="0.378" asserts="3" />
+                        </results>
+                      </test-suite>
+                      <test-suite type="TestFixture" name="TestLoaderWatcherTests" executed="True" result="Success" success="True" time="2.607" asserts="0">
+                        <results>
+                          <test-case name="NUnit.Util.Tests.TestLoaderWatcherTests.LoadShouldStartWatcher" executed="True" result="Success" success="True" time="0.353" asserts="3" />
+                          <test-case name="NUnit.Util.Tests.TestLoaderWatcherTests.LoadShouldStartWatcherDependingOnSettings" executed="True" result="Success" success="True" time="0.363" asserts="2" />
+                          <test-case name="NUnit.Util.Tests.TestLoaderWatcherTests.ReloadShouldStartWatcher" executed="True" result="Success" success="True" time="0.724" asserts="3" />
+                          <test-case name="NUnit.Util.Tests.TestLoaderWatcherTests.ReloadShouldStartWatcherDependingOnSettings" executed="True" result="Success" success="True" time="0.773" asserts="2" />
+                          <test-case name="NUnit.Util.Tests.TestLoaderWatcherTests.UnloadShouldStopWatcherAndFreeResources" executed="True" result="Success" success="True" time="0.384" asserts="3" />
+                        </results>
+                      </test-suite>
+                      <test-suite type="TestFixture" name="TestRunnerFactoryTests" executed="True" result="Success" success="True" time="0.006" asserts="0">
+                        <results>
+                          <test-case name="NUnit.Util.Tests.TestRunnerFactoryTests.DifferentRuntimeUsesProcessRunner" executed="True" result="Success" success="True" time="0.001" asserts="1" />
+                          <test-case name="NUnit.Util.Tests.TestRunnerFactoryTests.DifferentVersionUsesProcessRunner" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Util.Tests.TestRunnerFactoryTests.SameFrameworkUsesTestDomain" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                        </results>
+                      </test-suite>
+                      <test-suite type="TestFixture" name="VisualStudioConverterTests" executed="True" result="Success" success="True" time="0.278" asserts="0">
+                        <results>
+                          <test-case name="NUnit.Util.Tests.VisualStudioConverterTests.FromCppProject" executed="True" result="Success" success="True" time="0.058" asserts="5" />
+                          <test-case name="NUnit.Util.Tests.VisualStudioConverterTests.FromCSharpProject" executed="True" result="Success" success="True" time="0.007" asserts="5" />
+                          <test-case name="NUnit.Util.Tests.VisualStudioConverterTests.FromJsharpProject" executed="True" result="Success" success="True" time="0.007" asserts="5" />
+                          <test-case name="NUnit.Util.Tests.VisualStudioConverterTests.FromMakefileProject" executed="True" result="Success" success="True" time="0.008" asserts="3" />
+                          <test-case name="NUnit.Util.Tests.VisualStudioConverterTests.FromProjectWithHebrewFileIncluded" executed="True" result="Success" success="True" time="0.030" asserts="5" />
+                          <test-case name="NUnit.Util.Tests.VisualStudioConverterTests.FromSolutionWithDisabledProject" executed="True" result="Success" success="True" time="0.026" asserts="3" />
+                          <test-case name="NUnit.Util.Tests.VisualStudioConverterTests.FromVBProject" executed="True" result="Success" success="True" time="0.007" asserts="5" />
+                          <test-case name="NUnit.Util.Tests.VisualStudioConverterTests.FromVSSolution2003" executed="True" result="Success" success="True" time="0.036" asserts="5" />
+                          <test-case name="NUnit.Util.Tests.VisualStudioConverterTests.FromVSSolution2005" executed="True" result="Success" success="True" time="0.039" asserts="5" />
+                          <test-case name="NUnit.Util.Tests.VisualStudioConverterTests.FromWebApplication" executed="True" result="Success" success="True" time="0.014" asserts="3" />
+                          <test-case name="NUnit.Util.Tests.VisualStudioConverterTests.WithUnmanagedCpp" executed="True" result="Success" success="True" time="0.023" asserts="3" />
+                        </results>
+                      </test-suite>
+                      <test-suite type="TestFixture" name="VSProjectTests" executed="True" result="Success" success="True" time="0.167" asserts="0">
+                        <results>
+                          <test-case name="NUnit.Util.Tests.VSProjectTests.FileNotFoundError" executed="True" result="Success" success="True" time="0.001" asserts="0" />
+                          <test-case name="NUnit.Util.Tests.VSProjectTests.GenerateCorrectExtensionsFromVCProjectVS2005" executed="True" result="Success" success="True" time="0.009" asserts="4" />
+                          <test-case name="NUnit.Util.Tests.VSProjectTests.InvalidProjectFormat" executed="True" result="Success" success="True" time="0.003" asserts="0" />
+                          <test-case name="NUnit.Util.Tests.VSProjectTests.InvalidXmlFormat" executed="True" result="Success" success="True" time="0.024" asserts="0" />
+                          <test-case name="NUnit.Util.Tests.VSProjectTests.LoadCppProject" executed="True" result="Success" success="True" time="0.008" asserts="3" />
+                          <test-case name="NUnit.Util.Tests.VSProjectTests.LoadCppProjectVS2005" executed="True" result="Success" success="True" time="0.007" asserts="3" />
+                          <test-case name="NUnit.Util.Tests.VSProjectTests.LoadCppProjectWithMacros" executed="True" result="Success" success="True" time="0.008" asserts="4" />
+                          <test-case name="NUnit.Util.Tests.VSProjectTests.LoadCsharpProject" executed="True" result="Success" success="True" time="0.008" asserts="3" />
+                          <test-case name="NUnit.Util.Tests.VSProjectTests.LoadCsharpProjectVS2005" executed="True" result="Success" success="True" time="0.007" asserts="3" />
+                          <test-case name="NUnit.Util.Tests.VSProjectTests.LoadInvalidFileType" executed="True" result="Success" success="True" time="0.002" asserts="0" />
+                          <test-case name="NUnit.Util.Tests.VSProjectTests.LoadJsharpProject" executed="True" result="Success" success="True" time="0.006" asserts="3" />
+                          <test-case name="NUnit.Util.Tests.VSProjectTests.LoadJsharpProjectVS2005" executed="True" result="Success" success="True" time="0.008" asserts="3" />
+                          <test-case name="NUnit.Util.Tests.VSProjectTests.LoadProjectWithHebrewFileIncluded" executed="True" result="Success" success="True" time="0.007" asserts="3" />
+                          <test-case name="NUnit.Util.Tests.VSProjectTests.LoadProjectWithMissingOutputPath" executed="True" result="Success" success="True" time="0.007" asserts="3" />
+                          <test-case name="NUnit.Util.Tests.VSProjectTests.LoadVbProject" executed="True" result="Success" success="True" time="0.007" asserts="3" />
+                          <test-case name="NUnit.Util.Tests.VSProjectTests.LoadVbProjectVS2005" executed="True" result="Success" success="True" time="0.007" asserts="3" />
+                          <test-case name="NUnit.Util.Tests.VSProjectTests.MissingAttributes" executed="True" result="Success" success="True" time="0.002" asserts="0" />
+                          <test-case name="NUnit.Util.Tests.VSProjectTests.NoConfigurations" executed="True" result="Success" success="True" time="0.002" asserts="1" />
+                          <test-case name="NUnit.Util.Tests.VSProjectTests.NotWebProject" executed="True" result="Success" success="True" time="0.001" asserts="2" />
+                          <test-case name="NUnit.Util.Tests.VSProjectTests.ProjectExtensions" executed="True" result="Success" success="True" time="0.000" asserts="4" />
+                          <test-case name="NUnit.Util.Tests.VSProjectTests.SolutionExtension" executed="True" result="Success" success="True" time="0.000" asserts="2" />
+                        </results>
+                      </test-suite>
+                      <test-suite type="TestFixture" name="XmlResultWriterTest" executed="True" result="Success" success="True" time="0.067" asserts="0">
+                        <results>
+                          <test-case name="NUnit.Util.Tests.XmlResultWriterTest.FailingTestHasCorrectInformation" executed="True" result="Success" success="True" time="0.003" asserts="7" />
+                          <test-case name="NUnit.Util.Tests.XmlResultWriterTest.HasMultipleCategories" executed="True" result="Success" success="True" time="0.002" asserts="2" />
+                          <test-case name="NUnit.Util.Tests.XmlResultWriterTest.HasMultipleProperties" executed="True" result="Success" success="True" time="0.002" asserts="2" />
+                          <test-case name="NUnit.Util.Tests.XmlResultWriterTest.HasSingleCategory" executed="True" result="Success" success="True" time="0.001" asserts="3" />
+                          <test-case name="NUnit.Util.Tests.XmlResultWriterTest.HasSingleProperty" executed="True" result="Success" success="True" time="0.001" asserts="3" />
+                          <test-case name="NUnit.Util.Tests.XmlResultWriterTest.IgnoredTestHasCorrectInformation" executed="True" result="Success" success="True" time="0.001" asserts="5" />
+                          <test-case name="NUnit.Util.Tests.XmlResultWriterTest.InconclusiveTestHasCorrectInformation" executed="True" result="Success" success="True" time="0.000" asserts="6" />
+                          <test-case name="NUnit.Util.Tests.XmlResultWriterTest.PassingTestHasCorrectInformation" executed="True" result="Success" success="True" time="0.000" asserts="6" />
+                          <test-case name="NUnit.Util.Tests.XmlResultWriterTest.SuiteResultHasCategories" executed="True" result="Success" success="True" time="0.001" asserts="3" />
+                          <test-case name="NUnit.Util.Tests.XmlResultWriterTest.TestHasCultureInfo" executed="True" result="Success" success="True" time="0.000" asserts="5" />
+                          <test-case name="NUnit.Util.Tests.XmlResultWriterTest.TestHasEnvironmentInfo" executed="True" result="Success" success="True" time="0.001" asserts="9" />
+                        </results>
+                      </test-suite>
+                    </results>
+                  </test-suite>
+                </results>
+              </test-suite>
+            </results>
+          </test-suite>
+        </results>
+      </test-suite>
+      <test-suite type="Assembly" name="C:\Program Files\NUnit 2.6.2\bin\tests/nunit.mocks.tests.dll" executed="True" result="Success" success="True" time="0.134" asserts="0">
+        <results>
+          <test-suite type="Namespace" name="NUnit" executed="True" result="Success" success="True" time="0.134" asserts="0">
+            <results>
+              <test-suite type="Namespace" name="Mocks" executed="True" result="Success" success="True" time="0.133" asserts="0">
+                <results>
+                  <test-suite type="Namespace" name="Tests" executed="True" result="Success" success="True" time="0.133" asserts="0">
+                    <results>
+                      <test-suite type="TestFixture" name="DynamicMockTests" executed="True" result="Success" success="True" time="0.054" asserts="0">
+                        <results>
+                          <test-case name="NUnit.Mocks.Tests.DynamicMockTests.CallMethod" executed="True" result="Success" success="True" time="0.003" asserts="0" />
+                          <test-case name="NUnit.Mocks.Tests.DynamicMockTests.CallMethodWithArgs" executed="True" result="Success" success="True" time="0.000" asserts="0" />
+                          <test-case name="NUnit.Mocks.Tests.DynamicMockTests.CreateMockForMBRClass" executed="True" result="Success" success="True" time="0.003" asserts="13" />
+                          <test-case name="NUnit.Mocks.Tests.DynamicMockTests.CreateMockForNonMBRClassFails" executed="True" result="Success" success="True" time="0.018" asserts="0" />
+                          <test-case name="NUnit.Mocks.Tests.DynamicMockTests.DefaultReturnValues" executed="True" result="Success" success="True" time="0.001" asserts="5" />
+                          <test-case name="NUnit.Mocks.Tests.DynamicMockTests.ExpectedMethod" executed="True" result="Success" success="True" time="0.001" asserts="2" />
+                          <test-case name="NUnit.Mocks.Tests.DynamicMockTests.ExpectedMethodNotCalled" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Mocks.Tests.DynamicMockTests.MethodWithReturnValue" executed="True" result="Success" success="True" time="0.001" asserts="1" />
+                          <test-case name="NUnit.Mocks.Tests.DynamicMockTests.MockHasDefaultName" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Mocks.Tests.DynamicMockTests.MockHasNonDefaultName" executed="True" result="Success" success="True" time="0.001" asserts="1" />
+                          <test-case name="NUnit.Mocks.Tests.DynamicMockTests.OverrideMethodOnDynamicMock" executed="True" result="Success" success="True" time="0.001" asserts="1" />
+                          <test-case name="NUnit.Mocks.Tests.DynamicMockTests.RefParameter" executed="True" result="Success" success="True" time="0.000" asserts="2" />
+                          <test-case name="NUnit.Mocks.Tests.DynamicMockTests.WrongReturnType" executed="True" result="Success" success="True" time="0.001" asserts="0" />
+                        </results>
+                      </test-suite>
+                      <test-suite type="TestFixture" name="MockTests" executed="True" result="Success" success="True" time="0.076" asserts="0">
+                        <results>
+                          <test-case name="NUnit.Mocks.Tests.MockTests.CallMultipleMethodsInDifferentOrder" executed="True" result="Success" success="True" time="0.000" asserts="6" />
+                          <test-case name="NUnit.Mocks.Tests.MockTests.CallMultipleMethodsSomeWithoutExpectations" executed="True" result="Success" success="True" time="0.001" asserts="5" />
+                          <test-case name="NUnit.Mocks.Tests.MockTests.ChangeExpectAndReturnToFixedReturn" executed="True" result="Success" success="True" time="0.000" asserts="8" />
+                          <test-case name="NUnit.Mocks.Tests.MockTests.ChangeFixedReturnToExpectAndReturn" executed="True" result="Success" success="True" time="0.000" asserts="9" />
+                          <test-case name="NUnit.Mocks.Tests.MockTests.ConstraintArgumentSucceeds" executed="True" result="Success" success="True" time="0.001" asserts="3" />
+                          <test-case name="NUnit.Mocks.Tests.MockTests.ConstraintArgumentThatFails" executed="True" result="Success" success="True" time="0.001" asserts="3" />
+                          <test-case name="NUnit.Mocks.Tests.MockTests.ExpectAndReturn" executed="True" result="Success" success="True" time="0.000" asserts="4" />
+                          <test-case name="NUnit.Mocks.Tests.MockTests.ExpectAndReturnNull" executed="True" result="Success" success="True" time="0.000" asserts="4" />
+                          <test-case name="NUnit.Mocks.Tests.MockTests.ExpectAndReturnWithArgument" executed="True" result="Success" success="True" time="0.001" asserts="5" />
+                          <test-case name="NUnit.Mocks.Tests.MockTests.ExpectAndReturnWithWrongArgument" executed="True" result="Success" success="True" time="0.000" asserts="3" />
+                          <test-case name="NUnit.Mocks.Tests.MockTests.ExpectAndThrowException" executed="True" result="Success" success="True" time="0.001" asserts="2" />
+                          <test-case name="NUnit.Mocks.Tests.MockTests.ExpectNoCallFails" executed="True" result="Success" success="True" time="0.001" asserts="0" />
+                          <test-case name="NUnit.Mocks.Tests.MockTests.ExpectNoCallSucceeds" executed="True" result="Success" success="True" time="0.001" asserts="0" />
+                          <test-case name="NUnit.Mocks.Tests.MockTests.FailWithParametersSpecified" executed="True" result="Success" success="True" time="0.000" asserts="2" />
+                          <test-case name="NUnit.Mocks.Tests.MockTests.IgnoreArguments" executed="True" result="Success" success="True" time="0.000" asserts="2" />
+                          <test-case name="NUnit.Mocks.Tests.MockTests.MethodNotCalled" executed="True" result="Success" success="True" time="0.001" asserts="1" />
+                          <test-case name="NUnit.Mocks.Tests.MockTests.MockHasName" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Mocks.Tests.MockTests.MultipleCallsToSameMethod" executed="True" result="Success" success="True" time="0.000" asserts="4" />
+                          <test-case name="NUnit.Mocks.Tests.MockTests.MultipleExpectAndReturn" executed="True" result="Success" success="True" time="0.001" asserts="10" />
+                          <test-case name="NUnit.Mocks.Tests.MockTests.MultipleExpectations" executed="True" result="Success" success="True" time="0.001" asserts="12" />
+                          <test-case name="NUnit.Mocks.Tests.MockTests.NotEnoughCalls" executed="True" result="Success" success="True" time="0.001" asserts="3" />
+                          <test-case name="NUnit.Mocks.Tests.MockTests.OneExpectation" executed="True" result="Success" success="True" time="0.000" asserts="2" />
+                          <test-case name="NUnit.Mocks.Tests.MockTests.RequireArguments" executed="True" result="Success" success="True" time="0.001" asserts="2" />
+                          <test-case name="NUnit.Mocks.Tests.MockTests.SetReturnValue" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Mocks.Tests.MockTests.SetReturnValueMultipleTimesOnMultipleMethods" executed="True" result="Success" success="True" time="0.001" asserts="7" />
+                          <test-case name="NUnit.Mocks.Tests.MockTests.SetReturnValueRepeatedCalls" executed="True" result="Success" success="True" time="0.001" asserts="3" />
+                          <test-case name="NUnit.Mocks.Tests.MockTests.SetReturnValueWithoutCalling" executed="True" result="Success" success="True" time="0.000" asserts="0" />
+                          <test-case name="NUnit.Mocks.Tests.MockTests.StrictDefaultsToFalse" executed="True" result="Success" success="True" time="0.001" asserts="1" />
+                          <test-case name="NUnit.Mocks.Tests.MockTests.StrictMode" executed="True" result="Success" success="True" time="0.001" asserts="2" />
+                          <test-case name="NUnit.Mocks.Tests.MockTests.StrictMode_ExceptionsCaught" executed="True" result="Success" success="True" time="0.001" asserts="4" />
+                          <test-case name="NUnit.Mocks.Tests.MockTests.TooManyCalls" executed="True" result="Success" success="True" time="0.001" asserts="3" />
+                          <test-case name="NUnit.Mocks.Tests.MockTests.UnexpectedCallsIgnored" executed="True" result="Success" success="True" time="0.000" asserts="0" />
+                          <test-case name="NUnit.Mocks.Tests.MockTests.VerifyNewMock" executed="True" result="Success" success="True" time="0.000" asserts="0" />
+                        </results>
+                      </test-suite>
+                    </results>
+                  </test-suite>
+                </results>
+              </test-suite>
+            </results>
+          </test-suite>
+        </results>
+      </test-suite>
+      <test-suite type="Assembly" name="C:\Program Files\NUnit 2.6.2\bin\tests/nunit-console.tests.dll" executed="True" result="Success" success="True" time="9.385" asserts="0">
+        <results>
+          <test-suite type="Namespace" name="NUnit" executed="True" result="Success" success="True" time="9.385" asserts="0">
+            <results>
+              <test-suite type="Namespace" name="ConsoleRunner" executed="True" result="Success" success="True" time="9.384" asserts="0">
+                <results>
+                  <test-suite type="Namespace" name="Tests" executed="True" result="Success" success="True" time="9.384" asserts="0">
+                    <results>
+                      <test-suite type="TestFixture" name="CommandLineTests" executed="True" result="Success" success="True" time="0.124" asserts="0">
+                        <results>
+                          <test-case name="NUnit.ConsoleRunner.Tests.CommandLineTests.AllowForwardSlashDefaultsCorrectly" executed="True" result="Success" success="True" time="0.018" asserts="1" />
+                          <test-case name="NUnit.ConsoleRunner.Tests.CommandLineTests.AssemblyAloneIsValid" executed="True" result="Success" success="True" time="0.002" asserts="1" />
+                          <test-case name="NUnit.ConsoleRunner.Tests.CommandLineTests.AssemblyName" executed="True" result="Success" success="True" time="0.001" asserts="1" />
+                          <test-suite type="ParameterizedTest" name="BooleanOptionAreRecognized" executed="True" result="Success" success="True" time="0.035" asserts="0">
+                            <results>
+                              <test-case name="NUnit.ConsoleRunner.Tests.CommandLineTests.BooleanOptionAreRecognized(&quot;labels&quot;,&quot;labels&quot;)" executed="True" result="Success" success="True" time="0.005" asserts="6" />
+                              <test-case name="NUnit.ConsoleRunner.Tests.CommandLineTests.BooleanOptionAreRecognized(&quot;help&quot;,&quot;help&quot;)" executed="True" result="Success" success="True" time="0.002" asserts="6" />
+                              <test-case name="NUnit.ConsoleRunner.Tests.CommandLineTests.BooleanOptionAreRecognized(&quot;help&quot;,&quot;?&quot;)" executed="True" result="Success" success="True" time="0.002" asserts="6" />
+                              <test-case name="NUnit.ConsoleRunner.Tests.CommandLineTests.BooleanOptionAreRecognized(&quot;xmlConsole&quot;,&quot;xmlConsole&quot;)" executed="True" result="Success" success="True" time="0.001" asserts="6" />
+                              <test-case name="NUnit.ConsoleRunner.Tests.CommandLineTests.BooleanOptionAreRecognized(&quot;wait&quot;,&quot;wait&quot;)" executed="True" result="Success" success="True" time="0.002" asserts="6" />
+                              <test-case name="NUnit.ConsoleRunner.Tests.CommandLineTests.BooleanOptionAreRecognized(&quot;nologo&quot;,&quot;nologo&quot;)" executed="True" result="Success" success="True" time="0.002" asserts="6" />
+                              <test-case name="NUnit.ConsoleRunner.Tests.CommandLineTests.BooleanOptionAreRecognized(&quot;noshadow&quot;,&quot;noshadow&quot;)" executed="True" result="Success" success="True" time="0.012" asserts="6" />
+                              <test-case name="NUnit.ConsoleRunner.Tests.CommandLineTests.BooleanOptionAreRecognized(&quot;nothread&quot;,&quot;nothread&quot;)" executed="True" result="Success" success="True" time="0.001" asserts="6" />
+                            </results>
+                          </test-suite>
+                          <test-suite type="ParameterizedTest" name="EnumOptionsAreRecognized" executed="True" result="Success" success="True" time="0.003" asserts="0">
+                            <results>
+                              <test-case name="NUnit.ConsoleRunner.Tests.CommandLineTests.EnumOptionsAreRecognized(&quot;domain&quot;)" executed="True" result="Success" success="True" time="0.000" asserts="2" />
+                              <test-case name="NUnit.ConsoleRunner.Tests.CommandLineTests.EnumOptionsAreRecognized(&quot;trace&quot;)" executed="True" result="Success" success="True" time="0.000" asserts="2" />
+                            </results>
+                          </test-suite>
+                          <test-case name="NUnit.ConsoleRunner.Tests.CommandLineTests.FileNameWithoutXmlParameterLooksLikeParameter" executed="True" result="Success" success="True" time="0.001" asserts="2" />
+                          <test-case name="NUnit.ConsoleRunner.Tests.CommandLineTests.FixtureNamePlusAssemblyIsValid" executed="True" result="Success" success="True" time="0.000" asserts="3" />
+                          <test-case name="NUnit.ConsoleRunner.Tests.CommandLineTests.HelpTextUsesCorrectDelimiterForPlatform" executed="True" result="Success" success="True" time="0.002" asserts="2" />
+                          <test-case name="NUnit.ConsoleRunner.Tests.CommandLineTests.InvalidCommandLineParms" executed="True" result="Success" success="True" time="0.001" asserts="1" />
+                          <test-case name="NUnit.ConsoleRunner.Tests.CommandLineTests.InvalidOption" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.ConsoleRunner.Tests.CommandLineTests.NoFixtureNameProvided" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.ConsoleRunner.Tests.CommandLineTests.NoParametersCount" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                          <test-suite type="ParameterizedTest" name="StringOptionsAreRecognized" executed="True" result="Success" success="True" time="0.028" asserts="0">
+                            <results>
+                              <test-case name="NUnit.ConsoleRunner.Tests.CommandLineTests.StringOptionsAreRecognized(&quot;output&quot;,&quot;output&quot;)" executed="True" result="Success" success="True" time="0.002" asserts="6" />
+                              <test-case name="NUnit.ConsoleRunner.Tests.CommandLineTests.StringOptionsAreRecognized(&quot;exclude&quot;,&quot;exclude&quot;)" executed="True" result="Success" success="True" time="0.001" asserts="6" />
+                              <test-case name="NUnit.ConsoleRunner.Tests.CommandLineTests.StringOptionsAreRecognized(&quot;runlist&quot;,&quot;runlist&quot;)" executed="True" result="Success" success="True" time="0.000" asserts="6" />
+                              <test-case name="NUnit.ConsoleRunner.Tests.CommandLineTests.StringOptionsAreRecognized(&quot;basepath&quot;,&quot;basepath&quot;)" executed="True" result="Success" success="True" time="0.001" asserts="6" />
+                              <test-case name="NUnit.ConsoleRunner.Tests.CommandLineTests.StringOptionsAreRecognized(&quot;privatebinpath&quot;,&quot;privatebinpath&quot;)" executed="True" result="Success" success="True" time="0.001" asserts="6" />
+                              <test-case name="NUnit.ConsoleRunner.Tests.CommandLineTests.StringOptionsAreRecognized(&quot;config&quot;,&quot;config&quot;)" executed="True" result="Success" success="True" time="0.001" asserts="6" />
+                              <test-case name="NUnit.ConsoleRunner.Tests.CommandLineTests.StringOptionsAreRecognized(&quot;result&quot;,&quot;result&quot;)" executed="True" result="Success" success="True" time="0.001" asserts="6" />
+                              <test-case name="NUnit.ConsoleRunner.Tests.CommandLineTests.StringOptionsAreRecognized(&quot;run&quot;,&quot;run&quot;)" executed="True" result="Success" success="True" time="0.000" asserts="6" />
+                              <test-case name="NUnit.ConsoleRunner.Tests.CommandLineTests.StringOptionsAreRecognized(&quot;result&quot;,&quot;xml&quot;)" executed="True" result="Success" success="True" time="0.001" asserts="6" />
+                              <test-case name="NUnit.ConsoleRunner.Tests.CommandLineTests.StringOptionsAreRecognized(&quot;fixture&quot;,&quot;fixture&quot;)" executed="True" result="Success" success="True" time="0.001" asserts="6" />
+                              <test-case name="NUnit.ConsoleRunner.Tests.CommandLineTests.StringOptionsAreRecognized(&quot;output&quot;,&quot;out&quot;)" executed="True" result="Success" success="True" time="0.001" asserts="6" />
+                              <test-case name="NUnit.ConsoleRunner.Tests.CommandLineTests.StringOptionsAreRecognized(&quot;err&quot;,&quot;err&quot;)" executed="True" result="Success" success="True" time="0.001" asserts="6" />
+                              <test-case name="NUnit.ConsoleRunner.Tests.CommandLineTests.StringOptionsAreRecognized(&quot;include&quot;,&quot;include&quot;)" executed="True" result="Success" success="True" time="0.001" asserts="6" />
+                            </results>
+                          </test-suite>
+                          <test-case name="NUnit.ConsoleRunner.Tests.CommandLineTests.XmlParameter" executed="True" result="Success" success="True" time="0.001" asserts="3" />
+                          <test-case name="NUnit.ConsoleRunner.Tests.CommandLineTests.XmlParameterWithFullPath" executed="True" result="Success" success="True" time="0.001" asserts="3" />
+                          <test-case name="NUnit.ConsoleRunner.Tests.CommandLineTests.XmlParameterWithFullPathUsingEqualSign" executed="True" result="Success" success="True" time="0.000" asserts="3" />
+                          <test-case name="NUnit.ConsoleRunner.Tests.CommandLineTests.XmlParameterWithoutFileNameIsInvalid" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                        </results>
+                      </test-suite>
+                      <test-suite type="TestFixture" name="CommandLineTests_MultipleAssemblies" executed="True" result="Success" success="True" time="0.010" asserts="0">
+                        <results>
+                          <test-case name="NUnit.ConsoleRunner.Tests.CommandLineTests_MultipleAssemblies.CheckParameters" executed="True" result="Success" success="True" time="0.001" asserts="2" />
+                          <test-case name="NUnit.ConsoleRunner.Tests.CommandLineTests_MultipleAssemblies.FixtureParameters" executed="True" result="Success" success="True" time="0.001" asserts="3" />
+                          <test-case name="NUnit.ConsoleRunner.Tests.CommandLineTests_MultipleAssemblies.FixtureValidate" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.ConsoleRunner.Tests.CommandLineTests_MultipleAssemblies.MultipleAssemblyValidate" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.ConsoleRunner.Tests.CommandLineTests_MultipleAssemblies.ParameterCount" executed="True" result="Success" success="True" time="0.001" asserts="1" />
+                        </results>
+                      </test-suite>
+                      <test-suite type="TestFixture" name="ConsoleRunnerTest" executed="True" result="Success" success="True" time="9.212" asserts="0">
+                        <results>
+                          <test-case name="NUnit.ConsoleRunner.Tests.ConsoleRunnerTest.AssemblyNotFound" executed="True" result="Success" success="True" time="0.037" asserts="1" />
+                          <test-case name="NUnit.ConsoleRunner.Tests.ConsoleRunnerTest.Bug1073539Test" executed="True" result="Success" success="True" time="0.466" asserts="1" />
+                          <test-case name="NUnit.ConsoleRunner.Tests.ConsoleRunnerTest.Bug1311644Test" executed="True" result="Success" success="True" time="0.413" asserts="1" />
+                          <test-case name="NUnit.ConsoleRunner.Tests.ConsoleRunnerTest.CanRunWithMultipleTestDomains" executed="True" result="Success" success="True" time="0.981" asserts="2" />
+                          <test-case name="NUnit.ConsoleRunner.Tests.ConsoleRunnerTest.CanRunWithMultipleTestDomains_NoThread" executed="True" result="Success" success="True" time="1.035" asserts="2" />
+                          <test-case name="NUnit.ConsoleRunner.Tests.ConsoleRunnerTest.CanRunWithoutTestDomain" executed="True" result="Success" success="True" time="0.051" asserts="2" />
+                          <test-case name="NUnit.ConsoleRunner.Tests.ConsoleRunnerTest.CanRunWithoutTestDomain_NoThread" executed="True" result="Success" success="True" time="0.052" asserts="2" />
+                          <test-case name="NUnit.ConsoleRunner.Tests.ConsoleRunnerTest.CanRunWithSingleTestDomain" executed="True" result="Success" success="True" time="0.571" asserts="2" />
+                          <test-case name="NUnit.ConsoleRunner.Tests.ConsoleRunnerTest.CanRunWithSingleTestDomain_NoThread" executed="True" result="Success" success="True" time="0.540" asserts="2" />
+                          <test-case name="NUnit.ConsoleRunner.Tests.ConsoleRunnerTest.CanSpecifyBasePathAndPrivateBinPath" executed="True" result="Success" success="True" time="1.026" asserts="2" />
+                          <test-case name="NUnit.ConsoleRunner.Tests.ConsoleRunnerTest.DoesNotFailIfRunListHasEmptyLines" executed="True" result="Success" success="True" time="0.389" asserts="2" />
+                          <test-case name="NUnit.ConsoleRunner.Tests.ConsoleRunnerTest.DoesNotFailWithEmptyRunList" executed="True" result="Success" success="True" time="0.392" asserts="2" />
+                          <test-case name="NUnit.ConsoleRunner.Tests.ConsoleRunnerTest.FailsGracefullyIfRunListPointsToNonExistingDirectory" executed="True" result="Success" success="True" time="0.360" asserts="2" />
+                          <test-case name="NUnit.ConsoleRunner.Tests.ConsoleRunnerTest.FailsGracefullyIfRunListPointsToNonExistingFile" executed="True" result="Success" success="True" time="0.353" asserts="2" />
+                          <test-case name="NUnit.ConsoleRunner.Tests.ConsoleRunnerTest.FailureFixture" executed="True" result="Success" success="True" time="0.446" asserts="1" />
+                          <test-case name="NUnit.ConsoleRunner.Tests.ConsoleRunnerTest.InvalidFixture" executed="True" result="Success" success="True" time="0.313" asserts="1" />
+                          <test-case name="NUnit.ConsoleRunner.Tests.ConsoleRunnerTest.MultiFailureFixture" executed="True" result="Success" success="True" time="0.426" asserts="1" />
+                          <test-case name="NUnit.ConsoleRunner.Tests.ConsoleRunnerTest.OneOfTwoAssembliesNotFound" executed="True" result="Success" success="True" time="0.021" asserts="1" />
+                          <test-case name="NUnit.ConsoleRunner.Tests.ConsoleRunnerTest.SuccessFixture" executed="True" result="Success" success="True" time="0.435" asserts="1" />
+                          <test-case name="NUnit.ConsoleRunner.Tests.ConsoleRunnerTest.XmlResult" executed="True" result="Success" success="True" time="0.425" asserts="2" />
+                          <test-case name="NUnit.ConsoleRunner.Tests.ConsoleRunnerTest.XmlToConsole" executed="True" result="Success" success="True" time="0.430" asserts="2" />
+                        </results>
+                      </test-suite>
+                      <test-suite type="TestFixture" name="TestNameParserTests" executed="True" result="Success" success="True" time="0.027" asserts="0">
+                        <results>
+                          <test-suite type="ParameterizedTest" name="SingleName" executed="True" result="Success" success="True" time="0.017" asserts="0">
+                            <results>
+                              <test-case name="NUnit.ConsoleRunner.Tests.TestNameParserTests.SingleName(&quot;  Test.Namespace.Fixture.Method  &quot;)" executed="True" result="Success" success="True" time="0.001" asserts="2" />
+                              <test-case name="NUnit.ConsoleRunner.Tests.TestNameParserTests.SingleName(&quot;Test.Namespace.Fixture.Method&quot;)" executed="True" result="Success" success="True" time="0.000" asserts="2" />
+                              <test-case name="NUnit.ConsoleRunner.Tests.TestNameParserTests.SingleName(&quot;  Test.Namespace.Fixture.Method  ,&quot;)" executed="True" result="Success" success="True" time="0.000" asserts="2" />
+                              <test-case name="NUnit.ConsoleRunner.Tests.TestNameParserTests.SingleName(&quot;Test.Namespace.Fixture.Method(\&quot;)\&quot;)&quot;)" executed="True" result="Success" success="True" time="0.000" asserts="2" />
+                              <test-case name="NUnit.ConsoleRunner.Tests.TestNameParserTests.SingleName(&quot;Test.Namespace.Fixture.Method,&quot;)" executed="True" result="Success" success="True" time="0.000" asserts="2" />
+                              <test-case name="NUnit.ConsoleRunner.Tests.TestNameParserTests.SingleName(&quot;Test.Namespace.Fixture.Method()&quot;)" executed="True" result="Success" success="True" time="0.001" asserts="2" />
+                              <test-case name="NUnit.ConsoleRunner.Tests.TestNameParserTests.SingleName(&quot;Test.Namespace.Fixture.Method(\&quot;string,argument\&quot;)&quot;)" executed="True" result="Success" success="True" time="0.000" asserts="2" />
+                              <test-case name="NUnit.ConsoleRunner.Tests.TestNameParserTests.SingleName(&quot;Test.Namespace.Fixture.Method(1,2,3)&quot;)" executed="True" result="Success" success="True" time="0.000" asserts="2" />
+                              <test-case name="NUnit.ConsoleRunner.Tests.TestNameParserTests.SingleName(&quot;Test.Namespace.Fixture.Method&lt;int,int&gt;()&quot;)" executed="True" result="Success" success="True" time="0.000" asserts="2" />
+                            </results>
+                          </test-suite>
+                          <test-suite type="ParameterizedTest" name="TwoNames" executed="True" result="Success" success="True" time="0.007" asserts="0">
+                            <results>
+                              <test-case name="NUnit.ConsoleRunner.Tests.TestNameParserTests.TwoNames(&quot;Test.Namespace.Fixture.Method1(1,2)&quot;,&quot;Test.Namespace.Fixture.Method2(3,4)&quot;)" executed="True" result="Success" success="True" time="0.001" asserts="3" />
+                              <test-case name="NUnit.ConsoleRunner.Tests.TestNameParserTests.TwoNames(&quot;Test.Namespace.Fixture.Method1&quot;,&quot;Test.Namespace.Fixture.Method2,&quot;)" executed="True" result="Success" success="True" time="0.000" asserts="3" />
+                              <test-case name="NUnit.ConsoleRunner.Tests.TestNameParserTests.TwoNames(&quot;Test.Namespace.Fixture.Method1(\&quot;(\&quot;)&quot;,&quot;Test.Namespace.Fixture.Method2(\&quot;&lt;\&quot;)&quot;)" executed="True" result="Success" success="True" time="0.001" asserts="3" />
+                              <test-case name="NUnit.ConsoleRunner.Tests.TestNameParserTests.TwoNames(&quot;Test.Namespace.Fixture.Method1&quot;,&quot;Test.Namespace.Fixture.Method2&quot;)" executed="True" result="Success" success="True" time="0.000" asserts="3" />
+                            </results>
+                          </test-suite>
+                        </results>
+                      </test-suite>
+                    </results>
+                  </test-suite>
+                </results>
+              </test-suite>
+            </results>
+          </test-suite>
+        </results>
+      </test-suite>
+      <test-suite type="Assembly" name="C:\Program Files\NUnit 2.6.2\bin\tests/nunit.uiexception.tests.dll" executed="True" result="Success" success="True" time="1.678" asserts="0">
+        <results>
+          <test-suite type="Namespace" name="NUnit" executed="True" result="Success" success="True" time="1.678" asserts="0">
+            <results>
+              <test-suite type="Namespace" name="UiException" executed="True" result="Success" success="True" time="1.678" asserts="0">
+                <results>
+                  <test-suite type="Namespace" name="Tests" executed="True" result="Success" success="True" time="1.677" asserts="0">
+                    <results>
+                      <test-suite type="Namespace" name="CodeFormatters" executed="True" result="Success" success="True" time="0.347" asserts="0">
+                        <results>
+                          <test-suite type="TestFixture" name="TestCodeFormatterCollection" executed="True" result="Success" success="True" time="0.039" asserts="0">
+                            <results>
+                              <test-case name="NUnit.UiException.Tests.CodeFormatters.TestCodeFormatterCollection.Clear" executed="True" result="Success" success="True" time="0.003" asserts="1" />
+                              <test-case name="NUnit.UiException.Tests.CodeFormatters.TestCodeFormatterCollection.ContainsFormatterFromExtension" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                              <test-case name="NUnit.UiException.Tests.CodeFormatters.TestCodeFormatterCollection.Indexer_Can_Throw_UnknownExtensionException" executed="True" result="Success" success="True" time="0.002" asserts="0" />
+                              <test-case name="NUnit.UiException.Tests.CodeFormatters.TestCodeFormatterCollection.ItemIndexer_Can_Throw_NullExtensionException" executed="True" result="Success" success="True" time="0.001" asserts="0" />
+                              <test-case name="NUnit.UiException.Tests.CodeFormatters.TestCodeFormatterCollection.Register_Can_Throw_NullExtensionException" executed="True" result="Success" success="True" time="0.001" asserts="0" />
+                              <test-case name="NUnit.UiException.Tests.CodeFormatters.TestCodeFormatterCollection.Register_Can_Throw_NullFormatterException" executed="True" result="Success" success="True" time="0.001" asserts="0" />
+                              <test-case name="NUnit.UiException.Tests.CodeFormatters.TestCodeFormatterCollection.Register_Check_Extension_Case" executed="True" result="Success" success="True" time="0.001" asserts="0" />
+                              <test-case name="NUnit.UiException.Tests.CodeFormatters.TestCodeFormatterCollection.Register_Check_Extension_Is_Not_Empty" executed="True" result="Success" success="True" time="0.001" asserts="0" />
+                              <test-case name="NUnit.UiException.Tests.CodeFormatters.TestCodeFormatterCollection.Register_Check_Extension_Not_Contain_Dot_Character" executed="True" result="Success" success="True" time="0.001" asserts="0" />
+                              <test-case name="NUnit.UiException.Tests.CodeFormatters.TestCodeFormatterCollection.Register_Check_Multiple_Extension_Definition" executed="True" result="Success" success="True" time="0.000" asserts="0" />
+                              <test-case name="NUnit.UiException.Tests.CodeFormatters.TestCodeFormatterCollection.Remove" executed="True" result="Success" success="True" time="0.002" asserts="4" />
+                              <test-case name="NUnit.UiException.Tests.CodeFormatters.TestCodeFormatterCollection.Remove_Is_Not_Case_Sensitive" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                              <test-case name="NUnit.UiException.Tests.CodeFormatters.TestCodeFormatterCollection.StringIndexer_Can_Throw_NullExtensionException" executed="True" result="Success" success="True" time="0.000" asserts="0" />
+                              <test-case name="NUnit.UiException.Tests.CodeFormatters.TestCodeFormatterCollection.Test_Default" executed="True" result="Success" success="True" time="0.002" asserts="10" />
+                            </results>
+                          </test-suite>
+                          <test-suite type="TestFixture" name="TestCSharpCodeFormatter" executed="True" result="Success" success="True" time="0.040" asserts="0">
+                            <results>
+                              <test-case name="NUnit.UiException.Tests.CodeFormatters.TestCSharpCodeFormatter.Format_Can_Throw_CSharpNullException" executed="True" result="Success" success="True" time="0.001" asserts="0" />
+                              <test-case name="NUnit.UiException.Tests.CodeFormatters.TestCSharpCodeFormatter.Test_Conserve_Intermediary_Spaces" executed="True" result="Success" success="True" time="0.020" asserts="9" />
+                              <test-case name="NUnit.UiException.Tests.CodeFormatters.TestCSharpCodeFormatter.Test_Default" executed="True" result="Success" success="True" time="0.001" asserts="4" />
+                              <test-case name="NUnit.UiException.Tests.CodeFormatters.TestCSharpCodeFormatter.Test_Format" executed="True" result="Success" success="True" time="0.003" asserts="1" />
+                              <test-case name="NUnit.UiException.Tests.CodeFormatters.TestCSharpCodeFormatter.Test_Format_2" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                              <test-case name="NUnit.UiException.Tests.CodeFormatters.TestCSharpCodeFormatter.Test_Format_3" executed="True" result="Success" success="True" time="0.001" asserts="2" />
+                              <test-case name="NUnit.UiException.Tests.CodeFormatters.TestCSharpCodeFormatter.Test_PreProcess" executed="True" result="Success" success="True" time="0.001" asserts="3" />
+                            </results>
+                          </test-suite>
+                          <test-suite type="TestFixture" name="TestFormattedCode" executed="True" result="Success" success="True" time="0.031" asserts="0">
+                            <results>
+                              <test-case name="NUnit.UiException.Tests.CodeFormatters.TestFormattedCode.CheckData_Can_Throw_NullDataException" executed="True" result="Success" success="True" time="0.002" asserts="0" />
+                              <test-case name="NUnit.UiException.Tests.CodeFormatters.TestFormattedCode.CheckData_IndexArray_And_TagArray_Count_Must_Match" executed="True" result="Success" success="True" time="0.001" asserts="0" />
+                              <test-case name="NUnit.UiException.Tests.CodeFormatters.TestFormattedCode.CheckData_LineArray_Values_Must_Always_Grow_Up" executed="True" result="Success" success="True" time="0.001" asserts="0" />
+                              <test-case name="NUnit.UiException.Tests.CodeFormatters.TestFormattedCode.CheckData_LineArray_Values_Must_Be_In_IndexArray_Count" executed="True" result="Success" success="True" time="0.001" asserts="0" />
+                              <test-case name="NUnit.UiException.Tests.CodeFormatters.TestFormattedCode.Empty" executed="True" result="Success" success="True" time="0.001" asserts="2" />
+                              <test-case name="NUnit.UiException.Tests.CodeFormatters.TestFormattedCode.Test_ComplexCollection" executed="True" result="Success" success="True" time="0.005" asserts="22" />
+                              <test-case name="NUnit.UiException.Tests.CodeFormatters.TestFormattedCode.Test_Equals" executed="True" result="Success" success="True" time="0.002" asserts="10" />
+                              <test-case name="NUnit.UiException.Tests.CodeFormatters.TestFormattedCode.Test_MaxLength" executed="True" result="Success" success="True" time="0.002" asserts="3" />
+                              <test-case name="NUnit.UiException.Tests.CodeFormatters.TestFormattedCode.Test_SimpleCollection" executed="True" result="Success" success="True" time="0.002" asserts="17" />
+                            </results>
+                          </test-suite>
+                          <test-suite type="TestFixture" name="TestGeneralCodeFormatter" executed="True" result="Success" success="True" time="0.096" asserts="0">
+                            <results>
+                              <test-case name="NUnit.UiException.Tests.CodeFormatters.TestGeneralCodeFormatter.All_Formatters_Have_Unique_Language_Value" executed="True" result="Success" success="True" time="0.002" asserts="2" />
+                              <test-case name="NUnit.UiException.Tests.CodeFormatters.TestGeneralCodeFormatter.All_Formatters_Should_Have_Overwrite_Behavior" executed="True" result="Success" success="True" time="0.006" asserts="2" />
+                              <test-case name="NUnit.UiException.Tests.CodeFormatters.TestGeneralCodeFormatter.All_Formatters_Should_PreProcess_Tab_Character" executed="True" result="Success" success="True" time="0.001" asserts="2" />
+                              <test-case name="NUnit.UiException.Tests.CodeFormatters.TestGeneralCodeFormatter.Any_Formatter_Should_Format_Any_Text" executed="True" result="Success" success="True" time="0.033" asserts="6" />
+                              <test-case name="NUnit.UiException.Tests.CodeFormatters.TestGeneralCodeFormatter.DefaultFormatter" executed="True" result="Success" success="True" time="0.001" asserts="1" />
+                              <test-case name="NUnit.UiException.Tests.CodeFormatters.TestGeneralCodeFormatter.DefaultFormatter_Can_Throw_FormatterNullException" executed="True" result="Success" success="True" time="0.000" asserts="0" />
+                              <test-case name="NUnit.UiException.Tests.CodeFormatters.TestGeneralCodeFormatter.Format" executed="True" result="Success" success="True" time="0.001" asserts="2" />
+                              <test-case name="NUnit.UiException.Tests.CodeFormatters.TestGeneralCodeFormatter.Format_Can_Throw_CodeNullException" executed="True" result="Success" success="True" time="0.001" asserts="0" />
+                              <test-case name="NUnit.UiException.Tests.CodeFormatters.TestGeneralCodeFormatter.Format_Can_Throw_LanguageNameNullException" executed="True" result="Success" success="True" time="0.000" asserts="0" />
+                              <test-case name="NUnit.UiException.Tests.CodeFormatters.TestGeneralCodeFormatter.Format_Pick_Best_Formatter" executed="True" result="Success" success="True" time="0.015" asserts="2" />
+                              <test-case name="NUnit.UiException.Tests.CodeFormatters.TestGeneralCodeFormatter.FormatFromExtension_Can_Throw_CodeNullException" executed="True" result="Success" success="True" time="0.001" asserts="0" />
+                              <test-case name="NUnit.UiException.Tests.CodeFormatters.TestGeneralCodeFormatter.FormatFromExtension_Can_Throw_ExtensionNullException" executed="True" result="Success" success="True" time="0.001" asserts="0" />
+                              <test-case name="NUnit.UiException.Tests.CodeFormatters.TestGeneralCodeFormatter.GetFormatterFromExtension_Can_Throw_ExtensionNullException" executed="True" result="Success" success="True" time="0.001" asserts="0" />
+                              <test-case name="NUnit.UiException.Tests.CodeFormatters.TestGeneralCodeFormatter.GetFormatterFromLanguage_Can_Throw_LanguageNullException" executed="True" result="Success" success="True" time="0.000" asserts="0" />
+                              <test-case name="NUnit.UiException.Tests.CodeFormatters.TestGeneralCodeFormatter.GetFormatterFroms" executed="True" result="Success" success="True" time="0.001" asserts="4" />
+                              <test-case name="NUnit.UiException.Tests.CodeFormatters.TestGeneralCodeFormatter.LanguageFromExtension" executed="True" result="Success" success="True" time="0.001" asserts="3" />
+                              <test-case name="NUnit.UiException.Tests.CodeFormatters.TestGeneralCodeFormatter.Test_Default" executed="True" result="Success" success="True" time="0.001" asserts="3" />
+                            </results>
+                          </test-suite>
+                          <test-suite type="TestFixture" name="TestLexer" executed="True" result="Success" success="True" time="0.033" asserts="0">
+                            <results>
+                              <test-case name="NUnit.UiException.Tests.CodeFormatters.TestLexer.Test_Default" executed="True" result="Success" success="True" time="0.000" asserts="3" />
+                              <test-case name="NUnit.UiException.Tests.CodeFormatters.TestLexer.Test_Dot_Character" executed="True" result="Success" success="True" time="0.002" asserts="5" />
+                              <test-case name="NUnit.UiException.Tests.CodeFormatters.TestLexer.Test_SetText_Throws_NullArgumentException" executed="True" result="Success" success="True" time="0.001" asserts="0" />
+                              <test-case name="NUnit.UiException.Tests.CodeFormatters.TestLexer.Test_Split_ColonCharacter" executed="True" result="Success" success="True" time="0.001" asserts="20" />
+                              <test-case name="NUnit.UiException.Tests.CodeFormatters.TestLexer.Test_Split_CommentC" executed="True" result="Success" success="True" time="0.001" asserts="10" />
+                              <test-case name="NUnit.UiException.Tests.CodeFormatters.TestLexer.Test_Split_CommentCpp" executed="True" result="Success" success="True" time="0.001" asserts="5" />
+                              <test-case name="NUnit.UiException.Tests.CodeFormatters.TestLexer.Test_Split_DoubleQuote" executed="True" result="Success" success="True" time="0.001" asserts="19" />
+                              <test-case name="NUnit.UiException.Tests.CodeFormatters.TestLexer.Test_Split_Equals" executed="True" result="Success" success="True" time="0.000" asserts="5" />
+                              <test-case name="NUnit.UiException.Tests.CodeFormatters.TestLexer.Test_Split_New_Line" executed="True" result="Success" success="True" time="0.001" asserts="5" />
+                              <test-case name="NUnit.UiException.Tests.CodeFormatters.TestLexer.Test_Split_NumberSign" executed="True" result="Success" success="True" time="0.001" asserts="5" />
+                              <test-case name="NUnit.UiException.Tests.CodeFormatters.TestLexer.Test_Split_SingleQuote" executed="True" result="Success" success="True" time="0.000" asserts="5" />
+                              <test-case name="NUnit.UiException.Tests.CodeFormatters.TestLexer.Test_Split_WhiteSpaces" executed="True" result="Success" success="True" time="0.002" asserts="35" />
+                              <test-case name="NUnit.UiException.Tests.CodeFormatters.TestLexer.Test_Split_Words" executed="True" result="Success" success="True" time="0.001" asserts="10" />
+                            </results>
+                          </test-suite>
+                          <test-suite type="TestFixture" name="TestPlainTextCodeFormatter" executed="True" result="Success" success="True" time="0.010" asserts="0">
+                            <results>
+                              <test-case name="NUnit.UiException.Tests.CodeFormatters.TestPlainTextCodeFormatter.Format_Can_Throw_CodeNullException" executed="True" result="Success" success="True" time="0.001" asserts="0" />
+                              <test-case name="NUnit.UiException.Tests.CodeFormatters.TestPlainTextCodeFormatter.Format_HelloWorld" executed="True" result="Success" success="True" time="0.001" asserts="1" />
+                              <test-case name="NUnit.UiException.Tests.CodeFormatters.TestPlainTextCodeFormatter.Format_Lines" executed="True" result="Success" success="True" time="0.001" asserts="1" />
+                              <test-case name="NUnit.UiException.Tests.CodeFormatters.TestPlainTextCodeFormatter.Test_Language" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                              <test-case name="NUnit.UiException.Tests.CodeFormatters.TestPlainTextCodeFormatter.Test_PreProcess" executed="True" result="Success" success="True" time="0.000" asserts="3" />
+                            </results>
+                          </test-suite>
+                          <test-suite type="TestFixture" name="TestToken" executed="True" result="Success" success="True" time="0.002" asserts="0">
+                            <results>
+                              <test-case name="NUnit.UiException.Tests.CodeFormatters.TestToken.Test_Equals" executed="True" result="Success" success="True" time="0.001" asserts="6" />
+                            </results>
+                          </test-suite>
+                          <test-suite type="TestFixture" name="TestTokenClassifier" executed="True" result="Success" success="True" time="0.042" asserts="0">
+                            <results>
+                              <test-case name="NUnit.UiException.Tests.CodeFormatters.TestTokenClassifier.test_AcceptToken" executed="True" result="Success" success="True" time="0.003" asserts="60" />
+                              <test-case name="NUnit.UiException.Tests.CodeFormatters.TestTokenClassifier.Test_Classification_Cases" executed="True" result="Success" success="True" time="0.003" asserts="32" />
+                              <test-case name="NUnit.UiException.Tests.CodeFormatters.TestTokenClassifier.Test_Classify" executed="True" result="Success" success="True" time="0.003" asserts="60" />
+                              <test-case name="NUnit.UiException.Tests.CodeFormatters.TestTokenClassifier.Test_Classify_As_Keyword" executed="True" result="Success" success="True" time="0.004" asserts="81" />
+                              <test-case name="NUnit.UiException.Tests.CodeFormatters.TestTokenClassifier.Test_Classify_Can_Throw_ArgumentNullException" executed="True" result="Success" success="True" time="0.001" asserts="0" />
+                              <test-case name="NUnit.UiException.Tests.CodeFormatters.TestTokenClassifier.Test_Classify_Throw_NullArgException" executed="True" result="Success" success="True" time="0.001" asserts="0" />
+                              <test-case name="NUnit.UiException.Tests.CodeFormatters.TestTokenClassifier.Test_Escaping_sequence" executed="True" result="Success" success="True" time="0.005" asserts="61" />
+                              <test-case name="NUnit.UiException.Tests.CodeFormatters.TestTokenClassifier.Test_NewState" executed="True" result="Success" success="True" time="0.005" asserts="40" />
+                              <test-case name="NUnit.UiException.Tests.CodeFormatters.TestTokenClassifier.Test_Reset" executed="True" result="Success" success="True" time="0.001" asserts="1" />
+                            </results>
+                          </test-suite>
+                          <test-suite type="TestFixture" name="TestTokenDictionary" executed="True" result="Success" success="True" time="0.038" asserts="0">
+                            <results>
+                              <test-case name="NUnit.UiException.Tests.CodeFormatters.TestTokenDictionary.Add_can_throw_AlreadyDefinedException" executed="True" result="Success" success="True" time="0.001" asserts="2" />
+                              <test-case name="NUnit.UiException.Tests.CodeFormatters.TestTokenDictionary.Add_can_throw_EmptySequenceException" executed="True" result="Success" success="True" time="0.000" asserts="2" />
+                              <test-case name="NUnit.UiException.Tests.CodeFormatters.TestTokenDictionary.Add_can_throw_InvalidSortException" executed="True" result="Success" success="True" time="0.001" asserts="2" />
+                              <test-case name="NUnit.UiException.Tests.CodeFormatters.TestTokenDictionary.Add_can_throw_NullValueException" executed="True" result="Success" success="True" time="0.000" asserts="2" />
+                              <test-case name="NUnit.UiException.Tests.CodeFormatters.TestTokenDictionary.add_token" executed="True" result="Success" success="True" time="0.001" asserts="3" />
+                              <test-case name="NUnit.UiException.Tests.CodeFormatters.TestTokenDictionary.PopulateTokenStartingWith" executed="True" result="Success" success="True" time="0.003" asserts="14" />
+                              <test-case name="NUnit.UiException.Tests.CodeFormatters.TestTokenDictionary.PopulateTokenStartingWith_can_throw_NullOutputException" executed="True" result="Success" success="True" time="0.001" asserts="2" />
+                              <test-case name="NUnit.UiException.Tests.CodeFormatters.TestTokenDictionary.PopulateTokenStartingWith_can_throw_NullStarterException" executed="True" result="Success" success="True" time="0.001" asserts="2" />
+                              <test-case name="NUnit.UiException.Tests.CodeFormatters.TestTokenDictionary.test_default" executed="True" result="Success" success="True" time="0.001" asserts="3" />
+                              <test-case name="NUnit.UiException.Tests.CodeFormatters.TestTokenDictionary.TryMatch_can_throw_NullPredictionException" executed="True" result="Success" success="True" time="0.001" asserts="2" />
+                              <test-case name="NUnit.UiException.Tests.CodeFormatters.TestTokenDictionary.TryMatch_can_throw_NullTextException" executed="True" result="Success" success="True" time="0.001" asserts="2" />
+                              <test-case name="NUnit.UiException.Tests.CodeFormatters.TestTokenDictionary.TryMatch_no_prediction" executed="True" result="Success" success="True" time="0.001" asserts="146" />
+                              <test-case name="NUnit.UiException.Tests.CodeFormatters.TestTokenDictionary.TryMatch_prediction" executed="True" result="Success" success="True" time="0.001" asserts="19" />
+                            </results>
+                          </test-suite>
+                        </results>
+                      </test-suite>
+                      <test-suite type="Namespace" name="Controls" executed="True" result="Success" success="True" time="1.095" asserts="0">
+                        <results>
+                          <test-suite type="TestFixture" name="TestCodeBox" executed="True" result="Success" success="True" time="0.419" asserts="0">
+                            <results>
+                              <test-case name="NUnit.UiException.Tests.Controls.TestCodeBox.Can_Disable_ShowCurrentLine" executed="True" result="Success" success="True" time="0.360" asserts="3" />
+                              <test-case name="NUnit.UiException.Tests.Controls.TestCodeBox.Can_Set_Back_And_Fore_Colors" executed="True" result="Success" success="True" time="0.006" asserts="2" />
+                              <test-case name="NUnit.UiException.Tests.Controls.TestCodeBox.Changing_Font_Causes_Reformatting" executed="True" result="Success" success="True" time="0.008" asserts="2" />
+                              <test-case name="NUnit.UiException.Tests.Controls.TestCodeBox.Changing_Language_Causes_Reformatting" executed="True" result="Success" success="True" time="0.005" asserts="3" />
+                              <test-case name="NUnit.UiException.Tests.Controls.TestCodeBox.CurrentLine" executed="True" result="Success" success="True" time="0.008" asserts="5" />
+                              <test-case name="NUnit.UiException.Tests.Controls.TestCodeBox.DefaultState" executed="True" result="Success" success="True" time="0.003" asserts="11" />
+                              <test-case name="NUnit.UiException.Tests.Controls.TestCodeBox.Format_Text_With_Language" executed="True" result="Success" success="True" time="0.003" asserts="3" />
+                              <test-case name="NUnit.UiException.Tests.Controls.TestCodeBox.OnPaint" executed="True" result="Success" success="True" time="0.003" asserts="1" />
+                            </results>
+                          </test-suite>
+                          <test-suite type="TestFixture" name="TestCodeRenderingContext" executed="True" result="Success" success="True" time="0.011" asserts="0">
+                            <results>
+                              <test-case name="NUnit.UiException.Tests.Controls.TestCodeRenderingContext.Can_Change_Colors" executed="True" result="Success" success="True" time="0.006" asserts="43" />
+                              <test-case name="NUnit.UiException.Tests.Controls.TestCodeRenderingContext.DefaultState" executed="True" result="Success" success="True" time="0.002" asserts="38" />
+                            </results>
+                          </test-suite>
+                          <test-suite type="TestFixture" name="TestDefaultCodeRenderer" executed="True" result="Success" success="True" time="0.024" asserts="0">
+                            <results>
+                              <test-case name="NUnit.UiException.Tests.Controls.TestDefaultCodeRenderer.DrawToGraphics_Can_Raise_ArgumentNullException" executed="True" result="Success" success="True" time="0.003" asserts="2" />
+                              <test-case name="NUnit.UiException.Tests.Controls.TestDefaultCodeRenderer.GetDocumentSize" executed="True" result="Success" success="True" time="0.002" asserts="4" />
+                              <test-case name="NUnit.UiException.Tests.Controls.TestDefaultCodeRenderer.GetDocumentSize_Can_Raise_ArgumentNullException" executed="True" result="Success" success="True" time="0.001" asserts="3" />
+                              <test-case name="NUnit.UiException.Tests.Controls.TestDefaultCodeRenderer.LineIndexToYCoordinate" executed="True" result="Success" success="True" time="0.001" asserts="4" />
+                              <test-case name="NUnit.UiException.Tests.Controls.TestDefaultCodeRenderer.LineIndexToYCoordinate_Can_Raise_ArgumentNullException" executed="True" result="Success" success="True" time="0.001" asserts="2" />
+                              <test-case name="NUnit.UiException.Tests.Controls.TestDefaultCodeRenderer.ViewportLines" executed="True" result="Success" success="True" time="0.006" asserts="32" />
+                            </results>
+                          </test-suite>
+                          <test-suite type="TestFixture" name="TestDefaultErrorListRenderer" executed="True" result="Success" success="True" time="0.082" asserts="0">
+                            <results>
+                              <test-case name="NUnit.UiException.Tests.Controls.TestDefaultErrorListRenderer.DefaultState" executed="True" result="Success" success="True" time="0.014" asserts="2" />
+                              <test-case name="NUnit.UiException.Tests.Controls.TestDefaultErrorListRenderer.DrawToGraphics_Can_Throw_ArgumentNullException" executed="True" result="Success" success="True" time="0.003" asserts="2" />
+                              <test-case name="NUnit.UiException.Tests.Controls.TestDefaultErrorListRenderer.GetDocumentSize" executed="True" result="Success" success="True" time="0.003" asserts="5" />
+                              <test-case name="NUnit.UiException.Tests.Controls.TestDefaultErrorListRenderer.IsDirty" executed="True" result="Success" success="True" time="0.045" asserts="7" />
+                              <test-case name="NUnit.UiException.Tests.Controls.TestDefaultErrorListRenderer.ItemAt" executed="True" result="Success" success="True" time="0.004" asserts="7" />
+                              <test-case name="NUnit.UiException.Tests.Controls.TestDefaultErrorListRenderer.MeasureItem" executed="True" result="Success" success="True" time="0.003" asserts="6" />
+                            </results>
+                          </test-suite>
+                          <test-suite type="TestFixture" name="TestErrorBrowser" executed="True" result="Success" success="True" time="0.183" asserts="0">
+                            <results>
+                              <test-case name="NUnit.UiException.Tests.Controls.TestErrorBrowser.Can_Raise_ErrorSourceChanged" executed="True" result="Success" success="True" time="0.124" asserts="3" />
+                              <test-case name="NUnit.UiException.Tests.Controls.TestErrorBrowser.Cannot_Register_Null_Display" executed="True" result="Success" success="True" time="0.002" asserts="0" />
+                              <test-case name="NUnit.UiException.Tests.Controls.TestErrorBrowser.DefaultState" executed="True" result="Success" success="True" time="0.002" asserts="10" />
+                              <test-case name="NUnit.UiException.Tests.Controls.TestErrorBrowser.ErrorDisplay_Plugins_life_cycle_events" executed="True" result="Success" success="True" time="0.041" asserts="13" />
+                              <test-case name="NUnit.UiException.Tests.Controls.TestErrorBrowser.LayoutPanel_Auto_Resizes_When_Parent_Sizes_Change" executed="True" result="Success" success="True" time="0.004" asserts="4" />
+                            </results>
+                          </test-suite>
+                          <test-suite type="TestFixture" name="TestErrorList" executed="True" result="Success" success="True" time="0.065" asserts="0">
+                            <results>
+                              <test-case name="NUnit.UiException.Tests.Controls.TestErrorList.AutoSelectFirstItem" executed="True" result="Success" success="True" time="0.010" asserts="4" />
+                              <test-case name="NUnit.UiException.Tests.Controls.TestErrorList.CanReportInvalidItems" executed="True" result="Success" success="True" time="0.002" asserts="3" />
+                              <test-case name="NUnit.UiException.Tests.Controls.TestErrorList.Click_Can_Select_Item" executed="True" result="Success" success="True" time="0.005" asserts="4" />
+                              <test-case name="NUnit.UiException.Tests.Controls.TestErrorList.CurrentSelection" executed="True" result="Success" success="True" time="0.002" asserts="10" />
+                              <test-case name="NUnit.UiException.Tests.Controls.TestErrorList.DefaultState" executed="True" result="Success" success="True" time="0.001" asserts="7" />
+                              <test-case name="NUnit.UiException.Tests.Controls.TestErrorList.DrawItem" executed="True" result="Success" success="True" time="0.015" asserts="9" />
+                              <test-case name="NUnit.UiException.Tests.Controls.TestErrorList.Invoking_DrawToGraphics" executed="True" result="Success" success="True" time="0.005" asserts="0" />
+                              <test-case name="NUnit.UiException.Tests.Controls.TestErrorList.ListOrderPolicy" executed="True" result="Success" success="True" time="0.005" asserts="22" />
+                              <test-case name="NUnit.UiException.Tests.Controls.TestErrorList.Populate_StackTraceSource" executed="True" result="Success" success="True" time="0.003" asserts="6" />
+                            </results>
+                          </test-suite>
+                          <test-suite type="TestFixture" name="TestErrorPanelLayout" executed="True" result="Success" success="True" time="0.009" asserts="0">
+                            <results>
+                              <test-case name="NUnit.UiException.Tests.Controls.TestErrorPanelLayout.Can_Layout_Child_Controls_When_Size_Changed" executed="True" result="Success" success="True" time="0.001" asserts="16" />
+                              <test-case name="NUnit.UiException.Tests.Controls.TestErrorPanelLayout.DefaultState" executed="True" result="Success" success="True" time="0.001" asserts="13" />
+                              <test-case name="NUnit.UiException.Tests.Controls.TestErrorPanelLayout.Setting_Content" executed="True" result="Success" success="True" time="0.001" asserts="21" />
+                              <test-case name="NUnit.UiException.Tests.Controls.TestErrorPanelLayout.Setting_Toolbar" executed="True" result="Success" success="True" time="0.001" asserts="14" />
+                            </results>
+                          </test-suite>
+                          <test-suite type="TestFixture" name="TestErrorToolbar" executed="True" result="Success" success="True" time="0.113" asserts="0">
+                            <results>
+                              <test-case name="NUnit.UiException.Tests.Controls.TestErrorToolbar.Cannot_Register_Null_Display" executed="True" result="Success" success="True" time="0.004" asserts="2" />
+                              <test-case name="NUnit.UiException.Tests.Controls.TestErrorToolbar.Cannot_Select_UnRegistered_Display" executed="True" result="Success" success="True" time="0.003" asserts="0" />
+                              <test-case name="NUnit.UiException.Tests.Controls.TestErrorToolbar.DefaultState" executed="True" result="Success" success="True" time="0.004" asserts="8" />
+                              <test-case name="NUnit.UiException.Tests.Controls.TestErrorToolbar.NewStripButton" executed="True" result="Success" success="True" time="0.005" asserts="1" />
+                              <test-case name="NUnit.UiException.Tests.Controls.TestErrorToolbar.PluginItem_Click_Raises_SelectedRenderedChanged" executed="True" result="Success" success="True" time="0.020" asserts="4" />
+                              <test-case name="NUnit.UiException.Tests.Controls.TestErrorToolbar.Registering_displays_adds_ToolStripItem" executed="True" result="Success" success="True" time="0.052" asserts="8" />
+                              <test-case name="NUnit.UiException.Tests.Controls.TestErrorToolbar.SelectedDisplay" executed="True" result="Success" success="True" time="0.004" asserts="9" />
+                              <test-case name="NUnit.UiException.Tests.Controls.TestErrorToolbar.Set_Or_Unset_Check_Flag_On_Selection" executed="True" result="Success" success="True" time="0.005" asserts="6" />
+                            </results>
+                          </test-suite>
+                          <test-suite type="TestFixture" name="TestSourceCodeDisplay" executed="True" result="Success" success="True" time="0.076" asserts="0">
+                            <results>
+                              <test-case name="NUnit.UiException.Tests.Controls.TestSourceCodeDisplay.CanReportFileException" executed="True" result="Success" success="True" time="0.024" asserts="2" />
+                              <test-case name="NUnit.UiException.Tests.Controls.TestSourceCodeDisplay.DefaultState" executed="True" result="Success" success="True" time="0.005" asserts="15" />
+                              <test-case name="NUnit.UiException.Tests.Controls.TestSourceCodeDisplay.ListOrderPolicy" executed="True" result="Success" success="True" time="0.010" asserts="2" />
+                              <test-case name="NUnit.UiException.Tests.Controls.TestSourceCodeDisplay.SelectedItemChanged" executed="True" result="Success" success="True" time="0.014" asserts="5" />
+                              <test-case name="NUnit.UiException.Tests.Controls.TestSourceCodeDisplay.SplitOrientation" executed="True" result="Success" success="True" time="0.004" asserts="4" />
+                              <test-case name="NUnit.UiException.Tests.Controls.TestSourceCodeDisplay.SplitterDistance" executed="True" result="Success" success="True" time="0.004" asserts="2" />
+                            </results>
+                          </test-suite>
+                          <test-suite type="TestFixture" name="TestSplitterBox" executed="True" result="Success" success="True" time="0.036" asserts="0">
+                            <results>
+                              <test-case name="NUnit.UiException.Tests.Controls.TestSplitterBox.CanChangeDefaultControl1" executed="True" result="Success" success="True" time="0.003" asserts="48" />
+                              <test-case name="NUnit.UiException.Tests.Controls.TestSplitterBox.CanChangeDefaultControl2" executed="True" result="Success" success="True" time="0.000" asserts="48" />
+                              <test-case name="NUnit.UiException.Tests.Controls.TestSplitterBox.ChangingSizeInvokeDoLayout" executed="True" result="Success" success="True" time="0.003" asserts="28" />
+                              <test-case name="NUnit.UiException.Tests.Controls.TestSplitterBox.CollapseControl" executed="True" result="Success" success="True" time="0.005" asserts="82" />
+                              <test-case name="NUnit.UiException.Tests.Controls.TestSplitterBox.DefaultState" executed="True" result="Success" success="True" time="0.001" asserts="51" />
+                              <test-case name="NUnit.UiException.Tests.Controls.TestSplitterBox.MouseActions" executed="True" result="Success" success="True" time="0.005" asserts="6" />
+                              <test-case name="NUnit.UiException.Tests.Controls.TestSplitterBox.OrientationAffectsLayout" executed="True" result="Success" success="True" time="0.000" asserts="25" />
+                              <test-case name="NUnit.UiException.Tests.Controls.TestSplitterBox.PointToSplit" executed="True" result="Success" success="True" time="0.000" asserts="75" />
+                              <test-case name="NUnit.UiException.Tests.Controls.TestSplitterBox.SplitterDistance" executed="True" result="Success" success="True" time="0.001" asserts="81" />
+                            </results>
+                          </test-suite>
+                          <test-suite type="TestFixture" name="TestStackTraceDisplay" executed="True" result="Success" success="True" time="0.056" asserts="0">
+                            <results>
+                              <test-case name="NUnit.UiException.Tests.Controls.TestStackTraceDisplay.CopyToClipBoard" executed="True" result="Success" success="True" time="0.046" asserts="4">
+                                <properties>
+                                  <property name="APARTMENT_STATE" value="STA" />
+                                </properties>
+                              </test-case>
+                              <test-case name="NUnit.UiException.Tests.Controls.TestStackTraceDisplay.DefaultState" executed="True" result="Success" success="True" time="0.001" asserts="10" />
+                              <test-case name="NUnit.UiException.Tests.Controls.TestStackTraceDisplay.FeedingDisplayWithGarbageDoesNotMakeItCrash" executed="True" result="Success" success="True" time="0.001" asserts="1" />
+                              <test-case name="NUnit.UiException.Tests.Controls.TestStackTraceDisplay.OnStackTraceChanged" executed="True" result="Success" success="True" time="0.000" asserts="3" />
+                            </results>
+                          </test-suite>
+                        </results>
+                      </test-suite>
+                      <test-suite type="Namespace" name="StackTraceAnalyzers" executed="True" result="Success" success="True" time="0.069" asserts="0">
+                        <results>
+                          <test-suite type="TestFixture" name="TestFunctionParser" executed="True" result="Success" success="True" time="0.014" asserts="0">
+                            <results>
+                              <test-case name="NUnit.UiException.Tests.StackTraceAnalyzers.TestFunctionParser.Test_Ability_To_Parse_Mono_Stack_Trace" executed="True" result="Success" success="True" time="0.001" asserts="2" />
+                              <test-case name="NUnit.UiException.Tests.StackTraceAnalyzers.TestFunctionParser.Test_Ability_To_Parse_Regular_Function_Values" executed="True" result="Success" success="True" time="0.000" asserts="7" />
+                              <test-case name="NUnit.UiException.Tests.StackTraceAnalyzers.TestFunctionParser.Test_Fail_To_Parse_Odd_Function_Values" executed="True" result="Success" success="True" time="0.000" asserts="5" />
+                              <test-case name="NUnit.UiException.Tests.StackTraceAnalyzers.TestFunctionParser.TestIErrorParser.Test_IErrorParser_Can_Throw_ArgsNullException" executed="True" result="Success" success="True" time="0.001" asserts="10" />
+                              <test-case name="NUnit.UiException.Tests.StackTraceAnalyzers.TestFunctionParser.TestIErrorParser.Test_IErrorParser_Can_Throw_ParserNullException" executed="True" result="Success" success="True" time="0.001" asserts="10" />
+                            </results>
+                          </test-suite>
+                          <test-suite type="TestFixture" name="TestIErrorParser" executed="True" result="Success" success="True" time="0.003" asserts="0">
+                            <results>
+                              <test-case name="NUnit.UiException.Tests.StackTraceAnalyzers.TestIErrorParser.Test_IErrorParser_Can_Throw_ArgsNullException" executed="True" result="Success" success="True" time="0.001" asserts="10" />
+                              <test-case name="NUnit.UiException.Tests.StackTraceAnalyzers.TestIErrorParser.Test_IErrorParser_Can_Throw_ParserNullException" executed="True" result="Success" success="True" time="0.000" asserts="10" />
+                            </results>
+                          </test-suite>
+                          <test-suite type="TestFixture" name="TestLineNumberParser" executed="True" result="Success" success="True" time="0.008" asserts="0">
+                            <results>
+                              <test-case name="NUnit.UiException.Tests.StackTraceAnalyzers.TestLineNumberParser.Test_Ability_To_Parse_Regular_Line_Number_Values" executed="True" result="Success" success="True" time="0.001" asserts="10" />
+                              <test-case name="NUnit.UiException.Tests.StackTraceAnalyzers.TestLineNumberParser.Test_Ability_To_Reject_Odd_Line_Number_Values" executed="True" result="Success" success="True" time="0.001" asserts="5" />
+                              <test-case name="NUnit.UiException.Tests.StackTraceAnalyzers.TestLineNumberParser.TestIErrorParser.Test_IErrorParser_Can_Throw_ArgsNullException" executed="True" result="Success" success="True" time="0.001" asserts="10" />
+                              <test-case name="NUnit.UiException.Tests.StackTraceAnalyzers.TestLineNumberParser.TestIErrorParser.Test_IErrorParser_Can_Throw_ParserNullException" executed="True" result="Success" success="True" time="0.001" asserts="10" />
+                            </results>
+                          </test-suite>
+                          <test-suite type="TestFixture" name="TestPathParser" executed="True" result="Success" success="True" time="0.008" asserts="0">
+                            <results>
+                              <test-case name="NUnit.UiException.Tests.StackTraceAnalyzers.TestPathParser.Test_Ability_To_Handle_Unix_Path_Like_Values" executed="True" result="Success" success="True" time="0.001" asserts="4" />
+                              <test-case name="NUnit.UiException.Tests.StackTraceAnalyzers.TestPathParser.Test_Ability_To_Handle_Windows_Path_Like_Values" executed="True" result="Success" success="True" time="0.000" asserts="4" />
+                              <test-case name="NUnit.UiException.Tests.StackTraceAnalyzers.TestPathParser.TestIErrorParser.Test_IErrorParser_Can_Throw_ArgsNullException" executed="True" result="Success" success="True" time="0.001" asserts="12" />
+                              <test-case name="NUnit.UiException.Tests.StackTraceAnalyzers.TestPathParser.TestIErrorParser.Test_IErrorParser_Can_Throw_ParserNullException" executed="True" result="Success" success="True" time="0.001" asserts="12" />
+                            </results>
+                          </test-suite>
+                          <test-suite type="TestFixture" name="TestUnixPathParser" executed="True" result="Success" success="True" time="0.009" asserts="0">
+                            <results>
+                              <test-case name="NUnit.UiException.Tests.StackTraceAnalyzers.TestUnixPathParser.Test_Ability_To_Parse_Regular_Unix_Like_Path_Values" executed="True" result="Success" success="True" time="0.001" asserts="21" />
+                              <test-case name="NUnit.UiException.Tests.StackTraceAnalyzers.TestUnixPathParser.Test_Inability_To_Parse_Non_Unix_Like_Path_Values" executed="True" result="Success" success="True" time="0.001" asserts="6" />
+                              <test-case name="NUnit.UiException.Tests.StackTraceAnalyzers.TestUnixPathParser.TestIErrorParser.Test_IErrorParser_Can_Throw_ArgsNullException" executed="True" result="Success" success="True" time="0.001" asserts="11" />
+                              <test-case name="NUnit.UiException.Tests.StackTraceAnalyzers.TestUnixPathParser.TestIErrorParser.Test_IErrorParser_Can_Throw_ParserNullException" executed="True" result="Success" success="True" time="0.000" asserts="11" />
+                            </results>
+                          </test-suite>
+                          <test-suite type="TestFixture" name="TestWindowsPathParser" executed="True" result="Success" success="True" time="0.009" asserts="0">
+                            <results>
+                              <test-case name="NUnit.UiException.Tests.StackTraceAnalyzers.TestWindowsPathParser.Test_Ability_To_Parse_Regular_Windows_Path" executed="True" result="Success" success="True" time="0.001" asserts="21" />
+                              <test-case name="NUnit.UiException.Tests.StackTraceAnalyzers.TestWindowsPathParser.Test_Inability_To_Parse_Non_Windows_Like_Path_Values" executed="True" result="Success" success="True" time="0.000" asserts="6" />
+                              <test-case name="NUnit.UiException.Tests.StackTraceAnalyzers.TestWindowsPathParser.TestIErrorParser.Test_IErrorParser_Can_Throw_ArgsNullException" executed="True" result="Success" success="True" time="0.000" asserts="11" />
+                              <test-case name="NUnit.UiException.Tests.StackTraceAnalyzers.TestWindowsPathParser.TestIErrorParser.Test_IErrorParser_Can_Throw_ParserNullException" executed="True" result="Success" success="True" time="0.001" asserts="11" />
+                            </results>
+                          </test-suite>
+                        </results>
+                      </test-suite>
+                      <test-suite type="TestFixture" name="TestDefaultTextManager" executed="True" result="Success" success="True" time="0.007" asserts="0">
+                        <results>
+                          <test-case name="NUnit.UiException.Tests.TestDefaultTextManager.Test_CodeBlockCollection" executed="True" result="Success" success="True" time="0.002" asserts="15" />
+                          <test-case name="NUnit.UiException.Tests.TestDefaultTextManager.Test_Default" executed="True" result="Success" success="True" time="0.000" asserts="3" />
+                          <test-case name="NUnit.UiException.Tests.TestDefaultTextManager.Test_MaxLength" executed="True" result="Success" success="True" time="0.000" asserts="3" />
+                        </results>
+                      </test-suite>
+                      <test-suite type="TestFixture" name="TestErrorItem" executed="True" result="Success" success="True" time="0.029" asserts="0">
+                        <results>
+                          <test-case name="NUnit.UiException.Tests.TestErrorItem.Can_Set_Properties" executed="True" result="Success" success="True" time="0.001" asserts="10" />
+                          <test-case name="NUnit.UiException.Tests.TestErrorItem.Ctor_2" executed="True" result="Success" success="True" time="0.001" asserts="10" />
+                          <test-case name="NUnit.UiException.Tests.TestErrorItem.Ctor_Throws_NullPathException" executed="True" result="Success" success="True" time="0.001" asserts="0" />
+                          <test-case name="NUnit.UiException.Tests.TestErrorItem.Ctor_With_Line_0" executed="True" result="Success" success="True" time="0.000" asserts="0" />
+                          <test-case name="NUnit.UiException.Tests.TestErrorItem.ReadFile" executed="True" result="Success" success="True" time="0.007" asserts="2" />
+                          <test-case name="NUnit.UiException.Tests.TestErrorItem.ReadFile_Throws_FileNotExistException" executed="True" result="Success" success="True" time="0.001" asserts="0" />
+                          <test-case name="NUnit.UiException.Tests.TestErrorItem.Test_Equals" executed="True" result="Success" success="True" time="0.001" asserts="8" />
+                          <test-case name="NUnit.UiException.Tests.TestErrorItem.Test_FileExtension" executed="True" result="Success" success="True" time="0.001" asserts="5" />
+                          <test-case name="NUnit.UiException.Tests.TestErrorItem.Test_MethodName" executed="True" result="Success" success="True" time="0.001" asserts="15" />
+                        </results>
+                      </test-suite>
+                      <test-suite type="TestFixture" name="TestErrorItemCollection" executed="True" result="Success" success="True" time="0.064" asserts="0">
+                        <results>
+                          <test-case name="NUnit.UiException.Tests.TestErrorItemCollection.Test_Add_Throws_NullItemException" executed="True" result="Success" success="True" time="0.015" asserts="0" />
+                          <test-case name="NUnit.UiException.Tests.TestErrorItemCollection.Test_Clear" executed="True" result="Success" success="True" time="0.013" asserts="2" />
+                          <test-case name="NUnit.UiException.Tests.TestErrorItemCollection.Test_Contains" executed="True" result="Success" success="True" time="0.014" asserts="3" />
+                          <test-case name="NUnit.UiException.Tests.TestErrorItemCollection.Test_TraceItems" executed="True" result="Success" success="True" time="0.015" asserts="7" />
+                        </results>
+                      </test-suite>
+                      <test-suite type="TestFixture" name="TestPaintLineLocation" executed="True" result="Success" success="True" time="0.008" asserts="0">
+                        <results>
+                          <test-case name="NUnit.UiException.Tests.TestPaintLineLocation.Test_Equals" executed="True" result="Success" success="True" time="0.002" asserts="8" />
+                          <test-case name="NUnit.UiException.Tests.TestPaintLineLocation.Test_PaintLineLocation" executed="True" result="Success" success="True" time="0.001" asserts="3" />
+                          <test-case name="NUnit.UiException.Tests.TestPaintLineLocation.Test_SetText_Throws_NullTextException" executed="True" result="Success" success="True" time="0.001" asserts="0" />
+                        </results>
+                      </test-suite>
+                      <test-suite type="TestFixture" name="TestStackTraceParser" executed="True" result="Success" success="True" time="0.024" asserts="0">
+                        <results>
+                          <test-case name="NUnit.UiException.Tests.TestStackTraceParser.Test_Ability_To_Handle_Different_Path_System_Syntaxes" executed="True" result="Success" success="True" time="0.000" asserts="3" />
+                          <test-case name="NUnit.UiException.Tests.TestStackTraceParser.Test_Ability_To_Handle_Files_With_Unknown_Extension" executed="True" result="Success" success="True" time="0.000" asserts="2" />
+                          <test-case name="NUnit.UiException.Tests.TestStackTraceParser.Test_Analysis_Does_Not_Depend_Upon_File_Extension" executed="True" result="Success" success="True" time="0.000" asserts="2" />
+                          <test-case name="NUnit.UiException.Tests.TestStackTraceParser.Test_Default" executed="True" result="Success" success="True" time="0.000" asserts="2" />
+                          <test-case name="NUnit.UiException.Tests.TestStackTraceParser.Test_English_Stack" executed="True" result="Success" success="True" time="0.000" asserts="2" />
+                          <test-case name="NUnit.UiException.Tests.TestStackTraceParser.Test_Missing_Line_Number" executed="True" result="Success" success="True" time="0.001" asserts="2" />
+                          <test-case name="NUnit.UiException.Tests.TestStackTraceParser.Test_Parse" executed="True" result="Success" success="True" time="0.000" asserts="3" />
+                          <test-case name="NUnit.UiException.Tests.TestStackTraceParser.Test_Parse_MultipleExtension" executed="True" result="Success" success="True" time="0.001" asserts="6" />
+                          <test-case name="NUnit.UiException.Tests.TestStackTraceParser.Test_Parse_Null" executed="True" result="Success" success="True" time="0.001" asserts="0" />
+                          <test-case name="NUnit.UiException.Tests.TestStackTraceParser.Test_Parse_With_Real_Life_Samples" executed="True" result="Success" success="True" time="0.001" asserts="5" />
+                          <test-case name="NUnit.UiException.Tests.TestStackTraceParser.Test_Trace_When_Missing_File" executed="True" result="Success" success="True" time="0.000" asserts="5" />
+                        </results>
+                      </test-suite>
+                    </results>
+                  </test-suite>
+                </results>
+              </test-suite>
+            </results>
+          </test-suite>
+        </results>
+      </test-suite>
+      <test-suite type="Assembly" name="C:\Program Files\NUnit 2.6.2\bin\tests/nunit.uikit.tests.dll" executed="True" result="Success" success="True" time="1.812" asserts="0">
+        <results>
+          <test-suite type="Namespace" name="NUnit" executed="True" result="Success" success="True" time="1.812" asserts="0">
+            <results>
+              <test-suite type="Namespace" name="UiKit" executed="True" result="Success" success="True" time="1.812" asserts="0">
+                <results>
+                  <test-suite type="Namespace" name="Tests" executed="True" result="Success" success="True" time="1.812" asserts="0">
+                    <results>
+                      <test-suite type="TestFixture" name="AddConfigurationDialogTests" executed="True" result="Success" success="True" time="0.352" asserts="0">
+                        <results>
+                          <test-case name="NUnit.UiKit.Tests.AddConfigurationDialogTests.CheckComboBox" executed="True" result="Success" success="True" time="0.251" asserts="5" />
+                          <test-case name="NUnit.UiKit.Tests.AddConfigurationDialogTests.CheckForControls" executed="True" result="Success" success="True" time="0.001" asserts="0" />
+                          <test-case name="NUnit.UiKit.Tests.AddConfigurationDialogTests.CheckTextBox" executed="True" result="Success" success="True" time="0.001" asserts="1" />
+                          <test-case name="NUnit.UiKit.Tests.AddConfigurationDialogTests.TestComplexEntry" executed="True" result="Success" success="True" time="0.073" asserts="2" />
+                          <test-case name="NUnit.UiKit.Tests.AddConfigurationDialogTests.TestSimpleEntry" executed="True" result="Success" success="True" time="0.015" asserts="2" />
+                        </results>
+                      </test-suite>
+                      <test-suite type="TestFixture" name="ErrorDisplayTests" executed="True" result="Success" success="True" time="0.030" asserts="0">
+                        <results>
+                          <test-case name="NUnit.UiKit.Tests.ErrorDisplayTests.ControlsArePositionedCorrectly" executed="True" result="Success" success="True" time="0.001" asserts="0" />
+                          <test-case name="NUnit.UiKit.Tests.ErrorDisplayTests.ControlsExist" executed="True" result="Success" success="True" time="0.000" asserts="0" />
+                        </results>
+                      </test-suite>
+                      <test-suite type="TestFixture" name="LongRunningOperationDisplayTests" executed="True" result="Success" success="True" time="0.016" asserts="0">
+                        <results>
+                          <test-case name="NUnit.UiKit.Tests.LongRunningOperationDisplayTests.CreateDisplay" executed="True" result="Success" success="True" time="0.016" asserts="2" />
+                        </results>
+                      </test-suite>
+                      <test-suite type="TestFixture" name="ProgressBarTests" executed="True" result="Success" success="True" time="0.042" asserts="0">
+                        <results>
+                          <test-case name="NUnit.UiKit.Tests.ProgressBarTests.TestProgressDisplay" executed="True" result="Success" success="True" time="0.041" asserts="5" />
+                        </results>
+                      </test-suite>
+                      <test-suite type="TestFixture" name="StatusBarTests" executed="True" result="Success" success="True" time="0.162" asserts="0">
+                        <results>
+                          <test-case name="NUnit.UiKit.Tests.StatusBarTests.TestConstruction" executed="True" result="Success" success="True" time="0.041" asserts="5" />
+                          <test-case name="NUnit.UiKit.Tests.StatusBarTests.TestFinalDisplay" executed="True" result="Success" success="True" time="0.043" asserts="5" />
+                          <test-case name="NUnit.UiKit.Tests.StatusBarTests.TestInitialization" executed="True" result="Success" success="True" time="0.030" asserts="10" />
+                          <test-case name="NUnit.UiKit.Tests.StatusBarTests.TestProgressDisplay" executed="True" result="Success" success="True" time="0.040" asserts="5" />
+                        </results>
+                      </test-suite>
+                      <test-suite type="TestFixture" name="TestSuiteTreeNodeTests" executed="True" result="Success" success="True" time="0.125" asserts="0">
+                        <results>
+                          <test-case name="NUnit.UiKit.Tests.TestSuiteTreeNodeTests.CanConstructFromTestCase" executed="True" result="Success" success="True" time="0.018" asserts="2" />
+                          <test-case name="NUnit.UiKit.Tests.TestSuiteTreeNodeTests.CanConstructFromTestFixture" executed="True" result="Success" success="True" time="0.005" asserts="2" />
+                          <test-case name="NUnit.UiKit.Tests.TestSuiteTreeNodeTests.CanConstructFromTestSuite" executed="True" result="Success" success="True" time="0.005" asserts="2" />
+                          <test-suite type="ParameterizedTest" name="WhenResultIsCleared_IndexReflectsRunState" executed="True" result="Success" success="True" time="0.017" asserts="0">
+                            <results>
+                              <test-case name="NUnit.UiKit.Tests.TestSuiteTreeNodeTests.WhenResultIsCleared_IndexReflectsRunState(&quot;MockTest4&quot;,3)" executed="True" result="Success" success="True" time="0.005" asserts="5" />
+                              <test-case name="NUnit.UiKit.Tests.TestSuiteTreeNodeTests.WhenResultIsCleared_IndexReflectsRunState(&quot;MockTest1&quot;,0)" executed="True" result="Success" success="True" time="0.004" asserts="5" />
+                              <test-case name="NUnit.UiKit.Tests.TestSuiteTreeNodeTests.WhenResultIsCleared_IndexReflectsRunState(&quot;NotRunnableTest&quot;,1)" executed="True" result="Success" success="True" time="0.003" asserts="5" />
+                            </results>
+                          </test-suite>
+                          <test-case name="NUnit.UiKit.Tests.TestSuiteTreeNodeTests.WhenResultIsCleared_NestedResultsAreAlsoCleared" executed="True" result="Success" success="True" time="0.008" asserts="8" />
+                          <test-suite type="ParameterizedTest" name="WhenResultIsNotSet_IndexReflectsRunState" executed="True" result="Success" success="True" time="0.015" asserts="0">
+                            <results>
+                              <test-case name="NUnit.UiKit.Tests.TestSuiteTreeNodeTests.WhenResultIsNotSet_IndexReflectsRunState(&quot;NotRunnableTest&quot;,1)" executed="True" result="Success" success="True" time="0.004" asserts="2" />
+                              <test-case name="NUnit.UiKit.Tests.TestSuiteTreeNodeTests.WhenResultIsNotSet_IndexReflectsRunState(&quot;MockTest1&quot;,0)" executed="True" result="Success" success="True" time="0.004" asserts="2" />
+                              <test-case name="NUnit.UiKit.Tests.TestSuiteTreeNodeTests.WhenResultIsNotSet_IndexReflectsRunState(&quot;MockTest4&quot;,3)" executed="True" result="Success" success="True" time="0.003" asserts="2" />
+                            </results>
+                          </test-suite>
+                          <test-suite type="ParameterizedTest" name="WhenResultIsSet_IndexReflectsResultState" executed="True" result="Success" success="True" time="0.045" asserts="0">
+                            <results>
+                              <test-case name="NUnit.UiKit.Tests.TestSuiteTreeNodeTests.WhenResultIsSet_IndexReflectsResultState(Success,2)" executed="True" result="Success" success="True" time="0.004" asserts="3" />
+                              <test-case name="NUnit.UiKit.Tests.TestSuiteTreeNodeTests.WhenResultIsSet_IndexReflectsResultState(Cancelled,1)" executed="True" result="Success" success="True" time="0.004" asserts="3" />
+                              <test-case name="NUnit.UiKit.Tests.TestSuiteTreeNodeTests.WhenResultIsSet_IndexReflectsResultState(Skipped,0)" executed="True" result="Success" success="True" time="0.004" asserts="3" />
+                              <test-case name="NUnit.UiKit.Tests.TestSuiteTreeNodeTests.WhenResultIsSet_IndexReflectsResultState(NotRunnable,1)" executed="True" result="Success" success="True" time="0.003" asserts="3" />
+                              <test-case name="NUnit.UiKit.Tests.TestSuiteTreeNodeTests.WhenResultIsSet_IndexReflectsResultState(Ignored,3)" executed="True" result="Success" success="True" time="0.006" asserts="3" />
+                              <test-case name="NUnit.UiKit.Tests.TestSuiteTreeNodeTests.WhenResultIsSet_IndexReflectsResultState(Inconclusive,4)" executed="True" result="Success" success="True" time="0.003" asserts="3" />
+                              <test-case name="NUnit.UiKit.Tests.TestSuiteTreeNodeTests.WhenResultIsSet_IndexReflectsResultState(Failure,1)" executed="True" result="Success" success="True" time="0.004" asserts="3" />
+                              <test-case name="NUnit.UiKit.Tests.TestSuiteTreeNodeTests.WhenResultIsSet_IndexReflectsResultState(Error,1)" executed="True" result="Success" success="True" time="0.004" asserts="3" />
+                            </results>
+                          </test-suite>
+                        </results>
+                      </test-suite>
+                      <test-suite type="TestFixture" name="TestSuiteTreeViewReloadTests" executed="True" result="Success" success="True" time="0.527" asserts="0">
+                        <results>
+                          <test-case name="NUnit.UiKit.Tests.TestSuiteTreeViewReloadTests.CanReloadAfterChangingOrder" executed="True" result="Success" success="True" time="0.094" asserts="178" />
+                          <test-case name="NUnit.UiKit.Tests.TestSuiteTreeViewReloadTests.CanReloadAfterDeletingBranch" executed="True" result="Success" success="True" time="0.039" asserts="137" />
+                          <test-case name="NUnit.UiKit.Tests.TestSuiteTreeViewReloadTests.CanReloadAfterDeletingOneTestCase" executed="True" result="Success" success="True" time="0.036" asserts="175" />
+                          <test-case name="NUnit.UiKit.Tests.TestSuiteTreeViewReloadTests.CanReloadAfterDeletingThreeTestCases" executed="True" result="Success" success="True" time="0.046" asserts="169" />
+                          <test-case name="NUnit.UiKit.Tests.TestSuiteTreeViewReloadTests.CanReloadAfterInsertingTestCase" executed="True" result="Success" success="True" time="0.037" asserts="181" />
+                          <test-case name="NUnit.UiKit.Tests.TestSuiteTreeViewReloadTests.CanReloadAfterInsertingTestFixture" executed="True" result="Success" success="True" time="0.040" asserts="182" />
+                          <test-case name="NUnit.UiKit.Tests.TestSuiteTreeViewReloadTests.CanReloadAfterMultipleChanges" executed="True" result="Success" success="True" time="0.038" asserts="179" />
+                          <test-case name="NUnit.UiKit.Tests.TestSuiteTreeViewReloadTests.CanReloadAfterTurningOffAutoNamespaces" executed="True" result="Success" success="True" time="0.066" asserts="159" />
+                          <test-case name="NUnit.UiKit.Tests.TestSuiteTreeViewReloadTests.CanReloadWithoutChange" executed="True" result="Success" success="True" time="0.039" asserts="177" />
+                          <test-case name="NUnit.UiKit.Tests.TestSuiteTreeViewReloadTests.ReloadTreeWithWrongTest" executed="True" result="Success" success="True" time="0.035" asserts="0" />
+                          <test-case name="NUnit.UiKit.Tests.TestSuiteTreeViewReloadTests.VerifyCheckTreeWorks" executed="True" result="Success" success="True" time="0.036" asserts="177" />
+                        </results>
+                      </test-suite>
+                      <test-suite type="TestFixture" name="TestSuiteTreeViewTests" executed="True" result="Success" success="True" time="0.199" asserts="0">
+                        <results>
+                          <test-case name="NUnit.UiKit.Tests.TestSuiteTreeViewTests.BuildFromResult" executed="True" result="Success" success="True" time="0.045" asserts="15" />
+                          <test-case name="NUnit.UiKit.Tests.TestSuiteTreeViewTests.BuildTreeView" executed="True" result="Success" success="True" time="0.034" asserts="5" />
+                          <test-case name="NUnit.UiKit.Tests.TestSuiteTreeViewTests.ClearTree" executed="True" result="Success" success="True" time="0.035" asserts="1" />
+                          <test-case name="NUnit.UiKit.Tests.TestSuiteTreeViewTests.ProcessChecks" executed="True" result="Success" success="True" time="0.039" asserts="7" />
+                          <test-case name="NUnit.UiKit.Tests.TestSuiteTreeViewTests.SetTestResult" executed="True" result="Success" success="True" time="0.035" asserts="3" />
+                        </results>
+                      </test-suite>
+                      <test-suite type="TestFixture" name="TestTreeTests" executed="True" result="Success" success="True" time="0.033" asserts="0">
+                        <results>
+                          <test-case name="NUnit.UiKit.Tests.TestTreeTests.SameCategoryShouldNotBeSelectedMoreThanOnce" executed="True" result="Success" success="True" time="0.032" asserts="4" />
+                        </results>
+                      </test-suite>
+                      <test-suite type="TestFixture" name="VisualStateTests" executed="True" result="Success" success="True" time="0.302" asserts="0">
+                        <results>
+                          <test-case name="NUnit.UiKit.Tests.VisualStateTests.SaveAndRestoreVisualState" executed="True" result="Success" success="True" time="0.301" asserts="5" />
+                        </results>
+                      </test-suite>
+                    </results>
+                  </test-suite>
+                </results>
+              </test-suite>
+            </results>
+          </test-suite>
+        </results>
+      </test-suite>
+      <test-suite type="Assembly" name="C:\Program Files\NUnit 2.6.2\bin\tests/nunit-gui.tests.dll" executed="True" result="Success" success="True" time="0.099" asserts="0">
+        <results>
+          <test-suite type="Namespace" name="NUnit" executed="True" result="Success" success="True" time="0.098" asserts="0">
+            <results>
+              <test-suite type="Namespace" name="Gui" executed="True" result="Success" success="True" time="0.098" asserts="0">
+                <results>
+                  <test-suite type="Namespace" name="Tests" executed="True" result="Success" success="True" time="0.098" asserts="0">
+                    <results>
+                      <test-suite type="TestFixture" name="CommandLineTests" executed="True" result="Success" success="True" time="0.039" asserts="0">
+                        <results>
+                          <test-case name="NUnit.Gui.Tests.CommandLineTests.AssemblyName" executed="True" result="Success" success="True" time="0.019" asserts="1" />
+                          <test-case name="NUnit.Gui.Tests.CommandLineTests.Help" executed="True" result="Success" success="True" time="0.001" asserts="1" />
+                          <test-case name="NUnit.Gui.Tests.CommandLineTests.HelpTextUsesCorrectDelimiterForPlatform" executed="True" result="Success" success="True" time="0.001" asserts="1" />
+                          <test-case name="NUnit.Gui.Tests.CommandLineTests.InvalidArgs" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Gui.Tests.CommandLineTests.InvalidCommandLineParms" executed="True" result="Success" success="True" time="0.001" asserts="1" />
+                          <test-case name="NUnit.Gui.Tests.CommandLineTests.NoNameValuePairs" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Gui.Tests.CommandLineTests.NoParametersCount" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Gui.Tests.CommandLineTests.ShortHelp" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Gui.Tests.CommandLineTests.ValidateSuccessful" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                        </results>
+                      </test-suite>
+                      <test-suite type="TestFixture" name="ExceptionDetailsFormTests" executed="True" result="Success" success="True" time="0.043" asserts="0">
+                        <results>
+                          <test-case name="NUnit.Gui.Tests.ExceptionDetailsFormTests.ControlsArePositionedCorrectly" executed="True" result="Success" success="True" time="0.000" asserts="0" />
+                          <test-case name="NUnit.Gui.Tests.ExceptionDetailsFormTests.ControlsExist" executed="True" result="Success" success="True" time="0.001" asserts="0" />
+                          <test-case name="NUnit.Gui.Tests.ExceptionDetailsFormTests.MessageDisplaysCorrectly" executed="True" result="Success" success="True" time="0.022" asserts="1" />
+                        </results>
+                      </test-suite>
+                      <test-suite type="TestFixture" name="RecentFileMenuHandlerTests" executed="True" result="Success" success="True" time="0.011" asserts="0">
+                        <results>
+                          <test-case name="NUnit.Gui.Tests.RecentFileMenuHandlerTests.DisableOnLoadWhenEmpty" executed="True" result="Success" success="True" time="0.002" asserts="1" />
+                          <test-case name="NUnit.Gui.Tests.RecentFileMenuHandlerTests.EnableOnLoadWhenNotEmpty" executed="True" result="Success" success="True" time="0.001" asserts="1" />
+                          <test-case name="NUnit.Gui.Tests.RecentFileMenuHandlerTests.LoadMenuItems" executed="True" result="Success" success="True" time="0.000" asserts="2" />
+                        </results>
+                      </test-suite>
+                    </results>
+                  </test-suite>
+                </results>
+              </test-suite>
+            </results>
+          </test-suite>
+        </results>
+      </test-suite>
+      <test-suite type="Assembly" name="C:\Program Files\NUnit 2.6.2\bin\tests/nunit-editor.tests.dll" executed="True" result="Success" success="True" time="1.444" asserts="0">
+        <results>
+          <test-suite type="Namespace" name="NUnit" executed="True" result="Success" success="True" time="1.444" asserts="0">
+            <results>
+              <test-suite type="Namespace" name="ProjectEditor" executed="True" result="Success" success="True" time="1.443" asserts="0">
+                <results>
+                  <test-suite type="Namespace" name="Tests" executed="True" result="Success" success="True" time="1.443" asserts="0">
+                    <results>
+                      <test-suite type="Namespace" name="Model" executed="True" result="Success" success="True" time="0.195" asserts="0">
+                        <results>
+                          <test-suite type="TestFixture" name="AssemblyListTests" executed="True" result="Success" success="True" time="0.023" asserts="0">
+                            <results>
+                              <test-case name="NUnit.ProjectEditor.Tests.Model.AssemblyListTests.CanAddAssemblies" executed="True" result="Success" success="True" time="0.007" asserts="3" />
+                              <test-case name="NUnit.ProjectEditor.Tests.Model.AssemblyListTests.CanInsertAssemblies" executed="True" result="Success" success="True" time="0.002" asserts="4" />
+                              <test-case name="NUnit.ProjectEditor.Tests.Model.AssemblyListTests.CanInsertAssemblyAtEnd" executed="True" result="Success" success="True" time="0.001" asserts="4" />
+                              <test-case name="NUnit.ProjectEditor.Tests.Model.AssemblyListTests.CanInsertAssemblyAtStart" executed="True" result="Success" success="True" time="0.000" asserts="4" />
+                              <test-case name="NUnit.ProjectEditor.Tests.Model.AssemblyListTests.CanRemoveAssemblies" executed="True" result="Success" success="True" time="0.002" asserts="3" />
+                              <test-case name="NUnit.ProjectEditor.Tests.Model.AssemblyListTests.EmptyList" executed="True" result="Success" success="True" time="0.001" asserts="1" />
+                            </results>
+                          </test-suite>
+                          <test-suite type="TestFixture" name="NUnitProjectSave" executed="True" result="Success" success="True" time="0.040" asserts="0">
+                            <results>
+                              <test-case name="NUnit.ProjectEditor.Tests.Model.NUnitProjectSave.EmptyConfigs" executed="True" result="Success" success="True" time="0.011" asserts="1" />
+                              <test-case name="NUnit.ProjectEditor.Tests.Model.NUnitProjectSave.EmptyProject" executed="True" result="Success" success="True" time="0.002" asserts="1" />
+                              <test-case name="NUnit.ProjectEditor.Tests.Model.NUnitProjectSave.NormalProject" executed="True" result="Success" success="True" time="0.003" asserts="1" />
+                              <test-case name="NUnit.ProjectEditor.Tests.Model.NUnitProjectSave.NormalProject_RoundTrip" executed="True" result="Success" success="True" time="0.002" asserts="1" />
+                              <test-case name="NUnit.ProjectEditor.Tests.Model.NUnitProjectSave.ProjectWithComplexSettings" executed="True" result="Success" success="True" time="0.004" asserts="1" />
+                              <test-case name="NUnit.ProjectEditor.Tests.Model.NUnitProjectSave.ProjectWithComplexSettings_RoundTrip" executed="True" result="Success" success="True" time="0.002" asserts="1" />
+                              <test-case name="NUnit.ProjectEditor.Tests.Model.NUnitProjectSave.ProjectWithComplexSettings_RoundTripWithChanges" executed="True" result="Success" success="True" time="0.003" asserts="1" />
+                            </results>
+                          </test-suite>
+                          <test-suite type="TestFixture" name="ProjectCreationTests" executed="True" result="Success" success="True" time="0.053" asserts="0">
+                            <results>
+                              <test-case name="NUnit.ProjectEditor.Tests.Model.ProjectCreationTests.AddConfigFiresChangedEvent" executed="True" result="Success" success="True" time="0.002" asserts="1" />
+                              <test-case name="NUnit.ProjectEditor.Tests.Model.ProjectCreationTests.AddConfigMakesProjectDirty" executed="True" result="Success" success="True" time="0.001" asserts="1" />
+                              <test-case name="NUnit.ProjectEditor.Tests.Model.ProjectCreationTests.CanAddConfigs" executed="True" result="Success" success="True" time="0.001" asserts="1" />
+                              <test-case name="NUnit.ProjectEditor.Tests.Model.ProjectCreationTests.CanSetAppBase" executed="True" result="Success" success="True" time="0.002" asserts="1" />
+                              <test-case name="NUnit.ProjectEditor.Tests.Model.ProjectCreationTests.DefaultProjectName" executed="True" result="Success" success="True" time="0.002" asserts="1" />
+                              <test-case name="NUnit.ProjectEditor.Tests.Model.ProjectCreationTests.IsNotDirty" executed="True" result="Success" success="True" time="0.001" asserts="1" />
+                              <test-case name="NUnit.ProjectEditor.Tests.Model.ProjectCreationTests.LoadMakesProjectNotDirty" executed="True" result="Success" success="True" time="0.002" asserts="1" />
+                              <test-case name="NUnit.ProjectEditor.Tests.Model.ProjectCreationTests.NameIsUnique" executed="True" result="Success" success="True" time="0.001" asserts="1" />
+                              <test-case name="NUnit.ProjectEditor.Tests.Model.ProjectCreationTests.NewProjectHasNoConfigs" executed="True" result="Success" success="True" time="0.002" asserts="2" />
+                              <test-case name="NUnit.ProjectEditor.Tests.Model.ProjectCreationTests.ProjectNodeHasNoAttributes" executed="True" result="Success" success="True" time="0.001" asserts="1" />
+                              <test-case name="NUnit.ProjectEditor.Tests.Model.ProjectCreationTests.ProjectNodeHasNoChildren" executed="True" result="Success" success="True" time="0.001" asserts="1" />
+                              <test-case name="NUnit.ProjectEditor.Tests.Model.ProjectCreationTests.ProjectPathIsSameAsName" executed="True" result="Success" success="True" time="0.001" asserts="1" />
+                              <test-case name="NUnit.ProjectEditor.Tests.Model.ProjectCreationTests.RootElementIsNUnitProject" executed="True" result="Success" success="True" time="0.001" asserts="1" />
+                              <test-case name="NUnit.ProjectEditor.Tests.Model.ProjectCreationTests.SaveMakesProjectNotDirty" executed="True" result="Success" success="True" time="0.002" asserts="1" />
+                              <test-case name="NUnit.ProjectEditor.Tests.Model.ProjectCreationTests.SaveSetsProjectPathAndName" executed="True" result="Success" success="True" time="0.003" asserts="2" />
+                            </results>
+                          </test-suite>
+                          <test-suite type="TestFixture" name="ProjectDocumentTests" executed="True" result="Success" success="True" time="0.009" asserts="0">
+                            <results>
+                              <test-case name="NUnit.ProjectEditor.Tests.Model.ProjectDocumentTests.AddingAttributeFiresChangedEvent" executed="True" result="Success" success="True" time="0.001" asserts="1" />
+                              <test-case name="NUnit.ProjectEditor.Tests.Model.ProjectDocumentTests.AddingAttributeMakesProjectDirty" executed="True" result="Success" success="True" time="0.001" asserts="1" />
+                              <test-case name="NUnit.ProjectEditor.Tests.Model.ProjectDocumentTests.AddingElementFiresChangedEvent" executed="True" result="Success" success="True" time="0.001" asserts="1" />
+                              <test-case name="NUnit.ProjectEditor.Tests.Model.ProjectDocumentTests.AddingElementMakesProjectDirty" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                            </results>
+                          </test-suite>
+                          <test-suite type="TestFixture" name="ProjectModelChangeTests" executed="True" result="Success" success="True" time="0.033" asserts="0">
+                            <results>
+                              <test-case name="NUnit.ProjectEditor.Tests.Model.ProjectModelChangeTests.AddingAssemblyFiresChangedEvent" executed="True" result="Success" success="True" time="0.001" asserts="1" />
+                              <test-case name="NUnit.ProjectEditor.Tests.Model.ProjectModelChangeTests.CanAddAssemblies" executed="True" result="Success" success="True" time="0.001" asserts="3" />
+                              <test-case name="NUnit.ProjectEditor.Tests.Model.ProjectModelChangeTests.CanSetActiveConfig" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                              <test-case name="NUnit.ProjectEditor.Tests.Model.ProjectModelChangeTests.RemoveAssemblyFiresChangedEvent" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                              <test-case name="NUnit.ProjectEditor.Tests.Model.ProjectModelChangeTests.RemoveConfigFiresChangedEvent" executed="True" result="Success" success="True" time="0.003" asserts="1" />
+                              <test-case name="NUnit.ProjectEditor.Tests.Model.ProjectModelChangeTests.RemoveConfigMakesProjectDirty" executed="True" result="Success" success="True" time="0.001" asserts="1" />
+                              <test-case name="NUnit.ProjectEditor.Tests.Model.ProjectModelChangeTests.RemovingActiveConfigRemovesActiveConfigNameAttribute" executed="True" result="Success" success="True" time="0.001" asserts="1" />
+                              <test-case name="NUnit.ProjectEditor.Tests.Model.ProjectModelChangeTests.RenameConfigFiresChangedEvent" executed="True" result="Success" success="True" time="0.001" asserts="1" />
+                              <test-case name="NUnit.ProjectEditor.Tests.Model.ProjectModelChangeTests.RenameConfigMakesProjectDirty" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                              <test-case name="NUnit.ProjectEditor.Tests.Model.ProjectModelChangeTests.RenamingActiveConfigChangesActiveConfigName" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                              <test-case name="NUnit.ProjectEditor.Tests.Model.ProjectModelChangeTests.SettingActiveConfigFiresChangedEvent" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                              <test-case name="NUnit.ProjectEditor.Tests.Model.ProjectModelChangeTests.SettingActiveConfigMakesProjectDirty" executed="True" result="Success" success="True" time="0.001" asserts="1" />
+                            </results>
+                          </test-suite>
+                          <test-suite type="TestFixture" name="ProjectModelLoadtests" executed="True" result="Success" success="True" time="0.025" asserts="0">
+                            <results>
+                              <test-case name="NUnit.ProjectEditor.Tests.Model.ProjectModelLoadtests.CanSaveAndReloadProject" executed="True" result="Success" success="True" time="0.003" asserts="8" />
+                              <test-case name="NUnit.ProjectEditor.Tests.Model.ProjectModelLoadtests.LoadEmptyConfigs" executed="True" result="Success" success="True" time="0.003" asserts="10" />
+                              <test-case name="NUnit.ProjectEditor.Tests.Model.ProjectModelLoadtests.LoadEmptyProject" executed="True" result="Success" success="True" time="0.002" asserts="8" />
+                              <test-case name="NUnit.ProjectEditor.Tests.Model.ProjectModelLoadtests.LoadNormalProject" executed="True" result="Success" success="True" time="0.002" asserts="14" />
+                              <test-case name="NUnit.ProjectEditor.Tests.Model.ProjectModelLoadtests.LoadProjectWithComplexSettings" executed="True" result="Success" success="True" time="0.003" asserts="16" />
+                              <test-case name="NUnit.ProjectEditor.Tests.Model.ProjectModelLoadtests.LoadProjectWithManualBinPath" executed="True" result="Success" success="True" time="0.002" asserts="8" />
+                            </results>
+                          </test-suite>
+                        </results>
+                      </test-suite>
+                      <test-suite type="Namespace" name="Presenters" executed="True" result="Success" success="True" time="1.016" asserts="0">
+                        <results>
+                          <test-suite type="TestFixture" name="AddConfigurationPresenterTests" executed="True" result="Success" success="True" time="0.066" asserts="0">
+                            <results>
+                              <test-case name="NUnit.ProjectEditor.Tests.Presenters.AddConfigurationPresenterTests.AddButton_AddExistingConfig_FailsWithErrorMessage" executed="True" result="Success" success="True" time="0.045" asserts="1" />
+                              <test-case name="NUnit.ProjectEditor.Tests.Presenters.AddConfigurationPresenterTests.AddButton_AddNewConfig_IsAddedToList" executed="True" result="Success" success="True" time="0.003" asserts="1" />
+                              <test-case name="NUnit.ProjectEditor.Tests.Presenters.AddConfigurationPresenterTests.ConfigList_LoadFromModel_SetsViewCorrectly" executed="True" result="Success" success="True" time="0.001" asserts="1" />
+                              <test-case name="NUnit.ProjectEditor.Tests.Presenters.AddConfigurationPresenterTests.ConfigToCopy_WhenNotSpecified_ConfigIsEmpty" executed="True" result="Success" success="True" time="0.002" asserts="3" />
+                              <test-case name="NUnit.ProjectEditor.Tests.Presenters.AddConfigurationPresenterTests.ConfigToCopy_WhenSpecified_ConfigIsCopied" executed="True" result="Success" success="True" time="0.005" asserts="3" />
+                            </results>
+                          </test-suite>
+                          <test-suite type="TestFixture" name="ConfigurationEditorTests" executed="True" result="Success" success="True" time="0.137" asserts="0">
+                            <results>
+                              <test-case name="NUnit.ProjectEditor.Tests.Presenters.ConfigurationEditorTests.ActiveButton_OnLoad_IsDisabled" executed="True" result="Success" success="True" time="0.024" asserts="1" />
+                              <test-case name="NUnit.ProjectEditor.Tests.Presenters.ConfigurationEditorTests.ActiveButton_OnLoad_IsSubscribed" executed="True" result="Success" success="True" time="0.004" asserts="0" />
+                              <test-case name="NUnit.ProjectEditor.Tests.Presenters.ConfigurationEditorTests.ActiveButton_WhenClicked_MakesConfigActive" executed="True" result="Success" success="True" time="0.007" asserts="1" />
+                              <test-case name="NUnit.ProjectEditor.Tests.Presenters.ConfigurationEditorTests.AddButton_OnLoad_IsEnabled" executed="True" result="Success" success="True" time="0.004" asserts="1" />
+                              <test-case name="NUnit.ProjectEditor.Tests.Presenters.ConfigurationEditorTests.AddButton_OnLoad_IsSubscribed" executed="True" result="Success" success="True" time="0.003" asserts="0" />
+                              <test-case name="NUnit.ProjectEditor.Tests.Presenters.ConfigurationEditorTests.AddButton_WhenClicked_AddsNewConfig" executed="True" result="Success" success="True" time="0.011" asserts="2" />
+                              <test-case name="NUnit.ProjectEditor.Tests.Presenters.ConfigurationEditorTests.ConfigList_OnLoad_IsCorrectlyInitialized" executed="True" result="Success" success="True" time="0.004" asserts="1" />
+                              <test-case name="NUnit.ProjectEditor.Tests.Presenters.ConfigurationEditorTests.ConfigList_OnLoad_SelectionChangedIsSubscribed" executed="True" result="Success" success="True" time="0.004" asserts="0" />
+                              <test-case name="NUnit.ProjectEditor.Tests.Presenters.ConfigurationEditorTests.RemoveButton_OnLoad_IsEnabled" executed="True" result="Success" success="True" time="0.003" asserts="1" />
+                              <test-case name="NUnit.ProjectEditor.Tests.Presenters.ConfigurationEditorTests.RemoveButton_OnLoad_IsSubscribed" executed="True" result="Success" success="True" time="0.004" asserts="0" />
+                              <test-case name="NUnit.ProjectEditor.Tests.Presenters.ConfigurationEditorTests.RemoveButton_WhenClicked_RemovesConfig" executed="True" result="Success" success="True" time="0.005" asserts="2" />
+                              <test-case name="NUnit.ProjectEditor.Tests.Presenters.ConfigurationEditorTests.RenameButton_OnLoad_IsEnabled" executed="True" result="Success" success="True" time="0.003" asserts="1" />
+                              <test-case name="NUnit.ProjectEditor.Tests.Presenters.ConfigurationEditorTests.RenameButton_OnLoad_IsSubscribed" executed="True" result="Success" success="True" time="0.003" asserts="0" />
+                              <test-case name="NUnit.ProjectEditor.Tests.Presenters.ConfigurationEditorTests.RenameButton_WhenClicked_PerformsRename" executed="True" result="Success" success="True" time="0.023" asserts="1" />
+                            </results>
+                          </test-suite>
+                          <test-suite type="TestFixture" name="MainPresenterTests" executed="True" result="Success" success="True" time="0.340" asserts="0">
+                            <results>
+                              <test-case name="NUnit.ProjectEditor.Tests.Presenters.MainPresenterTests.ActiveViewChanged_WhenNoProjectIsOpen_TabViewsRemainHidden" executed="True" result="Success" success="True" time="0.085" asserts="4" />
+                              <test-case name="NUnit.ProjectEditor.Tests.Presenters.MainPresenterTests.ActiveViewChanged_WhenProjectIsOpen_TabViewsAreVisible" executed="True" result="Success" success="True" time="0.014" asserts="2" />
+                              <test-case name="NUnit.ProjectEditor.Tests.Presenters.MainPresenterTests.CloseProject_AfterCreatingNewProject_IsEnabled" executed="True" result="Success" success="True" time="0.011" asserts="1" />
+                              <test-case name="NUnit.ProjectEditor.Tests.Presenters.MainPresenterTests.CloseProject_AfterOpeningGoodProject_IsEnabled" executed="True" result="Success" success="True" time="0.024" asserts="1" />
+                              <test-case name="NUnit.ProjectEditor.Tests.Presenters.MainPresenterTests.CloseProject_OnLoad_IsDisabled" executed="True" result="Success" success="True" time="0.008" asserts="1" />
+                              <test-case name="NUnit.ProjectEditor.Tests.Presenters.MainPresenterTests.NewProject_OnLoad_IsEnabled" executed="True" result="Success" success="True" time="0.008" asserts="1" />
+                              <test-case name="NUnit.ProjectEditor.Tests.Presenters.MainPresenterTests.NewProject_WhenClicked_CreatesNewProject" executed="True" result="Success" success="True" time="0.010" asserts="2" />
+                              <test-case name="NUnit.ProjectEditor.Tests.Presenters.MainPresenterTests.OpenProject_OnLoad_IsEnabled" executed="True" result="Success" success="True" time="0.008" asserts="1" />
+                              <test-case name="NUnit.ProjectEditor.Tests.Presenters.MainPresenterTests.OpenProject_WhenClickedAndProjectDoesNotExist_DisplaysError" executed="True" result="Success" success="True" time="0.019" asserts="2" />
+                              <test-case name="NUnit.ProjectEditor.Tests.Presenters.MainPresenterTests.OpenProject_WhenClickedAndProjectIsValid_OpensProject" executed="True" result="Success" success="True" time="0.018" asserts="3" />
+                              <test-case name="NUnit.ProjectEditor.Tests.Presenters.MainPresenterTests.OpenProject_WhenClickedAndProjectXmlIsNotValid_OpensProject" executed="True" result="Success" success="True" time="0.019" asserts="4" />
+                              <test-case name="NUnit.ProjectEditor.Tests.Presenters.MainPresenterTests.SaveProject_AfterCreatingNewProject_IsEnabled" executed="True" result="Success" success="True" time="0.012" asserts="1" />
+                              <test-case name="NUnit.ProjectEditor.Tests.Presenters.MainPresenterTests.SaveProject_AfterOpeningGoodProject_IsEnabled" executed="True" result="Success" success="True" time="0.020" asserts="1" />
+                              <test-case name="NUnit.ProjectEditor.Tests.Presenters.MainPresenterTests.SaveProject_OnLoad_IsDisabled" executed="True" result="Success" success="True" time="0.009" asserts="1" />
+                              <test-case name="NUnit.ProjectEditor.Tests.Presenters.MainPresenterTests.SaveProjectAs_AfterCreatingNewProject_IsEnabled" executed="True" result="Success" success="True" time="0.013" asserts="1" />
+                              <test-case name="NUnit.ProjectEditor.Tests.Presenters.MainPresenterTests.SaveProjectAs_AfterOpeningGoodProject_IsEnabled" executed="True" result="Success" success="True" time="0.019" asserts="1" />
+                              <test-case name="NUnit.ProjectEditor.Tests.Presenters.MainPresenterTests.SaveProjectAs_OnLoad_IsDisabled" executed="True" result="Success" success="True" time="0.008" asserts="1" />
+                            </results>
+                          </test-suite>
+                          <test-suite type="TestFixture" name="PropertyPresenterTests" executed="True" result="Success" success="True" time="0.416" asserts="0">
+                            <results>
+                              <test-case name="NUnit.ProjectEditor.Tests.Presenters.PropertyPresenterTests.ActiveConfigName_LoadFromModel_SetsViewCorrectly" executed="True" result="Success" success="True" time="0.023" asserts="1" />
+                              <test-case name="NUnit.ProjectEditor.Tests.Presenters.PropertyPresenterTests.ApplicationBase_LoadFromModel_SetsViewCorrectly" executed="True" result="Success" success="True" time="0.010" asserts="1" />
+                              <test-case name="NUnit.ProjectEditor.Tests.Presenters.PropertyPresenterTests.AssemblyList_LoadFromModel_SetsListCorrectly" executed="True" result="Success" success="True" time="0.011" asserts="1" />
+                              <test-case name="NUnit.ProjectEditor.Tests.Presenters.PropertyPresenterTests.AssemblyList_WhenEmpty_AddIsEnabled" executed="True" result="Success" success="True" time="0.012" asserts="1" />
+                              <test-case name="NUnit.ProjectEditor.Tests.Presenters.PropertyPresenterTests.AssemblyList_WhenEmpty_AssemblyPathBrowseIsDisabled" executed="True" result="Success" success="True" time="0.013" asserts="1" />
+                              <test-case name="NUnit.ProjectEditor.Tests.Presenters.PropertyPresenterTests.AssemblyList_WhenEmpty_RemoveIsDisabled" executed="True" result="Success" success="True" time="0.011" asserts="1" />
+                              <test-case name="NUnit.ProjectEditor.Tests.Presenters.PropertyPresenterTests.AssemblyPath_LoadFromModel_SetsViewCorrectly" executed="True" result="Success" success="True" time="0.012" asserts="1" />
+                              <test-case name="NUnit.ProjectEditor.Tests.Presenters.PropertyPresenterTests.BinPathType_LoadFromModel_SetsViewCorrectly" executed="True" result="Success" success="True" time="0.010" asserts="1" />
+                              <test-case name="NUnit.ProjectEditor.Tests.Presenters.PropertyPresenterTests.ConfigList_LoadFromModel_SelectsFirstConfig" executed="True" result="Success" success="True" time="0.012" asserts="2" />
+                              <test-case name="NUnit.ProjectEditor.Tests.Presenters.PropertyPresenterTests.ConfigList_LoadFromModel_SetsListCorrectly" executed="True" result="Success" success="True" time="0.009" asserts="1" />
+                              <test-case name="NUnit.ProjectEditor.Tests.Presenters.PropertyPresenterTests.ConfigurationFile_LoadFromModel_SetsViewCorrectly" executed="True" result="Success" success="True" time="0.010" asserts="1" />
+                              <test-case name="NUnit.ProjectEditor.Tests.Presenters.PropertyPresenterTests.DomainUsage_LoadFromModel_SelectsDefaultEntry" executed="True" result="Success" success="True" time="0.013" asserts="1" />
+                              <test-case name="NUnit.ProjectEditor.Tests.Presenters.PropertyPresenterTests.DomainUsage_LoadFromModel_SetsOptionsCorrectly" executed="True" result="Success" success="True" time="0.012" asserts="1" />
+                              <test-case name="NUnit.ProjectEditor.Tests.Presenters.PropertyPresenterTests.DomainUsage_WhenChanged_UpdatesProject" executed="True" result="Success" success="True" time="0.015" asserts="1" />
+                              <test-case name="NUnit.ProjectEditor.Tests.Presenters.PropertyPresenterTests.PrivateBinPath_LoadFromModel_SetsViewCorrectly" executed="True" result="Success" success="True" time="0.016" asserts="1" />
+                              <test-case name="NUnit.ProjectEditor.Tests.Presenters.PropertyPresenterTests.ProcessModel_LoadFromModel_SelectsDefaultEntry" executed="True" result="Success" success="True" time="0.016" asserts="1" />
+                              <test-case name="NUnit.ProjectEditor.Tests.Presenters.PropertyPresenterTests.ProcessModel_LoadFromModel_SetsOptionsCorrectly" executed="True" result="Success" success="True" time="0.015" asserts="1" />
+                              <test-case name="NUnit.ProjectEditor.Tests.Presenters.PropertyPresenterTests.ProcessModel_WhenChanged_UpdatesDomainUsageOptions" executed="True" result="Success" success="True" time="0.017" asserts="2" />
+                              <test-case name="NUnit.ProjectEditor.Tests.Presenters.PropertyPresenterTests.ProcessModel_WhenChanged_UpdatesProject" executed="True" result="Success" success="True" time="0.015" asserts="1" />
+                              <test-case name="NUnit.ProjectEditor.Tests.Presenters.PropertyPresenterTests.ProjectBase_LoadFromModel_SetsViewCorrectly" executed="True" result="Success" success="True" time="0.014" asserts="1" />
+                              <test-case name="NUnit.ProjectEditor.Tests.Presenters.PropertyPresenterTests.ProjectBase_WhenChanged_UpdatesProject" executed="True" result="Success" success="True" time="0.013" asserts="1" />
+                              <test-case name="NUnit.ProjectEditor.Tests.Presenters.PropertyPresenterTests.ProjectPath_LoadFromModel_SetsViewCorrectly" executed="True" result="Success" success="True" time="0.011" asserts="1" />
+                              <test-case name="NUnit.ProjectEditor.Tests.Presenters.PropertyPresenterTests.Runtime_LoadFromModel_SelectsAnyRuntime" executed="True" result="Success" success="True" time="0.011" asserts="1" />
+                              <test-case name="NUnit.ProjectEditor.Tests.Presenters.PropertyPresenterTests.Runtime_LoadFromModel_SetsOptionsCorrectly" executed="True" result="Success" success="True" time="0.010" asserts="1" />
+                              <test-case name="NUnit.ProjectEditor.Tests.Presenters.PropertyPresenterTests.Runtime_WhenChanged_UpdatesProject" executed="True" result="Success" success="True" time="0.016" asserts="2" />
+                              <test-case name="NUnit.ProjectEditor.Tests.Presenters.PropertyPresenterTests.RuntimeVersion_LoadFromModel_SetsOptionsCorretly" executed="True" result="Success" success="True" time="0.010" asserts="1" />
+                              <test-case name="NUnit.ProjectEditor.Tests.Presenters.PropertyPresenterTests.RuntimeVersion_WhenSelectionChanged_UpdatesProject" executed="True" result="Success" success="True" time="0.012" asserts="2" />
+                            </results>
+                          </test-suite>
+                          <test-suite type="TestFixture" name="RenameConfigurationPresenterTests" executed="True" result="Success" success="True" time="0.032" asserts="0">
+                            <results>
+                              <test-case name="NUnit.ProjectEditor.Tests.Presenters.RenameConfigurationPresenterTests.ConfigurationName_OnLoad_IsSetToOriginalName" executed="True" result="Success" success="True" time="0.002" asserts="1" />
+                              <test-case name="NUnit.ProjectEditor.Tests.Presenters.RenameConfigurationPresenterTests.ConfigurationName_OnLoad_OriginalNameIsSelected" executed="True" result="Success" success="True" time="0.001" asserts="0" />
+                              <test-case name="NUnit.ProjectEditor.Tests.Presenters.RenameConfigurationPresenterTests.ConfigurationName_WhenCleared_OkButtonIsDisabled" executed="True" result="Success" success="True" time="0.003" asserts="1" />
+                              <test-case name="NUnit.ProjectEditor.Tests.Presenters.RenameConfigurationPresenterTests.ConfigurationName_WhenSetToNewName_OkButtonIsEnabled" executed="True" result="Success" success="True" time="0.002" asserts="1" />
+                              <test-case name="NUnit.ProjectEditor.Tests.Presenters.RenameConfigurationPresenterTests.ConfigurationName_WhenSetToOriginalName_OkButtonIsDisabled" executed="True" result="Success" success="True" time="0.003" asserts="1" />
+                              <test-case name="NUnit.ProjectEditor.Tests.Presenters.RenameConfigurationPresenterTests.Dialog_WhenClosedWithoutClickingOK_LeavesConfigsUnchanged" executed="True" result="Success" success="True" time="0.004" asserts="1" />
+                              <test-case name="NUnit.ProjectEditor.Tests.Presenters.RenameConfigurationPresenterTests.OkButton_OnLoad_IsDisabled" executed="True" result="Success" success="True" time="0.001" asserts="1" />
+                              <test-case name="NUnit.ProjectEditor.Tests.Presenters.RenameConfigurationPresenterTests.OkButton_WhenClicked_PerformsRename" executed="True" result="Success" success="True" time="0.002" asserts="1" />
+                            </results>
+                          </test-suite>
+                          <test-suite type="TestFixture" name="XmlPresenterTests" executed="True" result="Success" success="True" time="0.012" asserts="0">
+                            <results>
+                              <test-case name="NUnit.ProjectEditor.Tests.Presenters.XmlPresenterTests.BadXmlSetsException" executed="True" result="Success" success="True" time="0.004" asserts="3" />
+                              <test-case name="NUnit.ProjectEditor.Tests.Presenters.XmlPresenterTests.XmlText_OnLoad_IsInitializedCorrectly" executed="True" result="Success" success="True" time="0.001" asserts="1" />
+                              <test-case name="NUnit.ProjectEditor.Tests.Presenters.XmlPresenterTests.XmlText_WhenChanged_ModelIsUpdated" executed="True" result="Success" success="True" time="0.002" asserts="1" />
+                            </results>
+                          </test-suite>
+                        </results>
+                      </test-suite>
+                      <test-suite type="Namespace" name="Views" executed="True" result="Success" success="True" time="0.214" asserts="0">
+                        <results>
+                          <test-suite type="TestFixture" name="AddConfigurationDialogTests" executed="True" result="Success" success="True" time="0.061" asserts="0">
+                            <results>
+                              <test-case name="NUnit.ProjectEditor.Tests.Views.AddConfigurationDialogTests.CheckForControls" executed="True" result="Success" success="True" time="0.006" asserts="0" />
+                              <test-case name="NUnit.ProjectEditor.Tests.Views.AddConfigurationDialogTests.ComboBox_OnLoad_IsInitializedCorrectly" executed="True" result="Success" success="True" time="0.012" asserts="5" />
+                              <test-case name="NUnit.ProjectEditor.Tests.Views.AddConfigurationDialogTests.TestComplexEntry" executed="True" result="Success" success="True" time="0.015" asserts="2" />
+                              <test-case name="NUnit.ProjectEditor.Tests.Views.AddConfigurationDialogTests.TestSimpleEntry" executed="True" result="Success" success="True" time="0.014" asserts="2" />
+                              <test-case name="NUnit.ProjectEditor.Tests.Views.AddConfigurationDialogTests.TextBox_OnLoad_IsEmpty" executed="True" result="Success" success="True" time="0.001" asserts="1" />
+                            </results>
+                          </test-suite>
+                          <test-suite type="TestFixture" name="ConfigurationEditorViewTests" executed="True" result="Success" success="True" time="0.025" asserts="0">
+                            <results>
+                              <test-case name="NUnit.ProjectEditor.Tests.Views.ConfigurationEditorViewTests.AllViewElementsAreWrapped" executed="True" result="Success" success="True" time="0.024" asserts="5" />
+                            </results>
+                          </test-suite>
+                          <test-suite type="TestFixture" name="PropertyViewTests" executed="True" result="Success" success="True" time="0.122" asserts="0">
+                            <results>
+                              <test-case name="NUnit.ProjectEditor.Tests.Views.PropertyViewTests.AllViewElementsAreInitialized" executed="True" result="Success" success="True" time="0.120" asserts="0" />
+                            </results>
+                          </test-suite>
+                        </results>
+                      </test-suite>
+                    </results>
+                  </test-suite>
+                </results>
+              </test-suite>
+            </results>
+          </test-suite>
+        </results>
+      </test-suite>
+    </results>
+  </test-suite>
+</test-results>

--- a/src/test-nunit-summary.exe/TestInput/TestResult-2.6.4.xml
+++ b/src/test-nunit-summary.exe/TestInput/TestResult-2.6.4.xml
@@ -1,0 +1,3093 @@
+<?xml version="1.0" encoding="utf-8" standalone="no"?>
+<!--This file represents the results of running a test suite-->
+<test-results name="D:\Dev\NUnit\nunit-2.6\bin\Debug\tests\nunit.framework.tests.dll" total="1580" errors="0" failures="0" not-run="0" inconclusive="0" ignored="0" skipped="0" invalid="0" date="2015-10-06" time="10:45:56">
+  <environment nunit-version="2.6.4.0" clr-version="2.0.50727.5485" os-version="Microsoft Windows NT 6.1.7601 Service Pack 1" platform="Win32NT" cwd="D:\Dev\NUnit\nunit-2.6\bin\Debug" machine-name="CHARLIE-LAPTOP" user="charlie" user-domain="charlie-laptop" />
+  <culture-info current-culture="en-US" current-uiculture="en-US" />
+  <test-suite type="Assembly" name="D:\Dev\NUnit\nunit-2.6\bin\Debug\tests\nunit.framework.tests.dll" executed="True" result="Success" success="True" time="18.407" asserts="0">
+    <results>
+      <test-suite type="Namespace" name="NUnit" executed="True" result="Success" success="True" time="18.386" asserts="0">
+        <results>
+          <test-suite type="Namespace" name="Framework" executed="True" result="Success" success="True" time="18.384" asserts="0">
+            <results>
+              <test-suite type="Namespace" name="Constraints" executed="True" result="Success" success="True" time="12.821" asserts="0">
+                <results>
+                  <test-suite type="TestFixture" name="AllItemsTests" executed="True" result="Success" success="True" time="0.076" asserts="0">
+                    <results>
+                      <test-case name="NUnit.Framework.Constraints.AllItemsTests.AllItemsAreInRange" executed="True" result="Success" success="True" time="0.021" asserts="1" />
+                      <test-case name="NUnit.Framework.Constraints.AllItemsTests.AllItemsAreInRange_UsingComparisonOfT" executed="True" result="Success" success="True" time="0.010" asserts="1" />
+                      <test-case name="NUnit.Framework.Constraints.AllItemsTests.AllItemsAreInRange_UsingIComparer" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                      <test-case name="NUnit.Framework.Constraints.AllItemsTests.AllItemsAreInRange_UsingIComparerOfT" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                      <test-case name="NUnit.Framework.Constraints.AllItemsTests.AllItemsAreInRangeFailureMessage" executed="True" result="Success" success="True" time="0.015" asserts="2" />
+                      <test-case name="NUnit.Framework.Constraints.AllItemsTests.AllItemsAreInstancesOfType" executed="True" result="Success" success="True" time="0.001" asserts="1" />
+                      <test-case name="NUnit.Framework.Constraints.AllItemsTests.AllItemsAreInstancesOfTypeFailureMessage" executed="True" result="Success" success="True" time="0.001" asserts="2" />
+                      <test-case name="NUnit.Framework.Constraints.AllItemsTests.AllItemsAreNotNull" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                      <test-case name="NUnit.Framework.Constraints.AllItemsTests.AllItemsAreNotNullFails" executed="True" result="Success" success="True" time="0.001" asserts="2" />
+                    </results>
+                  </test-suite>
+                  <test-suite type="TestFixture" name="AndConstraintTests" executed="True" result="Success" success="True" time="0.032" asserts="0">
+                    <results>
+                      <test-case name="NUnit.Framework.Constraints.AndConstraintTests.CanCombineTestsWithAndOperator" executed="True" result="Success" success="True" time="0.001" asserts="1" />
+                      <test-case name="NUnit.Framework.Constraints.AndConstraintTests.ConstraintTestBaseNoData.ProvidesProperDescription" executed="True" result="Success" success="True" time="0.001" asserts="1" />
+                      <test-case name="NUnit.Framework.Constraints.AndConstraintTests.ConstraintTestBaseNoData.ProvidesProperStringRepresentation" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                      <test-suite type="ParameterizedTest" name="FailsWithBadValues" executed="True" result="Success" success="True" time="0.004" asserts="0">
+                        <results>
+                          <test-case name="NUnit.Framework.Constraints.AndConstraintTests.FailsWithBadValues(37)" executed="True" result="Success" success="True" time="0.001" asserts="1" />
+                          <test-case name="NUnit.Framework.Constraints.AndConstraintTests.FailsWithBadValues(53)" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                        </results>
+                      </test-suite>
+                      <test-suite type="ParameterizedTest" name="ProvidesProperFailureMessage" executed="True" result="Success" success="True" time="0.003" asserts="0">
+                        <results>
+                          <test-case name="NUnit.Framework.Constraints.AndConstraintTests.ProvidesProperFailureMessage(37,&quot;37&quot;)" executed="True" result="Success" success="True" time="0.001" asserts="1" />
+                          <test-case name="NUnit.Framework.Constraints.AndConstraintTests.ProvidesProperFailureMessage(53,&quot;53&quot;)" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                        </results>
+                      </test-suite>
+                      <test-suite type="ParameterizedTest" name="SucceedsWithGoodValues" executed="True" result="Success" success="True" time="0.002" asserts="0">
+                        <results>
+                          <test-case name="NUnit.Framework.Constraints.AndConstraintTests.SucceedsWithGoodValues(42)" executed="True" result="Success" success="True" time="0.001" asserts="1" />
+                        </results>
+                      </test-suite>
+                    </results>
+                  </test-suite>
+                  <test-suite type="TestFixture" name="AssignableFromConstraintTests" executed="True" result="Success" success="True" time="0.008" asserts="0">
+                    <results>
+                      <test-case name="NUnit.Framework.Constraints.AssignableFromConstraintTests.ConstraintTestBaseNoData.ProvidesProperDescription" executed="True" result="Success" success="True" time="0.001" asserts="1" />
+                      <test-case name="NUnit.Framework.Constraints.AssignableFromConstraintTests.ConstraintTestBaseNoData.ProvidesProperStringRepresentation" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                      <test-suite type="ParameterizedTest" name="FailsWithBadValues" executed="True" result="Success" success="True" time="0.001" asserts="0">
+                        <results>
+                          <test-case name="NUnit.Framework.Constraints.AssignableFromConstraintTests.FailsWithBadValues(NUnit.Framework.Constraints.AssignableFromConstraintTests+D2)" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                        </results>
+                      </test-suite>
+                      <test-suite type="ParameterizedTest" name="ProvidesProperFailureMessage" executed="True" result="Success" success="True" time="0.001" asserts="0">
+                        <results>
+                          <test-case name="NUnit.Framework.Constraints.AssignableFromConstraintTests.ProvidesProperFailureMessage(NUnit.Framework.Constraints.AssignableFromConstraintTests+D2,&quot;&lt;NUnit.Framework.Constraints.AssignableFromConstraintTests+D2&gt;&quot;)" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                        </results>
+                      </test-suite>
+                      <test-suite type="ParameterizedTest" name="SucceedsWithGoodValues" executed="True" result="Success" success="True" time="0.002" asserts="0">
+                        <results>
+                          <test-case name="NUnit.Framework.Constraints.AssignableFromConstraintTests.SucceedsWithGoodValues(NUnit.Framework.Constraints.AssignableFromConstraintTests+D1)" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Framework.Constraints.AssignableFromConstraintTests.SucceedsWithGoodValues(NUnit.Framework.Constraints.AssignableFromConstraintTests+B)" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                        </results>
+                      </test-suite>
+                    </results>
+                  </test-suite>
+                  <test-suite type="TestFixture" name="AssignableToConstraintTests" executed="True" result="Success" success="True" time="0.009" asserts="0">
+                    <results>
+                      <test-case name="NUnit.Framework.Constraints.AssignableToConstraintTests.ConstraintTestBaseNoData.ProvidesProperDescription" executed="True" result="Success" success="True" time="0.001" asserts="1" />
+                      <test-case name="NUnit.Framework.Constraints.AssignableToConstraintTests.ConstraintTestBaseNoData.ProvidesProperStringRepresentation" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                      <test-suite type="ParameterizedTest" name="FailsWithBadValues" executed="True" result="Success" success="True" time="0.001" asserts="0">
+                        <results>
+                          <test-case name="NUnit.Framework.Constraints.AssignableToConstraintTests.FailsWithBadValues(NUnit.Framework.Constraints.AssignableToConstraintTests+B)" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                        </results>
+                      </test-suite>
+                      <test-suite type="ParameterizedTest" name="ProvidesProperFailureMessage" executed="True" result="Success" success="True" time="0.001" asserts="0">
+                        <results>
+                          <test-case name="NUnit.Framework.Constraints.AssignableToConstraintTests.ProvidesProperFailureMessage(NUnit.Framework.Constraints.AssignableToConstraintTests+B,&quot;&lt;NUnit.Framework.Constraints.AssignableToConstraintTests+B&gt;&quot;)" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                        </results>
+                      </test-suite>
+                      <test-suite type="ParameterizedTest" name="SucceedsWithGoodValues" executed="True" result="Success" success="True" time="0.002" asserts="0">
+                        <results>
+                          <test-case name="NUnit.Framework.Constraints.AssignableToConstraintTests.SucceedsWithGoodValues(NUnit.Framework.Constraints.AssignableToConstraintTests+D1)" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Framework.Constraints.AssignableToConstraintTests.SucceedsWithGoodValues(NUnit.Framework.Constraints.AssignableToConstraintTests+D2)" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                        </results>
+                      </test-suite>
+                    </results>
+                  </test-suite>
+                  <test-suite type="TestFixture" name="AttributeExistsConstraintTest" executed="True" result="Success" success="True" time="0.014" asserts="0">
+                    <results>
+                      <test-case name="NUnit.Framework.Constraints.AttributeExistsConstraintTest.AttributeExistsOnMethodInfo" executed="True" result="Success" success="True" time="0.001" asserts="1" />
+                      <test-case name="NUnit.Framework.Constraints.AttributeExistsConstraintTest.AttributeTestPropertyValueOnMethodInfo" description="my description" executed="True" result="Success" success="True" time="0.002" asserts="1" />
+                      <test-case name="NUnit.Framework.Constraints.AttributeExistsConstraintTest.CanCombineAttributeConstraints" executed="True" result="Success" success="True" time="0.001" asserts="1" />
+                      <test-case name="NUnit.Framework.Constraints.AttributeExistsConstraintTest.ConstraintTestBaseNoData.ProvidesProperDescription" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                      <test-case name="NUnit.Framework.Constraints.AttributeExistsConstraintTest.ConstraintTestBaseNoData.ProvidesProperStringRepresentation" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                      <test-suite type="ParameterizedTest" name="FailsWithBadValues" executed="True" result="Success" success="True" time="0.001" asserts="0">
+                        <results>
+                          <test-case name="NUnit.Framework.Constraints.AttributeExistsConstraintTest.FailsWithBadValues(NUnit.Framework.Constraints.D2)" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                        </results>
+                      </test-suite>
+                      <test-case name="NUnit.Framework.Constraints.AttributeExistsConstraintTest.NonAttributeThrowsException" executed="True" result="Success" success="True" time="0.001" asserts="0" />
+                      <test-suite type="ParameterizedTest" name="ProvidesProperFailureMessage" executed="True" result="Success" success="True" time="0.001" asserts="0">
+                        <results>
+                          <test-case name="NUnit.Framework.Constraints.AttributeExistsConstraintTest.ProvidesProperFailureMessage(NUnit.Framework.Constraints.D2,&quot;&lt;NUnit.Framework.Constraints.D2&gt;&quot;)" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                        </results>
+                      </test-suite>
+                      <test-suite type="ParameterizedTest" name="SucceedsWithGoodValues" executed="True" result="Success" success="True" time="0.001" asserts="0">
+                        <results>
+                          <test-case name="NUnit.Framework.Constraints.AttributeExistsConstraintTest.SucceedsWithGoodValues(NUnit.Framework.Constraints.AttributeExistsConstraintTest)" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                        </results>
+                      </test-suite>
+                    </results>
+                  </test-suite>
+                  <test-suite type="TestFixture" name="BinarySerializableTest" executed="True" result="Success" success="True" time="0.032" asserts="0">
+                    <results>
+                      <test-case name="NUnit.Framework.Constraints.BinarySerializableTest.ConstraintTestBaseNoData.ProvidesProperDescription" executed="True" result="Success" success="True" time="0.001" asserts="1" />
+                      <test-case name="NUnit.Framework.Constraints.BinarySerializableTest.ConstraintTestBaseNoData.ProvidesProperStringRepresentation" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                      <test-suite type="ParameterizedTest" name="FailsWithBadValues" executed="True" result="Success" success="True" time="0.020" asserts="0">
+                        <results>
+                          <test-case name="NUnit.Framework.Constraints.BinarySerializableTest.FailsWithBadValues(NUnit.Framework.Constraints.BinarySerializableTest+InternalClass)" executed="True" result="Success" success="True" time="0.019" asserts="1" />
+                        </results>
+                      </test-suite>
+                      <test-suite type="ParameterizedTest" name="InvalidDataThrowsArgumentException" executed="True" result="Success" success="True" time="0.001" asserts="0">
+                        <results>
+                          <test-case name="NUnit.Framework.Constraints.BinarySerializableTest.InvalidDataThrowsArgumentException(null)" executed="True" result="Success" success="True" time="0.001" asserts="0" />
+                        </results>
+                      </test-suite>
+                      <test-suite type="ParameterizedTest" name="ProvidesProperFailureMessage" executed="True" result="Success" success="True" time="0.001" asserts="0">
+                        <results>
+                          <test-case name="NUnit.Framework.Constraints.BinarySerializableTest.ProvidesProperFailureMessage(NUnit.Framework.Constraints.BinarySerializableTest+InternalClass,&quot;&lt;InternalClass&gt;&quot;)" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                        </results>
+                      </test-suite>
+                      <test-suite type="ParameterizedTest" name="SucceedsWithGoodValues" executed="True" result="Success" success="True" time="0.004" asserts="0">
+                        <results>
+                          <test-case name="NUnit.Framework.Constraints.BinarySerializableTest.SucceedsWithGoodValues(1)" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Framework.Constraints.BinarySerializableTest.SucceedsWithGoodValues(&quot;a&quot;)" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Framework.Constraints.BinarySerializableTest.SucceedsWithGoodValues(System.Collections.ArrayList)" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Framework.Constraints.BinarySerializableTest.SucceedsWithGoodValues(NUnit.Framework.Constraints.BinarySerializableTest+InternalWithSerializableAttributeClass)" executed="True" result="Success" success="True" time="0.001" asserts="1" />
+                        </results>
+                      </test-suite>
+                    </results>
+                  </test-suite>
+                  <test-suite type="TestFixture" name="CollectionContainsTests" executed="True" result="Success" success="True" time="0.028" asserts="0">
+                    <results>
+                      <test-case name="NUnit.Framework.Constraints.CollectionContainsTests.CanTestContentsOfArray" executed="True" result="Success" success="True" time="0.002" asserts="1" />
+                      <test-case name="NUnit.Framework.Constraints.CollectionContainsTests.CanTestContentsOfArrayList" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                      <test-case name="NUnit.Framework.Constraints.CollectionContainsTests.CanTestContentsOfCollectionNotImplementingIList" executed="True" result="Success" success="True" time="0.002" asserts="1" />
+                      <test-case name="NUnit.Framework.Constraints.CollectionContainsTests.CanTestContentsOfSortedList" executed="True" result="Success" success="True" time="0.000" asserts="2" />
+                      <test-case name="NUnit.Framework.Constraints.CollectionContainsTests.ContainsWithRecursiveStructure" executed="True" result="Success" success="True" time="0.002" asserts="1" />
+                      <test-case name="NUnit.Framework.Constraints.CollectionContainsTests.IgnoreCaseIsHonored" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                      <test-case name="NUnit.Framework.Constraints.CollectionContainsTests.UsesProvidedComparerOfT" executed="True" result="Success" success="True" time="0.005" asserts="2" />
+                      <test-case name="NUnit.Framework.Constraints.CollectionContainsTests.UsesProvidedComparisonOfT" executed="True" result="Success" success="True" time="0.002" asserts="2" />
+                      <test-case name="NUnit.Framework.Constraints.CollectionContainsTests.UsesProvidedEqualityComparer" executed="True" result="Success" success="True" time="0.001" asserts="2" />
+                      <test-case name="NUnit.Framework.Constraints.CollectionContainsTests.UsesProvidedEqualityComparerOfT" executed="True" result="Success" success="True" time="0.002" asserts="2" />
+                      <test-case name="NUnit.Framework.Constraints.CollectionContainsTests.UsesProvidedIComparer" executed="True" result="Success" success="True" time="0.001" asserts="2" />
+                      <test-case name="NUnit.Framework.Constraints.CollectionContainsTests.UsesProvidedLambdaExpression" executed="True" result="Success" success="True" time="0.001" asserts="1" />
+                    </results>
+                  </test-suite>
+                  <test-suite type="TestFixture" name="CollectionEquivalentTests" executed="True" result="Success" success="True" time="0.297" asserts="0">
+                    <results>
+                      <test-case name="NUnit.Framework.Constraints.CollectionEquivalentTests.EqualCollectionsAreEquivalent" executed="True" result="Success" success="True" time="0.002" asserts="1" />
+                      <test-case name="NUnit.Framework.Constraints.CollectionEquivalentTests.EquivalentFailsWithDuplicateElementInActual" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                      <test-case name="NUnit.Framework.Constraints.CollectionEquivalentTests.EquivalentFailsWithDuplicateElementInExpected" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                      <test-case name="NUnit.Framework.Constraints.CollectionEquivalentTests.EquivalentHandlesNull" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                      <test-case name="NUnit.Framework.Constraints.CollectionEquivalentTests.EquivalentHonorsIgnoreCase" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                      <test-case name="NUnit.Framework.Constraints.CollectionEquivalentTests.EquivalentHonorsUsing" executed="True" result="Success" success="True" time="0.001" asserts="1" />
+                      <test-case name="NUnit.Framework.Constraints.CollectionEquivalentTests.EquivalentIgnoresOrder" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                      <test-case name="NUnit.Framework.Constraints.CollectionEquivalentTests.FailureMessageWithHashSetAndArray" executed="True" result="Success" success="True" time="0.151" asserts="2" />
+                      <test-suite type="ParameterizedTest" name="HonorsIgnoreCase" executed="True" result="Success" success="True" time="0.119" asserts="0">
+                        <results>
+                          <test-case name="NUnit.Framework.Constraints.CollectionEquivalentTests.HonorsIgnoreCase(System.Char[],System.Object[])" executed="True" result="Success" success="True" time="0.001" asserts="1" />
+                          <test-case name="NUnit.Framework.Constraints.CollectionEquivalentTests.HonorsIgnoreCase(System.String[],System.Object[])" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Framework.Constraints.CollectionEquivalentTests.HonorsIgnoreCase(System.Collections.Generic.Dictionary`2[System.Int32,System.String],System.Collections.Generic.Dictionary`2[System.Int32,System.String])" executed="True" result="Success" success="True" time="0.083" asserts="1" />
+                          <test-case name="NUnit.Framework.Constraints.CollectionEquivalentTests.HonorsIgnoreCase(System.Collections.Generic.Dictionary`2[System.Int32,System.Char],System.Collections.Generic.Dictionary`2[System.Int32,System.Char])" executed="True" result="Success" success="True" time="0.004" asserts="1" />
+                          <test-case name="NUnit.Framework.Constraints.CollectionEquivalentTests.HonorsIgnoreCase(System.Collections.Generic.Dictionary`2[System.String,System.Int32],System.Collections.Generic.Dictionary`2[System.String,System.Int32])" executed="True" result="Success" success="True" time="0.012" asserts="1" />
+                          <test-case name="NUnit.Framework.Constraints.CollectionEquivalentTests.HonorsIgnoreCase(System.Collections.Generic.Dictionary`2[System.Char,System.Int32],System.Collections.Generic.Dictionary`2[System.Char,System.Int32])" executed="True" result="Success" success="True" time="0.004" asserts="1" />
+                          <test-case name="NUnit.Framework.Constraints.CollectionEquivalentTests.HonorsIgnoreCase(System.Collections.Hashtable,System.Collections.Hashtable)" executed="True" result="Success" success="True" time="0.001" asserts="1" />
+                          <test-case name="NUnit.Framework.Constraints.CollectionEquivalentTests.HonorsIgnoreCase(System.Collections.Hashtable,System.Collections.Hashtable)" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Framework.Constraints.CollectionEquivalentTests.HonorsIgnoreCase(System.Collections.Hashtable,System.Collections.Hashtable)" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Framework.Constraints.CollectionEquivalentTests.HonorsIgnoreCase(System.Collections.Hashtable,System.Collections.Hashtable)" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                        </results>
+                      </test-suite>
+                      <test-case name="NUnit.Framework.Constraints.CollectionEquivalentTests.WorksWithArrayAndHashSet" executed="True" result="Success" success="True" time="0.001" asserts="1" />
+                      <test-case name="NUnit.Framework.Constraints.CollectionEquivalentTests.WorksWithCollectionsOfArrays" executed="True" result="Success" success="True" time="0.001" asserts="2" />
+                      <test-case name="NUnit.Framework.Constraints.CollectionEquivalentTests.WorksWithHashSetAndArray" executed="True" result="Success" success="True" time="0.001" asserts="1" />
+                      <test-case name="NUnit.Framework.Constraints.CollectionEquivalentTests.WorksWithHashSets" executed="True" result="Success" success="True" time="0.001" asserts="1" />
+                    </results>
+                  </test-suite>
+                  <test-suite type="TestFixture" name="CollectionOrderedTests" executed="True" result="Success" success="True" time="0.083" asserts="0">
+                    <results>
+                      <test-case name="NUnit.Framework.Constraints.CollectionOrderedTests.IsOrdered" executed="True" result="Success" success="True" time="0.002" asserts="1" />
+                      <test-case name="NUnit.Framework.Constraints.CollectionOrderedTests.IsOrdered_2" executed="True" result="Success" success="True" time="0.001" asserts="1" />
+                      <test-case name="NUnit.Framework.Constraints.CollectionOrderedTests.IsOrdered_Allows_adjacent_equal_values" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                      <test-case name="NUnit.Framework.Constraints.CollectionOrderedTests.IsOrdered_AtLeastOneArgMustImplementIComparable" executed="True" result="Success" success="True" time="0.001" asserts="1" />
+                      <test-case name="NUnit.Framework.Constraints.CollectionOrderedTests.IsOrdered_Fails" executed="True" result="Success" success="True" time="0.001" asserts="2" />
+                      <test-case name="NUnit.Framework.Constraints.CollectionOrderedTests.IsOrdered_Handles_custom_comparison" executed="True" result="Success" success="True" time="0.001" asserts="2" />
+                      <test-case name="NUnit.Framework.Constraints.CollectionOrderedTests.IsOrdered_Handles_custom_comparison2" executed="True" result="Success" success="True" time="0.001" asserts="2" />
+                      <test-case name="NUnit.Framework.Constraints.CollectionOrderedTests.IsOrdered_Handles_null" executed="True" result="Success" success="True" time="0.001" asserts="1" />
+                      <test-case name="NUnit.Framework.Constraints.CollectionOrderedTests.IsOrdered_TypesMustBeComparable" executed="True" result="Success" success="True" time="0.044" asserts="1" />
+                      <test-case name="NUnit.Framework.Constraints.CollectionOrderedTests.IsOrderedBy" executed="True" result="Success" success="True" time="0.001" asserts="1" />
+                      <test-case name="NUnit.Framework.Constraints.CollectionOrderedTests.IsOrderedBy_Comparer" executed="True" result="Success" success="True" time="0.001" asserts="1" />
+                      <test-case name="NUnit.Framework.Constraints.CollectionOrderedTests.IsOrderedBy_Handles_heterogeneous_classes_as_long_as_the_property_is_of_same_type" executed="True" result="Success" success="True" time="0.001" asserts="1" />
+                      <test-case name="NUnit.Framework.Constraints.CollectionOrderedTests.IsOrderedDescending" executed="True" result="Success" success="True" time="0.001" asserts="1" />
+                      <test-case name="NUnit.Framework.Constraints.CollectionOrderedTests.IsOrderedDescending_2" executed="True" result="Success" success="True" time="0.001" asserts="1" />
+                      <test-case name="NUnit.Framework.Constraints.CollectionOrderedTests.UsesProvidedComparerOfT" executed="True" result="Success" success="True" time="0.004" asserts="2" />
+                      <test-case name="NUnit.Framework.Constraints.CollectionOrderedTests.UsesProvidedComparisonOfT" executed="True" result="Success" success="True" time="0.003" asserts="2" />
+                      <test-case name="NUnit.Framework.Constraints.CollectionOrderedTests.UsesProvidedLambda" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                    </results>
+                  </test-suite>
+                  <test-suite type="TestFixture" name="DelayedConstraintTest" executed="True" result="Success" success="True" time="9.419" asserts="0">
+                    <results>
+                      <test-case name="NUnit.Framework.Constraints.DelayedConstraintTest.CanTestContentsOfDelegateReturningList" executed="True" result="Success" success="True" time="0.157" asserts="1" />
+                      <test-case name="NUnit.Framework.Constraints.DelayedConstraintTest.CanTestContentsOfList" executed="True" result="Success" success="True" time="0.102" asserts="1" />
+                      <test-case name="NUnit.Framework.Constraints.DelayedConstraintTest.CanTestContentsOfRefList" executed="True" result="Success" success="True" time="0.105" asserts="1" />
+                      <test-case name="NUnit.Framework.Constraints.DelayedConstraintTest.CanTestInitiallyNullDelegate" executed="True" result="Success" success="True" time="1.101" asserts="1" />
+                      <test-case name="NUnit.Framework.Constraints.DelayedConstraintTest.CanTestInitiallyNullReference" executed="True" result="Success" success="True" time="1.101" asserts="1" />
+                      <test-case name="NUnit.Framework.Constraints.DelayedConstraintTest.ConstraintTestBaseNoData.ProvidesProperDescription" executed="True" result="Success" success="True" time="0.001" asserts="1" />
+                      <test-case name="NUnit.Framework.Constraints.DelayedConstraintTest.ConstraintTestBaseNoData.ProvidesProperStringRepresentation" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                      <test-suite type="ParameterizedTest" name="FailsWithBadDelegates" executed="True" result="Success" success="True" time="1.003" asserts="0">
+                        <results>
+                          <test-case name="NUnit.Framework.Constraints.DelayedConstraintTest.FailsWithBadDelegates(NUnit.Framework.Constraints.ActualValueDelegate`1[System.Object])" executed="True" result="Success" success="True" time="0.501" asserts="1" />
+                          <test-case name="NUnit.Framework.Constraints.DelayedConstraintTest.FailsWithBadDelegates(NUnit.Framework.Constraints.ActualValueDelegate`1[System.Object])" executed="True" result="Success" success="True" time="0.500" asserts="1" />
+                        </results>
+                      </test-suite>
+                      <test-suite type="ParameterizedTest" name="FailsWithBadValues" executed="True" result="Success" success="True" time="1.503" asserts="0">
+                        <results>
+                          <test-case name="NUnit.Framework.Constraints.DelayedConstraintTest.FailsWithBadValues(False)" executed="True" result="Success" success="True" time="0.500" asserts="1" />
+                          <test-case name="NUnit.Framework.Constraints.DelayedConstraintTest.FailsWithBadValues(0)" executed="True" result="Success" success="True" time="0.500" asserts="1" />
+                          <test-case name="NUnit.Framework.Constraints.DelayedConstraintTest.FailsWithBadValues(null)" executed="True" result="Success" success="True" time="0.500" asserts="1" />
+                        </results>
+                      </test-suite>
+                      <test-suite type="ParameterizedTest" name="ProvidesProperFailureMessage" executed="True" result="Success" success="True" time="1.503" asserts="0">
+                        <results>
+                          <test-case name="NUnit.Framework.Constraints.DelayedConstraintTest.ProvidesProperFailureMessage(False,&quot;False&quot;)" executed="True" result="Success" success="True" time="0.500" asserts="1" />
+                          <test-case name="NUnit.Framework.Constraints.DelayedConstraintTest.ProvidesProperFailureMessage(0,&quot;0&quot;)" executed="True" result="Success" success="True" time="0.500" asserts="1" />
+                          <test-case name="NUnit.Framework.Constraints.DelayedConstraintTest.ProvidesProperFailureMessage(null,&quot;null&quot;)" executed="True" result="Success" success="True" time="0.500" asserts="1" />
+                        </results>
+                      </test-suite>
+                      <test-case name="NUnit.Framework.Constraints.DelayedConstraintTest.SimpleTest" executed="True" result="Success" success="True" time="0.602" asserts="1" />
+                      <test-case name="NUnit.Framework.Constraints.DelayedConstraintTest.SimpleTestBoolDelegate" executed="True" result="Success" success="True" time="0.602" asserts="1" />
+                      <test-case name="NUnit.Framework.Constraints.DelayedConstraintTest.SimpleTestUsingReference" executed="True" result="Success" success="True" time="0.603" asserts="1" />
+                      <test-suite type="ParameterizedTest" name="SucceedsWithGoodDelegates" executed="True" result="Success" success="True" time="0.503" asserts="0">
+                        <results>
+                          <test-case name="NUnit.Framework.Constraints.DelayedConstraintTest.SucceedsWithGoodDelegates(NUnit.Framework.Constraints.ActualValueDelegate`1[System.Object])" executed="True" result="Success" success="True" time="0.501" asserts="1" />
+                        </results>
+                      </test-suite>
+                      <test-suite type="ParameterizedTest" name="SucceedsWithGoodValues" executed="True" result="Success" success="True" time="0.501" asserts="0">
+                        <results>
+                          <test-case name="NUnit.Framework.Constraints.DelayedConstraintTest.SucceedsWithGoodValues(True)" executed="True" result="Success" success="True" time="0.500" asserts="1" />
+                        </results>
+                      </test-suite>
+                      <test-case name="NUnit.Framework.Constraints.DelayedConstraintTest.ThatOverload_DoesNotAcceptNegativeDelayValues" executed="True" result="Success" success="True" time="0.001" asserts="0" />
+                      <test-case name="NUnit.Framework.Constraints.DelayedConstraintTest.ThatOverload_DoesNotAcceptNegativeDelayValues_IntDelegate" executed="True" result="Success" success="True" time="0.001" asserts="0" />
+                      <test-case name="NUnit.Framework.Constraints.DelayedConstraintTest.ThatOverload_ZeroDelayIsAllowed" executed="True" result="Success" success="True" time="0.001" asserts="1" />
+                      <test-case name="NUnit.Framework.Constraints.DelayedConstraintTest.ThatOverload_ZeroDelayIsAllowed_IntDelegate" executed="True" result="Success" success="True" time="0.003" asserts="1" />
+                    </results>
+                  </test-suite>
+                  <test-suite type="TestFixture" name="EmptyConstraintTest" executed="True" result="Success" success="True" time="0.021" asserts="0">
+                    <results>
+                      <test-case name="NUnit.Framework.Constraints.EmptyConstraintTest.ConstraintTestBaseNoData.ProvidesProperDescription" executed="True" result="Success" success="True" time="0.001" asserts="1" />
+                      <test-case name="NUnit.Framework.Constraints.EmptyConstraintTest.ConstraintTestBaseNoData.ProvidesProperStringRepresentation" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                      <test-suite type="ParameterizedTest" name="FailsWithBadValues" executed="True" result="Success" success="True" time="0.004" asserts="0">
+                        <results>
+                          <test-case name="NUnit.Framework.Constraints.EmptyConstraintTest.FailsWithBadValues(&quot;Hello&quot;)" executed="True" result="Success" success="True" time="0.001" asserts="1" />
+                          <test-case name="NUnit.Framework.Constraints.EmptyConstraintTest.FailsWithBadValues(System.Object[])" executed="True" result="Success" success="True" time="0.001" asserts="1" />
+                        </results>
+                      </test-suite>
+                      <test-suite type="ParameterizedTest" name="InvalidDataThrowsArgumentException" executed="True" result="Success" success="True" time="0.003" asserts="0">
+                        <results>
+                          <test-case name="NUnit.Framework.Constraints.EmptyConstraintTest.InvalidDataThrowsArgumentException(null)" executed="True" result="Success" success="True" time="0.001" asserts="0" />
+                          <test-case name="NUnit.Framework.Constraints.EmptyConstraintTest.InvalidDataThrowsArgumentException(5)" executed="True" result="Success" success="True" time="0.000" asserts="0" />
+                        </results>
+                      </test-suite>
+                      <test-suite type="ParameterizedTest" name="ProvidesProperFailureMessage" executed="True" result="Success" success="True" time="0.002" asserts="0">
+                        <results>
+                          <test-case name="NUnit.Framework.Constraints.EmptyConstraintTest.ProvidesProperFailureMessage(&quot;Hello&quot;,&quot;\&quot;Hello\&quot;&quot;)" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Framework.Constraints.EmptyConstraintTest.ProvidesProperFailureMessage(System.Object[],&quot;&lt; 1, 2, 3 &gt;&quot;)" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                        </results>
+                      </test-suite>
+                      <test-suite type="ParameterizedTest" name="SucceedsWithGoodValues" executed="True" result="Success" success="True" time="0.003" asserts="0">
+                        <results>
+                          <test-case name="NUnit.Framework.Constraints.EmptyConstraintTest.SucceedsWithGoodValues(&quot;&quot;)" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Framework.Constraints.EmptyConstraintTest.SucceedsWithGoodValues(System.Object[])" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Framework.Constraints.EmptyConstraintTest.SucceedsWithGoodValues(System.Collections.ArrayList)" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Framework.Constraints.EmptyConstraintTest.SucceedsWithGoodValues(System.Collections.Generic.List`1[System.Int32])" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                        </results>
+                      </test-suite>
+                    </results>
+                  </test-suite>
+                  <test-suite type="TestFixture" name="EndsWithTest" executed="True" result="Success" success="True" time="0.019" asserts="0">
+                    <results>
+                      <test-case name="NUnit.Framework.Constraints.EndsWithTest.ConstraintTestBaseNoData.ProvidesProperDescription" executed="True" result="Success" success="True" time="0.001" asserts="1" />
+                      <test-case name="NUnit.Framework.Constraints.EndsWithTest.ConstraintTestBaseNoData.ProvidesProperStringRepresentation" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                      <test-suite type="ParameterizedTest" name="FailsWithBadValues" executed="True" result="Success" success="True" time="0.006" asserts="0">
+                        <results>
+                          <test-case name="NUnit.Framework.Constraints.EndsWithTest.FailsWithBadValues(&quot;goodbye&quot;)" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Framework.Constraints.EndsWithTest.FailsWithBadValues(&quot;What the hell?&quot;)" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Framework.Constraints.EndsWithTest.FailsWithBadValues(&quot;hello there&quot;)" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Framework.Constraints.EndsWithTest.FailsWithBadValues(&quot;say hello to fred&quot;)" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Framework.Constraints.EndsWithTest.FailsWithBadValues(&quot;&quot;)" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Framework.Constraints.EndsWithTest.FailsWithBadValues(null)" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                        </results>
+                      </test-suite>
+                      <test-suite type="ParameterizedTest" name="ProvidesProperFailureMessage" executed="True" result="Success" success="True" time="0.006" asserts="0">
+                        <results>
+                          <test-case name="NUnit.Framework.Constraints.EndsWithTest.ProvidesProperFailureMessage(&quot;goodbye&quot;,&quot;\&quot;goodbye\&quot;&quot;)" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Framework.Constraints.EndsWithTest.ProvidesProperFailureMessage(&quot;What the hell?&quot;,&quot;\&quot;What the hell?\&quot;&quot;)" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Framework.Constraints.EndsWithTest.ProvidesProperFailureMessage(&quot;hello there&quot;,&quot;\&quot;hello there\&quot;&quot;)" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Framework.Constraints.EndsWithTest.ProvidesProperFailureMessage(&quot;say hello to fred&quot;,&quot;\&quot;say hello to fred\&quot;&quot;)" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Framework.Constraints.EndsWithTest.ProvidesProperFailureMessage(&quot;&quot;,&quot;&lt;string.Empty&gt;&quot;)" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Framework.Constraints.EndsWithTest.ProvidesProperFailureMessage(null,&quot;null&quot;)" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                        </results>
+                      </test-suite>
+                      <test-suite type="ParameterizedTest" name="SucceedsWithGoodValues" executed="True" result="Success" success="True" time="0.002" asserts="0">
+                        <results>
+                          <test-case name="NUnit.Framework.Constraints.EndsWithTest.SucceedsWithGoodValues(&quot;hello&quot;)" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Framework.Constraints.EndsWithTest.SucceedsWithGoodValues(&quot;I said hello&quot;)" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                        </results>
+                      </test-suite>
+                    </results>
+                  </test-suite>
+                  <test-suite type="TestFixture" name="EndsWithTestIgnoringCase" executed="True" result="Success" success="True" time="0.018" asserts="0">
+                    <results>
+                      <test-case name="NUnit.Framework.Constraints.EndsWithTestIgnoringCase.ConstraintTestBaseNoData.ProvidesProperDescription" executed="True" result="Success" success="True" time="0.001" asserts="1" />
+                      <test-case name="NUnit.Framework.Constraints.EndsWithTestIgnoringCase.ConstraintTestBaseNoData.ProvidesProperStringRepresentation" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                      <test-suite type="ParameterizedTest" name="FailsWithBadValues" executed="True" result="Success" success="True" time="0.006" asserts="0">
+                        <results>
+                          <test-case name="NUnit.Framework.Constraints.EndsWithTestIgnoringCase.FailsWithBadValues(&quot;goodbye&quot;)" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Framework.Constraints.EndsWithTestIgnoringCase.FailsWithBadValues(&quot;What the hell?&quot;)" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Framework.Constraints.EndsWithTestIgnoringCase.FailsWithBadValues(&quot;hello there&quot;)" executed="True" result="Success" success="True" time="0.001" asserts="1" />
+                          <test-case name="NUnit.Framework.Constraints.EndsWithTestIgnoringCase.FailsWithBadValues(&quot;say hello to fred&quot;)" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Framework.Constraints.EndsWithTestIgnoringCase.FailsWithBadValues(&quot;&quot;)" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Framework.Constraints.EndsWithTestIgnoringCase.FailsWithBadValues(null)" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                        </results>
+                      </test-suite>
+                      <test-suite type="ParameterizedTest" name="ProvidesProperFailureMessage" executed="True" result="Success" success="True" time="0.005" asserts="0">
+                        <results>
+                          <test-case name="NUnit.Framework.Constraints.EndsWithTestIgnoringCase.ProvidesProperFailureMessage(&quot;goodbye&quot;,&quot;\&quot;goodbye\&quot;&quot;)" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Framework.Constraints.EndsWithTestIgnoringCase.ProvidesProperFailureMessage(&quot;What the hell?&quot;,&quot;\&quot;What the hell?\&quot;&quot;)" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Framework.Constraints.EndsWithTestIgnoringCase.ProvidesProperFailureMessage(&quot;hello there&quot;,&quot;\&quot;hello there\&quot;&quot;)" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Framework.Constraints.EndsWithTestIgnoringCase.ProvidesProperFailureMessage(&quot;say hello to fred&quot;,&quot;\&quot;say hello to fred\&quot;&quot;)" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Framework.Constraints.EndsWithTestIgnoringCase.ProvidesProperFailureMessage(&quot;&quot;,&quot;&lt;string.Empty&gt;&quot;)" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Framework.Constraints.EndsWithTestIgnoringCase.ProvidesProperFailureMessage(null,&quot;null&quot;)" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                        </results>
+                      </test-suite>
+                      <test-suite type="ParameterizedTest" name="SucceedsWithGoodValues" executed="True" result="Success" success="True" time="0.002" asserts="0">
+                        <results>
+                          <test-case name="NUnit.Framework.Constraints.EndsWithTestIgnoringCase.SucceedsWithGoodValues(&quot;HELLO&quot;)" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Framework.Constraints.EndsWithTestIgnoringCase.SucceedsWithGoodValues(&quot;I said Hello&quot;)" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                        </results>
+                      </test-suite>
+                    </results>
+                  </test-suite>
+                  <test-suite type="TestFixture" name="EqualConstraintTests" executed="True" result="Success" success="True" time="0.247" asserts="0">
+                    <results>
+                      <test-case name="NUnit.Framework.Constraints.EqualConstraintTests.CanMatchDates" executed="True" result="Success" success="True" time="0.049" asserts="1" />
+                      <test-case name="NUnit.Framework.Constraints.EqualConstraintTests.CanMatchDatesWithinDays" executed="True" result="Success" success="True" time="0.002" asserts="1" />
+                      <test-case name="NUnit.Framework.Constraints.EqualConstraintTests.CanMatchDatesWithinHours" executed="True" result="Success" success="True" time="0.001" asserts="1" />
+                      <test-case name="NUnit.Framework.Constraints.EqualConstraintTests.CanMatchDatesWithinMilliseconds" executed="True" result="Success" success="True" time="0.001" asserts="1" />
+                      <test-case name="NUnit.Framework.Constraints.EqualConstraintTests.CanMatchDatesWithinMinutes" executed="True" result="Success" success="True" time="0.001" asserts="1" />
+                      <test-case name="NUnit.Framework.Constraints.EqualConstraintTests.CanMatchDatesWithinSeconds" executed="True" result="Success" success="True" time="0.001" asserts="1" />
+                      <test-case name="NUnit.Framework.Constraints.EqualConstraintTests.CanMatchDatesWithinTicks" executed="True" result="Success" success="True" time="0.001" asserts="1" />
+                      <test-case name="NUnit.Framework.Constraints.EqualConstraintTests.CanMatchDatesWithinTimeSpan" executed="True" result="Success" success="True" time="0.001" asserts="1" />
+                      <test-case name="NUnit.Framework.Constraints.EqualConstraintTests.CanMatchDictionaries_DifferentOrder" executed="True" result="Success" success="True" time="0.016" asserts="1" />
+                      <test-case name="NUnit.Framework.Constraints.EqualConstraintTests.CanMatchDictionaries_Failure" executed="True" result="Success" success="True" time="0.005" asserts="1" />
+                      <test-case name="NUnit.Framework.Constraints.EqualConstraintTests.CanMatchDictionaries_SameOrder" executed="True" result="Success" success="True" time="0.001" asserts="1" />
+                      <test-suite type="ParameterizedTest" name="CanMatchDoublesWithRelativeTolerance" executed="True" result="Success" success="True" time="0.007" asserts="0">
+                        <results>
+                          <test-case name="NUnit.Framework.Constraints.EqualConstraintTests.CanMatchDoublesWithRelativeTolerance(10000.0d)" executed="True" result="Success" success="True" time="0.002" asserts="1" />
+                          <test-case name="NUnit.Framework.Constraints.EqualConstraintTests.CanMatchDoublesWithRelativeTolerance(9500.0d)" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Framework.Constraints.EqualConstraintTests.CanMatchDoublesWithRelativeTolerance(10500.0d)" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                        </results>
+                      </test-suite>
+                      <test-suite type="ParameterizedTest" name="CanMatchDoublesWithUlpTolerance" executed="True" result="Success" success="True" time="0.004" asserts="0">
+                        <results>
+                          <test-case name="NUnit.Framework.Constraints.EqualConstraintTests.CanMatchDoublesWithUlpTolerance(2E+16.0d)" executed="True" result="Success" success="True" time="0.002" asserts="1" />
+                          <test-case name="NUnit.Framework.Constraints.EqualConstraintTests.CanMatchDoublesWithUlpTolerance(2E+16.0d)" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                        </results>
+                      </test-suite>
+                      <test-case name="NUnit.Framework.Constraints.EqualConstraintTests.CanMatchHashtables_DifferentOrder" executed="True" result="Success" success="True" time="0.001" asserts="1" />
+                      <test-case name="NUnit.Framework.Constraints.EqualConstraintTests.CanMatchHashtables_Failure" executed="True" result="Success" success="True" time="0.001" asserts="1" />
+                      <test-case name="NUnit.Framework.Constraints.EqualConstraintTests.CanMatchHashtables_SameOrder" executed="True" result="Success" success="True" time="0.001" asserts="1" />
+                      <test-case name="NUnit.Framework.Constraints.EqualConstraintTests.CanMatchHashtableWithDictionary" executed="True" result="Success" success="True" time="0.001" asserts="1" />
+                      <test-suite type="ParameterizedTest" name="CanMatchSinglesWithRelativeTolerance" executed="True" result="Success" success="True" time="0.005" asserts="0">
+                        <results>
+                          <test-case name="NUnit.Framework.Constraints.EqualConstraintTests.CanMatchSinglesWithRelativeTolerance(10500.0f)" executed="True" result="Success" success="True" time="0.001" asserts="1" />
+                          <test-case name="NUnit.Framework.Constraints.EqualConstraintTests.CanMatchSinglesWithRelativeTolerance(9500.0f)" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Framework.Constraints.EqualConstraintTests.CanMatchSinglesWithRelativeTolerance(10000.0f)" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                        </results>
+                      </test-suite>
+                      <test-suite type="ParameterizedTest" name="CanMatchSinglesWithUlpTolerance" executed="True" result="Success" success="True" time="0.003" asserts="0">
+                        <results>
+                          <test-case name="NUnit.Framework.Constraints.EqualConstraintTests.CanMatchSinglesWithUlpTolerance(2E+07.0f)" executed="True" result="Success" success="True" time="0.001" asserts="1" />
+                          <test-case name="NUnit.Framework.Constraints.EqualConstraintTests.CanMatchSinglesWithUlpTolerance(2E+07.0f)" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                        </results>
+                      </test-suite>
+                      <test-suite type="ParameterizedTest" name="CanMatchSpecialFloatingPointValues" executed="True" result="Success" success="True" time="0.007" asserts="0">
+                        <results>
+                          <test-case name="NUnit.Framework.Constraints.EqualConstraintTests.CanMatchSpecialFloatingPointValues(double.NegativeInfinity)" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Framework.Constraints.EqualConstraintTests.CanMatchSpecialFloatingPointValues(double.PositiveInfinity)" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Framework.Constraints.EqualConstraintTests.CanMatchSpecialFloatingPointValues(float.NaN)" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Framework.Constraints.EqualConstraintTests.CanMatchSpecialFloatingPointValues(float.PositiveInfinity)" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Framework.Constraints.EqualConstraintTests.CanMatchSpecialFloatingPointValues(float.NegativeInfinity)" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Framework.Constraints.EqualConstraintTests.CanMatchSpecialFloatingPointValues(double.NaN)" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                        </results>
+                      </test-suite>
+                      <test-case name="NUnit.Framework.Constraints.EqualConstraintTests.CanMatchTimeSpanWithinMinutes" executed="True" result="Success" success="True" time="0.001" asserts="1" />
+                      <test-case name="NUnit.Framework.Constraints.EqualConstraintTests.CanMatchUsingIsEqualToWithinTimeSpan" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                      <test-case name="NUnit.Framework.Constraints.EqualConstraintTests.ConstraintTestBaseNoData.ProvidesProperDescription" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                      <test-case name="NUnit.Framework.Constraints.EqualConstraintTests.ConstraintTestBaseNoData.ProvidesProperStringRepresentation" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                      <test-case name="NUnit.Framework.Constraints.EqualConstraintTests.ErrorIfDaysPrecedesWithin" executed="True" result="Success" success="True" time="0.001" asserts="0" />
+                      <test-case name="NUnit.Framework.Constraints.EqualConstraintTests.ErrorIfHoursPrecedesWithin" executed="True" result="Success" success="True" time="0.001" asserts="0" />
+                      <test-case name="NUnit.Framework.Constraints.EqualConstraintTests.ErrorIfMillisecondsPrecedesWithin" executed="True" result="Success" success="True" time="0.001" asserts="0" />
+                      <test-case name="NUnit.Framework.Constraints.EqualConstraintTests.ErrorIfMinutesPrecedesWithin" executed="True" result="Success" success="True" time="0.001" asserts="0" />
+                      <test-case name="NUnit.Framework.Constraints.EqualConstraintTests.ErrorIfPercentPrecedesWithin" executed="True" result="Success" success="True" time="0.001" asserts="0" />
+                      <test-case name="NUnit.Framework.Constraints.EqualConstraintTests.ErrorIfSecondsPrecedesWithin" executed="True" result="Success" success="True" time="0.001" asserts="0" />
+                      <test-case name="NUnit.Framework.Constraints.EqualConstraintTests.ErrorIfTicksPrecedesWithin" executed="True" result="Success" success="True" time="0.001" asserts="0" />
+                      <test-case name="NUnit.Framework.Constraints.EqualConstraintTests.ErrorIfUlpsIsUsedOnDecimal" executed="True" result="Success" success="True" time="0.001" asserts="1" />
+                      <test-suite type="ParameterizedTest" name="ErrorIfUlpsIsUsedOnIntegralType" executed="True" result="Success" success="True" time="0.007" asserts="0">
+                        <results>
+                          <test-case name="NUnit.Framework.Constraints.EqualConstraintTests.ErrorIfUlpsIsUsedOnIntegralType(1000,1010)" executed="True" result="Success" success="True" time="0.001" asserts="1" />
+                          <test-case name="NUnit.Framework.Constraints.EqualConstraintTests.ErrorIfUlpsIsUsedOnIntegralType(1000UL,1010UL)" executed="True" result="Success" success="True" time="0.001" asserts="1" />
+                          <test-case name="NUnit.Framework.Constraints.EqualConstraintTests.ErrorIfUlpsIsUsedOnIntegralType(1000,1010)" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Framework.Constraints.EqualConstraintTests.ErrorIfUlpsIsUsedOnIntegralType(1000L,1010L)" executed="True" result="Success" success="True" time="0.001" asserts="1" />
+                        </results>
+                      </test-suite>
+                      <test-case name="NUnit.Framework.Constraints.EqualConstraintTests.ErrorIfUlpsPrecedesWithin" executed="True" result="Success" success="True" time="0.001" asserts="0" />
+                      <test-case name="NUnit.Framework.Constraints.EqualConstraintTests.ErrorWithPercentAndUlpsToleranceModes" executed="True" result="Success" success="True" time="0.001" asserts="0" />
+                      <test-case name="NUnit.Framework.Constraints.EqualConstraintTests.ErrorWithUlpsAndPercentToleranceModes" executed="True" result="Success" success="True" time="0.001" asserts="0" />
+                      <test-suite type="ParameterizedTest" name="FailsOnDoublesOutsideOfRelativeTolerance" executed="True" result="Success" success="True" time="0.005" asserts="0">
+                        <results>
+                          <test-case name="NUnit.Framework.Constraints.EqualConstraintTests.FailsOnDoublesOutsideOfRelativeTolerance(8500.0d)" executed="True" result="Success" success="True" time="0.002" asserts="1" />
+                          <test-case name="NUnit.Framework.Constraints.EqualConstraintTests.FailsOnDoublesOutsideOfRelativeTolerance(11500.0d)" executed="True" result="Success" success="True" time="0.001" asserts="1" />
+                        </results>
+                      </test-suite>
+                      <test-suite type="ParameterizedTest" name="FailsOnDoublesOutsideOfUlpTolerance" executed="True" result="Success" success="True" time="0.003" asserts="0">
+                        <results>
+                          <test-case name="NUnit.Framework.Constraints.EqualConstraintTests.FailsOnDoublesOutsideOfUlpTolerance(2E+16.0d)" executed="True" result="Success" success="True" time="0.001" asserts="1" />
+                          <test-case name="NUnit.Framework.Constraints.EqualConstraintTests.FailsOnDoublesOutsideOfUlpTolerance(2E+16.0d)" executed="True" result="Success" success="True" time="0.001" asserts="1" />
+                        </results>
+                      </test-suite>
+                      <test-suite type="ParameterizedTest" name="FailsOnSinglesOutsideOfRelativeTolerance" executed="True" result="Success" success="True" time="0.004" asserts="0">
+                        <results>
+                          <test-case name="NUnit.Framework.Constraints.EqualConstraintTests.FailsOnSinglesOutsideOfRelativeTolerance(8500.0f)" executed="True" result="Success" success="True" time="0.001" asserts="1" />
+                          <test-case name="NUnit.Framework.Constraints.EqualConstraintTests.FailsOnSinglesOutsideOfRelativeTolerance(11500.0f)" executed="True" result="Success" success="True" time="0.001" asserts="1" />
+                        </results>
+                      </test-suite>
+                      <test-suite type="ParameterizedTest" name="FailsOnSinglesOutsideOfUlpTolerance" executed="True" result="Success" success="True" time="0.004" asserts="0">
+                        <results>
+                          <test-case name="NUnit.Framework.Constraints.EqualConstraintTests.FailsOnSinglesOutsideOfUlpTolerance(2E+07.0f)" executed="True" result="Success" success="True" time="0.001" asserts="1" />
+                          <test-case name="NUnit.Framework.Constraints.EqualConstraintTests.FailsOnSinglesOutsideOfUlpTolerance(2E+07.0f)" executed="True" result="Success" success="True" time="0.001" asserts="1" />
+                        </results>
+                      </test-suite>
+                      <test-suite type="ParameterizedTest" name="FailsWithBadValues" executed="True" result="Success" success="True" time="0.007" asserts="0">
+                        <results>
+                          <test-case name="NUnit.Framework.Constraints.EqualConstraintTests.FailsWithBadValues(5)" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Framework.Constraints.EqualConstraintTests.FailsWithBadValues(null)" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Framework.Constraints.EqualConstraintTests.FailsWithBadValues(&quot;Hello&quot;)" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Framework.Constraints.EqualConstraintTests.FailsWithBadValues(double.NaN)" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Framework.Constraints.EqualConstraintTests.FailsWithBadValues(double.PositiveInfinity)" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                        </results>
+                      </test-suite>
+                      <test-suite type="ParameterizedTest" name="ProvidesProperFailureMessage" executed="True" result="Success" success="True" time="0.006" asserts="0">
+                        <results>
+                          <test-case name="NUnit.Framework.Constraints.EqualConstraintTests.ProvidesProperFailureMessage(5,&quot;5&quot;)" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Framework.Constraints.EqualConstraintTests.ProvidesProperFailureMessage(null,&quot;null&quot;)" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Framework.Constraints.EqualConstraintTests.ProvidesProperFailureMessage(&quot;Hello&quot;,&quot;\&quot;Hello\&quot;&quot;)" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Framework.Constraints.EqualConstraintTests.ProvidesProperFailureMessage(double.NaN,&quot;NaN&quot;)" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Framework.Constraints.EqualConstraintTests.ProvidesProperFailureMessage(double.PositiveInfinity,&quot;Infinity&quot;)" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                        </results>
+                      </test-suite>
+                      <test-suite type="ParameterizedTest" name="SucceedsWithGoodValues" executed="True" result="Success" success="True" time="0.006" asserts="0">
+                        <results>
+                          <test-case name="NUnit.Framework.Constraints.EqualConstraintTests.SucceedsWithGoodValues(4)" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Framework.Constraints.EqualConstraintTests.SucceedsWithGoodValues(4.0f)" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Framework.Constraints.EqualConstraintTests.SucceedsWithGoodValues(4.0d)" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Framework.Constraints.EqualConstraintTests.SucceedsWithGoodValues(4.0000m)" executed="True" result="Success" success="True" time="0.001" asserts="1" />
+                        </results>
+                      </test-suite>
+                      <test-case name="NUnit.Framework.Constraints.EqualConstraintTests.UsesProvidedArrayComparer" executed="True" result="Success" success="True" time="0.002" asserts="1" />
+                      <test-case name="NUnit.Framework.Constraints.EqualConstraintTests.UsesProvidedComparerOfT" executed="True" result="Success" success="True" time="0.004" asserts="2" />
+                      <test-case name="NUnit.Framework.Constraints.EqualConstraintTests.UsesProvidedComparisonOfT" executed="True" result="Success" success="True" time="0.003" asserts="2" />
+                      <test-case name="NUnit.Framework.Constraints.EqualConstraintTests.UsesProvidedEqualityComparer" executed="True" result="Success" success="True" time="0.001" asserts="2" />
+                      <test-case name="NUnit.Framework.Constraints.EqualConstraintTests.UsesProvidedEqualityComparerOfT" executed="True" result="Success" success="True" time="0.003" asserts="2" />
+                      <test-case name="NUnit.Framework.Constraints.EqualConstraintTests.UsesProvidedIComparer" executed="True" result="Success" success="True" time="0.001" asserts="2" />
+                      <test-case name="NUnit.Framework.Constraints.EqualConstraintTests.UsesProvidedLambda_IntArgs" executed="True" result="Success" success="True" time="0.001" asserts="1" />
+                      <test-case name="NUnit.Framework.Constraints.EqualConstraintTests.UsesProvidedLambda_StringArgs" executed="True" result="Success" success="True" time="0.001" asserts="1" />
+                      <test-case name="NUnit.Framework.Constraints.EqualConstraintTests.UsesProvidedListComparer" executed="True" result="Success" success="True" time="0.003" asserts="1" />
+                    </results>
+                  </test-suite>
+                  <test-suite type="TestFixture" name="EqualConstraintTests+DateTimeOffSetEquality" executed="True" result="Success" success="True" time="0.016" asserts="0">
+                    <results>
+                      <test-case name="NUnit.Framework.Constraints.EqualConstraintTests+DateTimeOffSetEquality.CanMatchDates" executed="True" result="Success" success="True" time="0.001" asserts="1" />
+                      <test-case name="NUnit.Framework.Constraints.EqualConstraintTests+DateTimeOffSetEquality.CanMatchDatesWithinDays" executed="True" result="Success" success="True" time="0.001" asserts="1" />
+                      <test-case name="NUnit.Framework.Constraints.EqualConstraintTests+DateTimeOffSetEquality.CanMatchDatesWithinMilliseconds" executed="True" result="Success" success="True" time="0.001" asserts="1" />
+                      <test-case name="NUnit.Framework.Constraints.EqualConstraintTests+DateTimeOffSetEquality.CanMatchDatesWithinMinutes" executed="True" result="Success" success="True" time="0.001" asserts="1" />
+                      <test-case name="NUnit.Framework.Constraints.EqualConstraintTests+DateTimeOffSetEquality.CanMatchDatesWithinSeconds" executed="True" result="Success" success="True" time="0.001" asserts="1" />
+                      <test-case name="NUnit.Framework.Constraints.EqualConstraintTests+DateTimeOffSetEquality.CanMatchDatesWithinTicks" executed="True" result="Success" success="True" time="0.001" asserts="1" />
+                      <test-case name="NUnit.Framework.Constraints.EqualConstraintTests+DateTimeOffSetEquality.CanMatchDatesWithinTimeSpan" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                      <test-case name="NUnit.Framework.Constraints.EqualConstraintTests+DateTimeOffSetEquality.CanMatchUsingIsEqualToWithinTimeSpan" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                      <test-case name="NUnit.Framework.Constraints.EqualConstraintTests+DateTimeOffSetEquality.DTimeOffsetCanMatchDatesWithinHours" executed="True" result="Success" success="True" time="0.001" asserts="1" />
+                    </results>
+                  </test-suite>
+                  <test-suite type="TestFixture" name="EqualityComparerTests" executed="True" result="Success" success="True" time="0.012" asserts="0">
+                    <results>
+                      <test-case name="NUnit.Framework.Constraints.EqualityComparerTests.CanCompareArrayContainingSelfToSelf" executed="True" result="Success" success="True" time="0.001" asserts="1" />
+                      <test-case name="NUnit.Framework.Constraints.EqualityComparerTests.CrossReferencingRecursiveEnumerablesAreNotEqual" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                      <test-case name="NUnit.Framework.Constraints.EqualityComparerTests.IEquatableDifferentTypesSuccess_WhenActualImplementsIEquatable" executed="True" result="Success" success="True" time="0.001" asserts="1" />
+                      <test-case name="NUnit.Framework.Constraints.EqualityComparerTests.IEquatableDifferentTypesSuccess_WhenExpectedImplementsIEquatable" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                      <test-case name="NUnit.Framework.Constraints.EqualityComparerTests.IEquatableHasPrecedenceOverDefaultEquals" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                      <test-case name="NUnit.Framework.Constraints.EqualityComparerTests.IEquatableSuccess" executed="True" result="Success" success="True" time="0.001" asserts="1" />
+                      <test-case name="NUnit.Framework.Constraints.EqualityComparerTests.RecursionCheckDoesNotRelyOnValueEquality" executed="True" result="Success" success="True" time="0.002" asserts="1" />
+                      <test-case name="NUnit.Framework.Constraints.EqualityComparerTests.ReferenceEqualityHasPrecedenceOverIEquatable" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                      <test-case name="NUnit.Framework.Constraints.EqualityComparerTests.SelfContainingRecursiveEnumerablesAreNotEqual" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                    </results>
+                  </test-suite>
+                  <test-suite type="TestFixture" name="EqualTest" executed="True" result="Success" success="True" time="0.008" asserts="0">
+                    <results>
+                      <test-case name="NUnit.Framework.Constraints.EqualTest.FailedStringMatchShowsFailurePosition" executed="True" result="Success" success="True" time="0.003" asserts="2" />
+                      <test-case name="NUnit.Framework.Constraints.EqualTest.LongStringsAreTruncated" executed="True" result="Success" success="True" time="0.001" asserts="2" />
+                      <test-case name="NUnit.Framework.Constraints.EqualTest.LongStringsAreTruncatedAtBothEndsIfNecessary" executed="True" result="Success" success="True" time="0.000" asserts="2" />
+                      <test-case name="NUnit.Framework.Constraints.EqualTest.LongStringsAreTruncatedAtFrontEndIfNecessary" executed="True" result="Success" success="True" time="0.000" asserts="2" />
+                      <test-case name="NUnit.Framework.Constraints.EqualTest.TestPropertyWithPrivateSetter" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                    </results>
+                  </test-suite>
+                  <test-suite type="TestFixture" name="ExactCountConstraintTests" executed="True" result="Success" success="True" time="0.007" asserts="0">
+                    <results>
+                      <test-case name="NUnit.Framework.Constraints.ExactCountConstraintTests.ExactlyOneItemMatches" executed="True" result="Success" success="True" time="0.001" asserts="2" />
+                      <test-case name="NUnit.Framework.Constraints.ExactCountConstraintTests.ExactlyOneItemMatchFails" executed="True" result="Success" success="True" time="0.001" asserts="2" />
+                      <test-case name="NUnit.Framework.Constraints.ExactCountConstraintTests.ExactlyTwoItemsMatch" executed="True" result="Success" success="True" time="0.000" asserts="2" />
+                      <test-case name="NUnit.Framework.Constraints.ExactCountConstraintTests.ExactlyTwoItemsMatchFails" executed="True" result="Success" success="True" time="0.000" asserts="2" />
+                      <test-case name="NUnit.Framework.Constraints.ExactCountConstraintTests.ZeroItemsMatch" executed="True" result="Success" success="True" time="0.000" asserts="2" />
+                      <test-case name="NUnit.Framework.Constraints.ExactCountConstraintTests.ZeroItemsMatchFails" executed="True" result="Success" success="True" time="0.001" asserts="2" />
+                    </results>
+                  </test-suite>
+                  <test-suite type="TestFixture" name="ExactTypeConstraintTests" executed="True" result="Success" success="True" time="0.007" asserts="0">
+                    <results>
+                      <test-case name="NUnit.Framework.Constraints.ExactTypeConstraintTests.ConstraintTestBaseNoData.ProvidesProperDescription" executed="True" result="Success" success="True" time="0.001" asserts="1" />
+                      <test-case name="NUnit.Framework.Constraints.ExactTypeConstraintTests.ConstraintTestBaseNoData.ProvidesProperStringRepresentation" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                      <test-suite type="ParameterizedTest" name="FailsWithBadValues" executed="True" result="Success" success="True" time="0.001" asserts="0">
+                        <results>
+                          <test-case name="NUnit.Framework.Constraints.ExactTypeConstraintTests.FailsWithBadValues(NUnit.Framework.Constraints.ExactTypeConstraintTests+B)" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Framework.Constraints.ExactTypeConstraintTests.FailsWithBadValues(NUnit.Framework.Constraints.ExactTypeConstraintTests+D2)" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                        </results>
+                      </test-suite>
+                      <test-suite type="ParameterizedTest" name="ProvidesProperFailureMessage" executed="True" result="Success" success="True" time="0.001" asserts="0">
+                        <results>
+                          <test-case name="NUnit.Framework.Constraints.ExactTypeConstraintTests.ProvidesProperFailureMessage(NUnit.Framework.Constraints.ExactTypeConstraintTests+B,&quot;&lt;NUnit.Framework.Constraints.ExactTypeConstraintTests+B&gt;&quot;)" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Framework.Constraints.ExactTypeConstraintTests.ProvidesProperFailureMessage(NUnit.Framework.Constraints.ExactTypeConstraintTests+D2,&quot;&lt;NUnit.Framework.Constraints.ExactTypeConstraintTests+D2&gt;&quot;)" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                        </results>
+                      </test-suite>
+                      <test-suite type="ParameterizedTest" name="SucceedsWithGoodValues" executed="True" result="Success" success="True" time="0.000" asserts="0">
+                        <results>
+                          <test-case name="NUnit.Framework.Constraints.ExactTypeConstraintTests.SucceedsWithGoodValues(NUnit.Framework.Constraints.ExactTypeConstraintTests+D1)" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                        </results>
+                      </test-suite>
+                    </results>
+                  </test-suite>
+                  <test-suite type="TestFixture" name="FalseConstraintTest" executed="True" result="Success" success="True" time="0.012" asserts="0">
+                    <results>
+                      <test-case name="NUnit.Framework.Constraints.FalseConstraintTest.ConstraintTestBaseNoData.ProvidesProperDescription" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                      <test-case name="NUnit.Framework.Constraints.FalseConstraintTest.ConstraintTestBaseNoData.ProvidesProperStringRepresentation" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                      <test-suite type="ParameterizedTest" name="FailsWithBadValues" executed="True" result="Success" success="True" time="0.003" asserts="0">
+                        <results>
+                          <test-case name="NUnit.Framework.Constraints.FalseConstraintTest.FailsWithBadValues(null)" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Framework.Constraints.FalseConstraintTest.FailsWithBadValues(&quot;hello&quot;)" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Framework.Constraints.FalseConstraintTest.FailsWithBadValues(True)" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Framework.Constraints.FalseConstraintTest.FailsWithBadValues(True)" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                        </results>
+                      </test-suite>
+                      <test-suite type="ParameterizedTest" name="ProvidesProperFailureMessage" executed="True" result="Success" success="True" time="0.002" asserts="0">
+                        <results>
+                          <test-case name="NUnit.Framework.Constraints.FalseConstraintTest.ProvidesProperFailureMessage(null,&quot;null&quot;)" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Framework.Constraints.FalseConstraintTest.ProvidesProperFailureMessage(&quot;hello&quot;,&quot;\&quot;hello\&quot;&quot;)" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Framework.Constraints.FalseConstraintTest.ProvidesProperFailureMessage(True,&quot;True&quot;)" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Framework.Constraints.FalseConstraintTest.ProvidesProperFailureMessage(True,&quot;True&quot;)" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                        </results>
+                      </test-suite>
+                      <test-suite type="ParameterizedTest" name="SucceedsWithGoodValues" executed="True" result="Success" success="True" time="0.001" asserts="0">
+                        <results>
+                          <test-case name="NUnit.Framework.Constraints.FalseConstraintTest.SucceedsWithGoodValues(False)" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Framework.Constraints.FalseConstraintTest.SucceedsWithGoodValues(False)" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                        </results>
+                      </test-suite>
+                    </results>
+                  </test-suite>
+                  <test-suite type="TestFixture" name="FloatingPointNumericsTest" executed="True" result="Success" success="True" time="0.006" asserts="0">
+                    <results>
+                      <test-case name="NUnit.Framework.Constraints.FloatingPointNumericsTest.DoubleEqualityWithUlps" executed="True" result="Success" success="True" time="0.000" asserts="4" />
+                      <test-case name="NUnit.Framework.Constraints.FloatingPointNumericsTest.FloatEqualityWithUlps" executed="True" result="Success" success="True" time="0.000" asserts="4" />
+                      <test-case name="NUnit.Framework.Constraints.FloatingPointNumericsTest.MirroredDoubleReinterpretation" executed="True" result="Success" success="True" time="0.001" asserts="1" />
+                      <test-case name="NUnit.Framework.Constraints.FloatingPointNumericsTest.MirroredFloatReinterpretation" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                      <test-case name="NUnit.Framework.Constraints.FloatingPointNumericsTest.MirroredIntegerReinterpretation" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                      <test-case name="NUnit.Framework.Constraints.FloatingPointNumericsTest.MirroredLongReinterpretation" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                    </results>
+                  </test-suite>
+                  <test-suite type="TestFixture" name="GreaterThanConstraintTests" executed="True" result="Success" success="True" time="0.021" asserts="0">
+                    <results>
+                      <test-case name="NUnit.Framework.Constraints.GreaterThanConstraintTests.CanCompareIComparables" executed="True" result="Success" success="True" time="0.001" asserts="1" />
+                      <test-case name="NUnit.Framework.Constraints.GreaterThanConstraintTests.CanCompareIComparablesOfT" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                      <test-case name="NUnit.Framework.Constraints.GreaterThanConstraintTests.ComparisonConstraintTest.UsesProvidedComparerOfT" executed="True" result="Success" success="True" time="0.001" asserts="1" />
+                      <test-case name="NUnit.Framework.Constraints.GreaterThanConstraintTests.ComparisonConstraintTest.UsesProvidedComparisonOfT" executed="True" result="Success" success="True" time="0.001" asserts="1" />
+                      <test-case name="NUnit.Framework.Constraints.GreaterThanConstraintTests.ComparisonConstraintTest.UsesProvidedIComparer" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                      <test-case name="NUnit.Framework.Constraints.GreaterThanConstraintTests.ComparisonConstraintTest.UsesProvidedLambda" executed="True" result="Success" success="True" time="0.000" asserts="0" />
+                      <test-case name="NUnit.Framework.Constraints.GreaterThanConstraintTests.ConstraintTestBaseNoData.ProvidesProperDescription" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                      <test-case name="NUnit.Framework.Constraints.GreaterThanConstraintTests.ConstraintTestBaseNoData.ProvidesProperStringRepresentation" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                      <test-suite type="ParameterizedTest" name="FailsWithBadValues" executed="True" result="Success" success="True" time="0.001" asserts="0">
+                        <results>
+                          <test-case name="NUnit.Framework.Constraints.GreaterThanConstraintTests.FailsWithBadValues(4)" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Framework.Constraints.GreaterThanConstraintTests.FailsWithBadValues(5)" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                        </results>
+                      </test-suite>
+                      <test-suite type="ParameterizedTest" name="InvalidDataThrowsArgumentException" executed="True" result="Success" success="True" time="0.007" asserts="0">
+                        <results>
+                          <test-case name="NUnit.Framework.Constraints.GreaterThanConstraintTests.InvalidDataThrowsArgumentException(null)" executed="True" result="Success" success="True" time="0.000" asserts="0" />
+                          <test-case name="NUnit.Framework.Constraints.GreaterThanConstraintTests.InvalidDataThrowsArgumentException(&quot;xxx&quot;)" executed="True" result="Success" success="True" time="0.006" asserts="0" />
+                        </results>
+                      </test-suite>
+                      <test-suite type="ParameterizedTest" name="ProvidesProperFailureMessage" executed="True" result="Success" success="True" time="0.001" asserts="0">
+                        <results>
+                          <test-case name="NUnit.Framework.Constraints.GreaterThanConstraintTests.ProvidesProperFailureMessage(4,&quot;4&quot;)" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Framework.Constraints.GreaterThanConstraintTests.ProvidesProperFailureMessage(5,&quot;5&quot;)" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                        </results>
+                      </test-suite>
+                      <test-suite type="ParameterizedTest" name="SucceedsWithGoodValues" executed="True" result="Success" success="True" time="0.001" asserts="0">
+                        <results>
+                          <test-case name="NUnit.Framework.Constraints.GreaterThanConstraintTests.SucceedsWithGoodValues(6)" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Framework.Constraints.GreaterThanConstraintTests.SucceedsWithGoodValues(5.001d)" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                        </results>
+                      </test-suite>
+                    </results>
+                  </test-suite>
+                  <test-suite type="TestFixture" name="GreaterThanOrEqualConstraintTests" executed="True" result="Success" success="True" time="0.010" asserts="0">
+                    <results>
+                      <test-case name="NUnit.Framework.Constraints.GreaterThanOrEqualConstraintTests.CanCompareIComparables" executed="True" result="Success" success="True" time="0.001" asserts="1" />
+                      <test-case name="NUnit.Framework.Constraints.GreaterThanOrEqualConstraintTests.CanCompareIComparablesOfT" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                      <test-case name="NUnit.Framework.Constraints.GreaterThanOrEqualConstraintTests.ComparisonConstraintTest.UsesProvidedComparerOfT" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                      <test-case name="NUnit.Framework.Constraints.GreaterThanOrEqualConstraintTests.ComparisonConstraintTest.UsesProvidedComparisonOfT" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                      <test-case name="NUnit.Framework.Constraints.GreaterThanOrEqualConstraintTests.ComparisonConstraintTest.UsesProvidedIComparer" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                      <test-case name="NUnit.Framework.Constraints.GreaterThanOrEqualConstraintTests.ComparisonConstraintTest.UsesProvidedLambda" executed="True" result="Success" success="True" time="0.000" asserts="0" />
+                      <test-case name="NUnit.Framework.Constraints.GreaterThanOrEqualConstraintTests.ConstraintTestBaseNoData.ProvidesProperDescription" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                      <test-case name="NUnit.Framework.Constraints.GreaterThanOrEqualConstraintTests.ConstraintTestBaseNoData.ProvidesProperStringRepresentation" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                      <test-suite type="ParameterizedTest" name="FailsWithBadValues" executed="True" result="Success" success="True" time="0.000" asserts="0">
+                        <results>
+                          <test-case name="NUnit.Framework.Constraints.GreaterThanOrEqualConstraintTests.FailsWithBadValues(4)" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                        </results>
+                      </test-suite>
+                      <test-suite type="ParameterizedTest" name="InvalidDataThrowsArgumentException" executed="True" result="Success" success="True" time="0.001" asserts="0">
+                        <results>
+                          <test-case name="NUnit.Framework.Constraints.GreaterThanOrEqualConstraintTests.InvalidDataThrowsArgumentException(null)" executed="True" result="Success" success="True" time="0.000" asserts="0" />
+                          <test-case name="NUnit.Framework.Constraints.GreaterThanOrEqualConstraintTests.InvalidDataThrowsArgumentException(&quot;xxx&quot;)" executed="True" result="Success" success="True" time="0.000" asserts="0" />
+                        </results>
+                      </test-suite>
+                      <test-suite type="ParameterizedTest" name="ProvidesProperFailureMessage" executed="True" result="Success" success="True" time="0.000" asserts="0">
+                        <results>
+                          <test-case name="NUnit.Framework.Constraints.GreaterThanOrEqualConstraintTests.ProvidesProperFailureMessage(4,&quot;4&quot;)" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                        </results>
+                      </test-suite>
+                      <test-suite type="ParameterizedTest" name="SucceedsWithGoodValues" executed="True" result="Success" success="True" time="0.001" asserts="0">
+                        <results>
+                          <test-case name="NUnit.Framework.Constraints.GreaterThanOrEqualConstraintTests.SucceedsWithGoodValues(6)" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Framework.Constraints.GreaterThanOrEqualConstraintTests.SucceedsWithGoodValues(5)" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                        </results>
+                      </test-suite>
+                    </results>
+                  </test-suite>
+                  <test-suite type="TestFixture" name="InstanceOfTypeConstraintTests" executed="True" result="Success" success="True" time="0.005" asserts="0">
+                    <results>
+                      <test-case name="NUnit.Framework.Constraints.InstanceOfTypeConstraintTests.ConstraintTestBaseNoData.ProvidesProperDescription" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                      <test-case name="NUnit.Framework.Constraints.InstanceOfTypeConstraintTests.ConstraintTestBaseNoData.ProvidesProperStringRepresentation" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                      <test-suite type="ParameterizedTest" name="FailsWithBadValues" executed="True" result="Success" success="True" time="0.000" asserts="0">
+                        <results>
+                          <test-case name="NUnit.Framework.Constraints.InstanceOfTypeConstraintTests.FailsWithBadValues(NUnit.Framework.Constraints.InstanceOfTypeConstraintTests+B)" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                        </results>
+                      </test-suite>
+                      <test-suite type="ParameterizedTest" name="ProvidesProperFailureMessage" executed="True" result="Success" success="True" time="0.000" asserts="0">
+                        <results>
+                          <test-case name="NUnit.Framework.Constraints.InstanceOfTypeConstraintTests.ProvidesProperFailureMessage(NUnit.Framework.Constraints.InstanceOfTypeConstraintTests+B,&quot;&lt;NUnit.Framework.Constraints.InstanceOfTypeConstraintTests+B&gt;&quot;)" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                        </results>
+                      </test-suite>
+                      <test-suite type="ParameterizedTest" name="SucceedsWithGoodValues" executed="True" result="Success" success="True" time="0.001" asserts="0">
+                        <results>
+                          <test-case name="NUnit.Framework.Constraints.InstanceOfTypeConstraintTests.SucceedsWithGoodValues(NUnit.Framework.Constraints.InstanceOfTypeConstraintTests+D1)" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Framework.Constraints.InstanceOfTypeConstraintTests.SucceedsWithGoodValues(NUnit.Framework.Constraints.InstanceOfTypeConstraintTests+D2)" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                        </results>
+                      </test-suite>
+                    </results>
+                  </test-suite>
+                  <test-suite type="TestFixture" name="LessThanConstraintTests" executed="True" result="Success" success="True" time="0.011" asserts="0">
+                    <results>
+                      <test-case name="NUnit.Framework.Constraints.LessThanConstraintTests.CanCompareIComparables" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                      <test-case name="NUnit.Framework.Constraints.LessThanConstraintTests.CanCompareIComparablesOfT" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                      <test-case name="NUnit.Framework.Constraints.LessThanConstraintTests.ComparisonConstraintTest.UsesProvidedComparerOfT" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                      <test-case name="NUnit.Framework.Constraints.LessThanConstraintTests.ComparisonConstraintTest.UsesProvidedComparisonOfT" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                      <test-case name="NUnit.Framework.Constraints.LessThanConstraintTests.ComparisonConstraintTest.UsesProvidedIComparer" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                      <test-case name="NUnit.Framework.Constraints.LessThanConstraintTests.ComparisonConstraintTest.UsesProvidedLambda" executed="True" result="Success" success="True" time="0.000" asserts="0" />
+                      <test-case name="NUnit.Framework.Constraints.LessThanConstraintTests.ConstraintTestBaseNoData.ProvidesProperDescription" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                      <test-case name="NUnit.Framework.Constraints.LessThanConstraintTests.ConstraintTestBaseNoData.ProvidesProperStringRepresentation" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                      <test-suite type="ParameterizedTest" name="FailsWithBadValues" executed="True" result="Success" success="True" time="0.001" asserts="0">
+                        <results>
+                          <test-case name="NUnit.Framework.Constraints.LessThanConstraintTests.FailsWithBadValues(6)" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Framework.Constraints.LessThanConstraintTests.FailsWithBadValues(5)" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                        </results>
+                      </test-suite>
+                      <test-suite type="ParameterizedTest" name="InvalidDataThrowsArgumentException" executed="True" result="Success" success="True" time="0.001" asserts="0">
+                        <results>
+                          <test-case name="NUnit.Framework.Constraints.LessThanConstraintTests.InvalidDataThrowsArgumentException(null)" executed="True" result="Success" success="True" time="0.000" asserts="0" />
+                          <test-case name="NUnit.Framework.Constraints.LessThanConstraintTests.InvalidDataThrowsArgumentException(&quot;xxx&quot;)" executed="True" result="Success" success="True" time="0.000" asserts="0" />
+                        </results>
+                      </test-suite>
+                      <test-suite type="ParameterizedTest" name="ProvidesProperFailureMessage" executed="True" result="Success" success="True" time="0.001" asserts="0">
+                        <results>
+                          <test-case name="NUnit.Framework.Constraints.LessThanConstraintTests.ProvidesProperFailureMessage(6,&quot;6&quot;)" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Framework.Constraints.LessThanConstraintTests.ProvidesProperFailureMessage(5,&quot;5&quot;)" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                        </results>
+                      </test-suite>
+                      <test-suite type="ParameterizedTest" name="SucceedsWithGoodValues" executed="True" result="Success" success="True" time="0.001" asserts="0">
+                        <results>
+                          <test-case name="NUnit.Framework.Constraints.LessThanConstraintTests.SucceedsWithGoodValues(4)" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Framework.Constraints.LessThanConstraintTests.SucceedsWithGoodValues(4.999d)" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                        </results>
+                      </test-suite>
+                    </results>
+                  </test-suite>
+                  <test-suite type="TestFixture" name="LessThanOrEqualConstraintTests" executed="True" result="Success" success="True" time="0.011" asserts="0">
+                    <results>
+                      <test-case name="NUnit.Framework.Constraints.LessThanOrEqualConstraintTests.CanCompareIComparables" executed="True" result="Success" success="True" time="0.001" asserts="1" />
+                      <test-case name="NUnit.Framework.Constraints.LessThanOrEqualConstraintTests.CanCompareIComparablesOfT" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                      <test-case name="NUnit.Framework.Constraints.LessThanOrEqualConstraintTests.ComparisonConstraintTest.UsesProvidedComparerOfT" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                      <test-case name="NUnit.Framework.Constraints.LessThanOrEqualConstraintTests.ComparisonConstraintTest.UsesProvidedComparisonOfT" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                      <test-case name="NUnit.Framework.Constraints.LessThanOrEqualConstraintTests.ComparisonConstraintTest.UsesProvidedIComparer" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                      <test-case name="NUnit.Framework.Constraints.LessThanOrEqualConstraintTests.ComparisonConstraintTest.UsesProvidedLambda" executed="True" result="Success" success="True" time="0.000" asserts="0" />
+                      <test-case name="NUnit.Framework.Constraints.LessThanOrEqualConstraintTests.ConstraintTestBaseNoData.ProvidesProperDescription" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                      <test-case name="NUnit.Framework.Constraints.LessThanOrEqualConstraintTests.ConstraintTestBaseNoData.ProvidesProperStringRepresentation" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                      <test-suite type="ParameterizedTest" name="FailsWithBadValues" executed="True" result="Success" success="True" time="0.000" asserts="0">
+                        <results>
+                          <test-case name="NUnit.Framework.Constraints.LessThanOrEqualConstraintTests.FailsWithBadValues(6)" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                        </results>
+                      </test-suite>
+                      <test-suite type="ParameterizedTest" name="InvalidDataThrowsArgumentException" executed="True" result="Success" success="True" time="0.002" asserts="0">
+                        <results>
+                          <test-case name="NUnit.Framework.Constraints.LessThanOrEqualConstraintTests.InvalidDataThrowsArgumentException(null)" executed="True" result="Success" success="True" time="0.000" asserts="0" />
+                          <test-case name="NUnit.Framework.Constraints.LessThanOrEqualConstraintTests.InvalidDataThrowsArgumentException(&quot;xxx&quot;)" executed="True" result="Success" success="True" time="0.000" asserts="0" />
+                        </results>
+                      </test-suite>
+                      <test-suite type="ParameterizedTest" name="ProvidesProperFailureMessage" executed="True" result="Success" success="True" time="0.000" asserts="0">
+                        <results>
+                          <test-case name="NUnit.Framework.Constraints.LessThanOrEqualConstraintTests.ProvidesProperFailureMessage(6,&quot;6&quot;)" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                        </results>
+                      </test-suite>
+                      <test-suite type="ParameterizedTest" name="SucceedsWithGoodValues" executed="True" result="Success" success="True" time="0.001" asserts="0">
+                        <results>
+                          <test-case name="NUnit.Framework.Constraints.LessThanOrEqualConstraintTests.SucceedsWithGoodValues(4)" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Framework.Constraints.LessThanOrEqualConstraintTests.SucceedsWithGoodValues(5)" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                        </results>
+                      </test-suite>
+                    </results>
+                  </test-suite>
+                  <test-suite type="TestFixture" name="MsgUtilTests" executed="True" result="Success" success="True" time="0.020" asserts="0">
+                    <results>
+                      <test-case name="NUnit.Framework.Constraints.MsgUtilTests.ClipExpectedAndActual_StringsDoNotFitInLine" executed="True" result="Success" success="True" time="0.000" asserts="4" />
+                      <test-case name="NUnit.Framework.Constraints.MsgUtilTests.ClipExpectedAndActual_StringsFitInLine" executed="True" result="Success" success="True" time="0.000" asserts="4" />
+                      <test-case name="NUnit.Framework.Constraints.MsgUtilTests.ClipExpectedAndActual_StringTailsFitInLine" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                      <test-suite type="ParameterizedTest" name="EscapeControlCharsTest" executed="True" result="Success" success="True" time="0.013" asserts="0">
+                        <results>
+                          <test-case name="NUnit.Framework.Constraints.MsgUtilTests.EscapeControlCharsTest(&quot;\r\r&quot;,&quot;\\r\\r&quot;)" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Framework.Constraints.MsgUtilTests.EscapeControlCharsTest(&quot;\n\n\n&quot;,&quot;\\n\\n\\n&quot;)" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Framework.Constraints.MsgUtilTests.EscapeControlCharsTest(&quot;\r&quot;,&quot;\\r&quot;)" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Framework.Constraints.MsgUtilTests.EscapeControlCharsTest(&quot;\n&quot;,&quot;\\n&quot;)" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Framework.Constraints.MsgUtilTests.EscapeControlCharsTest(&quot;\r\r\r&quot;,&quot;\\r\\r\\r&quot;)" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Framework.Constraints.MsgUtilTests.EscapeControlCharsTest(&quot;\r\n&quot;,&quot;\\r\\n&quot;)" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Framework.Constraints.MsgUtilTests.EscapeControlCharsTest(&quot;\n\r&quot;,&quot;\\n\\r&quot;)" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Framework.Constraints.MsgUtilTests.EscapeControlCharsTest(&quot;This is a\rtest message&quot;,&quot;This is a\\rtest message&quot;)" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Framework.Constraints.MsgUtilTests.EscapeControlCharsTest(&quot;&quot;,&quot;&quot;)" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Framework.Constraints.MsgUtilTests.EscapeControlCharsTest(null,null)" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Framework.Constraints.MsgUtilTests.EscapeControlCharsTest(&quot;\t&quot;,&quot;\\t&quot;)" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Framework.Constraints.MsgUtilTests.EscapeControlCharsTest(&quot;\t\n&quot;,&quot;\\t\\n&quot;)" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Framework.Constraints.MsgUtilTests.EscapeControlCharsTest(&quot;\\r\\n&quot;,&quot;\\\\r\\\\n&quot;)" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Framework.Constraints.MsgUtilTests.EscapeControlCharsTest(&quot;\a&quot;,&quot;\\a&quot;)" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Framework.Constraints.MsgUtilTests.EscapeControlCharsTest(&quot;\b&quot;,&quot;\\b&quot;)" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Framework.Constraints.MsgUtilTests.EscapeControlCharsTest(&quot;\f&quot;,&quot;\\f&quot;)" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Framework.Constraints.MsgUtilTests.EscapeControlCharsTest(&quot;\v&quot;,&quot;\\v&quot;)" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Framework.Constraints.MsgUtilTests.EscapeControlCharsTest(&quot;\x0085&quot;,&quot;\\x0085&quot;)" description="Next line character" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Framework.Constraints.MsgUtilTests.EscapeControlCharsTest(&quot;\x2028&quot;,&quot;\\x2028&quot;)" description="Line separator character" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Framework.Constraints.MsgUtilTests.EscapeControlCharsTest(&quot;\x2029&quot;,&quot;\\x2029&quot;)" description="Paragraph separator character" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Framework.Constraints.MsgUtilTests.EscapeControlCharsTest(&quot;\n\n&quot;,&quot;\\n\\n&quot;)" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                        </results>
+                      </test-suite>
+                      <test-suite type="ParameterizedTest" name="TestClipString" executed="True" result="Success" success="True" time="0.002" asserts="0">
+                        <results>
+                          <test-case name="NUnit.Framework.Constraints.MsgUtilTests.NoClippingNeeded" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Framework.Constraints.MsgUtilTests.ClipAtStartAndEnd" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Framework.Constraints.MsgUtilTests.ClipAtEnd" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Framework.Constraints.MsgUtilTests.ClipAtStart" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                        </results>
+                      </test-suite>
+                    </results>
+                  </test-suite>
+                  <test-suite type="TestFixture" name="NaNConstraintTest" executed="True" result="Success" success="True" time="0.013" asserts="0">
+                    <results>
+                      <test-case name="NUnit.Framework.Constraints.NaNConstraintTest.ConstraintTestBaseNoData.ProvidesProperDescription" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                      <test-case name="NUnit.Framework.Constraints.NaNConstraintTest.ConstraintTestBaseNoData.ProvidesProperStringRepresentation" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                      <test-suite type="ParameterizedTest" name="FailsWithBadValues" executed="True" result="Success" success="True" time="0.003" asserts="0">
+                        <results>
+                          <test-case name="NUnit.Framework.Constraints.NaNConstraintTest.FailsWithBadValues(null)" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Framework.Constraints.NaNConstraintTest.FailsWithBadValues(&quot;hello&quot;)" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Framework.Constraints.NaNConstraintTest.FailsWithBadValues(42)" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Framework.Constraints.NaNConstraintTest.FailsWithBadValues(double.PositiveInfinity)" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Framework.Constraints.NaNConstraintTest.FailsWithBadValues(double.NegativeInfinity)" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Framework.Constraints.NaNConstraintTest.FailsWithBadValues(float.PositiveInfinity)" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Framework.Constraints.NaNConstraintTest.FailsWithBadValues(float.NegativeInfinity)" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                        </results>
+                      </test-suite>
+                      <test-suite type="ParameterizedTest" name="ProvidesProperFailureMessage" executed="True" result="Success" success="True" time="0.003" asserts="0">
+                        <results>
+                          <test-case name="NUnit.Framework.Constraints.NaNConstraintTest.ProvidesProperFailureMessage(null,&quot;null&quot;)" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Framework.Constraints.NaNConstraintTest.ProvidesProperFailureMessage(&quot;hello&quot;,&quot;\&quot;hello\&quot;&quot;)" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Framework.Constraints.NaNConstraintTest.ProvidesProperFailureMessage(42,&quot;42&quot;)" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Framework.Constraints.NaNConstraintTest.ProvidesProperFailureMessage(double.PositiveInfinity,&quot;Infinity&quot;)" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Framework.Constraints.NaNConstraintTest.ProvidesProperFailureMessage(double.NegativeInfinity,&quot;-Infinity&quot;)" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Framework.Constraints.NaNConstraintTest.ProvidesProperFailureMessage(float.PositiveInfinity,&quot;Infinity&quot;)" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Framework.Constraints.NaNConstraintTest.ProvidesProperFailureMessage(float.NegativeInfinity,&quot;-Infinity&quot;)" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                        </results>
+                      </test-suite>
+                      <test-suite type="ParameterizedTest" name="SucceedsWithGoodValues" executed="True" result="Success" success="True" time="0.001" asserts="0">
+                        <results>
+                          <test-case name="NUnit.Framework.Constraints.NaNConstraintTest.SucceedsWithGoodValues(double.NaN)" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Framework.Constraints.NaNConstraintTest.SucceedsWithGoodValues(float.NaN)" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                        </results>
+                      </test-suite>
+                    </results>
+                  </test-suite>
+                  <test-suite type="TestFixture" name="NotConstraintTests" executed="True" result="Success" success="True" time="0.009" asserts="0">
+                    <results>
+                      <test-case name="NUnit.Framework.Constraints.NotConstraintTests.CanUseNotOperator" executed="True" result="Success" success="True" time="0.001" asserts="1" />
+                      <test-case name="NUnit.Framework.Constraints.NotConstraintTests.ConstraintTestBaseNoData.ProvidesProperDescription" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                      <test-case name="NUnit.Framework.Constraints.NotConstraintTests.ConstraintTestBaseNoData.ProvidesProperStringRepresentation" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                      <test-suite type="ParameterizedTest" name="FailsWithBadValues" executed="True" result="Success" success="True" time="0.000" asserts="0">
+                        <results>
+                          <test-case name="NUnit.Framework.Constraints.NotConstraintTests.FailsWithBadValues(null)" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                        </results>
+                      </test-suite>
+                      <test-case name="NUnit.Framework.Constraints.NotConstraintTests.NotHonorsIgnoreCaseUsingConstructors" executed="True" result="Success" success="True" time="0.001" asserts="1" />
+                      <test-case name="NUnit.Framework.Constraints.NotConstraintTests.NotHonorsIgnoreCaseUsingPrefixNotation" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                      <test-case name="NUnit.Framework.Constraints.NotConstraintTests.NotHonorsTolerance" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                      <test-suite type="ParameterizedTest" name="ProvidesProperFailureMessage" executed="True" result="Success" success="True" time="0.000" asserts="0">
+                        <results>
+                          <test-case name="NUnit.Framework.Constraints.NotConstraintTests.ProvidesProperFailureMessage(null,&quot;null&quot;)" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                        </results>
+                      </test-suite>
+                      <test-suite type="ParameterizedTest" name="SucceedsWithGoodValues" executed="True" result="Success" success="True" time="0.001" asserts="0">
+                        <results>
+                          <test-case name="NUnit.Framework.Constraints.NotConstraintTests.SucceedsWithGoodValues(42)" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Framework.Constraints.NotConstraintTests.SucceedsWithGoodValues(&quot;Hello&quot;)" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                        </results>
+                      </test-suite>
+                    </results>
+                  </test-suite>
+                  <test-suite type="TestFixture" name="NullConstraintTest" executed="True" result="Success" success="True" time="0.004" asserts="0">
+                    <results>
+                      <test-case name="NUnit.Framework.Constraints.NullConstraintTest.ConstraintTestBaseNoData.ProvidesProperDescription" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                      <test-case name="NUnit.Framework.Constraints.NullConstraintTest.ConstraintTestBaseNoData.ProvidesProperStringRepresentation" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                      <test-suite type="ParameterizedTest" name="FailsWithBadValues" executed="True" result="Success" success="True" time="0.000" asserts="0">
+                        <results>
+                          <test-case name="NUnit.Framework.Constraints.NullConstraintTest.FailsWithBadValues(&quot;hello&quot;)" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                        </results>
+                      </test-suite>
+                      <test-suite type="ParameterizedTest" name="ProvidesProperFailureMessage" executed="True" result="Success" success="True" time="0.000" asserts="0">
+                        <results>
+                          <test-case name="NUnit.Framework.Constraints.NullConstraintTest.ProvidesProperFailureMessage(&quot;hello&quot;,&quot;\&quot;hello\&quot;&quot;)" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                        </results>
+                      </test-suite>
+                      <test-suite type="ParameterizedTest" name="SucceedsWithGoodValues" executed="True" result="Success" success="True" time="0.000" asserts="0">
+                        <results>
+                          <test-case name="NUnit.Framework.Constraints.NullConstraintTest.SucceedsWithGoodValues(null)" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                        </results>
+                      </test-suite>
+                    </results>
+                  </test-suite>
+                  <test-suite type="TestFixture" name="NullOrEmptyStringConstraintTest" executed="True" result="Success" success="True" time="0.008" asserts="0">
+                    <results>
+                      <test-case name="NUnit.Framework.Constraints.NullOrEmptyStringConstraintTest.ConstraintTestBaseNoData.ProvidesProperDescription" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                      <test-case name="NUnit.Framework.Constraints.NullOrEmptyStringConstraintTest.ConstraintTestBaseNoData.ProvidesProperStringRepresentation" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                      <test-suite type="ParameterizedTest" name="FailsWithBadValues" executed="True" result="Success" success="True" time="0.000" asserts="0">
+                        <results>
+                          <test-case name="NUnit.Framework.Constraints.NullOrEmptyStringConstraintTest.FailsWithBadValues(&quot;Hello&quot;)" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                        </results>
+                      </test-suite>
+                      <test-suite type="ParameterizedTest" name="InvalidDataThrowsArgumentException" executed="True" result="Success" success="True" time="0.001" asserts="0">
+                        <results>
+                          <test-case name="NUnit.Framework.Constraints.NullOrEmptyStringConstraintTest.InvalidDataThrowsArgumentException(5)" executed="True" result="Success" success="True" time="0.000" asserts="0" />
+                        </results>
+                      </test-suite>
+                      <test-suite type="ParameterizedTest" name="ProvidesProperFailureMessage" executed="True" result="Success" success="True" time="0.000" asserts="0">
+                        <results>
+                          <test-case name="NUnit.Framework.Constraints.NullOrEmptyStringConstraintTest.ProvidesProperFailureMessage(&quot;Hello&quot;,&quot;\&quot;Hello\&quot;&quot;)" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                        </results>
+                      </test-suite>
+                      <test-suite type="ParameterizedTest" name="SucceedsWithGoodValues" executed="True" result="Success" success="True" time="0.001" asserts="0">
+                        <results>
+                          <test-case name="NUnit.Framework.Constraints.NullOrEmptyStringConstraintTest.SucceedsWithGoodValues(&quot;&quot;)" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Framework.Constraints.NullOrEmptyStringConstraintTest.SucceedsWithGoodValues(null)" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                        </results>
+                      </test-suite>
+                    </results>
+                  </test-suite>
+                  <test-suite type="TestFixture" name="NumericsTest" executed="True" result="Success" success="True" time="0.041" asserts="0">
+                    <results>
+                      <test-case name="NUnit.Framework.Constraints.NumericsTest.CanMatchDecimalWithoutToleranceMode" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                      <test-case name="NUnit.Framework.Constraints.NumericsTest.CanMatchDecimalWithPercentage" executed="True" result="Success" success="True" time="0.014" asserts="3" />
+                      <test-suite type="ParameterizedTest" name="CanMatchIntegralsWithPercentage" executed="True" result="Success" success="True" time="0.009" asserts="0">
+                        <results>
+                          <test-case name="NUnit.Framework.Constraints.NumericsTest.CanMatchIntegralsWithPercentage(9500UL)" executed="True" result="Success" success="True" time="0.001" asserts="1" />
+                          <test-case name="NUnit.Framework.Constraints.NumericsTest.CanMatchIntegralsWithPercentage(10500)" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Framework.Constraints.NumericsTest.CanMatchIntegralsWithPercentage(10000)" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Framework.Constraints.NumericsTest.CanMatchIntegralsWithPercentage(10500)" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Framework.Constraints.NumericsTest.CanMatchIntegralsWithPercentage(9500)" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Framework.Constraints.NumericsTest.CanMatchIntegralsWithPercentage(10000)" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Framework.Constraints.NumericsTest.CanMatchIntegralsWithPercentage(9500)" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Framework.Constraints.NumericsTest.CanMatchIntegralsWithPercentage(9500L)" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Framework.Constraints.NumericsTest.CanMatchIntegralsWithPercentage(10000L)" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Framework.Constraints.NumericsTest.CanMatchIntegralsWithPercentage(10500L)" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Framework.Constraints.NumericsTest.CanMatchIntegralsWithPercentage(10000UL)" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Framework.Constraints.NumericsTest.CanMatchIntegralsWithPercentage(10500UL)" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                        </results>
+                      </test-suite>
+                      <test-suite type="ParameterizedTest" name="CanMatchWithoutToleranceMode" executed="True" result="Success" success="True" time="0.004" asserts="0">
+                        <results>
+                          <test-case name="NUnit.Framework.Constraints.NumericsTest.CanMatchWithoutToleranceMode(1234.568f)" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Framework.Constraints.NumericsTest.CanMatchWithoutToleranceMode(1234.5678d)" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Framework.Constraints.NumericsTest.CanMatchWithoutToleranceMode(123456789)" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Framework.Constraints.NumericsTest.CanMatchWithoutToleranceMode(123456789)" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Framework.Constraints.NumericsTest.CanMatchWithoutToleranceMode(123456789L)" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Framework.Constraints.NumericsTest.CanMatchWithoutToleranceMode(123456789UL)" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                        </results>
+                      </test-suite>
+                      <test-case name="NUnit.Framework.Constraints.NumericsTest.FailsOnDecimalAbovePercentage" executed="True" result="Success" success="True" time="0.001" asserts="1" />
+                      <test-case name="NUnit.Framework.Constraints.NumericsTest.FailsOnDecimalBelowPercentage" executed="True" result="Success" success="True" time="0.001" asserts="1" />
+                      <test-suite type="ParameterizedTest" name="FailsOnIntegralsOutsideOfPercentage" executed="True" result="Success" success="True" time="0.007" asserts="0">
+                        <results>
+                          <test-case name="NUnit.Framework.Constraints.NumericsTest.FailsOnIntegralsOutsideOfPercentage(11500L)" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Framework.Constraints.NumericsTest.FailsOnIntegralsOutsideOfPercentage(8500)" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Framework.Constraints.NumericsTest.FailsOnIntegralsOutsideOfPercentage(11500)" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Framework.Constraints.NumericsTest.FailsOnIntegralsOutsideOfPercentage(8500)" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Framework.Constraints.NumericsTest.FailsOnIntegralsOutsideOfPercentage(11500)" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Framework.Constraints.NumericsTest.FailsOnIntegralsOutsideOfPercentage(8500L)" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Framework.Constraints.NumericsTest.FailsOnIntegralsOutsideOfPercentage(8500UL)" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Framework.Constraints.NumericsTest.FailsOnIntegralsOutsideOfPercentage(11500UL)" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                        </results>
+                      </test-suite>
+                    </results>
+                  </test-suite>
+                  <test-suite type="TestFixture" name="NUnitComparerTests" executed="True" result="Success" success="True" time="0.022" asserts="0">
+                    <results>
+                      <test-suite type="ParameterizedTest" name="EqualItems" executed="True" result="Success" success="True" time="0.007" asserts="0">
+                        <results>
+                          <test-case name="NUnit.Framework.Constraints.NUnitComparerTests.EqualItems(4,4.0f)" executed="True" result="Success" success="True" time="0.000" asserts="2" />
+                          <test-case name="NUnit.Framework.Constraints.NUnitComparerTests.EqualItems(4.0d,4)" executed="True" result="Success" success="True" time="0.000" asserts="2" />
+                          <test-case name="NUnit.Framework.Constraints.NUnitComparerTests.EqualItems(4,4)" executed="True" result="Success" success="True" time="0.000" asserts="2" />
+                          <test-case name="NUnit.Framework.Constraints.NUnitComparerTests.EqualItems(4.0d,4.0d)" executed="True" result="Success" success="True" time="0.000" asserts="2" />
+                          <test-case name="NUnit.Framework.Constraints.NUnitComparerTests.EqualItems(4.0f,4.0f)" executed="True" result="Success" success="True" time="0.000" asserts="2" />
+                          <test-case name="NUnit.Framework.Constraints.NUnitComparerTests.EqualItems(4,4.0d)" executed="True" result="Success" success="True" time="0.000" asserts="2" />
+                          <test-case name="NUnit.Framework.Constraints.NUnitComparerTests.EqualItems(4.0d,4.0f)" executed="True" result="Success" success="True" time="0.000" asserts="2" />
+                          <test-case name="NUnit.Framework.Constraints.NUnitComparerTests.EqualItems(4.0f,4)" executed="True" result="Success" success="True" time="0.000" asserts="2" />
+                          <test-case name="NUnit.Framework.Constraints.NUnitComparerTests.EqualItems(4.0f,4.0d)" executed="True" result="Success" success="True" time="0.000" asserts="2" />
+                          <test-case name="NUnit.Framework.Constraints.NUnitComparerTests.EqualItems(null,null)" executed="True" result="Success" success="True" time="0.000" asserts="2" />
+                          <test-case name="NUnit.Framework.Constraints.NUnitComparerTests.EqualItems(null,null)" executed="True" result="Success" success="True" time="0.000" asserts="2" />
+                        </results>
+                      </test-suite>
+                      <test-suite type="ParameterizedTest" name="SpecialFloatingPointValues" executed="True" result="Success" success="True" time="0.004" asserts="0">
+                        <results>
+                          <test-case name="NUnit.Framework.Constraints.NUnitComparerTests.SpecialFloatingPointValues(float.NaN)" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Framework.Constraints.NUnitComparerTests.SpecialFloatingPointValues(double.NegativeInfinity)" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Framework.Constraints.NUnitComparerTests.SpecialFloatingPointValues(double.NaN)" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Framework.Constraints.NUnitComparerTests.SpecialFloatingPointValues(float.PositiveInfinity)" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Framework.Constraints.NUnitComparerTests.SpecialFloatingPointValues(double.PositiveInfinity)" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Framework.Constraints.NUnitComparerTests.SpecialFloatingPointValues(float.NegativeInfinity)" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                        </results>
+                      </test-suite>
+                      <test-suite type="ParameterizedTest" name="UnequalItems" executed="True" result="Success" success="True" time="0.007" asserts="0">
+                        <results>
+                          <test-case name="NUnit.Framework.Constraints.NUnitComparerTests.UnequalItems(4.0d,2.0d)" executed="True" result="Success" success="True" time="0.000" asserts="4" />
+                          <test-case name="NUnit.Framework.Constraints.NUnitComparerTests.UnequalItems(4.0f,2)" executed="True" result="Success" success="True" time="0.000" asserts="4" />
+                          <test-case name="NUnit.Framework.Constraints.NUnitComparerTests.UnequalItems(4,null)" executed="True" result="Success" success="True" time="0.000" asserts="4" />
+                          <test-case name="NUnit.Framework.Constraints.NUnitComparerTests.UnequalItems(4,null)" executed="True" result="Success" success="True" time="0.000" asserts="4" />
+                          <test-case name="NUnit.Framework.Constraints.NUnitComparerTests.UnequalItems(4,2)" executed="True" result="Success" success="True" time="0.000" asserts="4" />
+                          <test-case name="NUnit.Framework.Constraints.NUnitComparerTests.UnequalItems(4.0f,2.0f)" executed="True" result="Success" success="True" time="0.000" asserts="4" />
+                          <test-case name="NUnit.Framework.Constraints.NUnitComparerTests.UnequalItems(4,2.0d)" executed="True" result="Success" success="True" time="0.000" asserts="4" />
+                          <test-case name="NUnit.Framework.Constraints.NUnitComparerTests.UnequalItems(4.0f,2.0d)" executed="True" result="Success" success="True" time="0.000" asserts="4" />
+                          <test-case name="NUnit.Framework.Constraints.NUnitComparerTests.UnequalItems(4,2.0f)" executed="True" result="Success" success="True" time="0.000" asserts="4" />
+                          <test-case name="NUnit.Framework.Constraints.NUnitComparerTests.UnequalItems(4.0d,2)" executed="True" result="Success" success="True" time="0.000" asserts="4" />
+                          <test-case name="NUnit.Framework.Constraints.NUnitComparerTests.UnequalItems(4.0d,2.0f)" executed="True" result="Success" success="True" time="0.000" asserts="4" />
+                        </results>
+                      </test-suite>
+                    </results>
+                  </test-suite>
+                  <test-suite type="TestFixture" name="OrConstraintTests" executed="True" result="Success" success="True" time="0.006" asserts="0">
+                    <results>
+                      <test-case name="NUnit.Framework.Constraints.OrConstraintTests.CanCombineTestsWithOrOperator" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                      <test-case name="NUnit.Framework.Constraints.OrConstraintTests.ConstraintTestBaseNoData.ProvidesProperDescription" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                      <test-case name="NUnit.Framework.Constraints.OrConstraintTests.ConstraintTestBaseNoData.ProvidesProperStringRepresentation" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                      <test-suite type="ParameterizedTest" name="FailsWithBadValues" executed="True" result="Success" success="True" time="0.000" asserts="0">
+                        <results>
+                          <test-case name="NUnit.Framework.Constraints.OrConstraintTests.FailsWithBadValues(37)" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                        </results>
+                      </test-suite>
+                      <test-suite type="ParameterizedTest" name="ProvidesProperFailureMessage" executed="True" result="Success" success="True" time="0.000" asserts="0">
+                        <results>
+                          <test-case name="NUnit.Framework.Constraints.OrConstraintTests.ProvidesProperFailureMessage(37,&quot;37&quot;)" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                        </results>
+                      </test-suite>
+                      <test-suite type="ParameterizedTest" name="SucceedsWithGoodValues" executed="True" result="Success" success="True" time="0.001" asserts="0">
+                        <results>
+                          <test-case name="NUnit.Framework.Constraints.OrConstraintTests.SucceedsWithGoodValues(99)" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Framework.Constraints.OrConstraintTests.SucceedsWithGoodValues(42)" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                        </results>
+                      </test-suite>
+                    </results>
+                  </test-suite>
+                  <test-suite type="TestFixture" name="PredicateConstraintTests" executed="True" result="Success" success="True" time="0.007" asserts="0">
+                    <results>
+                      <test-case name="NUnit.Framework.Constraints.PredicateConstraintTests.ConstraintTestBaseNoData.ProvidesProperDescription" executed="True" result="Success" success="True" time="0.001" asserts="1" />
+                      <test-case name="NUnit.Framework.Constraints.PredicateConstraintTests.ConstraintTestBaseNoData.ProvidesProperStringRepresentation" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                      <test-suite type="ParameterizedTest" name="FailsWithBadValues" executed="True" result="Success" success="True" time="0.001" asserts="0">
+                        <results>
+                          <test-case name="NUnit.Framework.Constraints.PredicateConstraintTests.FailsWithBadValues(123)" executed="True" result="Success" success="True" time="0.001" asserts="1" />
+                        </results>
+                      </test-suite>
+                      <test-suite type="ParameterizedTest" name="ProvidesProperFailureMessage" executed="True" result="Success" success="True" time="0.000" asserts="0">
+                        <results>
+                          <test-case name="NUnit.Framework.Constraints.PredicateConstraintTests.ProvidesProperFailureMessage(123,&quot;123&quot;)" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                        </results>
+                      </test-suite>
+                      <test-suite type="ParameterizedTest" name="SucceedsWithGoodValues" executed="True" result="Success" success="True" time="0.001" asserts="0">
+                        <results>
+                          <test-case name="NUnit.Framework.Constraints.PredicateConstraintTests.SucceedsWithGoodValues(0)" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Framework.Constraints.PredicateConstraintTests.SucceedsWithGoodValues(-5)" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                        </results>
+                      </test-suite>
+                    </results>
+                  </test-suite>
+                  <test-suite type="TestFixture" name="PropertyExistsTest" executed="True" result="Success" success="True" time="0.013" asserts="0">
+                    <results>
+                      <test-case name="NUnit.Framework.Constraints.PropertyExistsTest.ConstraintTestBaseNoData.ProvidesProperDescription" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                      <test-case name="NUnit.Framework.Constraints.PropertyExistsTest.ConstraintTestBaseNoData.ProvidesProperStringRepresentation" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                      <test-suite type="ParameterizedTest" name="FailsWithBadValues" executed="True" result="Success" success="True" time="0.002" asserts="0">
+                        <results>
+                          <test-case name="NUnit.Framework.Constraints.PropertyExistsTest.FailsWithBadValues(42)" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Framework.Constraints.PropertyExistsTest.FailsWithBadValues(System.Collections.ArrayList)" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Framework.Constraints.PropertyExistsTest.FailsWithBadValues(System.Int32)" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                        </results>
+                      </test-suite>
+                      <test-suite type="ParameterizedTest" name="InvalidDataThrowsException" executed="True" result="Success" success="True" time="0.001" asserts="0">
+                        <results>
+                          <test-case name="NUnit.Framework.Constraints.PropertyExistsTest.InvalidDataThrowsException(null)" executed="True" result="Success" success="True" time="0.001" asserts="0" />
+                        </results>
+                      </test-suite>
+                      <test-suite type="ParameterizedTest" name="ProvidesProperFailureMessage" executed="True" result="Success" success="True" time="0.002" asserts="0">
+                        <results>
+                          <test-case name="NUnit.Framework.Constraints.PropertyExistsTest.ProvidesProperFailureMessage(42,&quot;&lt;System.Int32&gt;&quot;)" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Framework.Constraints.PropertyExistsTest.ProvidesProperFailureMessage(System.Collections.ArrayList,&quot;&lt;System.Collections.ArrayList&gt;&quot;)" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Framework.Constraints.PropertyExistsTest.ProvidesProperFailureMessage(System.Int32,&quot;&lt;System.Int32&gt;&quot;)" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                        </results>
+                      </test-suite>
+                      <test-suite type="ParameterizedTest" name="SucceedsWithGoodValues" executed="True" result="Success" success="True" time="0.002" asserts="0">
+                        <results>
+                          <test-case name="NUnit.Framework.Constraints.PropertyExistsTest.SucceedsWithGoodValues(System.Int32[])" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Framework.Constraints.PropertyExistsTest.SucceedsWithGoodValues(&quot;hello&quot;)" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Framework.Constraints.PropertyExistsTest.SucceedsWithGoodValues(System.Array)" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                        </results>
+                      </test-suite>
+                    </results>
+                  </test-suite>
+                  <test-suite type="TestFixture" name="PropertyTest" executed="True" result="Success" success="True" time="0.012" asserts="0">
+                    <results>
+                      <test-case name="NUnit.Framework.Constraints.PropertyTest.ConstraintTestBaseNoData.ProvidesProperDescription" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                      <test-case name="NUnit.Framework.Constraints.PropertyTest.ConstraintTestBaseNoData.ProvidesProperStringRepresentation" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                      <test-suite type="ParameterizedTest" name="FailsWithBadValues" executed="True" result="Success" success="True" time="0.001" asserts="0">
+                        <results>
+                          <test-case name="NUnit.Framework.Constraints.PropertyTest.FailsWithBadValues(System.Int32[])" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Framework.Constraints.PropertyTest.FailsWithBadValues(&quot;goodbye&quot;)" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                        </results>
+                      </test-suite>
+                      <test-suite type="ParameterizedTest" name="InvalidDataThrowsException" executed="True" result="Success" success="True" time="0.003" asserts="0">
+                        <results>
+                          <test-case name="NUnit.Framework.Constraints.PropertyTest.InvalidDataThrowsException(null)" executed="True" result="Success" success="True" time="0.000" asserts="0" />
+                          <test-case name="NUnit.Framework.Constraints.PropertyTest.InvalidDataThrowsException(42)" executed="True" result="Success" success="True" time="0.000" asserts="0" />
+                          <test-case name="NUnit.Framework.Constraints.PropertyTest.InvalidDataThrowsException(System.Collections.ArrayList)" executed="True" result="Success" success="True" time="0.000" asserts="0" />
+                        </results>
+                      </test-suite>
+                      <test-case name="NUnit.Framework.Constraints.PropertyTest.PropertyEqualToValueWithTolerance" executed="True" result="Success" success="True" time="0.001" asserts="2" />
+                      <test-suite type="ParameterizedTest" name="ProvidesProperFailureMessage" executed="True" result="Success" success="True" time="0.001" asserts="0">
+                        <results>
+                          <test-case name="NUnit.Framework.Constraints.PropertyTest.ProvidesProperFailureMessage(System.Int32[],&quot;3&quot;)" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Framework.Constraints.PropertyTest.ProvidesProperFailureMessage(&quot;goodbye&quot;,&quot;7&quot;)" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                        </results>
+                      </test-suite>
+                      <test-suite type="ParameterizedTest" name="SucceedsWithGoodValues" executed="True" result="Success" success="True" time="0.001" asserts="0">
+                        <results>
+                          <test-case name="NUnit.Framework.Constraints.PropertyTest.SucceedsWithGoodValues(System.Int32[])" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Framework.Constraints.PropertyTest.SucceedsWithGoodValues(&quot;hello&quot;)" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                        </results>
+                      </test-suite>
+                    </results>
+                  </test-suite>
+                  <test-suite type="TestFixture" name="RangeConstraintTests" executed="True" result="Success" success="True" time="0.016" asserts="0">
+                    <results>
+                      <test-case name="NUnit.Framework.Constraints.RangeConstraintTests.ConstraintTestBaseNoData.ProvidesProperDescription" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                      <test-case name="NUnit.Framework.Constraints.RangeConstraintTests.ConstraintTestBaseNoData.ProvidesProperStringRepresentation" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                      <test-suite type="ParameterizedTest" name="FailsWithBadValues" executed="True" result="Success" success="True" time="0.001" asserts="0">
+                        <results>
+                          <test-case name="NUnit.Framework.Constraints.RangeConstraintTests.FailsWithBadValues(4)" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Framework.Constraints.RangeConstraintTests.FailsWithBadValues(43)" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                        </results>
+                      </test-suite>
+                      <test-suite type="ParameterizedTest" name="InvalidDataThrowsArgumentException" executed="True" result="Success" success="True" time="0.002" asserts="0">
+                        <results>
+                          <test-case name="NUnit.Framework.Constraints.RangeConstraintTests.InvalidDataThrowsArgumentException(null)" executed="True" result="Success" success="True" time="0.000" asserts="0" />
+                          <test-case name="NUnit.Framework.Constraints.RangeConstraintTests.InvalidDataThrowsArgumentException(&quot;xxx&quot;)" executed="True" result="Success" success="True" time="0.000" asserts="0" />
+                        </results>
+                      </test-suite>
+                      <test-suite type="ParameterizedTest" name="ProvidesProperFailureMessage" executed="True" result="Success" success="True" time="0.001" asserts="0">
+                        <results>
+                          <test-case name="NUnit.Framework.Constraints.RangeConstraintTests.ProvidesProperFailureMessage(4,&quot;4&quot;)" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Framework.Constraints.RangeConstraintTests.ProvidesProperFailureMessage(43,&quot;43&quot;)" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                        </results>
+                      </test-suite>
+                      <test-case name="NUnit.Framework.Constraints.RangeConstraintTests.ShouldThrowExceptionIfFromIsLessThanTo" executed="True" result="Success" success="True" time="0.001" asserts="0" />
+                      <test-suite type="ParameterizedTest" name="SucceedsWithGoodValues" executed="True" result="Success" success="True" time="0.001" asserts="0">
+                        <results>
+                          <test-case name="NUnit.Framework.Constraints.RangeConstraintTests.SucceedsWithGoodValues(5)" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Framework.Constraints.RangeConstraintTests.SucceedsWithGoodValues(23)" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Framework.Constraints.RangeConstraintTests.SucceedsWithGoodValues(42)" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                        </results>
+                      </test-suite>
+                      <test-case name="NUnit.Framework.Constraints.RangeConstraintTests.UsesProvidedComparerOfT" executed="True" result="Success" success="True" time="0.001" asserts="2" />
+                      <test-case name="NUnit.Framework.Constraints.RangeConstraintTests.UsesProvidedComparisonOfT" executed="True" result="Success" success="True" time="0.001" asserts="2" />
+                      <test-case name="NUnit.Framework.Constraints.RangeConstraintTests.UsesProvidedIComparer" executed="True" result="Success" success="True" time="0.000" asserts="2" />
+                      <test-case name="NUnit.Framework.Constraints.RangeConstraintTests.UsesProvidedLambda" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                    </results>
+                  </test-suite>
+                  <test-suite type="TestFixture" name="ReusableConstraintTests" executed="True" result="Success" success="True" time="0.004" asserts="0">
+                    <results>
+                      <test-case name="NUnit.Framework.Constraints.ReusableConstraintTests.CanCreateReusableConstraintByImplicitConversion" executed="True" result="Success" success="True" time="0.000" asserts="3" />
+                      <test-suite type="Theory" name="CanReuseReusableConstraintMultipleTimes" executed="True" result="Success" success="True" time="0.002" asserts="0">
+                        <results>
+                          <test-case name="NUnit.Framework.Constraints.ReusableConstraintTests.CanReuseReusableConstraintMultipleTimes(&lt;not &lt;empty&gt;&gt;)" executed="True" result="Success" success="True" time="0.000" asserts="3" />
+                          <test-case name="NUnit.Framework.Constraints.ReusableConstraintTests.CanReuseReusableConstraintMultipleTimes(&lt;not &lt;null&gt;&gt;)" executed="True" result="Success" success="True" time="0.000" asserts="3" />
+                          <test-case name="NUnit.Framework.Constraints.ReusableConstraintTests.CanReuseReusableConstraintMultipleTimes(&lt;property Length &lt;greaterthan 3&gt;&gt;)" executed="True" result="Success" success="True" time="0.000" asserts="3" />
+                          <test-case name="NUnit.Framework.Constraints.ReusableConstraintTests.CanReuseReusableConstraintMultipleTimes(&lt;and &lt;property Length &lt;equal 4&gt;&gt; &lt;startswith &quot;te&quot;&gt;&gt;)" executed="True" result="Success" success="True" time="0.000" asserts="3" />
+                        </results>
+                      </test-suite>
+                    </results>
+                  </test-suite>
+                  <test-suite type="TestFixture" name="SameAsTest" executed="True" result="Success" success="True" time="0.007" asserts="0">
+                    <results>
+                      <test-case name="NUnit.Framework.Constraints.SameAsTest.ConstraintTestBaseNoData.ProvidesProperDescription" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                      <test-case name="NUnit.Framework.Constraints.SameAsTest.ConstraintTestBaseNoData.ProvidesProperStringRepresentation" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                      <test-suite type="ParameterizedTest" name="FailsWithBadValues" executed="True" result="Success" success="True" time="0.001" asserts="0">
+                        <results>
+                          <test-case name="NUnit.Framework.Constraints.SameAsTest.FailsWithBadValues(System.Object)" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Framework.Constraints.SameAsTest.FailsWithBadValues(3)" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Framework.Constraints.SameAsTest.FailsWithBadValues(&quot;Hello&quot;)" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                        </results>
+                      </test-suite>
+                      <test-suite type="ParameterizedTest" name="ProvidesProperFailureMessage" executed="True" result="Success" success="True" time="0.001" asserts="0">
+                        <results>
+                          <test-case name="NUnit.Framework.Constraints.SameAsTest.ProvidesProperFailureMessage(System.Object,&quot;&lt;System.Object&gt;&quot;)" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Framework.Constraints.SameAsTest.ProvidesProperFailureMessage(3,&quot;3&quot;)" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Framework.Constraints.SameAsTest.ProvidesProperFailureMessage(&quot;Hello&quot;,&quot;\&quot;Hello\&quot;&quot;)" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                        </results>
+                      </test-suite>
+                      <test-suite type="ParameterizedTest" name="SucceedsWithGoodValues" executed="True" result="Success" success="True" time="0.001" asserts="0">
+                        <results>
+                          <test-case name="NUnit.Framework.Constraints.SameAsTest.SucceedsWithGoodValues(System.Object)" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                        </results>
+                      </test-suite>
+                    </results>
+                  </test-suite>
+                  <test-suite type="TestFixture" name="SamePathOrUnderTest_Linux" executed="True" result="Success" success="True" time="0.017" asserts="0">
+                    <results>
+                      <test-case name="NUnit.Framework.Constraints.SamePathOrUnderTest_Linux.ConstraintTestBaseNoData.ProvidesProperDescription" executed="True" result="Success" success="True" time="0.001" asserts="1" />
+                      <test-case name="NUnit.Framework.Constraints.SamePathOrUnderTest_Linux.ConstraintTestBaseNoData.ProvidesProperStringRepresentation" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                      <test-suite type="ParameterizedTest" name="FailsWithBadValues" executed="True" result="Success" success="True" time="0.004" asserts="0">
+                        <results>
+                          <test-case name="NUnit.Framework.Constraints.SamePathOrUnderTest_Linux.FailsWithBadValues(123)" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Framework.Constraints.SamePathOrUnderTest_Linux.FailsWithBadValues(&quot;/Folder1/Folder2&quot;)" executed="True" result="Success" success="True" time="0.001" asserts="1" />
+                          <test-case name="NUnit.Framework.Constraints.SamePathOrUnderTest_Linux.FailsWithBadValues(&quot;/FOLDER1/./junk/../Folder2&quot;)" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Framework.Constraints.SamePathOrUnderTest_Linux.FailsWithBadValues(&quot;/FOLDER1/./junk/../Folder2/temp/../Folder3&quot;)" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Framework.Constraints.SamePathOrUnderTest_Linux.FailsWithBadValues(&quot;/folder1/folder3&quot;)" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Framework.Constraints.SamePathOrUnderTest_Linux.FailsWithBadValues(&quot;/folder1/./folder2/../folder3&quot;)" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Framework.Constraints.SamePathOrUnderTest_Linux.FailsWithBadValues(&quot;/folder1&quot;)" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                        </results>
+                      </test-suite>
+                      <test-suite type="ParameterizedTest" name="ProvidesProperFailureMessage" executed="True" result="Success" success="True" time="0.003" asserts="0">
+                        <results>
+                          <test-case name="NUnit.Framework.Constraints.SamePathOrUnderTest_Linux.ProvidesProperFailureMessage(123,&quot;123&quot;)" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Framework.Constraints.SamePathOrUnderTest_Linux.ProvidesProperFailureMessage(&quot;/Folder1/Folder2&quot;,&quot;\&quot;/Folder1/Folder2\&quot;&quot;)" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Framework.Constraints.SamePathOrUnderTest_Linux.ProvidesProperFailureMessage(&quot;/FOLDER1/./junk/../Folder2&quot;,&quot;\&quot;/FOLDER1/./junk/../Folder2\&quot;&quot;)" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Framework.Constraints.SamePathOrUnderTest_Linux.ProvidesProperFailureMessage(&quot;/FOLDER1/./junk/../Folder2/temp/../Folder3&quot;,&quot;\&quot;/FOLDER1/./junk/../Folder2/temp/../Folder3\&quot;&quot;)" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Framework.Constraints.SamePathOrUnderTest_Linux.ProvidesProperFailureMessage(&quot;/folder1/folder3&quot;,&quot;\&quot;/folder1/folder3\&quot;&quot;)" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Framework.Constraints.SamePathOrUnderTest_Linux.ProvidesProperFailureMessage(&quot;/folder1/./folder2/../folder3&quot;,&quot;\&quot;/folder1/./folder2/../folder3\&quot;&quot;)" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Framework.Constraints.SamePathOrUnderTest_Linux.ProvidesProperFailureMessage(&quot;/folder1&quot;,&quot;\&quot;/folder1\&quot;&quot;)" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                        </results>
+                      </test-suite>
+                      <test-suite type="ParameterizedTest" name="SucceedsWithGoodValues" executed="True" result="Success" success="True" time="0.004" asserts="0">
+                        <results>
+                          <test-case name="NUnit.Framework.Constraints.SamePathOrUnderTest_Linux.SucceedsWithGoodValues(&quot;/folder1/folder2&quot;)" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Framework.Constraints.SamePathOrUnderTest_Linux.SucceedsWithGoodValues(&quot;/folder1/./folder2&quot;)" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Framework.Constraints.SamePathOrUnderTest_Linux.SucceedsWithGoodValues(&quot;/folder1/junk/../folder2&quot;)" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Framework.Constraints.SamePathOrUnderTest_Linux.SucceedsWithGoodValues(&quot;\\folder1\\folder2&quot;)" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Framework.Constraints.SamePathOrUnderTest_Linux.SucceedsWithGoodValues(&quot;/folder1/folder2/folder3&quot;)" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Framework.Constraints.SamePathOrUnderTest_Linux.SucceedsWithGoodValues(&quot;/folder1/./folder2/folder3&quot;)" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Framework.Constraints.SamePathOrUnderTest_Linux.SucceedsWithGoodValues(&quot;/folder1/junk/../folder2/folder3&quot;)" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Framework.Constraints.SamePathOrUnderTest_Linux.SucceedsWithGoodValues(&quot;\\folder1\\folder2\\folder3&quot;)" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                        </results>
+                      </test-suite>
+                    </results>
+                  </test-suite>
+                  <test-suite type="TestFixture" name="SamePathOrUnderTest_Windows" executed="True" result="Success" success="True" time="0.013" asserts="0">
+                    <results>
+                      <test-case name="NUnit.Framework.Constraints.SamePathOrUnderTest_Windows.ConstraintTestBaseNoData.ProvidesProperDescription" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                      <test-case name="NUnit.Framework.Constraints.SamePathOrUnderTest_Windows.ConstraintTestBaseNoData.ProvidesProperStringRepresentation" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                      <test-suite type="ParameterizedTest" name="FailsWithBadValues" executed="True" result="Success" success="True" time="0.001" asserts="0">
+                        <results>
+                          <test-case name="NUnit.Framework.Constraints.SamePathOrUnderTest_Windows.FailsWithBadValues(123)" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Framework.Constraints.SamePathOrUnderTest_Windows.FailsWithBadValues(&quot;C:\\folder1\\folder3&quot;)" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Framework.Constraints.SamePathOrUnderTest_Windows.FailsWithBadValues(&quot;C:\\folder1\\.\\folder2\\..\\file.temp&quot;)" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                        </results>
+                      </test-suite>
+                      <test-suite type="ParameterizedTest" name="ProvidesProperFailureMessage" executed="True" result="Success" success="True" time="0.001" asserts="0">
+                        <results>
+                          <test-case name="NUnit.Framework.Constraints.SamePathOrUnderTest_Windows.ProvidesProperFailureMessage(123,&quot;123&quot;)" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Framework.Constraints.SamePathOrUnderTest_Windows.ProvidesProperFailureMessage(&quot;C:\\folder1\\folder3&quot;,&quot;\&quot;C:\\folder1\\folder3\&quot;&quot;)" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Framework.Constraints.SamePathOrUnderTest_Windows.ProvidesProperFailureMessage(&quot;C:\\folder1\\.\\folder2\\..\\file.temp&quot;,&quot;\&quot;C:\\folder1\\.\\folder2\\..\\file.temp\&quot;&quot;)" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                        </results>
+                      </test-suite>
+                      <test-suite type="ParameterizedTest" name="SucceedsWithGoodValues" executed="True" result="Success" success="True" time="0.007" asserts="0">
+                        <results>
+                          <test-case name="NUnit.Framework.Constraints.SamePathOrUnderTest_Windows.SucceedsWithGoodValues(&quot;C:\\folder1\\folder2&quot;)" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Framework.Constraints.SamePathOrUnderTest_Windows.SucceedsWithGoodValues(&quot;C:\\Folder1\\Folder2&quot;)" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Framework.Constraints.SamePathOrUnderTest_Windows.SucceedsWithGoodValues(&quot;C:\\folder1\\.\\folder2&quot;)" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Framework.Constraints.SamePathOrUnderTest_Windows.SucceedsWithGoodValues(&quot;C:\\folder1\\junk\\..\\folder2&quot;)" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Framework.Constraints.SamePathOrUnderTest_Windows.SucceedsWithGoodValues(&quot;C:\\FOLDER1\\.\\junk\\..\\Folder2&quot;)" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Framework.Constraints.SamePathOrUnderTest_Windows.SucceedsWithGoodValues(&quot;C:/folder1/folder2&quot;)" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Framework.Constraints.SamePathOrUnderTest_Windows.SucceedsWithGoodValues(&quot;C:\\folder1\\folder2\\folder3&quot;)" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Framework.Constraints.SamePathOrUnderTest_Windows.SucceedsWithGoodValues(&quot;C:\\folder1\\.\\folder2\\folder3&quot;)" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Framework.Constraints.SamePathOrUnderTest_Windows.SucceedsWithGoodValues(&quot;C:\\folder1\\junk\\..\\folder2\\folder3&quot;)" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Framework.Constraints.SamePathOrUnderTest_Windows.SucceedsWithGoodValues(&quot;C:\\FOLDER1\\.\\junk\\..\\Folder2\\temp\\..\\Folder3&quot;)" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Framework.Constraints.SamePathOrUnderTest_Windows.SucceedsWithGoodValues(&quot;C:/folder1/folder2/folder3&quot;)" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                        </results>
+                      </test-suite>
+                    </results>
+                  </test-suite>
+                  <test-suite type="TestFixture" name="SamePathTest_Linux" executed="True" result="Success" success="True" time="0.016" asserts="0">
+                    <results>
+                      <test-case name="NUnit.Framework.Constraints.SamePathTest_Linux.ConstraintTestBaseNoData.ProvidesProperDescription" executed="True" result="Success" success="True" time="0.001" asserts="1" />
+                      <test-case name="NUnit.Framework.Constraints.SamePathTest_Linux.ConstraintTestBaseNoData.ProvidesProperStringRepresentation" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                      <test-suite type="ParameterizedTest" name="FailsWithBadValues" executed="True" result="Success" success="True" time="0.004" asserts="0">
+                        <results>
+                          <test-case name="NUnit.Framework.Constraints.SamePathTest_Linux.FailsWithBadValues(123)" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Framework.Constraints.SamePathTest_Linux.FailsWithBadValues(&quot;/folder2/file.tmp&quot;)" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Framework.Constraints.SamePathTest_Linux.FailsWithBadValues(&quot;folder1/file.tmp&quot;)" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Framework.Constraints.SamePathTest_Linux.FailsWithBadValues(&quot;//folder1/file.tmp&quot;)" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Framework.Constraints.SamePathTest_Linux.FailsWithBadValues(&quot;/folder1/./folder2/../file.temp&quot;)" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Framework.Constraints.SamePathTest_Linux.FailsWithBadValues(&quot;/Folder1/File.TMP&quot;)" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Framework.Constraints.SamePathTest_Linux.FailsWithBadValues(&quot;/FOLDER1/./folder2/../File.TMP&quot;)" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                        </results>
+                      </test-suite>
+                      <test-suite type="ParameterizedTest" name="ProvidesProperFailureMessage" executed="True" result="Success" success="True" time="0.004" asserts="0">
+                        <results>
+                          <test-case name="NUnit.Framework.Constraints.SamePathTest_Linux.ProvidesProperFailureMessage(123,&quot;123&quot;)" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Framework.Constraints.SamePathTest_Linux.ProvidesProperFailureMessage(&quot;/folder2/file.tmp&quot;,&quot;\&quot;/folder2/file.tmp\&quot;&quot;)" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Framework.Constraints.SamePathTest_Linux.ProvidesProperFailureMessage(&quot;folder1/file.tmp&quot;,&quot;\&quot;folder1/file.tmp\&quot;&quot;)" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Framework.Constraints.SamePathTest_Linux.ProvidesProperFailureMessage(&quot;//folder1/file.tmp&quot;,&quot;\&quot;//folder1/file.tmp\&quot;&quot;)" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Framework.Constraints.SamePathTest_Linux.ProvidesProperFailureMessage(&quot;/folder1/./folder2/../file.temp&quot;,&quot;\&quot;/folder1/./folder2/../file.temp\&quot;&quot;)" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Framework.Constraints.SamePathTest_Linux.ProvidesProperFailureMessage(&quot;/Folder1/File.TMP&quot;,&quot;\&quot;/Folder1/File.TMP\&quot;&quot;)" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Framework.Constraints.SamePathTest_Linux.ProvidesProperFailureMessage(&quot;/FOLDER1/./folder2/../File.TMP&quot;,&quot;\&quot;/FOLDER1/./folder2/../File.TMP\&quot;&quot;)" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                        </results>
+                      </test-suite>
+                      <test-case name="NUnit.Framework.Constraints.SamePathTest_Linux.RootPathEquality" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                      <test-suite type="ParameterizedTest" name="SucceedsWithGoodValues" executed="True" result="Success" success="True" time="0.002" asserts="0">
+                        <results>
+                          <test-case name="NUnit.Framework.Constraints.SamePathTest_Linux.SucceedsWithGoodValues(&quot;/folder1/file.tmp&quot;)" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Framework.Constraints.SamePathTest_Linux.SucceedsWithGoodValues(&quot;/folder1/./file.tmp&quot;)" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Framework.Constraints.SamePathTest_Linux.SucceedsWithGoodValues(&quot;/folder1/folder2/../file.tmp&quot;)" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Framework.Constraints.SamePathTest_Linux.SucceedsWithGoodValues(&quot;/folder1/./folder2/../file.tmp&quot;)" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Framework.Constraints.SamePathTest_Linux.SucceedsWithGoodValues(&quot;\\folder1\\file.tmp&quot;)" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                        </results>
+                      </test-suite>
+                    </results>
+                  </test-suite>
+                  <test-suite type="TestFixture" name="SamePathTest_Windows" executed="True" result="Success" success="True" time="0.010" asserts="0">
+                    <results>
+                      <test-case name="NUnit.Framework.Constraints.SamePathTest_Windows.ConstraintTestBaseNoData.ProvidesProperDescription" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                      <test-case name="NUnit.Framework.Constraints.SamePathTest_Windows.ConstraintTestBaseNoData.ProvidesProperStringRepresentation" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                      <test-suite type="ParameterizedTest" name="FailsWithBadValues" executed="True" result="Success" success="True" time="0.001" asserts="0">
+                        <results>
+                          <test-case name="NUnit.Framework.Constraints.SamePathTest_Windows.FailsWithBadValues(123)" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Framework.Constraints.SamePathTest_Windows.FailsWithBadValues(&quot;C:\\folder2\\file.tmp&quot;)" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Framework.Constraints.SamePathTest_Windows.FailsWithBadValues(&quot;C:\\folder1\\.\\folder2\\..\\file.temp&quot;)" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                        </results>
+                      </test-suite>
+                      <test-suite type="ParameterizedTest" name="ProvidesProperFailureMessage" executed="True" result="Success" success="True" time="0.001" asserts="0">
+                        <results>
+                          <test-case name="NUnit.Framework.Constraints.SamePathTest_Windows.ProvidesProperFailureMessage(123,&quot;123&quot;)" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Framework.Constraints.SamePathTest_Windows.ProvidesProperFailureMessage(&quot;C:\\folder2\\file.tmp&quot;,&quot;\&quot;C:\\folder2\\file.tmp\&quot;&quot;)" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Framework.Constraints.SamePathTest_Windows.ProvidesProperFailureMessage(&quot;C:\\folder1\\.\\folder2\\..\\file.temp&quot;,&quot;\&quot;C:\\folder1\\.\\folder2\\..\\file.temp\&quot;&quot;)" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                        </results>
+                      </test-suite>
+                      <test-case name="NUnit.Framework.Constraints.SamePathTest_Windows.RootPathEquality" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                      <test-suite type="ParameterizedTest" name="SucceedsWithGoodValues" executed="True" result="Success" success="True" time="0.003" asserts="0">
+                        <results>
+                          <test-case name="NUnit.Framework.Constraints.SamePathTest_Windows.SucceedsWithGoodValues(&quot;C:\\folder1\\file.tmp&quot;)" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Framework.Constraints.SamePathTest_Windows.SucceedsWithGoodValues(&quot;C:\\Folder1\\File.TMP&quot;)" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Framework.Constraints.SamePathTest_Windows.SucceedsWithGoodValues(&quot;C:\\folder1\\.\\file.tmp&quot;)" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Framework.Constraints.SamePathTest_Windows.SucceedsWithGoodValues(&quot;C:\\folder1\\folder2\\..\\file.tmp&quot;)" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Framework.Constraints.SamePathTest_Windows.SucceedsWithGoodValues(&quot;C:\\FOLDER1\\.\\folder2\\..\\File.TMP&quot;)" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Framework.Constraints.SamePathTest_Windows.SucceedsWithGoodValues(&quot;C:/folder1/file.tmp&quot;)" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                        </results>
+                      </test-suite>
+                    </results>
+                  </test-suite>
+                  <test-suite type="TestFixture" name="StartsWithTest" executed="True" result="Success" success="True" time="0.010" asserts="0">
+                    <results>
+                      <test-case name="NUnit.Framework.Constraints.StartsWithTest.ConstraintTestBaseNoData.ProvidesProperDescription" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                      <test-case name="NUnit.Framework.Constraints.StartsWithTest.ConstraintTestBaseNoData.ProvidesProperStringRepresentation" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                      <test-suite type="ParameterizedTest" name="FailsWithBadValues" executed="True" result="Success" success="True" time="0.003" asserts="0">
+                        <results>
+                          <test-case name="NUnit.Framework.Constraints.StartsWithTest.FailsWithBadValues(&quot;goodbye&quot;)" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Framework.Constraints.StartsWithTest.FailsWithBadValues(&quot;HELLO THERE&quot;)" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Framework.Constraints.StartsWithTest.FailsWithBadValues(&quot;I said hello&quot;)" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Framework.Constraints.StartsWithTest.FailsWithBadValues(&quot;say hello to fred&quot;)" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Framework.Constraints.StartsWithTest.FailsWithBadValues(&quot;&quot;)" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Framework.Constraints.StartsWithTest.FailsWithBadValues(null)" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                        </results>
+                      </test-suite>
+                      <test-suite type="ParameterizedTest" name="ProvidesProperFailureMessage" executed="True" result="Success" success="True" time="0.003" asserts="0">
+                        <results>
+                          <test-case name="NUnit.Framework.Constraints.StartsWithTest.ProvidesProperFailureMessage(&quot;goodbye&quot;,&quot;\&quot;goodbye\&quot;&quot;)" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Framework.Constraints.StartsWithTest.ProvidesProperFailureMessage(&quot;HELLO THERE&quot;,&quot;\&quot;HELLO THERE\&quot;&quot;)" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Framework.Constraints.StartsWithTest.ProvidesProperFailureMessage(&quot;I said hello&quot;,&quot;\&quot;I said hello\&quot;&quot;)" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Framework.Constraints.StartsWithTest.ProvidesProperFailureMessage(&quot;say hello to fred&quot;,&quot;\&quot;say hello to fred\&quot;&quot;)" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Framework.Constraints.StartsWithTest.ProvidesProperFailureMessage(&quot;&quot;,&quot;&lt;string.Empty&gt;&quot;)" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Framework.Constraints.StartsWithTest.ProvidesProperFailureMessage(null,&quot;null&quot;)" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                        </results>
+                      </test-suite>
+                      <test-suite type="ParameterizedTest" name="SucceedsWithGoodValues" executed="True" result="Success" success="True" time="0.001" asserts="0">
+                        <results>
+                          <test-case name="NUnit.Framework.Constraints.StartsWithTest.SucceedsWithGoodValues(&quot;hello&quot;)" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Framework.Constraints.StartsWithTest.SucceedsWithGoodValues(&quot;hello there&quot;)" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                        </results>
+                      </test-suite>
+                    </results>
+                  </test-suite>
+                  <test-suite type="TestFixture" name="StartsWithTestIgnoringCase" executed="True" result="Success" success="True" time="0.012" asserts="0">
+                    <results>
+                      <test-case name="NUnit.Framework.Constraints.StartsWithTestIgnoringCase.ConstraintTestBaseNoData.ProvidesProperDescription" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                      <test-case name="NUnit.Framework.Constraints.StartsWithTestIgnoringCase.ConstraintTestBaseNoData.ProvidesProperStringRepresentation" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                      <test-suite type="ParameterizedTest" name="FailsWithBadValues" executed="True" result="Success" success="True" time="0.003" asserts="0">
+                        <results>
+                          <test-case name="NUnit.Framework.Constraints.StartsWithTestIgnoringCase.FailsWithBadValues(&quot;goodbye&quot;)" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Framework.Constraints.StartsWithTestIgnoringCase.FailsWithBadValues(&quot;What the hell?&quot;)" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Framework.Constraints.StartsWithTestIgnoringCase.FailsWithBadValues(&quot;I said hello&quot;)" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Framework.Constraints.StartsWithTestIgnoringCase.FailsWithBadValues(&quot;say Hello to fred&quot;)" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Framework.Constraints.StartsWithTestIgnoringCase.FailsWithBadValues(&quot;&quot;)" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Framework.Constraints.StartsWithTestIgnoringCase.FailsWithBadValues(null)" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                        </results>
+                      </test-suite>
+                      <test-suite type="ParameterizedTest" name="ProvidesProperFailureMessage" executed="True" result="Success" success="True" time="0.003" asserts="0">
+                        <results>
+                          <test-case name="NUnit.Framework.Constraints.StartsWithTestIgnoringCase.ProvidesProperFailureMessage(&quot;goodbye&quot;,&quot;\&quot;goodbye\&quot;&quot;)" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Framework.Constraints.StartsWithTestIgnoringCase.ProvidesProperFailureMessage(&quot;What the hell?&quot;,&quot;\&quot;What the hell?\&quot;&quot;)" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Framework.Constraints.StartsWithTestIgnoringCase.ProvidesProperFailureMessage(&quot;I said hello&quot;,&quot;\&quot;I said hello\&quot;&quot;)" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Framework.Constraints.StartsWithTestIgnoringCase.ProvidesProperFailureMessage(&quot;say Hello to fred&quot;,&quot;\&quot;say Hello to fred\&quot;&quot;)" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Framework.Constraints.StartsWithTestIgnoringCase.ProvidesProperFailureMessage(&quot;&quot;,&quot;&lt;string.Empty&gt;&quot;)" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Framework.Constraints.StartsWithTestIgnoringCase.ProvidesProperFailureMessage(null,&quot;null&quot;)" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                        </results>
+                      </test-suite>
+                      <test-suite type="ParameterizedTest" name="SucceedsWithGoodValues" executed="True" result="Success" success="True" time="0.001" asserts="0">
+                        <results>
+                          <test-case name="NUnit.Framework.Constraints.StartsWithTestIgnoringCase.SucceedsWithGoodValues(&quot;Hello&quot;)" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Framework.Constraints.StartsWithTestIgnoringCase.SucceedsWithGoodValues(&quot;HELLO there&quot;)" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                        </results>
+                      </test-suite>
+                    </results>
+                  </test-suite>
+                  <test-suite type="TestFixture" name="SubPathTest_Linux" executed="True" result="Success" success="True" time="0.021" asserts="0">
+                    <results>
+                      <test-case name="NUnit.Framework.Constraints.SubPathTest_Linux.ConstraintTestBaseNoData.ProvidesProperDescription" executed="True" result="Success" success="True" time="0.001" asserts="1" />
+                      <test-case name="NUnit.Framework.Constraints.SubPathTest_Linux.ConstraintTestBaseNoData.ProvidesProperStringRepresentation" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                      <test-suite type="ParameterizedTest" name="FailsWithBadValues" executed="True" result="Success" success="True" time="0.007" asserts="0">
+                        <results>
+                          <test-case name="NUnit.Framework.Constraints.SubPathTest_Linux.FailsWithBadValues(123)" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Framework.Constraints.SubPathTest_Linux.FailsWithBadValues(&quot;/Folder1/Folder2&quot;)" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Framework.Constraints.SubPathTest_Linux.FailsWithBadValues(&quot;/FOLDER1/./junk/../Folder2&quot;)" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Framework.Constraints.SubPathTest_Linux.FailsWithBadValues(&quot;/FOLDER1/./junk/../Folder2/temp/../Folder3&quot;)" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Framework.Constraints.SubPathTest_Linux.FailsWithBadValues(&quot;/folder1/folder3&quot;)" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Framework.Constraints.SubPathTest_Linux.FailsWithBadValues(&quot;/folder1/./folder2/../folder3&quot;)" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Framework.Constraints.SubPathTest_Linux.FailsWithBadValues(&quot;/folder1&quot;)" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Framework.Constraints.SubPathTest_Linux.FailsWithBadValues(&quot;/folder1/folder2&quot;)" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Framework.Constraints.SubPathTest_Linux.FailsWithBadValues(&quot;/folder1/./folder2&quot;)" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Framework.Constraints.SubPathTest_Linux.FailsWithBadValues(&quot;/folder1/junk/../folder2&quot;)" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Framework.Constraints.SubPathTest_Linux.FailsWithBadValues(&quot;\\folder1\\folder2&quot;)" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                        </results>
+                      </test-suite>
+                      <test-suite type="ParameterizedTest" name="ProvidesProperFailureMessage" executed="True" result="Success" success="True" time="0.006" asserts="0">
+                        <results>
+                          <test-case name="NUnit.Framework.Constraints.SubPathTest_Linux.ProvidesProperFailureMessage(123,&quot;123&quot;)" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Framework.Constraints.SubPathTest_Linux.ProvidesProperFailureMessage(&quot;/Folder1/Folder2&quot;,&quot;\&quot;/Folder1/Folder2\&quot;&quot;)" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Framework.Constraints.SubPathTest_Linux.ProvidesProperFailureMessage(&quot;/FOLDER1/./junk/../Folder2&quot;,&quot;\&quot;/FOLDER1/./junk/../Folder2\&quot;&quot;)" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Framework.Constraints.SubPathTest_Linux.ProvidesProperFailureMessage(&quot;/FOLDER1/./junk/../Folder2/temp/../Folder3&quot;,&quot;\&quot;/FOLDER1/./junk/../Folder2/temp/../Folder3\&quot;&quot;)" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Framework.Constraints.SubPathTest_Linux.ProvidesProperFailureMessage(&quot;/folder1/folder3&quot;,&quot;\&quot;/folder1/folder3\&quot;&quot;)" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Framework.Constraints.SubPathTest_Linux.ProvidesProperFailureMessage(&quot;/folder1/./folder2/../folder3&quot;,&quot;\&quot;/folder1/./folder2/../folder3\&quot;&quot;)" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Framework.Constraints.SubPathTest_Linux.ProvidesProperFailureMessage(&quot;/folder1&quot;,&quot;\&quot;/folder1\&quot;&quot;)" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Framework.Constraints.SubPathTest_Linux.ProvidesProperFailureMessage(&quot;/folder1/folder2&quot;,&quot;\&quot;/folder1/folder2\&quot;&quot;)" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Framework.Constraints.SubPathTest_Linux.ProvidesProperFailureMessage(&quot;/folder1/./folder2&quot;,&quot;\&quot;/folder1/./folder2\&quot;&quot;)" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Framework.Constraints.SubPathTest_Linux.ProvidesProperFailureMessage(&quot;/folder1/junk/../folder2&quot;,&quot;\&quot;/folder1/junk/../folder2\&quot;&quot;)" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Framework.Constraints.SubPathTest_Linux.ProvidesProperFailureMessage(&quot;\\folder1\\folder2&quot;,&quot;\&quot;\\folder1\\folder2\&quot;&quot;)" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                        </results>
+                      </test-suite>
+                      <test-case name="NUnit.Framework.Constraints.SubPathTest_Linux.SubPathOfRoot" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                      <test-suite type="ParameterizedTest" name="SucceedsWithGoodValues" executed="True" result="Success" success="True" time="0.002" asserts="0">
+                        <results>
+                          <test-case name="NUnit.Framework.Constraints.SubPathTest_Linux.SucceedsWithGoodValues(&quot;/folder1/folder2/folder3&quot;)" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Framework.Constraints.SubPathTest_Linux.SucceedsWithGoodValues(&quot;/folder1/./folder2/folder3&quot;)" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Framework.Constraints.SubPathTest_Linux.SucceedsWithGoodValues(&quot;/folder1/junk/../folder2/folder3&quot;)" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Framework.Constraints.SubPathTest_Linux.SucceedsWithGoodValues(&quot;\\folder1\\folder2\\folder3&quot;)" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                        </results>
+                      </test-suite>
+                    </results>
+                  </test-suite>
+                  <test-suite type="TestFixture" name="SubPathTest_Windows" executed="True" result="Success" success="True" time="0.018" asserts="0">
+                    <results>
+                      <test-case name="NUnit.Framework.Constraints.SubPathTest_Windows.ConstraintTestBaseNoData.ProvidesProperDescription" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                      <test-case name="NUnit.Framework.Constraints.SubPathTest_Windows.ConstraintTestBaseNoData.ProvidesProperStringRepresentation" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                      <test-suite type="ParameterizedTest" name="FailsWithBadValues" executed="True" result="Success" success="True" time="0.005" asserts="0">
+                        <results>
+                          <test-case name="NUnit.Framework.Constraints.SubPathTest_Windows.FailsWithBadValues(123)" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Framework.Constraints.SubPathTest_Windows.FailsWithBadValues(&quot;C:\\folder1\\folder3&quot;)" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Framework.Constraints.SubPathTest_Windows.FailsWithBadValues(&quot;C:\\folder1\\.\\folder2\\..\\file.temp&quot;)" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Framework.Constraints.SubPathTest_Windows.FailsWithBadValues(&quot;C:\\folder1\\folder2&quot;)" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Framework.Constraints.SubPathTest_Windows.FailsWithBadValues(&quot;C:\\Folder1\\Folder2&quot;)" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Framework.Constraints.SubPathTest_Windows.FailsWithBadValues(&quot;C:\\folder1\\.\\folder2&quot;)" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Framework.Constraints.SubPathTest_Windows.FailsWithBadValues(&quot;C:\\folder1\\junk\\..\\folder2&quot;)" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Framework.Constraints.SubPathTest_Windows.FailsWithBadValues(&quot;C:\\FOLDER1\\.\\junk\\..\\Folder2&quot;)" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Framework.Constraints.SubPathTest_Windows.FailsWithBadValues(&quot;C:/folder1/folder2&quot;)" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                        </results>
+                      </test-suite>
+                      <test-suite type="ParameterizedTest" name="ProvidesProperFailureMessage" executed="True" result="Success" success="True" time="0.005" asserts="0">
+                        <results>
+                          <test-case name="NUnit.Framework.Constraints.SubPathTest_Windows.ProvidesProperFailureMessage(123,&quot;123&quot;)" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Framework.Constraints.SubPathTest_Windows.ProvidesProperFailureMessage(&quot;C:\\folder1\\folder3&quot;,&quot;\&quot;C:\\folder1\\folder3\&quot;&quot;)" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Framework.Constraints.SubPathTest_Windows.ProvidesProperFailureMessage(&quot;C:\\folder1\\.\\folder2\\..\\file.temp&quot;,&quot;\&quot;C:\\folder1\\.\\folder2\\..\\file.temp\&quot;&quot;)" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Framework.Constraints.SubPathTest_Windows.ProvidesProperFailureMessage(&quot;C:\\folder1\\folder2&quot;,&quot;\&quot;C:\\folder1\\folder2\&quot;&quot;)" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Framework.Constraints.SubPathTest_Windows.ProvidesProperFailureMessage(&quot;C:\\Folder1\\Folder2&quot;,&quot;\&quot;C:\\Folder1\\Folder2\&quot;&quot;)" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Framework.Constraints.SubPathTest_Windows.ProvidesProperFailureMessage(&quot;C:\\folder1\\.\\folder2&quot;,&quot;\&quot;C:\\folder1\\.\\folder2\&quot;&quot;)" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Framework.Constraints.SubPathTest_Windows.ProvidesProperFailureMessage(&quot;C:\\folder1\\junk\\..\\folder2&quot;,&quot;\&quot;C:\\folder1\\junk\\..\\folder2\&quot;&quot;)" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Framework.Constraints.SubPathTest_Windows.ProvidesProperFailureMessage(&quot;C:\\FOLDER1\\.\\junk\\..\\Folder2&quot;,&quot;\&quot;C:\\FOLDER1\\.\\junk\\..\\Folder2\&quot;&quot;)" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Framework.Constraints.SubPathTest_Windows.ProvidesProperFailureMessage(&quot;C:/folder1/folder2&quot;,&quot;\&quot;C:/folder1/folder2\&quot;&quot;)" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                        </results>
+                      </test-suite>
+                      <test-case name="NUnit.Framework.Constraints.SubPathTest_Windows.SubPathOfRoot" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                      <test-suite type="ParameterizedTest" name="SucceedsWithGoodValues" executed="True" result="Success" success="True" time="0.003" asserts="0">
+                        <results>
+                          <test-case name="NUnit.Framework.Constraints.SubPathTest_Windows.SucceedsWithGoodValues(&quot;C:\\folder1\\folder2\\folder3&quot;)" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Framework.Constraints.SubPathTest_Windows.SucceedsWithGoodValues(&quot;C:\\folder1\\.\\folder2\\folder3&quot;)" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Framework.Constraints.SubPathTest_Windows.SucceedsWithGoodValues(&quot;C:\\folder1\\junk\\..\\folder2\\folder3&quot;)" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Framework.Constraints.SubPathTest_Windows.SucceedsWithGoodValues(&quot;C:\\FOLDER1\\.\\junk\\..\\Folder2\\temp\\..\\Folder3&quot;)" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Framework.Constraints.SubPathTest_Windows.SucceedsWithGoodValues(&quot;C:/folder1/folder2/folder3&quot;)" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                        </results>
+                      </test-suite>
+                    </results>
+                  </test-suite>
+                  <test-suite type="TestFixture" name="SubstringTest" executed="True" result="Success" success="True" time="0.010" asserts="0">
+                    <results>
+                      <test-case name="NUnit.Framework.Constraints.SubstringTest.ConstraintTestBaseNoData.ProvidesProperDescription" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                      <test-case name="NUnit.Framework.Constraints.SubstringTest.ConstraintTestBaseNoData.ProvidesProperStringRepresentation" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                      <test-suite type="ParameterizedTest" name="FailsWithBadValues" executed="True" result="Success" success="True" time="0.003" asserts="0">
+                        <results>
+                          <test-case name="NUnit.Framework.Constraints.SubstringTest.FailsWithBadValues(&quot;goodbye&quot;)" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Framework.Constraints.SubstringTest.FailsWithBadValues(&quot;HELLO&quot;)" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Framework.Constraints.SubstringTest.FailsWithBadValues(&quot;What the hell?&quot;)" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Framework.Constraints.SubstringTest.FailsWithBadValues(&quot;&quot;)" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Framework.Constraints.SubstringTest.FailsWithBadValues(null)" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                        </results>
+                      </test-suite>
+                      <test-suite type="ParameterizedTest" name="ProvidesProperFailureMessage" executed="True" result="Success" success="True" time="0.002" asserts="0">
+                        <results>
+                          <test-case name="NUnit.Framework.Constraints.SubstringTest.ProvidesProperFailureMessage(&quot;goodbye&quot;,&quot;\&quot;goodbye\&quot;&quot;)" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Framework.Constraints.SubstringTest.ProvidesProperFailureMessage(&quot;HELLO&quot;,&quot;\&quot;HELLO\&quot;&quot;)" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Framework.Constraints.SubstringTest.ProvidesProperFailureMessage(&quot;What the hell?&quot;,&quot;\&quot;What the hell?\&quot;&quot;)" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Framework.Constraints.SubstringTest.ProvidesProperFailureMessage(&quot;&quot;,&quot;&lt;string.Empty&gt;&quot;)" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Framework.Constraints.SubstringTest.ProvidesProperFailureMessage(null,&quot;null&quot;)" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                        </results>
+                      </test-suite>
+                      <test-suite type="ParameterizedTest" name="SucceedsWithGoodValues" executed="True" result="Success" success="True" time="0.002" asserts="0">
+                        <results>
+                          <test-case name="NUnit.Framework.Constraints.SubstringTest.SucceedsWithGoodValues(&quot;hello&quot;)" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Framework.Constraints.SubstringTest.SucceedsWithGoodValues(&quot;hello there&quot;)" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Framework.Constraints.SubstringTest.SucceedsWithGoodValues(&quot;I said hello&quot;)" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Framework.Constraints.SubstringTest.SucceedsWithGoodValues(&quot;say hello to fred&quot;)" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                        </results>
+                      </test-suite>
+                    </results>
+                  </test-suite>
+                  <test-suite type="TestFixture" name="SubstringTestIgnoringCase" executed="True" result="Success" success="True" time="0.010" asserts="0">
+                    <results>
+                      <test-case name="NUnit.Framework.Constraints.SubstringTestIgnoringCase.ConstraintTestBaseNoData.ProvidesProperDescription" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                      <test-case name="NUnit.Framework.Constraints.SubstringTestIgnoringCase.ConstraintTestBaseNoData.ProvidesProperStringRepresentation" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                      <test-suite type="ParameterizedTest" name="FailsWithBadValues" executed="True" result="Success" success="True" time="0.002" asserts="0">
+                        <results>
+                          <test-case name="NUnit.Framework.Constraints.SubstringTestIgnoringCase.FailsWithBadValues(&quot;goodbye&quot;)" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Framework.Constraints.SubstringTestIgnoringCase.FailsWithBadValues(&quot;What the hell?&quot;)" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Framework.Constraints.SubstringTestIgnoringCase.FailsWithBadValues(&quot;&quot;)" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Framework.Constraints.SubstringTestIgnoringCase.FailsWithBadValues(null)" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                        </results>
+                      </test-suite>
+                      <test-suite type="ParameterizedTest" name="ProvidesProperFailureMessage" executed="True" result="Success" success="True" time="0.002" asserts="0">
+                        <results>
+                          <test-case name="NUnit.Framework.Constraints.SubstringTestIgnoringCase.ProvidesProperFailureMessage(&quot;goodbye&quot;,&quot;\&quot;goodbye\&quot;&quot;)" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Framework.Constraints.SubstringTestIgnoringCase.ProvidesProperFailureMessage(&quot;What the hell?&quot;,&quot;\&quot;What the hell?\&quot;&quot;)" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Framework.Constraints.SubstringTestIgnoringCase.ProvidesProperFailureMessage(&quot;&quot;,&quot;&lt;string.Empty&gt;&quot;)" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Framework.Constraints.SubstringTestIgnoringCase.ProvidesProperFailureMessage(null,&quot;null&quot;)" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                        </results>
+                      </test-suite>
+                      <test-suite type="ParameterizedTest" name="SucceedsWithGoodValues" executed="True" result="Success" success="True" time="0.002" asserts="0">
+                        <results>
+                          <test-case name="NUnit.Framework.Constraints.SubstringTestIgnoringCase.SucceedsWithGoodValues(&quot;Hello&quot;)" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Framework.Constraints.SubstringTestIgnoringCase.SucceedsWithGoodValues(&quot;HellO there&quot;)" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Framework.Constraints.SubstringTestIgnoringCase.SucceedsWithGoodValues(&quot;I said HELLO&quot;)" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Framework.Constraints.SubstringTestIgnoringCase.SucceedsWithGoodValues(&quot;say hello to fred&quot;)" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                        </results>
+                      </test-suite>
+                    </results>
+                  </test-suite>
+                  <test-suite type="TestFixture" name="ThrowsConstraintTest_ExactType" executed="True" result="Success" success="True" time="0.010" asserts="0">
+                    <results>
+                      <test-case name="NUnit.Framework.Constraints.ThrowsConstraintTest_ExactType.ConstraintTestBaseNoData.ProvidesProperDescription" executed="True" result="Success" success="True" time="0.001" asserts="1" />
+                      <test-case name="NUnit.Framework.Constraints.ThrowsConstraintTest_ExactType.ConstraintTestBaseNoData.ProvidesProperStringRepresentation" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                      <test-suite type="ParameterizedTest" name="FailsWithBadValues" executed="True" result="Success" success="True" time="0.003" asserts="0">
+                        <results>
+                          <test-case name="NUnit.Framework.Constraints.ThrowsConstraintTest_ExactType.FailsWithBadValues(NUnit.Framework.TestDelegate)" executed="True" result="Success" success="True" time="0.001" asserts="1" />
+                          <test-case name="NUnit.Framework.Constraints.ThrowsConstraintTest_ExactType.FailsWithBadValues(NUnit.Framework.TestDelegate)" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Framework.Constraints.ThrowsConstraintTest_ExactType.FailsWithBadValues(NUnit.Framework.TestDelegate)" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                        </results>
+                      </test-suite>
+                      <test-suite type="ParameterizedTest" name="ProvidesProperFailureMessage" executed="True" result="Success" success="True" time="0.002" asserts="0">
+                        <results>
+                          <test-case name="NUnit.Framework.Constraints.ThrowsConstraintTest_ExactType.ProvidesProperFailureMessage(NUnit.Framework.TestDelegate,&quot;&lt;System.ApplicationException&gt;&quot;)" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Framework.Constraints.ThrowsConstraintTest_ExactType.ProvidesProperFailureMessage(NUnit.Framework.TestDelegate,&quot;no exception thrown&quot;)" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Framework.Constraints.ThrowsConstraintTest_ExactType.ProvidesProperFailureMessage(NUnit.Framework.TestDelegate,&quot;&lt;System.Exception&gt;&quot;)" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                        </results>
+                      </test-suite>
+                      <test-suite type="ParameterizedTest" name="SucceedsWithGoodValues" executed="True" result="Success" success="True" time="0.001" asserts="0">
+                        <results>
+                          <test-case name="NUnit.Framework.Constraints.ThrowsConstraintTest_ExactType.SucceedsWithGoodValues(NUnit.Framework.TestDelegate)" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                        </results>
+                      </test-suite>
+                    </results>
+                  </test-suite>
+                  <test-suite type="TestFixture" name="ThrowsConstraintTest_InstanceOfType" executed="True" result="Success" success="True" time="0.024" asserts="0">
+                    <results>
+                      <test-case name="NUnit.Framework.Constraints.ThrowsConstraintTest_InstanceOfType.ConstraintTestBaseNoData.ProvidesProperDescription" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                      <test-case name="NUnit.Framework.Constraints.ThrowsConstraintTest_InstanceOfType.ConstraintTestBaseNoData.ProvidesProperStringRepresentation" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                      <test-suite type="ParameterizedTest" name="FailsWithBadValues" executed="True" result="Success" success="True" time="0.002" asserts="0">
+                        <results>
+                          <test-case name="NUnit.Framework.Constraints.ThrowsConstraintTest_InstanceOfType.FailsWithBadValues(NUnit.Framework.TestDelegate)" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Framework.Constraints.ThrowsConstraintTest_InstanceOfType.FailsWithBadValues(NUnit.Framework.TestDelegate)" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Framework.Constraints.ThrowsConstraintTest_InstanceOfType.FailsWithBadValues(NUnit.Framework.TestDelegate)" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                        </results>
+                      </test-suite>
+                      <test-suite type="ParameterizedTest" name="ProvidesProperFailureMessage" executed="True" result="Success" success="True" time="0.002" asserts="0">
+                        <results>
+                          <test-case name="NUnit.Framework.Constraints.ThrowsConstraintTest_InstanceOfType.ProvidesProperFailureMessage(NUnit.Framework.TestDelegate,&quot;&lt;System.ArgumentException&gt;&quot;)" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Framework.Constraints.ThrowsConstraintTest_InstanceOfType.ProvidesProperFailureMessage(NUnit.Framework.TestDelegate,&quot;no exception thrown&quot;)" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Framework.Constraints.ThrowsConstraintTest_InstanceOfType.ProvidesProperFailureMessage(NUnit.Framework.TestDelegate,&quot;&lt;System.Exception&gt;&quot;)" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                        </results>
+                      </test-suite>
+                      <test-suite type="ParameterizedTest" name="SucceedsWithGoodValues" executed="True" result="Success" success="True" time="0.015" asserts="0">
+                        <results>
+                          <test-case name="NUnit.Framework.Constraints.ThrowsConstraintTest_InstanceOfType.SucceedsWithGoodValues(NUnit.Framework.TestDelegate)" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Framework.Constraints.ThrowsConstraintTest_InstanceOfType.SucceedsWithGoodValues(NUnit.Framework.TestDelegate)" executed="True" result="Success" success="True" time="0.013" asserts="1" />
+                        </results>
+                      </test-suite>
+                    </results>
+                  </test-suite>
+                  <test-suite type="TestFixture" name="ThrowsConstraintTest_WithConstraint" executed="True" result="Success" success="True" time="0.008" asserts="0">
+                    <results>
+                      <test-case name="NUnit.Framework.Constraints.ThrowsConstraintTest_WithConstraint.ConstraintTestBaseNoData.ProvidesProperDescription" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                      <test-case name="NUnit.Framework.Constraints.ThrowsConstraintTest_WithConstraint.ConstraintTestBaseNoData.ProvidesProperStringRepresentation" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                      <test-suite type="ParameterizedTest" name="FailsWithBadValues" executed="True" result="Success" success="True" time="0.002" asserts="0">
+                        <results>
+                          <test-case name="NUnit.Framework.Constraints.ThrowsConstraintTest_WithConstraint.FailsWithBadValues(NUnit.Framework.TestDelegate)" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Framework.Constraints.ThrowsConstraintTest_WithConstraint.FailsWithBadValues(NUnit.Framework.TestDelegate)" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Framework.Constraints.ThrowsConstraintTest_WithConstraint.FailsWithBadValues(NUnit.Framework.TestDelegate)" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                        </results>
+                      </test-suite>
+                      <test-suite type="ParameterizedTest" name="ProvidesProperFailureMessage" executed="True" result="Success" success="True" time="0.002" asserts="0">
+                        <results>
+                          <test-case name="NUnit.Framework.Constraints.ThrowsConstraintTest_WithConstraint.ProvidesProperFailureMessage(NUnit.Framework.TestDelegate,&quot;&lt;System.ApplicationException&gt;&quot;)" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Framework.Constraints.ThrowsConstraintTest_WithConstraint.ProvidesProperFailureMessage(NUnit.Framework.TestDelegate,&quot;no exception thrown&quot;)" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Framework.Constraints.ThrowsConstraintTest_WithConstraint.ProvidesProperFailureMessage(NUnit.Framework.TestDelegate,&quot;&lt;System.Exception&gt;&quot;)" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                        </results>
+                      </test-suite>
+                      <test-suite type="ParameterizedTest" name="SucceedsWithGoodValues" executed="True" result="Success" success="True" time="0.001" asserts="0">
+                        <results>
+                          <test-case name="NUnit.Framework.Constraints.ThrowsConstraintTest_WithConstraint.SucceedsWithGoodValues(NUnit.Framework.TestDelegate)" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                        </results>
+                      </test-suite>
+                    </results>
+                  </test-suite>
+                  <test-suite type="TestFixture" name="ToStringTests" executed="True" result="Success" success="True" time="0.007" asserts="0">
+                    <results>
+                      <test-case name="NUnit.Framework.Constraints.ToStringTests.CanDisplayPrefixConstraints_Resolved" executed="True" result="Success" success="True" time="0.001" asserts="3" />
+                      <test-case name="NUnit.Framework.Constraints.ToStringTests.CanDisplaySimpleConstraints_Resolved" executed="True" result="Success" success="True" time="0.001" asserts="3" />
+                      <test-case name="NUnit.Framework.Constraints.ToStringTests.CanDisplaySimpleConstraints_Unresolved" executed="True" result="Success" success="True" time="0.000" asserts="3" />
+                      <test-case name="NUnit.Framework.Constraints.ToStringTests.DisplayBinaryConstraints_Resolved" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                      <test-case name="NUnit.Framework.Constraints.ToStringTests.DisplayBinaryConstraints_UnResolved" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                      <test-case name="NUnit.Framework.Constraints.ToStringTests.DisplayPrefixConstraints_Unresolved" executed="True" result="Success" success="True" time="0.000" asserts="4" />
+                    </results>
+                  </test-suite>
+                  <test-suite type="TestFixture" name="TrueConstraintTest" executed="True" result="Success" success="True" time="0.009" asserts="0">
+                    <results>
+                      <test-case name="NUnit.Framework.Constraints.TrueConstraintTest.ConstraintTestBaseNoData.ProvidesProperDescription" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                      <test-case name="NUnit.Framework.Constraints.TrueConstraintTest.ConstraintTestBaseNoData.ProvidesProperStringRepresentation" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                      <test-suite type="ParameterizedTest" name="FailsWithBadValues" executed="True" result="Success" success="True" time="0.002" asserts="0">
+                        <results>
+                          <test-case name="NUnit.Framework.Constraints.TrueConstraintTest.FailsWithBadValues(null)" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Framework.Constraints.TrueConstraintTest.FailsWithBadValues(&quot;hello&quot;)" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Framework.Constraints.TrueConstraintTest.FailsWithBadValues(False)" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Framework.Constraints.TrueConstraintTest.FailsWithBadValues(False)" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                        </results>
+                      </test-suite>
+                      <test-suite type="ParameterizedTest" name="ProvidesProperFailureMessage" executed="True" result="Success" success="True" time="0.002" asserts="0">
+                        <results>
+                          <test-case name="NUnit.Framework.Constraints.TrueConstraintTest.ProvidesProperFailureMessage(null,&quot;null&quot;)" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Framework.Constraints.TrueConstraintTest.ProvidesProperFailureMessage(&quot;hello&quot;,&quot;\&quot;hello\&quot;&quot;)" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Framework.Constraints.TrueConstraintTest.ProvidesProperFailureMessage(False,&quot;False&quot;)" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Framework.Constraints.TrueConstraintTest.ProvidesProperFailureMessage(False,&quot;False&quot;)" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                        </results>
+                      </test-suite>
+                      <test-suite type="ParameterizedTest" name="SucceedsWithGoodValues" executed="True" result="Success" success="True" time="0.001" asserts="0">
+                        <results>
+                          <test-case name="NUnit.Framework.Constraints.TrueConstraintTest.SucceedsWithGoodValues(True)" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Framework.Constraints.TrueConstraintTest.SucceedsWithGoodValues(True)" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                        </results>
+                      </test-suite>
+                    </results>
+                  </test-suite>
+                  <test-suite type="TestFixture" name="XmlSerializableTest" executed="True" result="Success" success="True" time="1.821" asserts="0">
+                    <results>
+                      <test-case name="NUnit.Framework.Constraints.XmlSerializableTest.ConstraintTestBaseNoData.ProvidesProperDescription" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                      <test-case name="NUnit.Framework.Constraints.XmlSerializableTest.ConstraintTestBaseNoData.ProvidesProperStringRepresentation" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                      <test-suite type="ParameterizedTest" name="FailsWithBadValues" executed="True" result="Success" success="True" time="0.813" asserts="0">
+                        <results>
+                          <test-case name="NUnit.Framework.Constraints.XmlSerializableTest.FailsWithBadValues(System.Collections.Generic.Dictionary`2[System.String,System.String])" executed="True" result="Success" success="True" time="0.544" asserts="1" />
+                          <test-case name="NUnit.Framework.Constraints.XmlSerializableTest.FailsWithBadValues(NUnit.Framework.Constraints.XmlSerializableTest+InternalClass)" executed="True" result="Success" success="True" time="0.242" asserts="1" />
+                          <test-case name="NUnit.Framework.Constraints.XmlSerializableTest.FailsWithBadValues(NUnit.Framework.Constraints.XmlSerializableTest+InternalWithSerializableAttributeClass)" executed="True" result="Success" success="True" time="0.024" asserts="1" />
+                        </results>
+                      </test-suite>
+                      <test-suite type="ParameterizedTest" name="InvalidDataThrowsArgumentException" executed="True" result="Success" success="True" time="0.001" asserts="0">
+                        <results>
+                          <test-case name="NUnit.Framework.Constraints.XmlSerializableTest.InvalidDataThrowsArgumentException(null)" executed="True" result="Success" success="True" time="0.001" asserts="0" />
+                        </results>
+                      </test-suite>
+                      <test-suite type="ParameterizedTest" name="ProvidesProperFailureMessage" executed="True" result="Success" success="True" time="0.055" asserts="0">
+                        <results>
+                          <test-case name="NUnit.Framework.Constraints.XmlSerializableTest.ProvidesProperFailureMessage(System.Collections.Generic.Dictionary`2[System.String,System.String],&quot;&lt;Dictionary`2&gt;&quot;)" executed="True" result="Success" success="True" time="0.020" asserts="1" />
+                          <test-case name="NUnit.Framework.Constraints.XmlSerializableTest.ProvidesProperFailureMessage(NUnit.Framework.Constraints.XmlSerializableTest+InternalClass,&quot;&lt;InternalClass&gt;&quot;)" executed="True" result="Success" success="True" time="0.018" asserts="1" />
+                          <test-case name="NUnit.Framework.Constraints.XmlSerializableTest.ProvidesProperFailureMessage(NUnit.Framework.Constraints.XmlSerializableTest+InternalWithSerializableAttributeClass,&quot;&lt;InternalWithSerializableAttributeClass&gt;&quot;)" executed="True" result="Success" success="True" time="0.014" asserts="1" />
+                        </results>
+                      </test-suite>
+                      <test-suite type="ParameterizedTest" name="SucceedsWithGoodValues" executed="True" result="Success" success="True" time="0.945" asserts="0">
+                        <results>
+                          <test-case name="NUnit.Framework.Constraints.XmlSerializableTest.SucceedsWithGoodValues(1)" executed="True" result="Success" success="True" time="0.051" asserts="1" />
+                          <test-case name="NUnit.Framework.Constraints.XmlSerializableTest.SucceedsWithGoodValues(&quot;a&quot;)" executed="True" result="Success" success="True" time="0.003" asserts="1" />
+                          <test-case name="NUnit.Framework.Constraints.XmlSerializableTest.SucceedsWithGoodValues(System.Collections.ArrayList)" executed="True" result="Success" success="True" time="0.889" asserts="1" />
+                        </results>
+                      </test-suite>
+                    </results>
+                  </test-suite>
+                </results>
+              </test-suite>
+              <test-suite type="Namespace" name="Syntax" executed="True" result="Success" success="True" time="4.223" asserts="0">
+                <results>
+                  <test-suite type="TestFixture" name="AfterSyntaxUsingActualPassedByRef" executed="True" result="Success" success="True" time="1.417" asserts="0">
+                    <results>
+                      <test-case name="NUnit.Framework.Syntax.AfterSyntaxUsingActualPassedByRef.EqualToTest" executed="True" result="Success" success="True" time="0.201" asserts="1" />
+                      <test-case name="NUnit.Framework.Syntax.AfterSyntaxUsingActualPassedByRef.GreaterTest" executed="True" result="Success" success="True" time="0.201" asserts="1" />
+                      <test-case name="NUnit.Framework.Syntax.AfterSyntaxUsingActualPassedByRef.HasMemberTest" executed="True" result="Success" success="True" time="0.201" asserts="1" />
+                      <test-case name="NUnit.Framework.Syntax.AfterSyntaxUsingActualPassedByRef.NullTest" executed="True" result="Success" success="True" time="0.201" asserts="1" />
+                      <test-case name="NUnit.Framework.Syntax.AfterSyntaxUsingActualPassedByRef.SameAsTest" executed="True" result="Success" success="True" time="0.201" asserts="1" />
+                      <test-case name="NUnit.Framework.Syntax.AfterSyntaxUsingActualPassedByRef.TextTest" executed="True" result="Success" success="True" time="0.201" asserts="1" />
+                      <test-case name="NUnit.Framework.Syntax.AfterSyntaxUsingActualPassedByRef.TrueTest" executed="True" result="Success" success="True" time="0.200" asserts="1" />
+                    </results>
+                  </test-suite>
+                  <test-suite type="TestFixture" name="AfterSyntaxUsingAnonymousDelegates" executed="True" result="Success" success="True" time="1.522" asserts="0">
+                    <results>
+                      <test-case name="NUnit.Framework.Syntax.AfterSyntaxUsingAnonymousDelegates.EqualToTest" executed="True" result="Success" success="True" time="0.201" asserts="1" />
+                      <test-case name="NUnit.Framework.Syntax.AfterSyntaxUsingAnonymousDelegates.GreaterTest" executed="True" result="Success" success="True" time="0.201" asserts="1" />
+                      <test-case name="NUnit.Framework.Syntax.AfterSyntaxUsingAnonymousDelegates.HasMemberTest" executed="True" result="Success" success="True" time="0.202" asserts="1" />
+                      <test-case name="NUnit.Framework.Syntax.AfterSyntaxUsingAnonymousDelegates.NullTest" executed="True" result="Success" success="True" time="0.202" asserts="1" />
+                      <test-case name="NUnit.Framework.Syntax.AfterSyntaxUsingAnonymousDelegates.SameAsTest" executed="True" result="Success" success="True" time="0.202" asserts="1" />
+                      <test-case name="NUnit.Framework.Syntax.AfterSyntaxUsingAnonymousDelegates.TextTest" executed="True" result="Success" success="True" time="0.201" asserts="1" />
+                      <test-case name="NUnit.Framework.Syntax.AfterSyntaxUsingAnonymousDelegates.ThrowsTest" executed="True" result="Success" success="True" time="0.103" asserts="1" />
+                      <test-case name="NUnit.Framework.Syntax.AfterSyntaxUsingAnonymousDelegates.TrueTest" executed="True" result="Success" success="True" time="0.201" asserts="1" />
+                    </results>
+                  </test-suite>
+                  <test-suite type="TestFixture" name="AfterTest_AndOperator" executed="True" result="Success" success="True" time="0.008" asserts="0">
+                    <results>
+                      <test-case name="NUnit.Framework.Syntax.AfterTest_AndOperator.SyntaxTest.SupportedByConstraintBuilder" executed="True" result="Success" success="True" time="0.002" asserts="1" />
+                      <test-case name="NUnit.Framework.Syntax.AfterTest_AndOperator.SyntaxTest.SupportedByInheritedSyntax" executed="True" result="Success" success="True" time="0.001" asserts="1" />
+                      <test-case name="NUnit.Framework.Syntax.AfterTest_AndOperator.SyntaxTest.SupportedByStaticSyntax" executed="True" result="Success" success="True" time="0.001" asserts="1" />
+                    </results>
+                  </test-suite>
+                  <test-suite type="TestFixture" name="AfterTest_ProperyTest" executed="True" result="Success" success="True" time="0.005" asserts="0">
+                    <results>
+                      <test-case name="NUnit.Framework.Syntax.AfterTest_ProperyTest.SyntaxTest.SupportedByConstraintBuilder" executed="True" result="Success" success="True" time="0.001" asserts="1" />
+                      <test-case name="NUnit.Framework.Syntax.AfterTest_ProperyTest.SyntaxTest.SupportedByInheritedSyntax" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                      <test-case name="NUnit.Framework.Syntax.AfterTest_ProperyTest.SyntaxTest.SupportedByStaticSyntax" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                    </results>
+                  </test-suite>
+                  <test-suite type="TestFixture" name="AfterTest_SimpleConstraint" executed="True" result="Success" success="True" time="0.005" asserts="0">
+                    <results>
+                      <test-case name="NUnit.Framework.Syntax.AfterTest_SimpleConstraint.SyntaxTest.SupportedByConstraintBuilder" executed="True" result="Success" success="True" time="0.001" asserts="1" />
+                      <test-case name="NUnit.Framework.Syntax.AfterTest_SimpleConstraint.SyntaxTest.SupportedByInheritedSyntax" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                      <test-case name="NUnit.Framework.Syntax.AfterTest_SimpleConstraint.SyntaxTest.SupportedByStaticSyntax" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                    </results>
+                  </test-suite>
+                  <test-suite type="TestFixture" name="AllTest" executed="True" result="Success" success="True" time="0.007" asserts="0">
+                    <results>
+                      <test-case name="NUnit.Framework.Syntax.AllTest.SyntaxTest.SupportedByConstraintBuilder" executed="True" result="Success" success="True" time="0.001" asserts="1" />
+                      <test-case name="NUnit.Framework.Syntax.AllTest.SyntaxTest.SupportedByInheritedSyntax" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                      <test-case name="NUnit.Framework.Syntax.AllTest.SyntaxTest.SupportedByStaticSyntax" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                    </results>
+                  </test-suite>
+                  <test-suite type="TestFixture" name="AndIsEvaluatedBeforeFollowingOr" executed="True" result="Success" success="True" time="0.006" asserts="0">
+                    <results>
+                      <test-case name="NUnit.Framework.Syntax.AndIsEvaluatedBeforeFollowingOr.SyntaxTest.SupportedByConstraintBuilder" executed="True" result="Success" success="True" time="0.002" asserts="1" />
+                      <test-case name="NUnit.Framework.Syntax.AndIsEvaluatedBeforeFollowingOr.SyntaxTest.SupportedByInheritedSyntax" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                      <test-case name="NUnit.Framework.Syntax.AndIsEvaluatedBeforeFollowingOr.SyntaxTest.SupportedByStaticSyntax" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                    </results>
+                  </test-suite>
+                  <test-suite type="TestFixture" name="AndIsEvaluatedBeforePrecedingOr" executed="True" result="Success" success="True" time="0.005" asserts="0">
+                    <results>
+                      <test-case name="NUnit.Framework.Syntax.AndIsEvaluatedBeforePrecedingOr.SyntaxTest.SupportedByConstraintBuilder" executed="True" result="Success" success="True" time="0.001" asserts="1" />
+                      <test-case name="NUnit.Framework.Syntax.AndIsEvaluatedBeforePrecedingOr.SyntaxTest.SupportedByInheritedSyntax" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                      <test-case name="NUnit.Framework.Syntax.AndIsEvaluatedBeforePrecedingOr.SyntaxTest.SupportedByStaticSyntax" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                    </results>
+                  </test-suite>
+                  <test-suite type="TestFixture" name="AndOperatorOverride" description="Test" executed="True" result="Success" success="True" time="0.008" asserts="0">
+                    <results>
+                      <test-case name="NUnit.Framework.Syntax.AndOperatorOverride.AndOperatorCanCombineConstraintAndResolvableConstraintExpression" executed="True" result="Success" success="True" time="0.001" asserts="1" />
+                      <test-case name="NUnit.Framework.Syntax.AndOperatorOverride.AndOperatorCanCombineResolvableConstraintExpressionAndConstraint" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                      <test-case name="NUnit.Framework.Syntax.AndOperatorOverride.AndOperatorCanCombineTwoResolvableConstraintExpressions" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                      <test-case name="NUnit.Framework.Syntax.AndOperatorOverride.SyntaxTest.SupportedByConstraintBuilder" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                      <test-case name="NUnit.Framework.Syntax.AndOperatorOverride.SyntaxTest.SupportedByInheritedSyntax" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                      <test-case name="NUnit.Framework.Syntax.AndOperatorOverride.SyntaxTest.SupportedByStaticSyntax" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                    </results>
+                  </test-suite>
+                  <test-suite type="TestFixture" name="AndTest" executed="True" result="Success" success="True" time="0.003" asserts="0">
+                    <results>
+                      <test-case name="NUnit.Framework.Syntax.AndTest.SyntaxTest.SupportedByConstraintBuilder" executed="True" result="Success" success="True" time="0.001" asserts="1" />
+                      <test-case name="NUnit.Framework.Syntax.AndTest.SyntaxTest.SupportedByInheritedSyntax" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                      <test-case name="NUnit.Framework.Syntax.AndTest.SyntaxTest.SupportedByStaticSyntax" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                    </results>
+                  </test-suite>
+                  <test-suite type="TestFixture" name="AndTest_ThreeAndsWithNot" executed="True" result="Success" success="True" time="0.003" asserts="0">
+                    <results>
+                      <test-case name="NUnit.Framework.Syntax.AndTest_ThreeAndsWithNot.SyntaxTest.SupportedByConstraintBuilder" executed="True" result="Success" success="True" time="0.001" asserts="1" />
+                      <test-case name="NUnit.Framework.Syntax.AndTest_ThreeAndsWithNot.SyntaxTest.SupportedByInheritedSyntax" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                      <test-case name="NUnit.Framework.Syntax.AndTest_ThreeAndsWithNot.SyntaxTest.SupportedByStaticSyntax" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                    </results>
+                  </test-suite>
+                  <test-suite type="TestFixture" name="ArbitraryConstraintMatching" executed="True" result="Success" success="True" time="0.009" asserts="0">
+                    <results>
+                      <test-case name="NUnit.Framework.Syntax.ArbitraryConstraintMatching.ApplyMatchesToProperty" executed="True" result="Success" success="True" time="0.001" asserts="5" />
+                      <test-case name="NUnit.Framework.Syntax.ArbitraryConstraintMatching.CanMatchCustomConstraint" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                      <test-case name="NUnit.Framework.Syntax.ArbitraryConstraintMatching.CanMatchCustomConstraintAfterPrefix" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                      <test-case name="NUnit.Framework.Syntax.ArbitraryConstraintMatching.CanMatchCustomConstraintsUnderAndOperator" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                      <test-case name="NUnit.Framework.Syntax.ArbitraryConstraintMatching.CanMatchLambda" executed="True" result="Success" success="True" time="0.001" asserts="2" />
+                      <test-case name="NUnit.Framework.Syntax.ArbitraryConstraintMatching.CanMatchPredicate" executed="True" result="Success" success="True" time="0.001" asserts="2" />
+                    </results>
+                  </test-suite>
+                  <test-suite type="TestFixture" name="AssignableFromTest" executed="True" result="Success" success="True" time="0.004" asserts="0">
+                    <results>
+                      <test-case name="NUnit.Framework.Syntax.AssignableFromTest.SyntaxTest.SupportedByConstraintBuilder" executed="True" result="Success" success="True" time="0.001" asserts="1" />
+                      <test-case name="NUnit.Framework.Syntax.AssignableFromTest.SyntaxTest.SupportedByInheritedSyntax" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                      <test-case name="NUnit.Framework.Syntax.AssignableFromTest.SyntaxTest.SupportedByStaticSyntax" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                    </results>
+                  </test-suite>
+                  <test-suite type="TestFixture" name="AssignableFromTest_Generic" executed="True" result="Success" success="True" time="0.004" asserts="0">
+                    <results>
+                      <test-case name="NUnit.Framework.Syntax.AssignableFromTest_Generic.SyntaxTest.SupportedByConstraintBuilder" executed="True" result="Success" success="True" time="0.001" asserts="1" />
+                      <test-case name="NUnit.Framework.Syntax.AssignableFromTest_Generic.SyntaxTest.SupportedByInheritedSyntax" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                      <test-case name="NUnit.Framework.Syntax.AssignableFromTest_Generic.SyntaxTest.SupportedByStaticSyntax" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                    </results>
+                  </test-suite>
+                  <test-suite type="TestFixture" name="AssignableToTest" executed="True" result="Success" success="True" time="0.003" asserts="0">
+                    <results>
+                      <test-case name="NUnit.Framework.Syntax.AssignableToTest.SyntaxTest.SupportedByConstraintBuilder" executed="True" result="Success" success="True" time="0.001" asserts="1" />
+                      <test-case name="NUnit.Framework.Syntax.AssignableToTest.SyntaxTest.SupportedByInheritedSyntax" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                      <test-case name="NUnit.Framework.Syntax.AssignableToTest.SyntaxTest.SupportedByStaticSyntax" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                    </results>
+                  </test-suite>
+                  <test-suite type="TestFixture" name="AssignableToTest_Generic" executed="True" result="Success" success="True" time="0.004" asserts="0">
+                    <results>
+                      <test-case name="NUnit.Framework.Syntax.AssignableToTest_Generic.SyntaxTest.SupportedByConstraintBuilder" executed="True" result="Success" success="True" time="0.001" asserts="1" />
+                      <test-case name="NUnit.Framework.Syntax.AssignableToTest_Generic.SyntaxTest.SupportedByInheritedSyntax" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                      <test-case name="NUnit.Framework.Syntax.AssignableToTest_Generic.SyntaxTest.SupportedByStaticSyntax" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                    </results>
+                  </test-suite>
+                  <test-suite type="TestFixture" name="AtLeastTest" executed="True" result="Success" success="True" time="0.003" asserts="0">
+                    <results>
+                      <test-case name="NUnit.Framework.Syntax.AtLeastTest.SyntaxTest.SupportedByConstraintBuilder" executed="True" result="Success" success="True" time="0.001" asserts="1" />
+                      <test-case name="NUnit.Framework.Syntax.AtLeastTest.SyntaxTest.SupportedByInheritedSyntax" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                      <test-case name="NUnit.Framework.Syntax.AtLeastTest.SyntaxTest.SupportedByStaticSyntax" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                    </results>
+                  </test-suite>
+                  <test-suite type="TestFixture" name="AtMostTest" executed="True" result="Success" success="True" time="0.003" asserts="0">
+                    <results>
+                      <test-case name="NUnit.Framework.Syntax.AtMostTest.SyntaxTest.SupportedByConstraintBuilder" executed="True" result="Success" success="True" time="0.001" asserts="1" />
+                      <test-case name="NUnit.Framework.Syntax.AtMostTest.SyntaxTest.SupportedByInheritedSyntax" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                      <test-case name="NUnit.Framework.Syntax.AtMostTest.SyntaxTest.SupportedByStaticSyntax" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                    </results>
+                  </test-suite>
+                  <test-suite type="TestFixture" name="AttributeTest" executed="True" result="Success" success="True" time="0.004" asserts="0">
+                    <results>
+                      <test-case name="NUnit.Framework.Syntax.AttributeTest.SyntaxTest.SupportedByConstraintBuilder" executed="True" result="Success" success="True" time="0.001" asserts="1" />
+                      <test-case name="NUnit.Framework.Syntax.AttributeTest.SyntaxTest.SupportedByInheritedSyntax" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                      <test-case name="NUnit.Framework.Syntax.AttributeTest.SyntaxTest.SupportedByStaticSyntax" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                    </results>
+                  </test-suite>
+                  <test-suite type="TestFixture" name="AttributeTest_Generic" executed="True" result="Success" success="True" time="0.004" asserts="0">
+                    <results>
+                      <test-case name="NUnit.Framework.Syntax.AttributeTest_Generic.SyntaxTest.SupportedByConstraintBuilder" executed="True" result="Success" success="True" time="0.001" asserts="1" />
+                      <test-case name="NUnit.Framework.Syntax.AttributeTest_Generic.SyntaxTest.SupportedByInheritedSyntax" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                      <test-case name="NUnit.Framework.Syntax.AttributeTest_Generic.SyntaxTest.SupportedByStaticSyntax" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                    </results>
+                  </test-suite>
+                  <test-suite type="TestFixture" name="AttributeTestWithFollowingConstraint" executed="True" result="Success" success="True" time="0.003" asserts="0">
+                    <results>
+                      <test-case name="NUnit.Framework.Syntax.AttributeTestWithFollowingConstraint.SyntaxTest.SupportedByConstraintBuilder" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                      <test-case name="NUnit.Framework.Syntax.AttributeTestWithFollowingConstraint.SyntaxTest.SupportedByInheritedSyntax" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                      <test-case name="NUnit.Framework.Syntax.AttributeTestWithFollowingConstraint.SyntaxTest.SupportedByStaticSyntax" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                    </results>
+                  </test-suite>
+                  <test-suite type="TestFixture" name="BinarySerializableTest" executed="True" result="Success" success="True" time="0.003" asserts="0">
+                    <results>
+                      <test-case name="NUnit.Framework.Syntax.BinarySerializableTest.SyntaxTest.SupportedByConstraintBuilder" executed="True" result="Success" success="True" time="0.001" asserts="1" />
+                      <test-case name="NUnit.Framework.Syntax.BinarySerializableTest.SyntaxTest.SupportedByInheritedSyntax" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                      <test-case name="NUnit.Framework.Syntax.BinarySerializableTest.SyntaxTest.SupportedByStaticSyntax" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                    </results>
+                  </test-suite>
+                  <test-suite type="TestFixture" name="CollectionContainsTest" executed="True" result="Success" success="True" time="0.004" asserts="0">
+                    <results>
+                      <test-case name="NUnit.Framework.Syntax.CollectionContainsTest.SyntaxTest.SupportedByConstraintBuilder" executed="True" result="Success" success="True" time="0.001" asserts="1" />
+                      <test-case name="NUnit.Framework.Syntax.CollectionContainsTest.SyntaxTest.SupportedByInheritedSyntax" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                      <test-case name="NUnit.Framework.Syntax.CollectionContainsTest.SyntaxTest.SupportedByStaticSyntax" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                    </results>
+                  </test-suite>
+                  <test-suite type="TestFixture" name="CollectionContainsTest_Comparer" executed="True" result="Success" success="True" time="0.006" asserts="0">
+                    <results>
+                      <test-case name="NUnit.Framework.Syntax.CollectionContainsTest_Comparer.ComparerIsCalled" executed="True" result="Success" success="True" time="0.001" asserts="2" />
+                      <test-case name="NUnit.Framework.Syntax.CollectionContainsTest_Comparer.ComparerIsCalledInExpression" executed="True" result="Success" success="True" time="0.001" asserts="2" />
+                      <test-case name="NUnit.Framework.Syntax.CollectionContainsTest_Comparer.SyntaxTest.SupportedByConstraintBuilder" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                      <test-case name="NUnit.Framework.Syntax.CollectionContainsTest_Comparer.SyntaxTest.SupportedByInheritedSyntax" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                      <test-case name="NUnit.Framework.Syntax.CollectionContainsTest_Comparer.SyntaxTest.SupportedByStaticSyntax" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                    </results>
+                  </test-suite>
+                  <test-suite type="TestFixture" name="CollectionContainsTest_Comparer_String" executed="True" result="Success" success="True" time="0.008" asserts="0">
+                    <results>
+                      <test-case name="NUnit.Framework.Syntax.CollectionContainsTest_Comparer_String.ComparerIsCalled" executed="True" result="Success" success="True" time="0.001" asserts="2" />
+                      <test-case name="NUnit.Framework.Syntax.CollectionContainsTest_Comparer_String.ComparerIsCalledInExpression" executed="True" result="Success" success="True" time="0.001" asserts="2" />
+                      <test-case name="NUnit.Framework.Syntax.CollectionContainsTest_Comparer_String.SyntaxTest.SupportedByConstraintBuilder" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                      <test-case name="NUnit.Framework.Syntax.CollectionContainsTest_Comparer_String.SyntaxTest.SupportedByInheritedSyntax" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                      <test-case name="NUnit.Framework.Syntax.CollectionContainsTest_Comparer_String.SyntaxTest.SupportedByStaticSyntax" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                    </results>
+                  </test-suite>
+                  <test-suite type="TestFixture" name="CollectionContainsTest_String" executed="True" result="Success" success="True" time="0.003" asserts="0">
+                    <results>
+                      <test-case name="NUnit.Framework.Syntax.CollectionContainsTest_String.SyntaxTest.SupportedByConstraintBuilder" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                      <test-case name="NUnit.Framework.Syntax.CollectionContainsTest_String.SyntaxTest.SupportedByInheritedSyntax" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                      <test-case name="NUnit.Framework.Syntax.CollectionContainsTest_String.SyntaxTest.SupportedByStaticSyntax" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                    </results>
+                  </test-suite>
+                  <test-suite type="TestFixture" name="CollectionEquivalentTest" executed="True" result="Success" success="True" time="0.003" asserts="0">
+                    <results>
+                      <test-case name="NUnit.Framework.Syntax.CollectionEquivalentTest.SyntaxTest.SupportedByConstraintBuilder" executed="True" result="Success" success="True" time="0.001" asserts="1" />
+                      <test-case name="NUnit.Framework.Syntax.CollectionEquivalentTest.SyntaxTest.SupportedByInheritedSyntax" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                      <test-case name="NUnit.Framework.Syntax.CollectionEquivalentTest.SyntaxTest.SupportedByStaticSyntax" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                    </results>
+                  </test-suite>
+                  <test-suite type="TestFixture" name="CollectionMemberTest" executed="True" result="Success" success="True" time="0.003" asserts="0">
+                    <results>
+                      <test-case name="NUnit.Framework.Syntax.CollectionMemberTest.SyntaxTest.SupportedByConstraintBuilder" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                      <test-case name="NUnit.Framework.Syntax.CollectionMemberTest.SyntaxTest.SupportedByInheritedSyntax" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                      <test-case name="NUnit.Framework.Syntax.CollectionMemberTest.SyntaxTest.SupportedByStaticSyntax" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                    </results>
+                  </test-suite>
+                  <test-suite type="TestFixture" name="CollectionMemberTest_Comparer" executed="True" result="Success" success="True" time="0.003" asserts="0">
+                    <results>
+                      <test-case name="NUnit.Framework.Syntax.CollectionMemberTest_Comparer.SyntaxTest.SupportedByConstraintBuilder" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                      <test-case name="NUnit.Framework.Syntax.CollectionMemberTest_Comparer.SyntaxTest.SupportedByInheritedSyntax" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                      <test-case name="NUnit.Framework.Syntax.CollectionMemberTest_Comparer.SyntaxTest.SupportedByStaticSyntax" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                    </results>
+                  </test-suite>
+                  <test-suite type="TestFixture" name="CollectionOrderedByTest" executed="True" result="Success" success="True" time="0.003" asserts="0">
+                    <results>
+                      <test-case name="NUnit.Framework.Syntax.CollectionOrderedByTest.SyntaxTest.SupportedByConstraintBuilder" executed="True" result="Success" success="True" time="0.001" asserts="1" />
+                      <test-case name="NUnit.Framework.Syntax.CollectionOrderedByTest.SyntaxTest.SupportedByInheritedSyntax" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                      <test-case name="NUnit.Framework.Syntax.CollectionOrderedByTest.SyntaxTest.SupportedByStaticSyntax" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                    </results>
+                  </test-suite>
+                  <test-suite type="TestFixture" name="CollectionOrderedByTest_Comparer" executed="True" result="Success" success="True" time="0.003" asserts="0">
+                    <results>
+                      <test-case name="NUnit.Framework.Syntax.CollectionOrderedByTest_Comparer.SyntaxTest.SupportedByConstraintBuilder" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                      <test-case name="NUnit.Framework.Syntax.CollectionOrderedByTest_Comparer.SyntaxTest.SupportedByInheritedSyntax" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                      <test-case name="NUnit.Framework.Syntax.CollectionOrderedByTest_Comparer.SyntaxTest.SupportedByStaticSyntax" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                    </results>
+                  </test-suite>
+                  <test-suite type="TestFixture" name="CollectionOrderedByTest_Comparer_Descending" executed="True" result="Success" success="True" time="0.003" asserts="0">
+                    <results>
+                      <test-case name="NUnit.Framework.Syntax.CollectionOrderedByTest_Comparer_Descending.SyntaxTest.SupportedByConstraintBuilder" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                      <test-case name="NUnit.Framework.Syntax.CollectionOrderedByTest_Comparer_Descending.SyntaxTest.SupportedByInheritedSyntax" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                      <test-case name="NUnit.Framework.Syntax.CollectionOrderedByTest_Comparer_Descending.SyntaxTest.SupportedByStaticSyntax" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                    </results>
+                  </test-suite>
+                  <test-suite type="TestFixture" name="CollectionOrderedByTest_Descending" executed="True" result="Success" success="True" time="0.003" asserts="0">
+                    <results>
+                      <test-case name="NUnit.Framework.Syntax.CollectionOrderedByTest_Descending.SyntaxTest.SupportedByConstraintBuilder" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                      <test-case name="NUnit.Framework.Syntax.CollectionOrderedByTest_Descending.SyntaxTest.SupportedByInheritedSyntax" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                      <test-case name="NUnit.Framework.Syntax.CollectionOrderedByTest_Descending.SyntaxTest.SupportedByStaticSyntax" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                    </results>
+                  </test-suite>
+                  <test-suite type="TestFixture" name="CollectionOrderedTest" executed="True" result="Success" success="True" time="0.003" asserts="0">
+                    <results>
+                      <test-case name="NUnit.Framework.Syntax.CollectionOrderedTest.SyntaxTest.SupportedByConstraintBuilder" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                      <test-case name="NUnit.Framework.Syntax.CollectionOrderedTest.SyntaxTest.SupportedByInheritedSyntax" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                      <test-case name="NUnit.Framework.Syntax.CollectionOrderedTest.SyntaxTest.SupportedByStaticSyntax" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                    </results>
+                  </test-suite>
+                  <test-suite type="TestFixture" name="CollectionOrderedTest_Comparer" executed="True" result="Success" success="True" time="0.003" asserts="0">
+                    <results>
+                      <test-case name="NUnit.Framework.Syntax.CollectionOrderedTest_Comparer.SyntaxTest.SupportedByConstraintBuilder" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                      <test-case name="NUnit.Framework.Syntax.CollectionOrderedTest_Comparer.SyntaxTest.SupportedByInheritedSyntax" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                      <test-case name="NUnit.Framework.Syntax.CollectionOrderedTest_Comparer.SyntaxTest.SupportedByStaticSyntax" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                    </results>
+                  </test-suite>
+                  <test-suite type="TestFixture" name="CollectionOrderedTest_Comparer_Descending" executed="True" result="Success" success="True" time="0.003" asserts="0">
+                    <results>
+                      <test-case name="NUnit.Framework.Syntax.CollectionOrderedTest_Comparer_Descending.SyntaxTest.SupportedByConstraintBuilder" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                      <test-case name="NUnit.Framework.Syntax.CollectionOrderedTest_Comparer_Descending.SyntaxTest.SupportedByInheritedSyntax" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                      <test-case name="NUnit.Framework.Syntax.CollectionOrderedTest_Comparer_Descending.SyntaxTest.SupportedByStaticSyntax" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                    </results>
+                  </test-suite>
+                  <test-suite type="TestFixture" name="CollectionOrderedTest_Descending" executed="True" result="Success" success="True" time="0.003" asserts="0">
+                    <results>
+                      <test-case name="NUnit.Framework.Syntax.CollectionOrderedTest_Descending.SyntaxTest.SupportedByConstraintBuilder" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                      <test-case name="NUnit.Framework.Syntax.CollectionOrderedTest_Descending.SyntaxTest.SupportedByInheritedSyntax" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                      <test-case name="NUnit.Framework.Syntax.CollectionOrderedTest_Descending.SyntaxTest.SupportedByStaticSyntax" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                    </results>
+                  </test-suite>
+                  <test-suite type="TestFixture" name="CollectionSubsetTest" executed="True" result="Success" success="True" time="0.004" asserts="0">
+                    <results>
+                      <test-case name="NUnit.Framework.Syntax.CollectionSubsetTest.SyntaxTest.SupportedByConstraintBuilder" executed="True" result="Success" success="True" time="0.001" asserts="1" />
+                      <test-case name="NUnit.Framework.Syntax.CollectionSubsetTest.SyntaxTest.SupportedByInheritedSyntax" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                      <test-case name="NUnit.Framework.Syntax.CollectionSubsetTest.SyntaxTest.SupportedByStaticSyntax" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                    </results>
+                  </test-suite>
+                  <test-suite type="TestFixture" name="CountTest" executed="True" result="Success" success="True" time="0.003" asserts="0">
+                    <results>
+                      <test-case name="NUnit.Framework.Syntax.CountTest.SyntaxTest.SupportedByConstraintBuilder" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                      <test-case name="NUnit.Framework.Syntax.CountTest.SyntaxTest.SupportedByInheritedSyntax" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                      <test-case name="NUnit.Framework.Syntax.CountTest.SyntaxTest.SupportedByStaticSyntax" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                    </results>
+                  </test-suite>
+                  <test-suite type="TestFixture" name="EmptyTest" executed="True" result="Success" success="True" time="0.002" asserts="0">
+                    <results>
+                      <test-case name="NUnit.Framework.Syntax.EmptyTest.SyntaxTest.SupportedByConstraintBuilder" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                      <test-case name="NUnit.Framework.Syntax.EmptyTest.SyntaxTest.SupportedByInheritedSyntax" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                      <test-case name="NUnit.Framework.Syntax.EmptyTest.SyntaxTest.SupportedByStaticSyntax" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                    </results>
+                  </test-suite>
+                  <test-suite type="TestFixture" name="EndsWithTest" executed="True" result="Success" success="True" time="0.002" asserts="0">
+                    <results>
+                      <test-case name="NUnit.Framework.Syntax.EndsWithTest.SyntaxTest.SupportedByConstraintBuilder" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                      <test-case name="NUnit.Framework.Syntax.EndsWithTest.SyntaxTest.SupportedByInheritedSyntax" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                      <test-case name="NUnit.Framework.Syntax.EndsWithTest.SyntaxTest.SupportedByStaticSyntax" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                    </results>
+                  </test-suite>
+                  <test-suite type="TestFixture" name="EndsWithTest_IgnoreCase" executed="True" result="Success" success="True" time="0.002" asserts="0">
+                    <results>
+                      <test-case name="NUnit.Framework.Syntax.EndsWithTest_IgnoreCase.SyntaxTest.SupportedByConstraintBuilder" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                      <test-case name="NUnit.Framework.Syntax.EndsWithTest_IgnoreCase.SyntaxTest.SupportedByInheritedSyntax" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                      <test-case name="NUnit.Framework.Syntax.EndsWithTest_IgnoreCase.SyntaxTest.SupportedByStaticSyntax" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                    </results>
+                  </test-suite>
+                  <test-suite type="TestFixture" name="EqualityTests" executed="True" result="Success" success="True" time="0.005" asserts="0">
+                    <results>
+                      <test-case name="NUnit.Framework.Syntax.EqualityTests.EqualityTestsUsingDefaultFloatingPointTolerance" executed="True" result="Success" success="True" time="0.000" asserts="3" />
+                      <test-case name="NUnit.Framework.Syntax.EqualityTests.EqualityTestsWithTolerance" executed="True" result="Success" success="True" time="0.001" asserts="8" />
+                      <test-case name="NUnit.Framework.Syntax.EqualityTests.EqualityTestsWithTolerance_MixedFloatAndDouble" executed="True" result="Success" success="True" time="0.000" asserts="6" />
+                      <test-case name="NUnit.Framework.Syntax.EqualityTests.EqualityTestsWithTolerance_MixingTypesGenerally" executed="True" result="Success" success="True" time="0.001" asserts="7" />
+                      <test-case name="NUnit.Framework.Syntax.EqualityTests.SimpleEqualityTests" executed="True" result="Success" success="True" time="0.001" asserts="6" />
+                    </results>
+                  </test-suite>
+                  <test-suite type="TestFixture" name="EqualToTest" executed="True" result="Success" success="True" time="0.002" asserts="0">
+                    <results>
+                      <test-case name="NUnit.Framework.Syntax.EqualToTest.SyntaxTest.SupportedByConstraintBuilder" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                      <test-case name="NUnit.Framework.Syntax.EqualToTest.SyntaxTest.SupportedByInheritedSyntax" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                      <test-case name="NUnit.Framework.Syntax.EqualToTest.SyntaxTest.SupportedByStaticSyntax" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                    </results>
+                  </test-suite>
+                  <test-suite type="TestFixture" name="EqualToTest_IgnoreCase" executed="True" result="Success" success="True" time="0.003" asserts="0">
+                    <results>
+                      <test-case name="NUnit.Framework.Syntax.EqualToTest_IgnoreCase.SyntaxTest.SupportedByConstraintBuilder" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                      <test-case name="NUnit.Framework.Syntax.EqualToTest_IgnoreCase.SyntaxTest.SupportedByInheritedSyntax" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                      <test-case name="NUnit.Framework.Syntax.EqualToTest_IgnoreCase.SyntaxTest.SupportedByStaticSyntax" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                    </results>
+                  </test-suite>
+                  <test-suite type="TestFixture" name="EqualToTest_WithinTolerance" executed="True" result="Success" success="True" time="0.002" asserts="0">
+                    <results>
+                      <test-case name="NUnit.Framework.Syntax.EqualToTest_WithinTolerance.SyntaxTest.SupportedByConstraintBuilder" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                      <test-case name="NUnit.Framework.Syntax.EqualToTest_WithinTolerance.SyntaxTest.SupportedByInheritedSyntax" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                      <test-case name="NUnit.Framework.Syntax.EqualToTest_WithinTolerance.SyntaxTest.SupportedByStaticSyntax" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                    </results>
+                  </test-suite>
+                  <test-suite type="TestFixture" name="ExactTypeTest" executed="True" result="Success" success="True" time="0.002" asserts="0">
+                    <results>
+                      <test-case name="NUnit.Framework.Syntax.ExactTypeTest.SyntaxTest.SupportedByConstraintBuilder" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                      <test-case name="NUnit.Framework.Syntax.ExactTypeTest.SyntaxTest.SupportedByInheritedSyntax" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                      <test-case name="NUnit.Framework.Syntax.ExactTypeTest.SyntaxTest.SupportedByStaticSyntax" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                    </results>
+                  </test-suite>
+                  <test-suite type="TestFixture" name="ExactTypeTest_Generic" executed="True" result="Success" success="True" time="0.003" asserts="0">
+                    <results>
+                      <test-case name="NUnit.Framework.Syntax.ExactTypeTest_Generic.SyntaxTest.SupportedByConstraintBuilder" executed="True" result="Success" success="True" time="0.001" asserts="1" />
+                      <test-case name="NUnit.Framework.Syntax.ExactTypeTest_Generic.SyntaxTest.SupportedByInheritedSyntax" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                      <test-case name="NUnit.Framework.Syntax.ExactTypeTest_Generic.SyntaxTest.SupportedByStaticSyntax" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                    </results>
+                  </test-suite>
+                  <test-suite type="TestFixture" name="FalseTest" executed="True" result="Success" success="True" time="0.002" asserts="0">
+                    <results>
+                      <test-case name="NUnit.Framework.Syntax.FalseTest.SyntaxTest.SupportedByConstraintBuilder" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                      <test-case name="NUnit.Framework.Syntax.FalseTest.SyntaxTest.SupportedByInheritedSyntax" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                      <test-case name="NUnit.Framework.Syntax.FalseTest.SyntaxTest.SupportedByStaticSyntax" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                    </results>
+                  </test-suite>
+                  <test-suite type="TestFixture" name="GreaterThanOrEqualTest" executed="True" result="Success" success="True" time="0.002" asserts="0">
+                    <results>
+                      <test-case name="NUnit.Framework.Syntax.GreaterThanOrEqualTest.SyntaxTest.SupportedByConstraintBuilder" executed="True" result="Success" success="True" time="0.001" asserts="1" />
+                      <test-case name="NUnit.Framework.Syntax.GreaterThanOrEqualTest.SyntaxTest.SupportedByInheritedSyntax" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                      <test-case name="NUnit.Framework.Syntax.GreaterThanOrEqualTest.SyntaxTest.SupportedByStaticSyntax" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                    </results>
+                  </test-suite>
+                  <test-suite type="TestFixture" name="GreaterThanTest" executed="True" result="Success" success="True" time="0.002" asserts="0">
+                    <results>
+                      <test-case name="NUnit.Framework.Syntax.GreaterThanTest.SyntaxTest.SupportedByConstraintBuilder" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                      <test-case name="NUnit.Framework.Syntax.GreaterThanTest.SyntaxTest.SupportedByInheritedSyntax" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                      <test-case name="NUnit.Framework.Syntax.GreaterThanTest.SyntaxTest.SupportedByStaticSyntax" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                    </results>
+                  </test-suite>
+                  <test-suite type="TestFixture" name="InstanceOfTest" executed="True" result="Success" success="True" time="0.003" asserts="0">
+                    <results>
+                      <test-case name="NUnit.Framework.Syntax.InstanceOfTest.SyntaxTest.SupportedByConstraintBuilder" executed="True" result="Success" success="True" time="0.001" asserts="1" />
+                      <test-case name="NUnit.Framework.Syntax.InstanceOfTest.SyntaxTest.SupportedByInheritedSyntax" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                      <test-case name="NUnit.Framework.Syntax.InstanceOfTest.SyntaxTest.SupportedByStaticSyntax" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                    </results>
+                  </test-suite>
+                  <test-suite type="TestFixture" name="InstanceOfTest_Generic" executed="True" result="Success" success="True" time="0.003" asserts="0">
+                    <results>
+                      <test-case name="NUnit.Framework.Syntax.InstanceOfTest_Generic.SyntaxTest.SupportedByConstraintBuilder" executed="True" result="Success" success="True" time="0.001" asserts="1" />
+                      <test-case name="NUnit.Framework.Syntax.InstanceOfTest_Generic.SyntaxTest.SupportedByInheritedSyntax" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                      <test-case name="NUnit.Framework.Syntax.InstanceOfTest_Generic.SyntaxTest.SupportedByStaticSyntax" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                    </results>
+                  </test-suite>
+                  <test-suite type="TestFixture" name="InstanceOfTypeTest" executed="True" result="Success" success="True" time="0.003" asserts="0">
+                    <results>
+                      <test-case name="NUnit.Framework.Syntax.InstanceOfTypeTest.SyntaxTest.SupportedByConstraintBuilder" executed="True" result="Success" success="True" time="0.001" asserts="1" />
+                      <test-case name="NUnit.Framework.Syntax.InstanceOfTypeTest.SyntaxTest.SupportedByInheritedSyntax" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                      <test-case name="NUnit.Framework.Syntax.InstanceOfTypeTest.SyntaxTest.SupportedByStaticSyntax" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                    </results>
+                  </test-suite>
+                  <test-suite type="TestFixture" name="InstanceOfTypeTest_Generic" executed="True" result="Success" success="True" time="0.004" asserts="0">
+                    <results>
+                      <test-case name="NUnit.Framework.Syntax.InstanceOfTypeTest_Generic.SyntaxTest.SupportedByConstraintBuilder" executed="True" result="Success" success="True" time="0.001" asserts="1" />
+                      <test-case name="NUnit.Framework.Syntax.InstanceOfTypeTest_Generic.SyntaxTest.SupportedByInheritedSyntax" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                      <test-case name="NUnit.Framework.Syntax.InstanceOfTypeTest_Generic.SyntaxTest.SupportedByStaticSyntax" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                    </results>
+                  </test-suite>
+                  <test-suite type="TestFixture" name="InvalidCodeTests" executed="True" result="Success" success="True" time="0.789" asserts="0">
+                    <results>
+                      <test-suite type="ParameterizedTest" name="CodeShouldNotCompile" executed="True" result="Success" success="True" time="0.519" asserts="0">
+                        <results>
+                          <test-case name="NUnit.Framework.Syntax.InvalidCodeTests.CodeShouldNotCompile(&quot;Is.Null.And.Throws&quot;)" executed="True" result="Success" success="True" time="0.133" asserts="0" />
+                          <test-case name="NUnit.Framework.Syntax.InvalidCodeTests.CodeShouldNotCompile(&quot;Is.Null.Not&quot;)" executed="True" result="Success" success="True" time="0.055" asserts="0" />
+                          <test-case name="NUnit.Framework.Syntax.InvalidCodeTests.CodeShouldNotCompile(&quot;Is.Not.Null.GreaterThan(10))&quot;)" executed="True" result="Success" success="True" time="0.118" asserts="0" />
+                          <test-case name="NUnit.Framework.Syntax.InvalidCodeTests.CodeShouldNotCompile(&quot;Is.Null.All&quot;)" executed="True" result="Success" success="True" time="0.069" asserts="0" />
+                          <test-case name="NUnit.Framework.Syntax.InvalidCodeTests.CodeShouldNotCompile(&quot;Is.And&quot;)" executed="True" result="Success" success="True" time="0.082" asserts="0" />
+                          <test-case name="NUnit.Framework.Syntax.InvalidCodeTests.CodeShouldNotCompile(&quot;Is.All.And.And&quot;)" executed="True" result="Success" success="True" time="0.057" asserts="0" />
+                        </results>
+                      </test-suite>
+                      <test-suite type="ParameterizedTest" name="CodeShouldNotCompileAsFinishedConstraint" executed="True" result="Success" success="True" time="0.269" asserts="0">
+                        <results>
+                          <test-case name="NUnit.Framework.Syntax.InvalidCodeTests.CodeShouldNotCompileAsFinishedConstraint(&quot;Is.All.Not&quot;)" executed="True" result="Success" success="True" time="0.091" asserts="0" />
+                          <test-case name="NUnit.Framework.Syntax.InvalidCodeTests.CodeShouldNotCompileAsFinishedConstraint(&quot;Is.Not&quot;)" executed="True" result="Success" success="True" time="0.058" asserts="0" />
+                          <test-case name="NUnit.Framework.Syntax.InvalidCodeTests.CodeShouldNotCompileAsFinishedConstraint(&quot;Is.All&quot;)" executed="True" result="Success" success="True" time="0.059" asserts="0" />
+                          <test-case name="NUnit.Framework.Syntax.InvalidCodeTests.CodeShouldNotCompileAsFinishedConstraint(&quot;Is.Not.All&quot;)" executed="True" result="Success" success="True" time="0.058" asserts="0" />
+                        </results>
+                      </test-suite>
+                    </results>
+                  </test-suite>
+                  <test-suite type="TestFixture" name="LengthTest" executed="True" result="Success" success="True" time="0.004" asserts="0">
+                    <results>
+                      <test-case name="NUnit.Framework.Syntax.LengthTest.SyntaxTest.SupportedByConstraintBuilder" executed="True" result="Success" success="True" time="0.001" asserts="1" />
+                      <test-case name="NUnit.Framework.Syntax.LengthTest.SyntaxTest.SupportedByInheritedSyntax" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                      <test-case name="NUnit.Framework.Syntax.LengthTest.SyntaxTest.SupportedByStaticSyntax" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                    </results>
+                  </test-suite>
+                  <test-suite type="TestFixture" name="LessThanOrEqualTest" executed="True" result="Success" success="True" time="0.004" asserts="0">
+                    <results>
+                      <test-case name="NUnit.Framework.Syntax.LessThanOrEqualTest.SyntaxTest.SupportedByConstraintBuilder" executed="True" result="Success" success="True" time="0.001" asserts="1" />
+                      <test-case name="NUnit.Framework.Syntax.LessThanOrEqualTest.SyntaxTest.SupportedByInheritedSyntax" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                      <test-case name="NUnit.Framework.Syntax.LessThanOrEqualTest.SyntaxTest.SupportedByStaticSyntax" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                    </results>
+                  </test-suite>
+                  <test-suite type="TestFixture" name="LessThanTest" executed="True" result="Success" success="True" time="0.003" asserts="0">
+                    <results>
+                      <test-case name="NUnit.Framework.Syntax.LessThanTest.SyntaxTest.SupportedByConstraintBuilder" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                      <test-case name="NUnit.Framework.Syntax.LessThanTest.SyntaxTest.SupportedByInheritedSyntax" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                      <test-case name="NUnit.Framework.Syntax.LessThanTest.SyntaxTest.SupportedByStaticSyntax" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                    </results>
+                  </test-suite>
+                  <test-suite type="TestFixture" name="MessageTest" executed="True" result="Success" success="True" time="0.004" asserts="0">
+                    <results>
+                      <test-case name="NUnit.Framework.Syntax.MessageTest.SyntaxTest.SupportedByConstraintBuilder" executed="True" result="Success" success="True" time="0.001" asserts="1" />
+                      <test-case name="NUnit.Framework.Syntax.MessageTest.SyntaxTest.SupportedByInheritedSyntax" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                      <test-case name="NUnit.Framework.Syntax.MessageTest.SyntaxTest.SupportedByStaticSyntax" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                    </results>
+                  </test-suite>
+                  <test-suite type="TestFixture" name="MixedOperatorOverrides" executed="True" result="Success" success="True" time="0.002" asserts="0">
+                    <results>
+                      <test-case name="NUnit.Framework.Syntax.MixedOperatorOverrides.ComplexTests" executed="True" result="Success" success="True" time="0.001" asserts="3" />
+                    </results>
+                  </test-suite>
+                  <test-suite type="TestFixture" name="NaNTest" executed="True" result="Success" success="True" time="0.004" asserts="0">
+                    <results>
+                      <test-case name="NUnit.Framework.Syntax.NaNTest.SyntaxTest.SupportedByConstraintBuilder" executed="True" result="Success" success="True" time="0.001" asserts="1" />
+                      <test-case name="NUnit.Framework.Syntax.NaNTest.SyntaxTest.SupportedByInheritedSyntax" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                      <test-case name="NUnit.Framework.Syntax.NaNTest.SyntaxTest.SupportedByStaticSyntax" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                    </results>
+                  </test-suite>
+                  <test-suite type="TestFixture" name="NegativeTest" executed="True" result="Success" success="True" time="0.003" asserts="0">
+                    <results>
+                      <test-case name="NUnit.Framework.Syntax.NegativeTest.SyntaxTest.SupportedByConstraintBuilder" executed="True" result="Success" success="True" time="0.001" asserts="1" />
+                      <test-case name="NUnit.Framework.Syntax.NegativeTest.SyntaxTest.SupportedByInheritedSyntax" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                      <test-case name="NUnit.Framework.Syntax.NegativeTest.SyntaxTest.SupportedByStaticSyntax" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                    </results>
+                  </test-suite>
+                  <test-suite type="TestFixture" name="NoneTest" executed="True" result="Success" success="True" time="0.004" asserts="0">
+                    <results>
+                      <test-case name="NUnit.Framework.Syntax.NoneTest.SyntaxTest.SupportedByConstraintBuilder" executed="True" result="Success" success="True" time="0.001" asserts="1" />
+                      <test-case name="NUnit.Framework.Syntax.NoneTest.SyntaxTest.SupportedByInheritedSyntax" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                      <test-case name="NUnit.Framework.Syntax.NoneTest.SyntaxTest.SupportedByStaticSyntax" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                    </results>
+                  </test-suite>
+                  <test-suite type="TestFixture" name="NotOperatorOverride" executed="True" result="Success" success="True" time="0.005" asserts="0">
+                    <results>
+                      <test-case name="NUnit.Framework.Syntax.NotOperatorOverride.NotOperatorCanApplyToResolvableConstraintExpression" executed="True" result="Success" success="True" time="0.001" asserts="1" />
+                      <test-case name="NUnit.Framework.Syntax.NotOperatorOverride.SyntaxTest.SupportedByConstraintBuilder" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                      <test-case name="NUnit.Framework.Syntax.NotOperatorOverride.SyntaxTest.SupportedByInheritedSyntax" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                      <test-case name="NUnit.Framework.Syntax.NotOperatorOverride.SyntaxTest.SupportedByStaticSyntax" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                    </results>
+                  </test-suite>
+                  <test-suite type="TestFixture" name="NotSamePathOrUnderTest_IgnoreCase" executed="True" result="Success" success="True" time="0.003" asserts="0">
+                    <results>
+                      <test-case name="NUnit.Framework.Syntax.NotSamePathOrUnderTest_IgnoreCase.SyntaxTest.SupportedByConstraintBuilder" executed="True" result="Success" success="True" time="0.001" asserts="1" />
+                      <test-case name="NUnit.Framework.Syntax.NotSamePathOrUnderTest_IgnoreCase.SyntaxTest.SupportedByInheritedSyntax" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                      <test-case name="NUnit.Framework.Syntax.NotSamePathOrUnderTest_IgnoreCase.SyntaxTest.SupportedByStaticSyntax" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                    </results>
+                  </test-suite>
+                  <test-suite type="TestFixture" name="NotSamePathOrUnderTest_RespectCase" executed="True" result="Success" success="True" time="0.003" asserts="0">
+                    <results>
+                      <test-case name="NUnit.Framework.Syntax.NotSamePathOrUnderTest_RespectCase.SyntaxTest.SupportedByConstraintBuilder" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                      <test-case name="NUnit.Framework.Syntax.NotSamePathOrUnderTest_RespectCase.SyntaxTest.SupportedByInheritedSyntax" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                      <test-case name="NUnit.Framework.Syntax.NotSamePathOrUnderTest_RespectCase.SyntaxTest.SupportedByStaticSyntax" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                    </results>
+                  </test-suite>
+                  <test-suite type="TestFixture" name="NotSamePathTest_IgnoreCase" executed="True" result="Success" success="True" time="0.003" asserts="0">
+                    <results>
+                      <test-case name="NUnit.Framework.Syntax.NotSamePathTest_IgnoreCase.SyntaxTest.SupportedByConstraintBuilder" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                      <test-case name="NUnit.Framework.Syntax.NotSamePathTest_IgnoreCase.SyntaxTest.SupportedByInheritedSyntax" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                      <test-case name="NUnit.Framework.Syntax.NotSamePathTest_IgnoreCase.SyntaxTest.SupportedByStaticSyntax" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                    </results>
+                  </test-suite>
+                  <test-suite type="TestFixture" name="NotSamePathTest_RespectCase" executed="True" result="Success" success="True" time="0.003" asserts="0">
+                    <results>
+                      <test-case name="NUnit.Framework.Syntax.NotSamePathTest_RespectCase.SyntaxTest.SupportedByConstraintBuilder" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                      <test-case name="NUnit.Framework.Syntax.NotSamePathTest_RespectCase.SyntaxTest.SupportedByInheritedSyntax" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                      <test-case name="NUnit.Framework.Syntax.NotSamePathTest_RespectCase.SyntaxTest.SupportedByStaticSyntax" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                    </results>
+                  </test-suite>
+                  <test-suite type="TestFixture" name="NotTest" executed="True" result="Success" success="True" time="0.003" asserts="0">
+                    <results>
+                      <test-case name="NUnit.Framework.Syntax.NotTest.SyntaxTest.SupportedByConstraintBuilder" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                      <test-case name="NUnit.Framework.Syntax.NotTest.SyntaxTest.SupportedByInheritedSyntax" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                      <test-case name="NUnit.Framework.Syntax.NotTest.SyntaxTest.SupportedByStaticSyntax" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                    </results>
+                  </test-suite>
+                  <test-suite type="TestFixture" name="NotTest_Cascaded" executed="True" result="Success" success="True" time="0.003" asserts="0">
+                    <results>
+                      <test-case name="NUnit.Framework.Syntax.NotTest_Cascaded.SyntaxTest.SupportedByConstraintBuilder" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                      <test-case name="NUnit.Framework.Syntax.NotTest_Cascaded.SyntaxTest.SupportedByInheritedSyntax" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                      <test-case name="NUnit.Framework.Syntax.NotTest_Cascaded.SyntaxTest.SupportedByStaticSyntax" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                    </results>
+                  </test-suite>
+                  <test-suite type="TestFixture" name="NullTest" executed="True" result="Success" success="True" time="0.004" asserts="0">
+                    <results>
+                      <test-case name="NUnit.Framework.Syntax.NullTest.SyntaxTest.SupportedByConstraintBuilder" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                      <test-case name="NUnit.Framework.Syntax.NullTest.SyntaxTest.SupportedByInheritedSyntax" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                      <test-case name="NUnit.Framework.Syntax.NullTest.SyntaxTest.SupportedByStaticSyntax" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                    </results>
+                  </test-suite>
+                  <test-suite type="TestFixture" name="OperatorPrecedenceTests" executed="True" result="Success" success="True" time="0.005" asserts="0">
+                    <results>
+                      <test-case name="NUnit.Framework.Syntax.OperatorPrecedenceTests.SomeTests" executed="True" result="Success" success="True" time="0.001" asserts="2" />
+                      <test-case name="NUnit.Framework.Syntax.OperatorPrecedenceTests.WithTests" executed="True" result="Success" success="True" time="0.002" asserts="6" />
+                    </results>
+                  </test-suite>
+                  <test-suite type="TestFixture" name="OrOperatorOverride" executed="True" result="Success" success="True" time="0.007" asserts="0">
+                    <results>
+                      <test-case name="NUnit.Framework.Syntax.OrOperatorOverride.OrOperatorCanCombineConstraintAndResolvableConstraintExpression" executed="True" result="Success" success="True" time="0.001" asserts="1" />
+                      <test-case name="NUnit.Framework.Syntax.OrOperatorOverride.OrOperatorCanCombineResolvableConstraintExpressionAndConstraint" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                      <test-case name="NUnit.Framework.Syntax.OrOperatorOverride.OrOperatorCanCombineTwoResolvableConstraintExpressions" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                      <test-case name="NUnit.Framework.Syntax.OrOperatorOverride.SyntaxTest.SupportedByConstraintBuilder" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                      <test-case name="NUnit.Framework.Syntax.OrOperatorOverride.SyntaxTest.SupportedByInheritedSyntax" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                      <test-case name="NUnit.Framework.Syntax.OrOperatorOverride.SyntaxTest.SupportedByStaticSyntax" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                    </results>
+                  </test-suite>
+                  <test-suite type="TestFixture" name="OrTest" executed="True" result="Success" success="True" time="0.003" asserts="0">
+                    <results>
+                      <test-case name="NUnit.Framework.Syntax.OrTest.SyntaxTest.SupportedByConstraintBuilder" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                      <test-case name="NUnit.Framework.Syntax.OrTest.SyntaxTest.SupportedByInheritedSyntax" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                      <test-case name="NUnit.Framework.Syntax.OrTest.SyntaxTest.SupportedByStaticSyntax" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                    </results>
+                  </test-suite>
+                  <test-suite type="TestFixture" name="OrTest_ThreeOrs" executed="True" result="Success" success="True" time="0.003" asserts="0">
+                    <results>
+                      <test-case name="NUnit.Framework.Syntax.OrTest_ThreeOrs.SyntaxTest.SupportedByConstraintBuilder" executed="True" result="Success" success="True" time="0.001" asserts="1" />
+                      <test-case name="NUnit.Framework.Syntax.OrTest_ThreeOrs.SyntaxTest.SupportedByInheritedSyntax" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                      <test-case name="NUnit.Framework.Syntax.OrTest_ThreeOrs.SyntaxTest.SupportedByStaticSyntax" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                    </results>
+                  </test-suite>
+                  <test-suite type="TestFixture" name="PositiveTest" executed="True" result="Success" success="True" time="0.003" asserts="0">
+                    <results>
+                      <test-case name="NUnit.Framework.Syntax.PositiveTest.SyntaxTest.SupportedByConstraintBuilder" executed="True" result="Success" success="True" time="0.001" asserts="1" />
+                      <test-case name="NUnit.Framework.Syntax.PositiveTest.SyntaxTest.SupportedByInheritedSyntax" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                      <test-case name="NUnit.Framework.Syntax.PositiveTest.SyntaxTest.SupportedByStaticSyntax" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                    </results>
+                  </test-suite>
+                  <test-suite type="TestFixture" name="PropertyExistsTest" executed="True" result="Success" success="True" time="0.004" asserts="0">
+                    <results>
+                      <test-case name="NUnit.Framework.Syntax.PropertyExistsTest.SyntaxTest.SupportedByConstraintBuilder" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                      <test-case name="NUnit.Framework.Syntax.PropertyExistsTest.SyntaxTest.SupportedByInheritedSyntax" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                      <test-case name="NUnit.Framework.Syntax.PropertyExistsTest.SyntaxTest.SupportedByStaticSyntax" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                    </results>
+                  </test-suite>
+                  <test-suite type="TestFixture" name="PropertyExistsTest_AndFollows" executed="True" result="Success" success="True" time="0.003" asserts="0">
+                    <results>
+                      <test-case name="NUnit.Framework.Syntax.PropertyExistsTest_AndFollows.SyntaxTest.SupportedByConstraintBuilder" executed="True" result="Success" success="True" time="0.001" asserts="1" />
+                      <test-case name="NUnit.Framework.Syntax.PropertyExistsTest_AndFollows.SyntaxTest.SupportedByInheritedSyntax" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                      <test-case name="NUnit.Framework.Syntax.PropertyExistsTest_AndFollows.SyntaxTest.SupportedByStaticSyntax" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                    </results>
+                  </test-suite>
+                  <test-suite type="TestFixture" name="PropertySyntaxVariations" executed="True" result="Success" success="True" time="0.003" asserts="0">
+                    <results>
+                      <test-case name="NUnit.Framework.Syntax.PropertySyntaxVariations.ExistenceTest" executed="True" result="Success" success="True" time="0.000" asserts="2" />
+                      <test-case name="NUnit.Framework.Syntax.PropertySyntaxVariations.SeparateConstraintTest" executed="True" result="Success" success="True" time="0.000" asserts="2" />
+                    </results>
+                  </test-suite>
+                  <test-suite type="TestFixture" name="PropertyTest_ConstraintFollows" executed="True" result="Success" success="True" time="0.003" asserts="0">
+                    <results>
+                      <test-case name="NUnit.Framework.Syntax.PropertyTest_ConstraintFollows.SyntaxTest.SupportedByConstraintBuilder" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                      <test-case name="NUnit.Framework.Syntax.PropertyTest_ConstraintFollows.SyntaxTest.SupportedByInheritedSyntax" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                      <test-case name="NUnit.Framework.Syntax.PropertyTest_ConstraintFollows.SyntaxTest.SupportedByStaticSyntax" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                    </results>
+                  </test-suite>
+                  <test-suite type="TestFixture" name="PropertyTest_NotFollows" executed="True" result="Success" success="True" time="0.003" asserts="0">
+                    <results>
+                      <test-case name="NUnit.Framework.Syntax.PropertyTest_NotFollows.SyntaxTest.SupportedByConstraintBuilder" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                      <test-case name="NUnit.Framework.Syntax.PropertyTest_NotFollows.SyntaxTest.SupportedByInheritedSyntax" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                      <test-case name="NUnit.Framework.Syntax.PropertyTest_NotFollows.SyntaxTest.SupportedByStaticSyntax" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                    </results>
+                  </test-suite>
+                  <test-suite type="TestFixture" name="RegexTest" executed="True" result="Success" success="True" time="0.003" asserts="0">
+                    <results>
+                      <test-case name="NUnit.Framework.Syntax.RegexTest.SyntaxTest.SupportedByConstraintBuilder" executed="True" result="Success" success="True" time="0.001" asserts="1" />
+                      <test-case name="NUnit.Framework.Syntax.RegexTest.SyntaxTest.SupportedByInheritedSyntax" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                      <test-case name="NUnit.Framework.Syntax.RegexTest.SyntaxTest.SupportedByStaticSyntax" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                    </results>
+                  </test-suite>
+                  <test-suite type="TestFixture" name="RegexTest_IgnoreCase" executed="True" result="Success" success="True" time="0.002" asserts="0">
+                    <results>
+                      <test-case name="NUnit.Framework.Syntax.RegexTest_IgnoreCase.SyntaxTest.SupportedByConstraintBuilder" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                      <test-case name="NUnit.Framework.Syntax.RegexTest_IgnoreCase.SyntaxTest.SupportedByInheritedSyntax" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                      <test-case name="NUnit.Framework.Syntax.RegexTest_IgnoreCase.SyntaxTest.SupportedByStaticSyntax" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                    </results>
+                  </test-suite>
+                  <test-suite type="TestFixture" name="SamePathOrUnderTest" executed="True" result="Success" success="True" time="0.003" asserts="0">
+                    <results>
+                      <test-case name="NUnit.Framework.Syntax.SamePathOrUnderTest.SyntaxTest.SupportedByConstraintBuilder" executed="True" result="Success" success="True" time="0.001" asserts="1" />
+                      <test-case name="NUnit.Framework.Syntax.SamePathOrUnderTest.SyntaxTest.SupportedByInheritedSyntax" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                      <test-case name="NUnit.Framework.Syntax.SamePathOrUnderTest.SyntaxTest.SupportedByStaticSyntax" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                    </results>
+                  </test-suite>
+                  <test-suite type="TestFixture" name="SamePathOrUnderTest_IgnoreCase" executed="True" result="Success" success="True" time="0.003" asserts="0">
+                    <results>
+                      <test-case name="NUnit.Framework.Syntax.SamePathOrUnderTest_IgnoreCase.SyntaxTest.SupportedByConstraintBuilder" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                      <test-case name="NUnit.Framework.Syntax.SamePathOrUnderTest_IgnoreCase.SyntaxTest.SupportedByInheritedSyntax" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                      <test-case name="NUnit.Framework.Syntax.SamePathOrUnderTest_IgnoreCase.SyntaxTest.SupportedByStaticSyntax" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                    </results>
+                  </test-suite>
+                  <test-suite type="TestFixture" name="SamePathOrUnderTest_RespectCase" executed="True" result="Success" success="True" time="0.003" asserts="0">
+                    <results>
+                      <test-case name="NUnit.Framework.Syntax.SamePathOrUnderTest_RespectCase.SyntaxTest.SupportedByConstraintBuilder" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                      <test-case name="NUnit.Framework.Syntax.SamePathOrUnderTest_RespectCase.SyntaxTest.SupportedByInheritedSyntax" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                      <test-case name="NUnit.Framework.Syntax.SamePathOrUnderTest_RespectCase.SyntaxTest.SupportedByStaticSyntax" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                    </results>
+                  </test-suite>
+                  <test-suite type="TestFixture" name="SamePathTest" executed="True" result="Success" success="True" time="0.003" asserts="0">
+                    <results>
+                      <test-case name="NUnit.Framework.Syntax.SamePathTest.SyntaxTest.SupportedByConstraintBuilder" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                      <test-case name="NUnit.Framework.Syntax.SamePathTest.SyntaxTest.SupportedByInheritedSyntax" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                      <test-case name="NUnit.Framework.Syntax.SamePathTest.SyntaxTest.SupportedByStaticSyntax" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                    </results>
+                  </test-suite>
+                  <test-suite type="TestFixture" name="SamePathTest_IgnoreCase" executed="True" result="Success" success="True" time="0.003" asserts="0">
+                    <results>
+                      <test-case name="NUnit.Framework.Syntax.SamePathTest_IgnoreCase.SyntaxTest.SupportedByConstraintBuilder" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                      <test-case name="NUnit.Framework.Syntax.SamePathTest_IgnoreCase.SyntaxTest.SupportedByInheritedSyntax" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                      <test-case name="NUnit.Framework.Syntax.SamePathTest_IgnoreCase.SyntaxTest.SupportedByStaticSyntax" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                    </results>
+                  </test-suite>
+                  <test-suite type="TestFixture" name="SamePathTest_RespectCase" executed="True" result="Success" success="True" time="0.003" asserts="0">
+                    <results>
+                      <test-case name="NUnit.Framework.Syntax.SamePathTest_RespectCase.SyntaxTest.SupportedByConstraintBuilder" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                      <test-case name="NUnit.Framework.Syntax.SamePathTest_RespectCase.SyntaxTest.SupportedByInheritedSyntax" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                      <test-case name="NUnit.Framework.Syntax.SamePathTest_RespectCase.SyntaxTest.SupportedByStaticSyntax" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                    </results>
+                  </test-suite>
+                  <test-suite type="TestFixture" name="SomeTest" executed="True" result="Success" success="True" time="0.003" asserts="0">
+                    <results>
+                      <test-case name="NUnit.Framework.Syntax.SomeTest.SyntaxTest.SupportedByConstraintBuilder" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                      <test-case name="NUnit.Framework.Syntax.SomeTest.SyntaxTest.SupportedByInheritedSyntax" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                      <test-case name="NUnit.Framework.Syntax.SomeTest.SyntaxTest.SupportedByStaticSyntax" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                    </results>
+                  </test-suite>
+                  <test-suite type="TestFixture" name="SomeTest_BeforeBinaryOperators" executed="True" result="Success" success="True" time="0.003" asserts="0">
+                    <results>
+                      <test-case name="NUnit.Framework.Syntax.SomeTest_BeforeBinaryOperators.SyntaxTest.SupportedByConstraintBuilder" executed="True" result="Success" success="True" time="0.001" asserts="1" />
+                      <test-case name="NUnit.Framework.Syntax.SomeTest_BeforeBinaryOperators.SyntaxTest.SupportedByInheritedSyntax" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                      <test-case name="NUnit.Framework.Syntax.SomeTest_BeforeBinaryOperators.SyntaxTest.SupportedByStaticSyntax" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                    </results>
+                  </test-suite>
+                  <test-suite type="TestFixture" name="SomeTest_NestedSome" executed="True" result="Success" success="True" time="0.003" asserts="0">
+                    <results>
+                      <test-case name="NUnit.Framework.Syntax.SomeTest_NestedSome.SyntaxTest.SupportedByConstraintBuilder" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                      <test-case name="NUnit.Framework.Syntax.SomeTest_NestedSome.SyntaxTest.SupportedByInheritedSyntax" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                      <test-case name="NUnit.Framework.Syntax.SomeTest_NestedSome.SyntaxTest.SupportedByStaticSyntax" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                    </results>
+                  </test-suite>
+                  <test-suite type="TestFixture" name="SomeTest_UseOfAndSome" executed="True" result="Success" success="True" time="0.002" asserts="0">
+                    <results>
+                      <test-case name="NUnit.Framework.Syntax.SomeTest_UseOfAndSome.SyntaxTest.SupportedByConstraintBuilder" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                      <test-case name="NUnit.Framework.Syntax.SomeTest_UseOfAndSome.SyntaxTest.SupportedByInheritedSyntax" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                      <test-case name="NUnit.Framework.Syntax.SomeTest_UseOfAndSome.SyntaxTest.SupportedByStaticSyntax" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                    </results>
+                  </test-suite>
+                  <test-suite type="TestFixture" name="StartsWithTest" executed="True" result="Success" success="True" time="0.002" asserts="0">
+                    <results>
+                      <test-case name="NUnit.Framework.Syntax.StartsWithTest.SyntaxTest.SupportedByConstraintBuilder" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                      <test-case name="NUnit.Framework.Syntax.StartsWithTest.SyntaxTest.SupportedByInheritedSyntax" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                      <test-case name="NUnit.Framework.Syntax.StartsWithTest.SyntaxTest.SupportedByStaticSyntax" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                    </results>
+                  </test-suite>
+                  <test-suite type="TestFixture" name="StartsWithTest_IgnoreCase" executed="True" result="Success" success="True" time="0.002" asserts="0">
+                    <results>
+                      <test-case name="NUnit.Framework.Syntax.StartsWithTest_IgnoreCase.SyntaxTest.SupportedByConstraintBuilder" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                      <test-case name="NUnit.Framework.Syntax.StartsWithTest_IgnoreCase.SyntaxTest.SupportedByInheritedSyntax" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                      <test-case name="NUnit.Framework.Syntax.StartsWithTest_IgnoreCase.SyntaxTest.SupportedByStaticSyntax" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                    </results>
+                  </test-suite>
+                  <test-suite type="TestFixture" name="SubstringTest" executed="True" result="Success" success="True" time="0.002" asserts="0">
+                    <results>
+                      <test-case name="NUnit.Framework.Syntax.SubstringTest.SyntaxTest.SupportedByConstraintBuilder" executed="True" result="Success" success="True" time="0.001" asserts="1" />
+                      <test-case name="NUnit.Framework.Syntax.SubstringTest.SyntaxTest.SupportedByInheritedSyntax" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                      <test-case name="NUnit.Framework.Syntax.SubstringTest.SyntaxTest.SupportedByStaticSyntax" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                    </results>
+                  </test-suite>
+                  <test-suite type="TestFixture" name="SubstringTest_IgnoreCase" executed="True" result="Success" success="True" time="0.002" asserts="0">
+                    <results>
+                      <test-case name="NUnit.Framework.Syntax.SubstringTest_IgnoreCase.SyntaxTest.SupportedByConstraintBuilder" executed="True" result="Success" success="True" time="0.001" asserts="1" />
+                      <test-case name="NUnit.Framework.Syntax.SubstringTest_IgnoreCase.SyntaxTest.SupportedByInheritedSyntax" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                      <test-case name="NUnit.Framework.Syntax.SubstringTest_IgnoreCase.SyntaxTest.SupportedByStaticSyntax" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                    </results>
+                  </test-suite>
+                  <test-suite type="TestFixture" name="TextContains" executed="True" result="Success" success="True" time="0.003" asserts="0">
+                    <results>
+                      <test-case name="NUnit.Framework.Syntax.TextContains.SyntaxTest.SupportedByConstraintBuilder" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                      <test-case name="NUnit.Framework.Syntax.TextContains.SyntaxTest.SupportedByInheritedSyntax" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                      <test-case name="NUnit.Framework.Syntax.TextContains.SyntaxTest.SupportedByStaticSyntax" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                    </results>
+                  </test-suite>
+                  <test-suite type="TestFixture" name="TextEndsWithTest" executed="True" result="Success" success="True" time="0.005" asserts="0">
+                    <results>
+                      <test-case name="NUnit.Framework.Syntax.TextEndsWithTest.SyntaxTest.SupportedByConstraintBuilder" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                      <test-case name="NUnit.Framework.Syntax.TextEndsWithTest.SyntaxTest.SupportedByInheritedSyntax" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                      <test-case name="NUnit.Framework.Syntax.TextEndsWithTest.SyntaxTest.SupportedByStaticSyntax" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                    </results>
+                  </test-suite>
+                  <test-suite type="TestFixture" name="TextMatchesTest" executed="True" result="Success" success="True" time="0.003" asserts="0">
+                    <results>
+                      <test-case name="NUnit.Framework.Syntax.TextMatchesTest.SyntaxTest.SupportedByConstraintBuilder" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                      <test-case name="NUnit.Framework.Syntax.TextMatchesTest.SyntaxTest.SupportedByInheritedSyntax" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                      <test-case name="NUnit.Framework.Syntax.TextMatchesTest.SyntaxTest.SupportedByStaticSyntax" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                    </results>
+                  </test-suite>
+                  <test-suite type="TestFixture" name="TextStartsWithTest" executed="True" result="Success" success="True" time="0.003" asserts="0">
+                    <results>
+                      <test-case name="NUnit.Framework.Syntax.TextStartsWithTest.SyntaxTest.SupportedByConstraintBuilder" executed="True" result="Success" success="True" time="0.001" asserts="1" />
+                      <test-case name="NUnit.Framework.Syntax.TextStartsWithTest.SyntaxTest.SupportedByInheritedSyntax" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                      <test-case name="NUnit.Framework.Syntax.TextStartsWithTest.SyntaxTest.SupportedByStaticSyntax" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                    </results>
+                  </test-suite>
+                  <test-suite type="TestFixture" name="ThrowsTests" executed="True" result="Success" success="True" time="0.022" asserts="0">
+                    <results>
+                      <test-case name="NUnit.Framework.Syntax.ThrowsTests.DelegateThrowsException" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                      <test-case name="NUnit.Framework.Syntax.ThrowsTests.LambdaThrowsException" executed="True" result="Success" success="True" time="0.002" asserts="1" />
+                      <test-case name="NUnit.Framework.Syntax.ThrowsTests.LambdaThrowsExceptionWithMessage" executed="True" result="Success" success="True" time="0.001" asserts="1" />
+                      <test-case name="NUnit.Framework.Syntax.ThrowsTests.LambdaThrowsNothing" executed="True" result="Success" success="True" time="0.001" asserts="1" />
+                      <test-case name="NUnit.Framework.Syntax.ThrowsTests.ThrowsArgumentException" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                      <test-case name="NUnit.Framework.Syntax.ThrowsTests.ThrowsException" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                      <test-case name="NUnit.Framework.Syntax.ThrowsTests.ThrowsExceptionInstanceOf" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                      <test-case name="NUnit.Framework.Syntax.ThrowsTests.ThrowsExceptionTypeOf" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                      <test-case name="NUnit.Framework.Syntax.ThrowsTests.ThrowsExceptionTypeOfAndConstraint" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                      <test-case name="NUnit.Framework.Syntax.ThrowsTests.ThrowsExceptionWithConstraint" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                      <test-case name="NUnit.Framework.Syntax.ThrowsTests.ThrowsExceptionWithInnerException" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                      <test-case name="NUnit.Framework.Syntax.ThrowsTests.ThrowsInnerException" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                      <test-case name="NUnit.Framework.Syntax.ThrowsTests.ThrowsInstanceOf" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                      <test-case name="NUnit.Framework.Syntax.ThrowsTests.ThrowsInvalidOperationException" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                      <test-case name="NUnit.Framework.Syntax.ThrowsTests.ThrowsTargetInvocationExceptionWithInnerException" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                      <test-case name="NUnit.Framework.Syntax.ThrowsTests.ThrowsTypeOf" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                      <test-case name="NUnit.Framework.Syntax.ThrowsTests.ThrowsTypeOfAndConstraint" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                      <test-case name="NUnit.Framework.Syntax.ThrowsTests.ThrowsTypeOfWithConstraint" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                      <test-case name="NUnit.Framework.Syntax.ThrowsTests.ThrowsTypeOfWithInnerException" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                      <test-case name="NUnit.Framework.Syntax.ThrowsTests.ThrowsTypeofWithMessage" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                    </results>
+                  </test-suite>
+                  <test-suite type="TestFixture" name="TrueTest" executed="True" result="Success" success="True" time="0.002" asserts="0">
+                    <results>
+                      <test-case name="NUnit.Framework.Syntax.TrueTest.SyntaxTest.SupportedByConstraintBuilder" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                      <test-case name="NUnit.Framework.Syntax.TrueTest.SyntaxTest.SupportedByInheritedSyntax" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                      <test-case name="NUnit.Framework.Syntax.TrueTest.SyntaxTest.SupportedByStaticSyntax" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                    </results>
+                  </test-suite>
+                  <test-suite type="TestFixture" name="UniqueTest" executed="True" result="Success" success="True" time="0.003" asserts="0">
+                    <results>
+                      <test-case name="NUnit.Framework.Syntax.UniqueTest.SyntaxTest.SupportedByConstraintBuilder" executed="True" result="Success" success="True" time="0.001" asserts="1" />
+                      <test-case name="NUnit.Framework.Syntax.UniqueTest.SyntaxTest.SupportedByInheritedSyntax" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                      <test-case name="NUnit.Framework.Syntax.UniqueTest.SyntaxTest.SupportedByStaticSyntax" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                    </results>
+                  </test-suite>
+                  <test-suite type="TestFixture" name="XmlSerializableTest" executed="True" result="Success" success="True" time="0.002" asserts="0">
+                    <results>
+                      <test-case name="NUnit.Framework.Syntax.XmlSerializableTest.SyntaxTest.SupportedByConstraintBuilder" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                      <test-case name="NUnit.Framework.Syntax.XmlSerializableTest.SyntaxTest.SupportedByInheritedSyntax" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                      <test-case name="NUnit.Framework.Syntax.XmlSerializableTest.SyntaxTest.SupportedByStaticSyntax" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                    </results>
+                  </test-suite>
+                </results>
+              </test-suite>
+              <test-suite type="Namespace" name="Tests" executed="True" result="Success" success="True" time="1.170" asserts="0">
+                <results>
+                  <test-suite type="TestFixture" name="ArrayEqualsFailureMessageFixture" executed="True" result="Success" success="True" time="0.065" asserts="0">
+                    <results>
+                      <test-case name="NUnit.Framework.Tests.ArrayEqualsFailureMessageFixture.ActualArrayIsLonger" executed="True" result="Success" success="True" time="0.002" asserts="2" />
+                      <test-case name="NUnit.Framework.Tests.ArrayEqualsFailureMessageFixture.ArrayAndCollection_Failure" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                      <test-case name="NUnit.Framework.Tests.ArrayEqualsFailureMessageFixture.ArraysDeclaredAsDifferentTypes" executed="True" result="Success" success="True" time="0.001" asserts="2" />
+                      <test-case name="NUnit.Framework.Tests.ArrayEqualsFailureMessageFixture.ArraysHaveDifferentRanks" executed="True" result="Success" success="True" time="0.030" asserts="2" />
+                      <test-case name="NUnit.Framework.Tests.ArrayEqualsFailureMessageFixture.ArraysWithDifferentDimensionsAsCollection" executed="True" result="Success" success="True" time="0.001" asserts="2" />
+                      <test-case name="NUnit.Framework.Tests.ArrayEqualsFailureMessageFixture.ArraysWithDifferentRanksAsCollection" executed="True" result="Success" success="True" time="0.001" asserts="2" />
+                      <test-case name="NUnit.Framework.Tests.ArrayEqualsFailureMessageFixture.DifferentArrayTypesEqualFails" executed="True" result="Success" success="True" time="0.001" asserts="2" />
+                      <test-case name="NUnit.Framework.Tests.ArrayEqualsFailureMessageFixture.DoubleDimensionedArrays" executed="True" result="Success" success="True" time="0.001" asserts="2" />
+                      <test-case name="NUnit.Framework.Tests.ArrayEqualsFailureMessageFixture.ExpectedArrayIsLonger" executed="True" result="Success" success="True" time="0.002" asserts="2" />
+                      <test-case name="NUnit.Framework.Tests.ArrayEqualsFailureMessageFixture.FailureOnSingleDimensionedArrays" executed="True" result="Success" success="True" time="0.001" asserts="2" />
+                      <test-case name="NUnit.Framework.Tests.ArrayEqualsFailureMessageFixture.FiveDimensionedArrays" executed="True" result="Success" success="True" time="0.001" asserts="2" />
+                      <test-case name="NUnit.Framework.Tests.ArrayEqualsFailureMessageFixture.JaggedArrayComparedToSimpleArray" executed="True" result="Success" success="True" time="0.002" asserts="2" />
+                      <test-case name="NUnit.Framework.Tests.ArrayEqualsFailureMessageFixture.JaggedArrays" executed="True" result="Success" success="True" time="0.002" asserts="2" />
+                      <test-case name="NUnit.Framework.Tests.ArrayEqualsFailureMessageFixture.SameLengthDifferentContent" executed="True" result="Success" success="True" time="0.001" asserts="2" />
+                      <test-case name="NUnit.Framework.Tests.ArrayEqualsFailureMessageFixture.TripleDimensionedArrays" executed="True" result="Success" success="True" time="0.001" asserts="2" />
+                    </results>
+                  </test-suite>
+                  <test-suite type="TestFixture" name="ArrayEqualsFixture" executed="True" result="Success" success="True" time="0.025" asserts="0">
+                    <results>
+                      <test-case name="NUnit.Framework.Tests.ArrayEqualsFixture.ArrayAndCollection" executed="True" result="Success" success="True" time="0.000" asserts="4" />
+                      <test-case name="NUnit.Framework.Tests.ArrayEqualsFixture.ArrayIsEqualToItself" executed="True" result="Success" success="True" time="0.000" asserts="3" />
+                      <test-case name="NUnit.Framework.Tests.ArrayEqualsFixture.ArrayOfIntAndArrayOfDouble" executed="True" result="Success" success="True" time="0.000" asserts="4" />
+                      <test-case name="NUnit.Framework.Tests.ArrayEqualsFixture.ArraysDeclaredAsDifferentTypes" executed="True" result="Success" success="True" time="0.001" asserts="4" />
+                      <test-case name="NUnit.Framework.Tests.ArrayEqualsFixture.ArraysOfArrays" executed="True" result="Success" success="True" time="0.001" asserts="4" />
+                      <test-case name="NUnit.Framework.Tests.ArrayEqualsFixture.ArraysOfDecimal" executed="True" result="Success" success="True" time="0.001" asserts="4" />
+                      <test-case name="NUnit.Framework.Tests.ArrayEqualsFixture.ArraysOfDouble" executed="True" result="Success" success="True" time="0.000" asserts="4" />
+                      <test-case name="NUnit.Framework.Tests.ArrayEqualsFixture.ArraysOfInt" executed="True" result="Success" success="True" time="0.000" asserts="4" />
+                      <test-case name="NUnit.Framework.Tests.ArrayEqualsFixture.ArraysOfMixedTypes" executed="True" result="Success" success="True" time="0.001" asserts="4" />
+                      <test-case name="NUnit.Framework.Tests.ArrayEqualsFixture.ArraysOfString" executed="True" result="Success" success="True" time="0.000" asserts="5" />
+                      <test-case name="NUnit.Framework.Tests.ArrayEqualsFixture.ArraysPassedAsObjects" executed="True" result="Success" success="True" time="0.000" asserts="4" />
+                      <test-case name="NUnit.Framework.Tests.ArrayEqualsFixture.ArraysWithDifferentDimensionsMatchedAsCollection" executed="True" result="Success" success="True" time="0.001" asserts="3" />
+                      <test-case name="NUnit.Framework.Tests.ArrayEqualsFixture.ArraysWithDifferentRanksComparedAsCollection" executed="True" result="Success" success="True" time="0.000" asserts="3" />
+                      <test-case name="NUnit.Framework.Tests.ArrayEqualsFixture.DoubleDimensionedArrays" executed="True" result="Success" success="True" time="0.000" asserts="4" />
+                      <test-case name="NUnit.Framework.Tests.ArrayEqualsFixture.FiveDimensionedArrays" executed="True" result="Success" success="True" time="0.001" asserts="2" />
+                      <test-case name="NUnit.Framework.Tests.ArrayEqualsFixture.JaggedArrays" executed="True" result="Success" success="True" time="0.001" asserts="2" />
+                      <test-case name="NUnit.Framework.Tests.ArrayEqualsFixture.TripleDimensionedArrays" executed="True" result="Success" success="True" time="0.000" asserts="2" />
+                    </results>
+                  </test-suite>
+                  <test-suite type="TestFixture" name="ArrayNotEqualFixture" executed="True" result="Success" success="True" time="0.004" asserts="0">
+                    <results>
+                      <test-case name="NUnit.Framework.Tests.ArrayNotEqualFixture.ArraysDeclaredAsDifferentTypes" executed="True" result="Success" success="True" time="0.000" asserts="3" />
+                      <test-case name="NUnit.Framework.Tests.ArrayNotEqualFixture.DifferentLengthArrays" executed="True" result="Success" success="True" time="0.000" asserts="4" />
+                      <test-case name="NUnit.Framework.Tests.ArrayNotEqualFixture.SameLengthDifferentContent" executed="True" result="Success" success="True" time="0.000" asserts="4" />
+                    </results>
+                  </test-suite>
+                  <test-suite type="TestFixture" name="AssertThrowsTests" executed="True" result="Success" success="True" time="0.128" asserts="0">
+                    <results>
+                      <test-case name="NUnit.Framework.Tests.AssertThrowsTests.BaseExceptionThrown" executed="True" result="Success" success="True" time="0.093" asserts="2" />
+                      <test-case name="NUnit.Framework.Tests.AssertThrowsTests.CanCatchExceptionOfDerivedType" executed="True" result="Success" success="True" time="0.002" asserts="4" />
+                      <test-case name="NUnit.Framework.Tests.AssertThrowsTests.CanCatchExceptionOfExactType" executed="True" result="Success" success="True" time="0.001" asserts="4" />
+                      <test-case name="NUnit.Framework.Tests.AssertThrowsTests.CanCatchUnspecifiedException" executed="True" result="Success" success="True" time="0.001" asserts="4" />
+                      <test-case name="NUnit.Framework.Tests.AssertThrowsTests.CorrectExceptionIsReturnedToMethod" executed="True" result="Success" success="True" time="0.003" asserts="16" />
+                      <test-case name="NUnit.Framework.Tests.AssertThrowsTests.CorrectExceptionThrown" executed="True" result="Success" success="True" time="0.002" asserts="5" />
+                      <test-case name="NUnit.Framework.Tests.AssertThrowsTests.DerivedExceptionThrown" executed="True" result="Success" success="True" time="0.002" asserts="2" />
+                      <test-case name="NUnit.Framework.Tests.AssertThrowsTests.DoesNotThrowFails" executed="True" result="Success" success="True" time="0.003" asserts="1" />
+                      <test-case name="NUnit.Framework.Tests.AssertThrowsTests.DoesNotThrowSuceeds" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                      <test-case name="NUnit.Framework.Tests.AssertThrowsTests.NoExceptionThrown" executed="True" result="Success" success="True" time="0.001" asserts="2" />
+                      <test-case name="NUnit.Framework.Tests.AssertThrowsTests.UnrelatedExceptionThrown" executed="True" result="Success" success="True" time="0.002" asserts="2" />
+                    </results>
+                  </test-suite>
+                  <test-suite type="TestFixture" name="AssumeThatTests" executed="True" result="Success" success="True" time="0.037" asserts="0">
+                    <results>
+                      <test-case name="NUnit.Framework.Tests.AssumeThatTests.AssumptionPasses_ActualAndConstraint" executed="True" result="Success" success="True" time="0.000" asserts="0" />
+                      <test-case name="NUnit.Framework.Tests.AssumeThatTests.AssumptionPasses_ActualAndConstraintWithMessage" executed="True" result="Success" success="True" time="0.001" asserts="0" />
+                      <test-case name="NUnit.Framework.Tests.AssumeThatTests.AssumptionPasses_ActualAndConstraintWithMessageAndArgs" executed="True" result="Success" success="True" time="0.000" asserts="0" />
+                      <test-case name="NUnit.Framework.Tests.AssumeThatTests.AssumptionPasses_Boolean" executed="True" result="Success" success="True" time="0.000" asserts="0" />
+                      <test-case name="NUnit.Framework.Tests.AssumeThatTests.AssumptionPasses_BooleanWithMessage" executed="True" result="Success" success="True" time="0.001" asserts="0" />
+                      <test-case name="NUnit.Framework.Tests.AssumeThatTests.AssumptionPasses_BooleanWithMessageAndArgs" executed="True" result="Success" success="True" time="0.001" asserts="0" />
+                      <test-case name="NUnit.Framework.Tests.AssumeThatTests.AssumptionPasses_DelegateAndConstraint" executed="True" result="Success" success="True" time="0.003" asserts="0" />
+                      <test-case name="NUnit.Framework.Tests.AssumeThatTests.AssumptionPasses_DelegateAndConstraintWithMessage" executed="True" result="Success" success="True" time="0.001" asserts="0" />
+                      <test-case name="NUnit.Framework.Tests.AssumeThatTests.AssumptionPasses_DelegateAndConstraintWithMessageAndArgs" executed="True" result="Success" success="True" time="0.000" asserts="0" />
+                      <test-case name="NUnit.Framework.Tests.AssumeThatTests.AssumptionPasses_ReferenceAndConstraint" executed="True" result="Success" success="True" time="0.001" asserts="0" />
+                      <test-case name="NUnit.Framework.Tests.AssumeThatTests.AssumptionPasses_ReferenceAndConstraintWithMessage" executed="True" result="Success" success="True" time="0.000" asserts="0" />
+                      <test-case name="NUnit.Framework.Tests.AssumeThatTests.AssumptionPasses_ReferenceAndConstraintWithMessageAndArgs" executed="True" result="Success" success="True" time="0.000" asserts="0" />
+                      <test-case name="NUnit.Framework.Tests.AssumeThatTests.FailureThrowsInconclusiveException_ActualAndConstraint" executed="True" result="Success" success="True" time="0.001" asserts="0" />
+                      <test-case name="NUnit.Framework.Tests.AssumeThatTests.FailureThrowsInconclusiveException_ActualAndConstraintWithMessage" executed="True" result="Success" success="True" time="0.000" asserts="0" />
+                      <test-case name="NUnit.Framework.Tests.AssumeThatTests.FailureThrowsInconclusiveException_ActualAndConstraintWithMessageAndArgs" executed="True" result="Success" success="True" time="0.001" asserts="0" />
+                      <test-case name="NUnit.Framework.Tests.AssumeThatTests.FailureThrowsInconclusiveException_Boolean" executed="True" result="Success" success="True" time="0.000" asserts="0" />
+                      <test-case name="NUnit.Framework.Tests.AssumeThatTests.FailureThrowsInconclusiveException_BooleanWithMessage" executed="True" result="Success" success="True" time="0.000" asserts="0" />
+                      <test-case name="NUnit.Framework.Tests.AssumeThatTests.FailureThrowsInconclusiveException_BooleanWithMessageAndArgs" executed="True" result="Success" success="True" time="0.000" asserts="0" />
+                      <test-case name="NUnit.Framework.Tests.AssumeThatTests.FailureThrowsInconclusiveException_DelegateAndConstraint" executed="True" result="Success" success="True" time="0.001" asserts="0" />
+                      <test-case name="NUnit.Framework.Tests.AssumeThatTests.FailureThrowsInconclusiveException_DelegateAndConstraintWithMessage" executed="True" result="Success" success="True" time="0.001" asserts="0" />
+                      <test-case name="NUnit.Framework.Tests.AssumeThatTests.FailureThrowsInconclusiveException_DelegateAndConstraintWithMessageAndArgs" executed="True" result="Success" success="True" time="0.001" asserts="0" />
+                      <test-case name="NUnit.Framework.Tests.AssumeThatTests.FailureThrowsInconclusiveException_ReferenceAndConstraint" executed="True" result="Success" success="True" time="0.000" asserts="0" />
+                      <test-case name="NUnit.Framework.Tests.AssumeThatTests.FailureThrowsInconclusiveException_ReferenceAndConstraintWithMessage" executed="True" result="Success" success="True" time="0.000" asserts="0" />
+                      <test-case name="NUnit.Framework.Tests.AssumeThatTests.FailureThrowsInconclusiveException_ReferenceAndConstraintWithMessageAndArgs" executed="True" result="Success" success="True" time="0.001" asserts="0" />
+                    </results>
+                  </test-suite>
+                  <test-suite type="TestFixture" name="CollectionAssertTest" executed="True" result="Success" success="True" time="0.081" asserts="0">
+                    <results>
+                      <test-case name="NUnit.Framework.Tests.CollectionAssertTest.AreEqual" executed="True" result="Success" success="True" time="0.001" asserts="3" />
+                      <test-case name="NUnit.Framework.Tests.CollectionAssertTest.AreEqual_HandlesNull" executed="True" result="Success" success="True" time="0.000" asserts="2" />
+                      <test-case name="NUnit.Framework.Tests.CollectionAssertTest.AreEqual_UsingIterator" executed="True" result="Success" success="True" time="0.001" asserts="1" />
+                      <test-case name="NUnit.Framework.Tests.CollectionAssertTest.AreEqual_UsingIterator_Fails" executed="True" result="Success" success="True" time="0.001" asserts="2" />
+                      <test-case name="NUnit.Framework.Tests.CollectionAssertTest.AreEqual_UsingLinqQuery" executed="True" result="Success" success="True" time="0.021" asserts="1" />
+                      <test-case name="NUnit.Framework.Tests.CollectionAssertTest.AreEqual_UsingLinqQuery_Fails" executed="True" result="Success" success="True" time="0.001" asserts="2" />
+                      <test-case name="NUnit.Framework.Tests.CollectionAssertTest.AreEqualFail" executed="True" result="Success" success="True" time="0.001" asserts="2" />
+                      <test-case name="NUnit.Framework.Tests.CollectionAssertTest.AreEqualFailCount" executed="True" result="Success" success="True" time="0.001" asserts="2" />
+                      <test-case name="NUnit.Framework.Tests.CollectionAssertTest.AreEquivalentHandlesNull" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                      <test-case name="NUnit.Framework.Tests.CollectionAssertTest.AreNotEqual" executed="True" result="Success" success="True" time="0.001" asserts="6" />
+                      <test-case name="NUnit.Framework.Tests.CollectionAssertTest.AreNotEqual_Fails" executed="True" result="Success" success="True" time="0.001" asserts="2" />
+                      <test-case name="NUnit.Framework.Tests.CollectionAssertTest.AreNotEqual_HandlesNull" executed="True" result="Success" success="True" time="0.000" asserts="2" />
+                      <test-case name="NUnit.Framework.Tests.CollectionAssertTest.Contains_ICollection" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                      <test-case name="NUnit.Framework.Tests.CollectionAssertTest.Contains_IList" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                      <test-case name="NUnit.Framework.Tests.CollectionAssertTest.ContainsFails_EmptyICollection" executed="True" result="Success" success="True" time="0.000" asserts="2" />
+                      <test-case name="NUnit.Framework.Tests.CollectionAssertTest.ContainsFails_EmptyIList" executed="True" result="Success" success="True" time="0.000" asserts="2" />
+                      <test-case name="NUnit.Framework.Tests.CollectionAssertTest.ContainsFails_ICollection" executed="True" result="Success" success="True" time="0.000" asserts="2" />
+                      <test-case name="NUnit.Framework.Tests.CollectionAssertTest.ContainsFails_ILIst" executed="True" result="Success" success="True" time="0.000" asserts="2" />
+                      <test-case name="NUnit.Framework.Tests.CollectionAssertTest.ContainsNull_ICollection" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                      <test-case name="NUnit.Framework.Tests.CollectionAssertTest.ContainsNull_IList" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                      <test-case name="NUnit.Framework.Tests.CollectionAssertTest.DoesNotContain" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                      <test-case name="NUnit.Framework.Tests.CollectionAssertTest.DoesNotContain_Empty" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                      <test-case name="NUnit.Framework.Tests.CollectionAssertTest.DoesNotContain_Fails" executed="True" result="Success" success="True" time="0.001" asserts="2" />
+                      <test-case name="NUnit.Framework.Tests.CollectionAssertTest.EnsureComparerIsUsed" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                      <test-case name="NUnit.Framework.Tests.CollectionAssertTest.Equivalent" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                      <test-case name="NUnit.Framework.Tests.CollectionAssertTest.EquivalentFailOne" executed="True" result="Success" success="True" time="0.001" asserts="2" />
+                      <test-case name="NUnit.Framework.Tests.CollectionAssertTest.EquivalentFailTwo" executed="True" result="Success" success="True" time="0.001" asserts="2" />
+                      <test-case name="NUnit.Framework.Tests.CollectionAssertTest.IsNotSubsetOf" executed="True" result="Success" success="True" time="0.001" asserts="2" />
+                      <test-case name="NUnit.Framework.Tests.CollectionAssertTest.IsNotSubsetOf_Fails" executed="True" result="Success" success="True" time="0.001" asserts="2" />
+                      <test-case name="NUnit.Framework.Tests.CollectionAssertTest.IsNotSubsetOfHandlesNull" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                      <test-case name="NUnit.Framework.Tests.CollectionAssertTest.IsOrdered" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                      <test-case name="NUnit.Framework.Tests.CollectionAssertTest.IsOrdered_Allows_adjacent_equal_values" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                      <test-case name="NUnit.Framework.Tests.CollectionAssertTest.IsOrdered_ContainedTypesMustBeCompatible" executed="True" result="Success" success="True" time="0.001" asserts="1" />
+                      <test-case name="NUnit.Framework.Tests.CollectionAssertTest.IsOrdered_Fails" executed="True" result="Success" success="True" time="0.001" asserts="2" />
+                      <test-case name="NUnit.Framework.Tests.CollectionAssertTest.IsOrdered_Handles_custom_comparison" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                      <test-case name="NUnit.Framework.Tests.CollectionAssertTest.IsOrdered_Handles_custom_comparison2" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                      <test-case name="NUnit.Framework.Tests.CollectionAssertTest.IsOrdered_Handles_null" executed="True" result="Success" success="True" time="0.001" asserts="1" />
+                      <test-case name="NUnit.Framework.Tests.CollectionAssertTest.IsOrdered_TypesMustImplementIComparable" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                      <test-case name="NUnit.Framework.Tests.CollectionAssertTest.IsSubsetOf" executed="True" result="Success" success="True" time="0.000" asserts="2" />
+                      <test-case name="NUnit.Framework.Tests.CollectionAssertTest.IsSubsetOf_Fails" executed="True" result="Success" success="True" time="0.001" asserts="2" />
+                      <test-case name="NUnit.Framework.Tests.CollectionAssertTest.IsSubsetOfHandlesNull" executed="True" result="Success" success="True" time="0.000" asserts="2" />
+                      <test-case name="NUnit.Framework.Tests.CollectionAssertTest.ItemsNotNull" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                      <test-case name="NUnit.Framework.Tests.CollectionAssertTest.ItemsNotNullFailure" executed="True" result="Success" success="True" time="0.000" asserts="2" />
+                      <test-case name="NUnit.Framework.Tests.CollectionAssertTest.ItemsOfType" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                      <test-case name="NUnit.Framework.Tests.CollectionAssertTest.ItemsOfTypeFailure" executed="True" result="Success" success="True" time="0.000" asserts="2" />
+                      <test-case name="NUnit.Framework.Tests.CollectionAssertTest.NotEquivalent" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                      <test-case name="NUnit.Framework.Tests.CollectionAssertTest.NotEquivalent_Fails" executed="True" result="Success" success="True" time="0.001" asserts="2" />
+                      <test-case name="NUnit.Framework.Tests.CollectionAssertTest.NotEquivalentHandlesNull" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                      <test-case name="NUnit.Framework.Tests.CollectionAssertTest.Unique_WithNull" executed="True" result="Success" success="True" time="0.001" asserts="1" />
+                      <test-case name="NUnit.Framework.Tests.CollectionAssertTest.Unique_WithObjects" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                      <test-case name="NUnit.Framework.Tests.CollectionAssertTest.Unique_WithStrings" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                      <test-case name="NUnit.Framework.Tests.CollectionAssertTest.UniqueFailure" executed="True" result="Success" success="True" time="0.001" asserts="2" />
+                      <test-case name="NUnit.Framework.Tests.CollectionAssertTest.UniqueFailure_WithTwoNulls" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                    </results>
+                  </test-suite>
+                  <test-suite type="TestFixture" name="ConditionAssertTests" executed="True" result="Success" success="True" time="0.021" asserts="0">
+                    <results>
+                      <test-case name="NUnit.Framework.Tests.ConditionAssertTests.IsEmpty" executed="True" result="Success" success="True" time="0.000" asserts="5" />
+                      <test-case name="NUnit.Framework.Tests.ConditionAssertTests.IsEmptyFailsOnNonEmptyArray" executed="True" result="Success" success="True" time="0.001" asserts="2" />
+                      <test-case name="NUnit.Framework.Tests.ConditionAssertTests.IsEmptyFailsOnNonEmptyIEnumerable" executed="True" result="Success" success="True" time="0.000" asserts="2" />
+                      <test-case name="NUnit.Framework.Tests.ConditionAssertTests.IsEmptyFailsOnNullString" executed="True" result="Success" success="True" time="0.000" asserts="2" />
+                      <test-case name="NUnit.Framework.Tests.ConditionAssertTests.IsEmptyFailsOnString" executed="True" result="Success" success="True" time="0.000" asserts="2" />
+                      <test-case name="NUnit.Framework.Tests.ConditionAssertTests.IsFalse" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                      <test-case name="NUnit.Framework.Tests.ConditionAssertTests.IsFalseFails" executed="True" result="Success" success="True" time="0.000" asserts="2" />
+                      <test-case name="NUnit.Framework.Tests.ConditionAssertTests.IsNaN" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                      <test-case name="NUnit.Framework.Tests.ConditionAssertTests.IsNaNFails" executed="True" result="Success" success="True" time="0.000" asserts="2" />
+                      <test-case name="NUnit.Framework.Tests.ConditionAssertTests.IsNotEmpty" executed="True" result="Success" success="True" time="0.000" asserts="5" />
+                      <test-case name="NUnit.Framework.Tests.ConditionAssertTests.IsNotEmptyFailsOnEmptyArray" executed="True" result="Success" success="True" time="0.001" asserts="2" />
+                      <test-case name="NUnit.Framework.Tests.ConditionAssertTests.IsNotEmptyFailsOnEmptyArrayList" executed="True" result="Success" success="True" time="0.000" asserts="2" />
+                      <test-case name="NUnit.Framework.Tests.ConditionAssertTests.IsNotEmptyFailsOnEmptyHashTable" executed="True" result="Success" success="True" time="0.000" asserts="2" />
+                      <test-case name="NUnit.Framework.Tests.ConditionAssertTests.IsNotEmptyFailsOnEmptyIEnumerable" executed="True" result="Success" success="True" time="0.001" asserts="2" />
+                      <test-case name="NUnit.Framework.Tests.ConditionAssertTests.IsNotEmptyFailsOnEmptyString" executed="True" result="Success" success="True" time="0.001" asserts="2" />
+                      <test-case name="NUnit.Framework.Tests.ConditionAssertTests.IsNotNull" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                      <test-case name="NUnit.Framework.Tests.ConditionAssertTests.IsNotNullFails" executed="True" result="Success" success="True" time="0.000" asserts="2" />
+                      <test-case name="NUnit.Framework.Tests.ConditionAssertTests.IsNull" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                      <test-case name="NUnit.Framework.Tests.ConditionAssertTests.IsNullFails" executed="True" result="Success" success="True" time="0.000" asserts="2" />
+                      <test-case name="NUnit.Framework.Tests.ConditionAssertTests.IsTrue" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                      <test-case name="NUnit.Framework.Tests.ConditionAssertTests.IsTrueFails" executed="True" result="Success" success="True" time="0.000" asserts="2" />
+                    </results>
+                  </test-suite>
+                  <test-suite type="TestFixture" name="DirectoryAssertTests" executed="True" result="Success" success="True" time="0.208" asserts="0">
+                    <results>
+                      <test-case name="NUnit.Framework.Tests.DirectoryAssertTests.AreEqualFailsWhenOneDoesNotExist" executed="True" result="Success" success="True" time="0.019" asserts="1" />
+                      <test-case name="NUnit.Framework.Tests.DirectoryAssertTests.AreEqualFailsWhenOneIsNull" executed="True" result="Success" success="True" time="0.005" asserts="1" />
+                      <test-case name="NUnit.Framework.Tests.DirectoryAssertTests.AreEqualFailsWithDirectoryInfos" executed="True" result="Success" success="True" time="0.010" asserts="1" />
+                      <test-case name="NUnit.Framework.Tests.DirectoryAssertTests.AreEqualFailsWithStringPath" executed="True" result="Success" success="True" time="0.011" asserts="1" />
+                      <test-case name="NUnit.Framework.Tests.DirectoryAssertTests.AreEqualPassesWhenBothAreNull" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                      <test-case name="NUnit.Framework.Tests.DirectoryAssertTests.AreEqualPassesWithDirectoryInfos" executed="True" result="Success" success="True" time="0.005" asserts="1" />
+                      <test-case name="NUnit.Framework.Tests.DirectoryAssertTests.AreEqualPassesWithStringPath" executed="True" result="Success" success="True" time="0.005" asserts="1" />
+                      <test-case name="NUnit.Framework.Tests.DirectoryAssertTests.AreNotEqualFailsWhenBothAreNull" executed="True" result="Success" success="True" time="0.001" asserts="2" />
+                      <test-case name="NUnit.Framework.Tests.DirectoryAssertTests.AreNotEqualFailsWithDirectoryInfos" executed="True" result="Success" success="True" time="0.005" asserts="1" />
+                      <test-case name="NUnit.Framework.Tests.DirectoryAssertTests.AreNotEqualFailsWithStringPath" executed="True" result="Success" success="True" time="0.006" asserts="1" />
+                      <test-case name="NUnit.Framework.Tests.DirectoryAssertTests.AreNotEqualPassesIfOneIsNull" executed="True" result="Success" success="True" time="0.005" asserts="1" />
+                      <test-case name="NUnit.Framework.Tests.DirectoryAssertTests.AreNotEqualPassesWhenOneDoesNotExist" executed="True" result="Success" success="True" time="0.005" asserts="1" />
+                      <test-case name="NUnit.Framework.Tests.DirectoryAssertTests.AreNotEqualPassesWithStringPath" executed="True" result="Success" success="True" time="0.010" asserts="1" />
+                      <test-case name="NUnit.Framework.Tests.DirectoryAssertTests.IsEmptyFailsWithInvalidDirectory" executed="True" result="Success" success="True" time="0.008" asserts="1" />
+                      <test-case name="NUnit.Framework.Tests.DirectoryAssertTests.IsEmptyFailsWithNonEmptyDirectoryUsingDirectoryInfo" executed="True" result="Success" success="True" time="0.006" asserts="1" />
+                      <test-case name="NUnit.Framework.Tests.DirectoryAssertTests.IsEmptyFailsWithNonEmptyDirectoryUsingStringPath" executed="True" result="Success" success="True" time="0.006" asserts="1" />
+                      <test-case name="NUnit.Framework.Tests.DirectoryAssertTests.IsEmptyPassesWithEmptyDirectoryUsingDirectoryInfo" executed="True" result="Success" success="True" time="0.003" asserts="2" />
+                      <test-case name="NUnit.Framework.Tests.DirectoryAssertTests.IsEmptyPassesWithEmptyDirectoryUsingStringPath" executed="True" result="Success" success="True" time="0.003" asserts="1" />
+                      <test-case name="NUnit.Framework.Tests.DirectoryAssertTests.IsEmptyThrowsUsingNull" executed="True" result="Success" success="True" time="0.001" asserts="1" />
+                      <test-case name="NUnit.Framework.Tests.DirectoryAssertTests.IsNotEmptyFailsWithEmptyDirectoryUsingDirectoryInfo" executed="True" result="Success" success="True" time="0.003" asserts="1" />
+                      <test-case name="NUnit.Framework.Tests.DirectoryAssertTests.IsNotEmptyFailsWithEmptyDirectoryUsingStringPath" executed="True" result="Success" success="True" time="0.003" asserts="1" />
+                      <test-case name="NUnit.Framework.Tests.DirectoryAssertTests.IsNotEmptyFailsWithInvalidDirectory" executed="True" result="Success" success="True" time="0.003" asserts="1" />
+                      <test-case name="NUnit.Framework.Tests.DirectoryAssertTests.IsNotEmptyPassesWithNonEmptyDirectoryUsingDirectoryInfo" executed="True" result="Success" success="True" time="0.006" asserts="2" />
+                      <test-case name="NUnit.Framework.Tests.DirectoryAssertTests.IsNotEmptyPassesWithNonEmptyDirectoryUsingStringPath" executed="True" result="Success" success="True" time="0.006" asserts="1" />
+                      <test-case name="NUnit.Framework.Tests.DirectoryAssertTests.IsNotEmptyThrowsUsingNull" executed="True" result="Success" success="True" time="0.001" asserts="1" />
+                      <test-case name="NUnit.Framework.Tests.DirectoryAssertTests.IsNotWithinFailsWithDirectoryInfo" executed="True" result="Success" success="True" time="0.006" asserts="1" />
+                      <test-case name="NUnit.Framework.Tests.DirectoryAssertTests.IsNotWithinFailsWithStringPath" executed="True" result="Success" success="True" time="0.006" asserts="1" />
+                      <test-case name="NUnit.Framework.Tests.DirectoryAssertTests.IsNotWithinPassesWhenOutsidePathUsingDirectoryInfo" executed="True" result="Success" success="True" time="0.006" asserts="1" />
+                      <test-case name="NUnit.Framework.Tests.DirectoryAssertTests.IsNotWithinPassesWhenOutsidePathUsingStringPath" executed="True" result="Success" success="True" time="0.006" asserts="1" />
+                      <test-case name="NUnit.Framework.Tests.DirectoryAssertTests.IsNotWithinThrowsWhenBothAreNull" executed="True" result="Success" success="True" time="0.001" asserts="0" />
+                      <test-case name="NUnit.Framework.Tests.DirectoryAssertTests.IsWithinFailsWhenOutsidePathUsingDirectoryInfo" executed="True" result="Success" success="True" time="0.006" asserts="1" />
+                      <test-case name="NUnit.Framework.Tests.DirectoryAssertTests.IsWithinFailsWhenOutsidePathUsingStringPath" executed="True" result="Success" success="True" time="0.006" asserts="1" />
+                      <test-case name="NUnit.Framework.Tests.DirectoryAssertTests.IsWithinPassesWithDirectoryInfo" executed="True" result="Success" success="True" time="0.005" asserts="1" />
+                      <test-case name="NUnit.Framework.Tests.DirectoryAssertTests.IsWithinPassesWithStringPath" executed="True" result="Success" success="True" time="0.005" asserts="1" />
+                      <test-case name="NUnit.Framework.Tests.DirectoryAssertTests.IsWithinPassesWithTempPath" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                      <test-case name="NUnit.Framework.Tests.DirectoryAssertTests.IsWithinThrowsWhenBothAreNull" executed="True" result="Success" success="True" time="0.001" asserts="0" />
+                    </results>
+                  </test-suite>
+                  <test-suite type="TestFixture" name="EqualsFixture" executed="True" result="Success" success="True" time="0.048" asserts="0">
+                    <results>
+                      <test-case name="NUnit.Framework.Tests.EqualsFixture.Bug575936Int32Int64Comparison" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                      <test-case name="NUnit.Framework.Tests.EqualsFixture.Byte" executed="True" result="Success" success="True" time="0.000" asserts="2" />
+                      <test-case name="NUnit.Framework.Tests.EqualsFixture.DateTimeEqual" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                      <test-case name="NUnit.Framework.Tests.EqualsFixture.DateTimeNotEqual" executed="True" result="Success" success="True" time="0.001" asserts="2" />
+                      <test-case name="NUnit.Framework.Tests.EqualsFixture.Decimal" executed="True" result="Success" success="True" time="0.001" asserts="6" />
+                      <test-case name="NUnit.Framework.Tests.EqualsFixture.DirectoryInfoEquality" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                      <test-case name="NUnit.Framework.Tests.EqualsFixture.DirectoryInfoEqualityIgnoresTrailingDirectorySeparator" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                      <test-case name="NUnit.Framework.Tests.EqualsFixture.DoubleNotEqualMessageDisplaysAllDigits" executed="True" result="Success" success="True" time="0.001" asserts="2" />
+                      <test-case name="NUnit.Framework.Tests.EqualsFixture.DoubleNotEqualMessageDisplaysDefaultTolerance" executed="True" result="Success" success="True" time="0.001" asserts="2" />
+                      <test-case name="NUnit.Framework.Tests.EqualsFixture.DoubleNotEqualMessageDisplaysTolerance" executed="True" result="Success" success="True" time="0.001" asserts="2" />
+                      <test-case name="NUnit.Framework.Tests.EqualsFixture.DoubleNotEqualWithNanDoesNotDisplayDefaultTolerance" executed="True" result="Success" success="True" time="0.001" asserts="2" />
+                      <test-case name="NUnit.Framework.Tests.EqualsFixture.EnumsEqual" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                      <test-case name="NUnit.Framework.Tests.EqualsFixture.EnumsNotEqual" executed="True" result="Success" success="True" time="0.001" asserts="2" />
+                      <test-case name="NUnit.Framework.Tests.EqualsFixture.Equals" executed="True" result="Success" success="True" time="0.000" asserts="2" />
+                      <test-case name="NUnit.Framework.Tests.EqualsFixture.EqualsFail" executed="True" result="Success" success="True" time="0.001" asserts="2" />
+                      <test-case name="NUnit.Framework.Tests.EqualsFixture.EqualsNaNFails" executed="True" result="Success" success="True" time="0.000" asserts="2" />
+                      <test-case name="NUnit.Framework.Tests.EqualsFixture.EqualsNull" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                      <test-case name="NUnit.Framework.Tests.EqualsFixture.EqualsSameTypes" executed="True" result="Success" success="True" time="0.014" asserts="31" />
+                      <test-case name="NUnit.Framework.Tests.EqualsFixture.EqualsThrowsException" executed="True" result="Success" success="True" time="0.001" asserts="0" />
+                      <test-case name="NUnit.Framework.Tests.EqualsFixture.Float" executed="True" result="Success" success="True" time="0.000" asserts="2" />
+                      <test-case name="NUnit.Framework.Tests.EqualsFixture.FloatNotEqualMessageDisplaysAllDigits" executed="True" result="Success" success="True" time="0.000" asserts="2" />
+                      <test-case name="NUnit.Framework.Tests.EqualsFixture.FloatNotEqualMessageDisplaysTolerance" executed="True" result="Success" success="True" time="0.000" asserts="2" />
+                      <test-case name="NUnit.Framework.Tests.EqualsFixture.IEquatableSuccess_ConstraintSyntax" executed="True" result="Success" success="True" time="0.000" asserts="2" />
+                      <test-case name="NUnit.Framework.Tests.EqualsFixture.IEquatableSuccess_OldSyntax" executed="True" result="Success" success="True" time="0.000" asserts="2" />
+                      <test-case name="NUnit.Framework.Tests.EqualsFixture.Int" executed="True" result="Success" success="True" time="0.000" asserts="2" />
+                      <test-case name="NUnit.Framework.Tests.EqualsFixture.IntegerEquals" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                      <test-case name="NUnit.Framework.Tests.EqualsFixture.IntegerLongComparison" executed="True" result="Success" success="True" time="0.000" asserts="2" />
+                      <test-case name="NUnit.Framework.Tests.EqualsFixture.NanEqualsFails" executed="True" result="Success" success="True" time="0.000" asserts="2" />
+                      <test-case name="NUnit.Framework.Tests.EqualsFixture.NanEqualsNaNSucceeds" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                      <test-case name="NUnit.Framework.Tests.EqualsFixture.NegInfinityEqualsInfinity" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                      <test-case name="NUnit.Framework.Tests.EqualsFixture.PosInfinityEqualsInfinity" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                      <test-case name="NUnit.Framework.Tests.EqualsFixture.PosInfinityNotEquals" executed="True" result="Success" success="True" time="0.000" asserts="2" />
+                      <test-case name="NUnit.Framework.Tests.EqualsFixture.PosInfinityNotEqualsNegInfinity" executed="True" result="Success" success="True" time="0.000" asserts="2" />
+                      <test-case name="NUnit.Framework.Tests.EqualsFixture.ReferenceEqualsThrowsException" executed="True" result="Success" success="True" time="0.000" asserts="0" />
+                      <test-case name="NUnit.Framework.Tests.EqualsFixture.Short" executed="True" result="Success" success="True" time="0.000" asserts="2" />
+                      <test-case name="NUnit.Framework.Tests.EqualsFixture.SinglePosInfinityNotEqualsNegInfinity" executed="True" result="Success" success="True" time="0.000" asserts="2" />
+                      <test-case name="NUnit.Framework.Tests.EqualsFixture.String" executed="True" result="Success" success="True" time="0.000" asserts="2" />
+                      <test-case name="NUnit.Framework.Tests.EqualsFixture.UInt" executed="True" result="Success" success="True" time="0.000" asserts="2" />
+                    </results>
+                  </test-suite>
+                  <test-suite type="TestFixture" name="FileAssertTests" executed="True" result="Success" success="True" time="0.098" asserts="0">
+                    <results>
+                      <test-case name="NUnit.Framework.Tests.FileAssertTests.AreEqualFailsWhenOneIsNull" executed="True" result="Success" success="True" time="0.004" asserts="2" />
+                      <test-case name="NUnit.Framework.Tests.FileAssertTests.AreEqualFailsWithFileInfos" executed="True" result="Success" success="True" time="0.005" asserts="2" />
+                      <test-case name="NUnit.Framework.Tests.FileAssertTests.AreEqualFailsWithFiles" executed="True" result="Success" success="True" time="0.005" asserts="2" />
+                      <test-case name="NUnit.Framework.Tests.FileAssertTests.AreEqualFailsWithStreams" executed="True" result="Success" success="True" time="0.004" asserts="2" />
+                      <test-case name="NUnit.Framework.Tests.FileAssertTests.AreEqualFailsWithTextFilesAfterReadingBothFiles" executed="True" result="Success" success="True" time="0.005" asserts="1" />
+                      <test-case name="NUnit.Framework.Tests.FileAssertTests.AreEqualPassesUsingSameFileTwice" executed="True" result="Success" success="True" time="0.002" asserts="1" />
+                      <test-case name="NUnit.Framework.Tests.FileAssertTests.AreEqualPassesWhenBothAreNull" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                      <test-case name="NUnit.Framework.Tests.FileAssertTests.AreEqualPassesWithEqualStreams" executed="True" result="Success" success="True" time="0.003" asserts="1" />
+                      <test-case name="NUnit.Framework.Tests.FileAssertTests.AreEqualPassesWithFileInfos" executed="True" result="Success" success="True" time="0.004" asserts="2" />
+                      <test-case name="NUnit.Framework.Tests.FileAssertTests.AreEqualPassesWithFiles" executed="True" result="Success" success="True" time="0.003" asserts="1" />
+                      <test-case name="NUnit.Framework.Tests.FileAssertTests.AreEqualPassesWithSameStream" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                      <test-case name="NUnit.Framework.Tests.FileAssertTests.AreEqualPassesWithTextFiles" executed="True" result="Success" success="True" time="0.004" asserts="1" />
+                      <test-case name="NUnit.Framework.Tests.FileAssertTests.AreNotEqualFailsWhenBothAreNull" executed="True" result="Success" success="True" time="0.001" asserts="2" />
+                      <test-case name="NUnit.Framework.Tests.FileAssertTests.AreNotEqualFailsWithFileInfos" executed="True" result="Success" success="True" time="0.004" asserts="2" />
+                      <test-case name="NUnit.Framework.Tests.FileAssertTests.AreNotEqualFailsWithFiles" executed="True" result="Success" success="True" time="0.003" asserts="2" />
+                      <test-case name="NUnit.Framework.Tests.FileAssertTests.AreNotEqualFailsWithStreams" executed="True" result="Success" success="True" time="0.004" asserts="2" />
+                      <test-case name="NUnit.Framework.Tests.FileAssertTests.AreNotEqualIteratesOverTheEntireFile" executed="True" result="Success" success="True" time="0.004" asserts="1" />
+                      <test-case name="NUnit.Framework.Tests.FileAssertTests.AreNotEqualIteratesOverTheEntireFileAndFails" executed="True" result="Success" success="True" time="0.005" asserts="2" />
+                      <test-case name="NUnit.Framework.Tests.FileAssertTests.AreNotEqualPassesIfOneIsNull" executed="True" result="Success" success="True" time="0.002" asserts="1" />
+                      <test-case name="NUnit.Framework.Tests.FileAssertTests.AreNotEqualPassesWithFileInfos" executed="True" result="Success" success="True" time="0.004" asserts="1" />
+                      <test-case name="NUnit.Framework.Tests.FileAssertTests.AreNotEqualPassesWithFiles" executed="True" result="Success" success="True" time="0.003" asserts="1" />
+                      <test-case name="NUnit.Framework.Tests.FileAssertTests.AreNotEqualPassesWithStreams" executed="True" result="Success" success="True" time="0.004" asserts="1" />
+                      <test-case name="NUnit.Framework.Tests.FileAssertTests.NonReadableStreamGivesException" executed="True" result="Success" success="True" time="0.004" asserts="1" />
+                      <test-case name="NUnit.Framework.Tests.FileAssertTests.NonSeekableStreamGivesException" executed="True" result="Success" success="True" time="0.002" asserts="1" />
+                    </results>
+                  </test-suite>
+                  <test-suite type="TestFixture" name="GreaterEqualFixture" executed="True" result="Success" success="True" time="0.249" asserts="0">
+                    <results>
+                      <test-case name="NUnit.Framework.Tests.GreaterEqualFixture.FailureMessage" executed="True" result="Success" success="True" time="0.001" asserts="3" />
+                      <test-case name="NUnit.Framework.Tests.GreaterEqualFixture.GreaterOrEqual_Decimal" executed="True" result="Success" success="True" time="0.001" asserts="2" />
+                      <test-case name="NUnit.Framework.Tests.GreaterEqualFixture.GreaterOrEqual_Double" executed="True" result="Success" success="True" time="0.001" asserts="2" />
+                      <test-case name="NUnit.Framework.Tests.GreaterEqualFixture.GreaterOrEqual_Float" executed="True" result="Success" success="True" time="0.001" asserts="2" />
+                      <test-case name="NUnit.Framework.Tests.GreaterEqualFixture.GreaterOrEqual_Int32" executed="True" result="Success" success="True" time="0.000" asserts="2" />
+                      <test-case name="NUnit.Framework.Tests.GreaterEqualFixture.GreaterOrEqual_Long" executed="True" result="Success" success="True" time="0.000" asserts="2" />
+                      <test-case name="NUnit.Framework.Tests.GreaterEqualFixture.GreaterOrEqual_UInt32" executed="True" result="Success" success="True" time="0.001" asserts="2" />
+                      <test-case name="NUnit.Framework.Tests.GreaterEqualFixture.GreaterOrEqual_ULong" executed="True" result="Success" success="True" time="0.001" asserts="2" />
+                      <test-case name="NUnit.Framework.Tests.GreaterEqualFixture.MixedTypes" executed="True" result="Success" success="True" time="0.003" asserts="42" />
+                      <test-case name="NUnit.Framework.Tests.GreaterEqualFixture.NotGreaterEqualIComparable" executed="True" result="Success" success="True" time="0.003" asserts="2" />
+                      <test-case name="NUnit.Framework.Tests.GreaterEqualFixture.NotGreaterOrEqual" executed="True" result="Success" success="True" time="0.002" asserts="2" />
+                    </results>
+                  </test-suite>
+                  <test-suite type="TestFixture" name="GreaterFixture" executed="True" result="Success" success="True" time="0.009" asserts="0">
+                    <results>
+                      <test-case name="NUnit.Framework.Tests.GreaterFixture.FailureMessage" executed="True" result="Success" success="True" time="0.001" asserts="2" />
+                      <test-case name="NUnit.Framework.Tests.GreaterFixture.Greater" executed="True" result="Success" success="True" time="0.001" asserts="7" />
+                      <test-case name="NUnit.Framework.Tests.GreaterFixture.MixedTypes" executed="True" result="Success" success="True" time="0.002" asserts="42" />
+                      <test-case name="NUnit.Framework.Tests.GreaterFixture.NotGreater" executed="True" result="Success" success="True" time="0.000" asserts="2" />
+                      <test-case name="NUnit.Framework.Tests.GreaterFixture.NotGreaterIComparable" executed="True" result="Success" success="True" time="0.001" asserts="2" />
+                      <test-case name="NUnit.Framework.Tests.GreaterFixture.NotGreaterWhenEqual" executed="True" result="Success" success="True" time="0.000" asserts="2" />
+                    </results>
+                  </test-suite>
+                  <test-suite type="TestFixture" name="LessEqualFixture" executed="True" result="Success" success="True" time="0.010" asserts="0">
+                    <results>
+                      <test-case name="NUnit.Framework.Tests.LessEqualFixture.FailureMessage" executed="True" result="Success" success="True" time="0.001" asserts="2" />
+                      <test-case name="NUnit.Framework.Tests.LessEqualFixture.LessOrEqual" executed="True" result="Success" success="True" time="0.003" asserts="42" />
+                      <test-case name="NUnit.Framework.Tests.LessEqualFixture.MixedTypes" executed="True" result="Success" success="True" time="0.001" asserts="42" />
+                      <test-case name="NUnit.Framework.Tests.LessEqualFixture.NotLessEqualIComparable" executed="True" result="Success" success="True" time="0.001" asserts="2" />
+                      <test-case name="NUnit.Framework.Tests.LessEqualFixture.NotLessOrEqual" executed="True" result="Success" success="True" time="0.000" asserts="2" />
+                    </results>
+                  </test-suite>
+                  <test-suite type="TestFixture" name="LessFixture" executed="True" result="Success" success="True" time="0.009" asserts="0">
+                    <results>
+                      <test-case name="NUnit.Framework.Tests.LessFixture.FailureMessage" executed="True" result="Success" success="True" time="0.000" asserts="3" />
+                      <test-case name="NUnit.Framework.Tests.LessFixture.Less" executed="True" result="Success" success="True" time="0.002" asserts="18" />
+                      <test-case name="NUnit.Framework.Tests.LessFixture.MixedTypes" executed="True" result="Success" success="True" time="0.001" asserts="42" />
+                      <test-case name="NUnit.Framework.Tests.LessFixture.NotLess" executed="True" result="Success" success="True" time="0.001" asserts="2" />
+                      <test-case name="NUnit.Framework.Tests.LessFixture.NotLessIComparable" executed="True" result="Success" success="True" time="0.001" asserts="2" />
+                      <test-case name="NUnit.Framework.Tests.LessFixture.NotLessWhenEqual" executed="True" result="Success" success="True" time="0.000" asserts="2" />
+                    </results>
+                  </test-suite>
+                  <test-suite type="TestFixture" name="ListContentsTests" executed="True" result="Success" success="True" time="0.007" asserts="0">
+                    <results>
+                      <test-case name="NUnit.Framework.Tests.ListContentsTests.ArrayFails" executed="True" result="Success" success="True" time="0.001" asserts="2" />
+                      <test-case name="NUnit.Framework.Tests.ListContentsTests.ArrayListFails" executed="True" result="Success" success="True" time="0.000" asserts="2" />
+                      <test-case name="NUnit.Framework.Tests.ListContentsTests.ArrayListSucceeds" executed="True" result="Success" success="True" time="0.000" asserts="3" />
+                      <test-case name="NUnit.Framework.Tests.ListContentsTests.ArraySucceeds" executed="True" result="Success" success="True" time="0.000" asserts="3" />
+                      <test-case name="NUnit.Framework.Tests.ListContentsTests.DifferentTypesMayBeEqual" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                      <test-case name="NUnit.Framework.Tests.ListContentsTests.EmptyArrayFails" executed="True" result="Success" success="True" time="0.000" asserts="2" />
+                      <test-case name="NUnit.Framework.Tests.ListContentsTests.NullArrayIsError" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                    </results>
+                  </test-suite>
+                  <test-suite type="TestFixture" name="NotEqualFixture" executed="True" result="Success" success="True" time="0.009" asserts="0">
+                    <results>
+                      <test-case name="NUnit.Framework.Tests.NotEqualFixture.ArraysNotEqual" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                      <test-case name="NUnit.Framework.Tests.NotEqualFixture.ArraysNotEqualFails" executed="True" result="Success" success="True" time="0.001" asserts="2" />
+                      <test-case name="NUnit.Framework.Tests.NotEqualFixture.NotEqual" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                      <test-case name="NUnit.Framework.Tests.NotEqualFixture.NotEqualFails" executed="True" result="Success" success="True" time="0.000" asserts="2" />
+                      <test-case name="NUnit.Framework.Tests.NotEqualFixture.NotEqualSameTypes" executed="True" result="Success" success="True" time="0.001" asserts="21" />
+                      <test-case name="NUnit.Framework.Tests.NotEqualFixture.NullEqualsNull" executed="True" result="Success" success="True" time="0.001" asserts="2" />
+                      <test-case name="NUnit.Framework.Tests.NotEqualFixture.NullNotEqualToNonNull" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                      <test-case name="NUnit.Framework.Tests.NotEqualFixture.UInt" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                    </results>
+                  </test-suite>
+                  <test-suite type="TestFixture" name="NotSameFixture" executed="True" result="Success" success="True" time="0.002" asserts="0">
+                    <results>
+                      <test-case name="NUnit.Framework.Tests.NotSameFixture.NotSame" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                      <test-case name="NUnit.Framework.Tests.NotSameFixture.NotSameFails" executed="True" result="Success" success="True" time="0.000" asserts="2" />
+                    </results>
+                  </test-suite>
+                  <test-suite type="TestFixture" name="NullableTypesTests" executed="True" result="Success" success="True" time="0.007" asserts="0">
+                    <categories>
+                      <category name="Generics" />
+                    </categories>
+                    <results>
+                      <test-case name="NUnit.Framework.Tests.NullableTypesTests.CanCompareNullableEnums" executed="True" result="Success" success="True" time="0.001" asserts="3" />
+                      <test-case name="NUnit.Framework.Tests.NullableTypesTests.CanCompareNullableMixedNumerics" executed="True" result="Success" success="True" time="0.002" asserts="36" />
+                      <test-case name="NUnit.Framework.Tests.NullableTypesTests.CanCompareNullableStructs" executed="True" result="Success" success="True" time="0.001" asserts="4" />
+                      <test-case name="NUnit.Framework.Tests.NullableTypesTests.CanCompareWithTolerance" executed="True" result="Success" success="True" time="0.001" asserts="4" />
+                      <test-case name="NUnit.Framework.Tests.NullableTypesTests.CanTestForNaN" executed="True" result="Success" success="True" time="0.000" asserts="2" />
+                      <test-case name="NUnit.Framework.Tests.NullableTypesTests.CanTestForNull" executed="True" result="Success" success="True" time="0.000" asserts="4" />
+                    </results>
+                  </test-suite>
+                  <test-suite type="TestFixture" name="RandomizerTests" executed="True" result="Success" success="True" time="0.007" asserts="0">
+                    <results>
+                      <test-case name="NUnit.Framework.Tests.RandomizerTests.RandomDoublesAreUnique" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                      <test-case name="NUnit.Framework.Tests.RandomizerTests.RandomIntsAreUnique" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                      <test-case name="NUnit.Framework.Tests.RandomizerTests.RandomizersWithDifferentSeedsReturnDifferentValues" executed="True" result="Success" success="True" time="0.000" asserts="10" />
+                      <test-case name="NUnit.Framework.Tests.RandomizerTests.RandomizersWithSameSeedsReturnSameValues" executed="True" result="Success" success="True" time="0.000" asserts="10" />
+                      <test-case name="NUnit.Framework.Tests.RandomizerTests.RandomSeedsAreUnique" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                      <test-case name="NUnit.Framework.Tests.RandomizerTests.ReturnsDifferentRandomizersForDifferentMethods" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                      <test-case name="NUnit.Framework.Tests.RandomizerTests.ReturnsSameRandomizerForDifferentParametersOfSameMethod" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                      <test-case name="NUnit.Framework.Tests.RandomizerTests.ReturnsSameRandomizerForSameMethod" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                      <test-case name="NUnit.Framework.Tests.RandomizerTests.ReturnsSameRandomizerForSameParameter" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                    </results>
+                  </test-suite>
+                  <test-suite type="TestFixture" name="RangeTests" executed="True" result="Success" success="True" time="0.010" asserts="0">
+                    <results>
+                      <test-case name="NUnit.Framework.Tests.RangeTests.InRangeFails" executed="True" result="Success" success="True" time="0.001" asserts="2" />
+                      <test-case name="NUnit.Framework.Tests.RangeTests.InRangeSucceeds" executed="True" result="Success" success="True" time="0.002" asserts="3" />
+                      <test-case name="NUnit.Framework.Tests.RangeTests.NotInRangeFails" executed="True" result="Success" success="True" time="0.001" asserts="2" />
+                      <test-case name="NUnit.Framework.Tests.RangeTests.NotInRangeSucceeds" executed="True" result="Success" success="True" time="0.000" asserts="2" />
+                      <test-suite type="ParameterizedTest" name="RangeBoundaryConditions" executed="True" result="Success" success="True" time="0.002" asserts="0">
+                        <results>
+                          <test-case name="NUnit.Framework.Tests.RangeTests.RangeBoundaryConditions(9,9,10)" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Framework.Tests.RangeTests.RangeBoundaryConditions(10,9,10)" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                          <test-case name="NUnit.Framework.Tests.RangeTests.RangeBoundaryConditions(9,9,9)" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                        </results>
+                      </test-suite>
+                      <test-case name="NUnit.Framework.Tests.RangeTests.ShouldThrowExceptionIfFromIsLessThanTo" executed="True" result="Success" success="True" time="0.001" asserts="1" />
+                    </results>
+                  </test-suite>
+                  <test-suite type="TestFixture" name="SameFixture" executed="True" result="Success" success="True" time="0.003" asserts="0">
+                    <results>
+                      <test-case name="NUnit.Framework.Tests.SameFixture.Same" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                      <test-case name="NUnit.Framework.Tests.SameFixture.SameFails" executed="True" result="Success" success="True" time="0.001" asserts="2" />
+                      <test-case name="NUnit.Framework.Tests.SameFixture.SameValueTypes" executed="True" result="Success" success="True" time="0.000" asserts="2" />
+                    </results>
+                  </test-suite>
+                  <test-suite type="TestFixture" name="StringAssertTests" executed="True" result="Success" success="True" time="0.017" asserts="0">
+                    <results>
+                      <test-case name="NUnit.Framework.Tests.StringAssertTests.CaseInsensitiveCompare" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                      <test-case name="NUnit.Framework.Tests.StringAssertTests.CaseInsensitiveCompareFails" executed="True" result="Success" success="True" time="0.001" asserts="2" />
+                      <test-case name="NUnit.Framework.Tests.StringAssertTests.Contains" executed="True" result="Success" success="True" time="0.000" asserts="3" />
+                      <test-case name="NUnit.Framework.Tests.StringAssertTests.ContainsFails" executed="True" result="Success" success="True" time="0.000" asserts="2" />
+                      <test-case name="NUnit.Framework.Tests.StringAssertTests.DifferentEncodingsOfSameStringAreNotEqual" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                      <test-case name="NUnit.Framework.Tests.StringAssertTests.DoesNotContain" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                      <test-case name="NUnit.Framework.Tests.StringAssertTests.DoesNotContainFails" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                      <test-case name="NUnit.Framework.Tests.StringAssertTests.DoesNotEndWith" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                      <test-case name="NUnit.Framework.Tests.StringAssertTests.DoesNotEndWithFails" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                      <test-case name="NUnit.Framework.Tests.StringAssertTests.DoesNotStartWith" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                      <test-case name="NUnit.Framework.Tests.StringAssertTests.DoesNotStartWithFails" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                      <test-case name="NUnit.Framework.Tests.StringAssertTests.EndsWith" executed="True" result="Success" success="True" time="0.000" asserts="2" />
+                      <test-case name="NUnit.Framework.Tests.StringAssertTests.EndsWithFails" executed="True" result="Success" success="True" time="0.000" asserts="2" />
+                      <test-case name="NUnit.Framework.Tests.StringAssertTests.IsMatch" executed="True" result="Success" success="True" time="0.002" asserts="1" />
+                      <test-case name="NUnit.Framework.Tests.StringAssertTests.IsMatchFails" executed="True" result="Success" success="True" time="0.001" asserts="2" />
+                      <test-case name="NUnit.Framework.Tests.StringAssertTests.StartsWith" executed="True" result="Success" success="True" time="0.000" asserts="2" />
+                      <test-case name="NUnit.Framework.Tests.StringAssertTests.StartsWithFails" executed="True" result="Success" success="True" time="0.001" asserts="2" />
+                    </results>
+                  </test-suite>
+                  <test-suite type="TestFixture" name="TestFixtureAttributeTests" executed="True" result="Success" success="True" time="0.006" asserts="0">
+                    <results>
+                      <test-case name="NUnit.Framework.Tests.TestFixtureAttributeTests.ConstructWithCombinedArgs" executed="True" result="Success" success="True" time="0.000" asserts="2">
+                        <categories>
+                          <category name="Generics" />
+                        </categories>
+                      </test-case>
+                      <test-case name="NUnit.Framework.Tests.TestFixtureAttributeTests.ConstructWithFixtureArgs" executed="True" result="Success" success="True" time="0.000" asserts="2" />
+                      <test-case name="NUnit.Framework.Tests.TestFixtureAttributeTests.ConstructWithFixtureArgsAndSetTypeArgs" executed="True" result="Success" success="True" time="0.000" asserts="2">
+                        <categories>
+                          <category name="Generics" />
+                        </categories>
+                      </test-case>
+                      <test-case name="NUnit.Framework.Tests.TestFixtureAttributeTests.ConstructWithJustTypeArgs" executed="True" result="Success" success="True" time="0.000" asserts="2">
+                        <categories>
+                          <category name="Generics" />
+                        </categories>
+                      </test-case>
+                      <test-case name="NUnit.Framework.Tests.TestFixtureAttributeTests.ConstructWithNoArgumentsAndSetTypeArgs" executed="True" result="Success" success="True" time="0.000" asserts="2">
+                        <categories>
+                          <category name="Generics" />
+                        </categories>
+                      </test-case>
+                      <test-case name="NUnit.Framework.Tests.TestFixtureAttributeTests.ConstructWithoutArguments" executed="True" result="Success" success="True" time="0.000" asserts="2" />
+                    </results>
+                  </test-suite>
+                  <test-suite type="TestFixture" name="TextMessageWriterTests" executed="True" result="Success" success="True" time="0.009" asserts="0">
+                    <results>
+                      <test-case name="NUnit.Framework.Tests.TextMessageWriterTests.ConnectorIsWrittenWithSurroundingSpaces" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                      <test-case name="NUnit.Framework.Tests.TextMessageWriterTests.DateTimeTest" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                      <test-case name="NUnit.Framework.Tests.TextMessageWriterTests.DecimalIsWrittenToTwentyNineDigits" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                      <test-case name="NUnit.Framework.Tests.TextMessageWriterTests.DecimalIsWrittenWithTrailingM" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                      <test-case name="NUnit.Framework.Tests.TextMessageWriterTests.DisplayStringDifferences" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                      <test-case name="NUnit.Framework.Tests.TextMessageWriterTests.DisplayStringDifferences_NoClipping" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                      <test-case name="NUnit.Framework.Tests.TextMessageWriterTests.DoubleIsWrittenToSeventeenDigits" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                      <test-case name="NUnit.Framework.Tests.TextMessageWriterTests.DoubleIsWrittenWithTrailingD" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                      <test-case name="NUnit.Framework.Tests.TextMessageWriterTests.FloatIsWrittenToNineDigits" executed="True" result="Success" success="True" time="0.000" asserts="2" />
+                      <test-case name="NUnit.Framework.Tests.TextMessageWriterTests.FloatIsWrittenWithTrailingF" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                      <test-case name="NUnit.Framework.Tests.TextMessageWriterTests.IntegerIsWrittenAsIs" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                      <test-case name="NUnit.Framework.Tests.TextMessageWriterTests.PredicateIsWrittenWithTrailingSpace" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                      <test-case name="NUnit.Framework.Tests.TextMessageWriterTests.StringIsWrittenWithQuotes" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                    </results>
+                  </test-suite>
+                  <test-suite type="TestFixture" name="TypeAssertTests" executed="True" result="Success" success="True" time="0.010" asserts="0">
+                    <results>
+                      <test-case name="NUnit.Framework.Tests.TypeAssertTests.ExactType" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                      <test-case name="NUnit.Framework.Tests.TypeAssertTests.ExactTypeFails" executed="True" result="Success" success="True" time="0.001" asserts="2" />
+                      <test-case name="NUnit.Framework.Tests.TypeAssertTests.IsAssignableFrom" executed="True" result="Success" success="True" time="0.001" asserts="3" />
+                      <test-case name="NUnit.Framework.Tests.TypeAssertTests.IsAssignableFromFails" executed="True" result="Success" success="True" time="0.001" asserts="2" />
+                      <test-case name="NUnit.Framework.Tests.TypeAssertTests.IsInstanceOf" executed="True" result="Success" success="True" time="0.001" asserts="3" />
+                      <test-case name="NUnit.Framework.Tests.TypeAssertTests.IsInstanceOfFails" executed="True" result="Success" success="True" time="0.000" asserts="2" />
+                      <test-case name="NUnit.Framework.Tests.TypeAssertTests.IsNotAssignableFrom" executed="True" result="Success" success="True" time="0.001" asserts="3" />
+                      <test-case name="NUnit.Framework.Tests.TypeAssertTests.IsNotAssignableFromFails" executed="True" result="Success" success="True" time="0.000" asserts="2" />
+                      <test-case name="NUnit.Framework.Tests.TypeAssertTests.IsNotInstanceOf" executed="True" result="Success" success="True" time="0.001" asserts="3" />
+                      <test-case name="NUnit.Framework.Tests.TypeAssertTests.IsNotInstanceOfFails" executed="True" result="Success" success="True" time="0.000" asserts="2" />
+                    </results>
+                  </test-suite>
+                  <test-suite type="TestFixture" name="ValuesAttributeTests" executed="True" result="Success" success="True" time="0.041" asserts="0">
+                    <results>
+                      <test-suite type="ParameterizedTest" name="CanConverDoubleToDecimal" executed="True" result="Success" success="True" time="0.000" asserts="0">
+                        <results>
+                          <test-case name="NUnit.Framework.Tests.ValuesAttributeTests.CanConverDoubleToDecimal(12.5m)" executed="True" result="Success" success="True" time="0.000" asserts="0" />
+                        </results>
+                      </test-suite>
+                      <test-suite type="ParameterizedTest" name="CanConvertDoubleRangeToDecimal" executed="True" result="Success" success="True" time="0.002" asserts="0">
+                        <results>
+                          <test-case name="NUnit.Framework.Tests.ValuesAttributeTests.CanConvertDoubleRangeToDecimal(1m)" executed="True" result="Success" success="True" time="0.000" asserts="0" />
+                          <test-case name="NUnit.Framework.Tests.ValuesAttributeTests.CanConvertDoubleRangeToDecimal(1.1m)" executed="True" result="Success" success="True" time="0.000" asserts="0" />
+                          <test-case name="NUnit.Framework.Tests.ValuesAttributeTests.CanConvertDoubleRangeToDecimal(1.2m)" executed="True" result="Success" success="True" time="0.000" asserts="0" />
+                          <test-case name="NUnit.Framework.Tests.ValuesAttributeTests.CanConvertDoubleRangeToDecimal(1.3m)" executed="True" result="Success" success="True" time="0.000" asserts="0" />
+                        </results>
+                      </test-suite>
+                      <test-suite type="ParameterizedTest" name="CanConvertIntRangeToByte" executed="True" result="Success" success="True" time="0.001" asserts="0">
+                        <results>
+                          <test-case name="NUnit.Framework.Tests.ValuesAttributeTests.CanConvertIntRangeToByte(1)" executed="True" result="Success" success="True" time="0.000" asserts="0" />
+                          <test-case name="NUnit.Framework.Tests.ValuesAttributeTests.CanConvertIntRangeToByte(2)" executed="True" result="Success" success="True" time="0.000" asserts="0" />
+                          <test-case name="NUnit.Framework.Tests.ValuesAttributeTests.CanConvertIntRangeToByte(3)" executed="True" result="Success" success="True" time="0.000" asserts="0" />
+                        </results>
+                      </test-suite>
+                      <test-suite type="ParameterizedTest" name="CanConvertIntRangeToDecimal" executed="True" result="Success" success="True" time="0.001" asserts="0">
+                        <results>
+                          <test-case name="NUnit.Framework.Tests.ValuesAttributeTests.CanConvertIntRangeToDecimal(1m)" executed="True" result="Success" success="True" time="0.000" asserts="0" />
+                          <test-case name="NUnit.Framework.Tests.ValuesAttributeTests.CanConvertIntRangeToDecimal(2m)" executed="True" result="Success" success="True" time="0.000" asserts="0" />
+                          <test-case name="NUnit.Framework.Tests.ValuesAttributeTests.CanConvertIntRangeToDecimal(3m)" executed="True" result="Success" success="True" time="0.000" asserts="0" />
+                        </results>
+                      </test-suite>
+                      <test-suite type="ParameterizedTest" name="CanConvertIntRangeToSByte" executed="True" result="Success" success="True" time="0.001" asserts="0">
+                        <results>
+                          <test-case name="NUnit.Framework.Tests.ValuesAttributeTests.CanConvertIntRangeToSByte(1)" executed="True" result="Success" success="True" time="0.000" asserts="0" />
+                          <test-case name="NUnit.Framework.Tests.ValuesAttributeTests.CanConvertIntRangeToSByte(2)" executed="True" result="Success" success="True" time="0.000" asserts="0" />
+                          <test-case name="NUnit.Framework.Tests.ValuesAttributeTests.CanConvertIntRangeToSByte(3)" executed="True" result="Success" success="True" time="0.000" asserts="0" />
+                        </results>
+                      </test-suite>
+                      <test-suite type="ParameterizedTest" name="CanConvertIntRangeToShort" executed="True" result="Success" success="True" time="0.002" asserts="0">
+                        <results>
+                          <test-case name="NUnit.Framework.Tests.ValuesAttributeTests.CanConvertIntRangeToShort(1)" executed="True" result="Success" success="True" time="0.000" asserts="0" />
+                          <test-case name="NUnit.Framework.Tests.ValuesAttributeTests.CanConvertIntRangeToShort(2)" executed="True" result="Success" success="True" time="0.000" asserts="0" />
+                          <test-case name="NUnit.Framework.Tests.ValuesAttributeTests.CanConvertIntRangeToShort(3)" executed="True" result="Success" success="True" time="0.000" asserts="0" />
+                        </results>
+                      </test-suite>
+                      <test-suite type="ParameterizedTest" name="CanConvertIntToDecimal" executed="True" result="Success" success="True" time="0.001" asserts="0">
+                        <results>
+                          <test-case name="NUnit.Framework.Tests.ValuesAttributeTests.CanConvertIntToDecimal(12m)" executed="True" result="Success" success="True" time="0.000" asserts="0" />
+                        </results>
+                      </test-suite>
+                      <test-suite type="ParameterizedTest" name="CanConvertRandomDoubleToDecimal" executed="True" result="Success" success="True" time="0.002" asserts="0">
+                        <results>
+                          <test-case name="NUnit.Framework.Tests.ValuesAttributeTests.CanConvertRandomDoubleToDecimal(4.70040703271535m)" executed="True" result="Success" success="True" time="0.000" asserts="0" />
+                          <test-case name="NUnit.Framework.Tests.ValuesAttributeTests.CanConvertRandomDoubleToDecimal(8.88255674200252m)" executed="True" result="Success" success="True" time="0.001" asserts="0" />
+                          <test-case name="NUnit.Framework.Tests.ValuesAttributeTests.CanConvertRandomDoubleToDecimal(3.60711565036658m)" executed="True" result="Success" success="True" time="0.000" asserts="0" />
+                        </results>
+                      </test-suite>
+                      <test-suite type="ParameterizedTest" name="CanConvertRandomIntToByte" executed="True" result="Success" success="True" time="0.002" asserts="0">
+                        <results>
+                          <test-case name="NUnit.Framework.Tests.ValuesAttributeTests.CanConvertRandomIntToByte(8)" executed="True" result="Success" success="True" time="0.000" asserts="0" />
+                          <test-case name="NUnit.Framework.Tests.ValuesAttributeTests.CanConvertRandomIntToByte(8)" executed="True" result="Success" success="True" time="0.000" asserts="0" />
+                          <test-case name="NUnit.Framework.Tests.ValuesAttributeTests.CanConvertRandomIntToByte(8)" executed="True" result="Success" success="True" time="0.000" asserts="0" />
+                        </results>
+                      </test-suite>
+                      <test-suite type="ParameterizedTest" name="CanConvertRandomIntToDecimal" executed="True" result="Success" success="True" time="0.002" asserts="0">
+                        <results>
+                          <test-case name="NUnit.Framework.Tests.ValuesAttributeTests.CanConvertRandomIntToDecimal(2m)" executed="True" result="Success" success="True" time="0.000" asserts="0" />
+                          <test-case name="NUnit.Framework.Tests.ValuesAttributeTests.CanConvertRandomIntToDecimal(7m)" executed="True" result="Success" success="True" time="0.000" asserts="0" />
+                          <test-case name="NUnit.Framework.Tests.ValuesAttributeTests.CanConvertRandomIntToDecimal(9m)" executed="True" result="Success" success="True" time="0.000" asserts="0" />
+                        </results>
+                      </test-suite>
+                      <test-suite type="ParameterizedTest" name="CanConvertRandomIntToSByte" executed="True" result="Success" success="True" time="0.002" asserts="0">
+                        <results>
+                          <test-case name="NUnit.Framework.Tests.ValuesAttributeTests.CanConvertRandomIntToSByte(8)" executed="True" result="Success" success="True" time="0.000" asserts="0" />
+                          <test-case name="NUnit.Framework.Tests.ValuesAttributeTests.CanConvertRandomIntToSByte(3)" executed="True" result="Success" success="True" time="0.000" asserts="0" />
+                          <test-case name="NUnit.Framework.Tests.ValuesAttributeTests.CanConvertRandomIntToSByte(5)" executed="True" result="Success" success="True" time="0.000" asserts="0" />
+                        </results>
+                      </test-suite>
+                      <test-suite type="ParameterizedTest" name="CanConvertRandomIntToShort" executed="True" result="Success" success="True" time="0.002" asserts="0">
+                        <results>
+                          <test-case name="NUnit.Framework.Tests.ValuesAttributeTests.CanConvertRandomIntToShort(4)" executed="True" result="Success" success="True" time="0.000" asserts="0" />
+                          <test-case name="NUnit.Framework.Tests.ValuesAttributeTests.CanConvertRandomIntToShort(1)" executed="True" result="Success" success="True" time="0.000" asserts="0" />
+                          <test-case name="NUnit.Framework.Tests.ValuesAttributeTests.CanConvertRandomIntToShort(3)" executed="True" result="Success" success="True" time="0.000" asserts="0" />
+                        </results>
+                      </test-suite>
+                      <test-suite type="ParameterizedTest" name="CanConvertSmallIntsToByte" executed="True" result="Success" success="True" time="0.001" asserts="0">
+                        <results>
+                          <test-case name="NUnit.Framework.Tests.ValuesAttributeTests.CanConvertSmallIntsToByte(5)" executed="True" result="Success" success="True" time="0.000" asserts="0" />
+                        </results>
+                      </test-suite>
+                      <test-suite type="ParameterizedTest" name="CanConvertSmallIntsToSByte" executed="True" result="Success" success="True" time="0.001" asserts="0">
+                        <results>
+                          <test-case name="NUnit.Framework.Tests.ValuesAttributeTests.CanConvertSmallIntsToSByte(5)" executed="True" result="Success" success="True" time="0.000" asserts="0" />
+                        </results>
+                      </test-suite>
+                      <test-suite type="ParameterizedTest" name="CanConvertSmallIntsToShort" executed="True" result="Success" success="True" time="0.001" asserts="0">
+                        <results>
+                          <test-case name="NUnit.Framework.Tests.ValuesAttributeTests.CanConvertSmallIntsToShort(5)" executed="True" result="Success" success="True" time="0.000" asserts="0" />
+                        </results>
+                      </test-suite>
+                      <test-suite type="ParameterizedTest" name="CanConvertStringToDecimal" executed="True" result="Success" success="True" time="0.001" asserts="0">
+                        <results>
+                          <test-case name="NUnit.Framework.Tests.ValuesAttributeTests.CanConvertStringToDecimal(12.5m)" executed="True" result="Success" success="True" time="0.000" asserts="0" />
+                        </results>
+                      </test-suite>
+                      <test-case name="NUnit.Framework.Tests.ValuesAttributeTests.RangeAttributeWithDoubleRangeAndStep" executed="True" result="Success" success="True" time="0.001" asserts="1" />
+                      <test-case name="NUnit.Framework.Tests.ValuesAttributeTests.RangeAttributeWithFloatRangeAndStep" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                      <test-case name="NUnit.Framework.Tests.ValuesAttributeTests.RangeAttributeWithIntRange" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                      <test-case name="NUnit.Framework.Tests.ValuesAttributeTests.RangeAttributeWithIntRangeAndStep" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                      <test-case name="NUnit.Framework.Tests.ValuesAttributeTests.RangeAttributeWithLongRangeAndStep" executed="True" result="Success" success="True" time="0.001" asserts="1" />
+                      <test-case name="NUnit.Framework.Tests.ValuesAttributeTests.ValuesAttributeProvidesSpecifiedValues" executed="True" result="Success" success="True" time="0.000" asserts="1" />
+                    </results>
+                  </test-suite>
+                </results>
+              </test-suite>
+            </results>
+          </test-suite>
+        </results>
+      </test-suite>
+    </results>
+  </test-suite>
+</test-results>

--- a/src/test-nunit-summary.exe/test-nunit-summary.exe.csproj
+++ b/src/test-nunit-summary.exe/test-nunit-summary.exe.csproj
@@ -50,6 +50,7 @@
   </ItemGroup>
   <ItemGroup>
     <Compile Include="BriefHtmlOutputTests_NUnit3.cs" />
+    <Compile Include="MultipleInputSingleOutputTest.cs" />
     <Compile Include="DefaultHtmlOutputTests_NUnit2.cs" />
     <Compile Include="BriefHtmlOutputTests_NUnit2.cs" />
     <Compile Include="ReportCreationTests.cs" />
@@ -73,6 +74,27 @@
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </Content>
     <Content Include="TestInput\MockAssemblyTestResult-3.5.0.xml">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </Content>
+    <Content Include="TestInput\TestResult-2.2.10.xml">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </Content>
+    <Content Include="TestInput\TestResult-2.4.8.xml">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </Content>
+    <Content Include="TestInput\TestResult-2.5.10.xml">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </Content>
+    <Content Include="TestInput\TestResult-2.5.2.xml">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </Content>
+    <Content Include="TestInput\TestResult-2.6.0.xml">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </Content>
+    <Content Include="TestInput\TestResult-2.6.2.xml">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </Content>
+    <Content Include="TestInput\TestResult-2.6.4.xml">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </Content>
   </ItemGroup>


### PR DESCRIPTION
Cleaning out my local folders for nunit-summary, I found a group of test results from NUnit 2.2 through 2.6.4. I used these in the past to manually test multiple output reports.

I added the files as well as a test that uses them. It's a very brittle test, since it depends on line numbers, but I'll leave it to the next person to fix that, possibly after some improvements are made to FileAssert. Even so, it's a useful regression test when changes are made to the code and one represents a use case we were not testing.
